### PR TITLE
fix(terminal): store runtime state in app-data dir, not ~/.app-editor

### DIFF
--- a/apps/desktop/src-tauri/src/commands/app_paths.rs
+++ b/apps/desktop/src-tauri/src/commands/app_paths.rs
@@ -1,0 +1,69 @@
+// Resolves the root directory for Silo's per-user runtime state: the terminal
+// session registry, scrollback buffers, and backend logs.
+//
+// This lives in the OS application-data directory keyed by the *bundle
+// identifier* (on macOS `~/Library/Application Support/com.silo.desktop`, and
+// `…/com.silo.desktop.dev` for the "Silo Dev" build), matching where Tauri's
+// own plugins (store, window-state) persist. Keying by identity means dev and
+// prod never share state — the same isolation principle as `SILO_PTY_NS` (see
+// `lib.rs`).
+//
+// The path is computed once at startup in `run()` and exported as
+// `SILO_DATA_DIR`, because the self-forked PTY-host daemon (`main.rs`'s
+// `--session-host` branch) has no Tauri `AppHandle` to resolve paths from — it
+// inherits the value from the spawning app's environment, exactly like
+// `SILO_PTY_NS`.
+
+use std::path::PathBuf;
+
+/// Root directory for Silo's per-user runtime state.
+///
+/// Prefers `SILO_DATA_DIR` (set at startup from the bundle identifier, and
+/// inherited by the PTY-host daemon). Falls back to the production identifier
+/// under the OS data dir for processes/tests started without the env set; in
+/// that fallback dev/prod isolation is not guaranteed, which is why startup
+/// always exports the env explicitly.
+pub fn data_dir() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("SILO_DATA_DIR") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    dirs::data_dir().map(|d| d.join("com.silo.desktop"))
+}
+
+/// Serializes tests across this crate that mutate the process-global
+/// `SILO_DATA_DIR` (here and in `terminal_buffer`), since Rust runs `#[test]`s
+/// in parallel within a crate. Recover from poisoning so one panicking test
+/// doesn't cascade.
+#[cfg(test)]
+pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_from_env_with_prod_fallback() {
+        let _g = env_lock();
+
+        // Explicit env wins.
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("silo-data-dir-test-{}", std::process::id()));
+        std::env::set_var("SILO_DATA_DIR", &dir);
+        assert_eq!(data_dir(), Some(dir));
+
+        // Empty env is treated as unset → fall back to the prod identifier.
+        std::env::set_var("SILO_DATA_DIR", "");
+        let resolved = data_dir().expect("a data dir on supported platforms");
+        assert!(
+            resolved.ends_with("com.silo.desktop"),
+            "expected fallback under the prod identifier, got {resolved:?}"
+        );
+
+        std::env::remove_var("SILO_DATA_DIR");
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod app_paths;
 #[cfg(feature = "automation")]
 pub mod automation;
 pub mod devtools;

--- a/apps/desktop/src-tauri/src/commands/session_backend.rs
+++ b/apps/desktop/src-tauri/src/commands/session_backend.rs
@@ -114,8 +114,8 @@ pub fn log_event(event: &str, detail: &str) {
         .unwrap_or(0);
     let line = format!("{} {} {}\n", ts, event, detail);
     eprint!("[terminal] {}", line);
-    if let Some(home) = dirs::home_dir() {
-        let dir = home.join(".app-editor/logs");
+    if let Some(root) = super::app_paths::data_dir() {
+        let dir = root.join("logs");
         let _ = std::fs::create_dir_all(&dir);
         if let Ok(mut f) = std::fs::OpenOptions::new()
             .create(true)

--- a/apps/desktop/src-tauri/src/commands/session_registry.rs
+++ b/apps/desktop/src-tauri/src/commands/session_registry.rs
@@ -18,7 +18,7 @@ fn registry_path() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("SILO_SESSION_REGISTRY") {
         return Some(PathBuf::from(p));
     }
-    dirs::home_dir().map(|h| h.join(".app-editor/terminal-sessions.json"))
+    super::app_paths::data_dir().map(|d| d.join("terminal-sessions.json"))
 }
 
 // Serializes read-modify-write so concurrent terminal commands can't clobber

--- a/apps/desktop/src-tauri/src/commands/terminal_buffer.rs
+++ b/apps/desktop/src-tauri/src/commands/terminal_buffer.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 // not parse or interpret the data.
 
 fn get_buffer_dir() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("No home directory")?;
-    let dir = home.join(".app-editor/terminal-buffers");
+    let root = super::app_paths::data_dir().ok_or("No data directory")?;
+    let dir = root.join("terminal-buffers");
     fs::create_dir_all(&dir).map_err(|e| format!("Failed to create buffer dir: {}", e))?;
     Ok(dir)
 }
@@ -62,4 +62,29 @@ pub fn cleanup_stale_buffers() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_load_buffer_under_data_dir() {
+        let _g = super::super::app_paths::env_lock();
+        // Redirect the data root to a temp dir; buffers must land under it and
+        // round-trip, and a missing buffer reads back as empty (not an error).
+        let mut root = std::env::temp_dir();
+        root.push(format!("silo-buffer-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        std::env::set_var("SILO_DATA_DIR", &root);
+
+        assert_eq!(load_buffer("missing").as_deref(), Ok(""));
+
+        save_buffer("s1", "scrollback\x1b[0m").unwrap();
+        assert!(root.join("terminal-buffers/s1.term").exists());
+        assert_eq!(load_buffer("s1").as_deref(), Ok("scrollback\x1b[0m"));
+
+        std::env::remove_var("SILO_DATA_DIR");
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -24,6 +24,19 @@ pub fn run() {
         std::env::set_var("SILO_PTY_NS", ns);
     }
 
+    // Root for Silo's per-user runtime state (terminal session registry,
+    // scrollback buffers, backend logs), keyed by *app identity* under the OS
+    // app-data dir so dev and prod never share state — same isolation principle
+    // as SILO_PTY_NS above. Exported via env so the self-forked PTY-host daemon
+    // (`main.rs`), which has no Tauri AppHandle, inherits the same root. Read
+    // through `commands::app_paths::data_dir`.
+    if let Some(data_dir) = dirs::data_dir() {
+        std::env::set_var(
+            "SILO_DATA_DIR",
+            data_dir.join(&context.config().identifier),
+        );
+    }
+
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())

--- a/docs/proposals/0010-pty-host-daemon.md
+++ b/docs/proposals/0010-pty-host-daemon.md
@@ -60,7 +60,9 @@ them separate when reasoning about the replacement:
 2. **Screen/scrollback persistence (ours, backend-agnostic).** The frontend
    serializes the xterm.js buffer (SerializeAddon) to a self-contained string;
    `terminal_buffer.rs` stores it as an opaque keyed blob
-   (`~/.app-editor/terminal-buffers/<sessionId>.term`); on reattach the frontend
+   (`<app-data>/terminal-buffers/<sessionId>.term`, where `<app-data>` is the OS
+   app-data dir keyed by bundle identifier — see `commands/app_paths.rs`); on
+   reattach the frontend
    writes it back into a fresh same-size terminal. This is VS Code-style "process
    revive" and **does not depend on abduco** — it stays as-is.
 
@@ -81,7 +83,7 @@ struct Connection { master, reader, writer, child }       // a live attached PTY
 Supporting pieces, all backend-agnostic and **kept**:
 
 - `session_registry.rs` — persists `sessionId → handle` to
-  `~/.app-editor/terminal-sessions.json` so reattach never re-derives a handle.
+  `<app-data>/terminal-sessions.json` so reattach never re-derives a handle.
   Stores opaque strings; survives the swap untouched.
 - `terminal_io.rs` `run_reader_loop` — reads PTY bytes, UTF-8 decodes (carrying
   partial codepoints), emits `terminal_output:<sessionId>` Tauri events.
@@ -156,7 +158,7 @@ to.
   client disconnect (P1) and the daemon survives app exit (P2). On macOS/Linux:
   double-fork + `setsid`, reparented to init.
 - **Transport.** A Unix domain socket per host (e.g.
-  `~/.app-editor/host.sock`), framed protocol with two channels:
+  `<runtime-dir>/host.sock`), framed protocol with two channels:
   - **control** — `create/attach/resize/kill/exists/list/foreground` requests.
   - **data** — raw PTY bytes in/out, multiplexed by handle (or one socket per
     attached session — TBD, see open questions).


### PR DESCRIPTION
## What

Terminal runtime state — the session registry, xterm.js scrollback buffers, and the backend terminal log — lived in a legacy, brand-named home dotfile `~/.app-editor`. This routes all three to the OS app-data dir keyed by bundle identifier (`~/Library/Application Support/com.silo.desktop[.dev]` on macOS), where the rest of Silo's state (Tauri store, window-state) already lives.

## Why

Two problems with `~/.app-editor`:

1. **Legacy brand name** in source — the product is Silo.
2. **No dev/prod isolation.** The PTY sockets are already namespaced per app identity via `SILO_PTY_NS`, but the buffer/registry/log store ignored that and dumped everything into one shared dir — so a running `Silo` and `Silo Dev` clobbered each other's terminal state. Keying the data dir by bundle identifier fixes this for free.

## How

- New `commands::app_paths::data_dir()` resolves the state root, preferring a `SILO_DATA_DIR` env var.
- `lib.rs` exports `SILO_DATA_DIR` once at startup from `context.config().identifier`, right alongside the existing `SILO_PTY_NS`. Env (not a Tauri `AppHandle`) is the correct channel because `log_event` runs in the self-forked PTY-host daemon, which has no handle and inherits env — same mechanism as `SILO_PTY_NS`.
- Three call sites (`session_registry`, `terminal_buffer`, `session_backend`) rerouted. The `SILO_SESSION_REGISTRY` test override is preserved.
- RFC 0010 path references updated off the legacy name.

## Migration

None in-code (single user today; handled manually). Existing `~/.app-editor` data is simply left behind; each build starts fresh in its own isolated dir on next launch.

## Tests

- `app_paths`: env override + prod fallback resolution.
- `terminal_buffer`: save/load round-trip + missing-file-reads-empty fallback.
- Both serialized via a shared `env_lock()` since they mutate the process-global `SILO_DATA_DIR`.
- `cargo test --features automation` → 7 passed; `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)