### PR TITLE
ci: publish docs site to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: docs
+
+# Build the VitePress docs site and publish it to GitHub Pages
+# (https://silo-code.github.io/silo/). The site combines the hand-written
+# guides with the API reference TypeDoc generates from the SDK's TSDoc, so
+# `pnpm docs:build` runs `docs:api` before `vitepress build`.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - uses: actions/configure-pages@v5
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm docs:build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -81,6 +81,9 @@ export default withMermaid(
     title: "Silo",
     description:
       "A local-first, extensible code editor — extension API & guides.",
+    // Served from the GitHub Pages project URL https://silo-code.github.io/silo/,
+    // so every asset/link is resolved under this base path.
+    base: "/silo/",
     cleanUrls: true,
     lastUpdated: true,
     // api-intro.md is TypeDoc's readme source (merged into /api/index.md); it is


### PR DESCRIPTION
Hosts the VitePress docs site on GitHub Pages at **https://silo-code.github.io/silo/**.

## What's here
- **`.github/workflows/docs.yml`** — builds the docs (`pnpm docs:build`, which runs TypeDoc then `vitepress build`) on pushes to `main` and deploys to Pages via the official `upload-pages-artifact` / `deploy-pages` actions.
- **`apps/docs/.vitepress/config.ts`** — sets `base: "/silo/"` so assets and links resolve under the project Pages path.

## Already done outside this PR
- Repo made **public** (Pages requires it).
- Pages **source set to GitHub Actions** (`build_type=workflow`).
- Repo **description + homepage** updated to link the docs site.

## To go live
Merging this to `main` triggers the `docs` workflow, which publishes the first build to https://silo-code.github.io/silo/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)