### PR TITLE
fix(docs): update documentation links and improve pre-commit pnpm resolution

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,6 +5,26 @@
 #
 # In a genuine pinch you can bypass with:  git commit --no-verify
 
+# Robustly find pnpm (especially for GUI git clients on macOS)
+if ! command -v pnpm >/dev/null 2>&1; then
+  export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin"
+  # Try to load common version manager paths if still not found
+  [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"
+  [ -s "$HOME/.asdf/asdf.sh" ] && . "$HOME/.asdf/asdf.sh"
+fi
+
+# Fallback to npx if pnpm is still missing
+PNPM="pnpm"
+if ! command -v pnpm >/dev/null 2>&1; then
+  if command -v npx >/dev/null 2>&1; then
+    PNPM="npx --no-install pnpm"
+  else
+    echo "✖ Commit blocked: 'pnpm' command not found."
+    echo "  Please ensure pnpm is in your PATH."
+    exit 1
+  fi
+fi
+
 fail() {
   echo ""
   echo "✖ Commit blocked: $1"
@@ -16,7 +36,7 @@ echo "→ Running boundary lint…"
 # Root lint covers the whole workspace: eslint (platform/leaf boundaries) +
 # stylelint (design-token-only extension CSS). The primary import boundary is
 # enforced by each package's dependency graph. See MONOREPO-MIGRATION.md step 6.
-pnpm --silent lint || fail "lint failed (see errors above)"
+$PNPM --silent lint || fail "lint failed (see errors above)"
 
 echo "→ Formatting staged files…"
 # Auto-format staged files with Prettier and re-stage them. lint-staged stashes
@@ -28,4 +48,4 @@ echo "→ Running unit tests…"
 # unchanged packages). The integration layer (*.it.test.ts) drives a live dev
 # app over the RPC, so it's unsuitable for a commit gate — run it explicitly via
 # `pnpm --filter silo test:it`. See docs/AUTOMATION.md.
-pnpm --silent test 2>/dev/null || fail "tests failed (see errors above)"
+$PNPM --silent test 2>/dev/null || fail "tests failed (see errors above)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <div align="center">
   <img src="apps/desktop/src-tauri/icons/128x128.png" width="96" height="96" alt="Silo" />
-  <h1>Silo</h1>
   <p><strong>Run many workspaces at once — and switch between them instantly, without losing state.</strong></p>
 </div>
 
@@ -22,7 +21,7 @@ with Tauri, React, and TypeScript.
 
 Early and moving fast. The platform is **100% open source** (MIT); the bar for
 clean boundaries, a documented public surface, and a stable extension contract
-is intentionally high. See the [Roadmap](apps/docs/roadmap.md) for what's stable
+is intentionally high. See the [Roadmap](https://silo.dev/roadmap) for what's stable
 vs. planned.
 
 ## Develop
@@ -79,7 +78,7 @@ So cutting a release is just: land `feat:`/`fix:` PRs, then merge the release PR
   resolve what it depends on) and by lint (the platform ban + design-token CSS
   rule). See [`CLAUDE.md`](CLAUDE.md) and [`docs/`](docs/).
 - The API reference is generated from source into the
-  [docs site](apps/docs/) (`pnpm docs:api`).
+  [docs site](https://silo.dev/) (`pnpm docs:api`).
 
 ## License
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -58,10 +58,10 @@ exactly this surface — no more, no less.
 
 ## Docs
 
-- **Guide:** [Your first extension](https://github.com/silo-code/silo/blob/main/apps/docs/guide/getting-started.md)
-  · [Publishing an extension](https://github.com/silo-code/silo/blob/main/apps/docs/guide/publishing-an-extension.md)
+- **Guide:** [Your first extension](https://silo.dev/guide/getting-started)
+  · [Publishing an extension](https://silo.dev/guide/publishing-an-extension)
 - **API reference:** generated from this package — see the
-  [docs site](https://github.com/silo-code/silo/tree/main/apps/docs).
+  [docs site](https://silo.dev/).
 - **Examples:** [`examples/extensions`](https://github.com/silo-code/silo/tree/main/examples/extensions).
 
 ## License


### PR DESCRIPTION
This PR updates documentation links in the README and SDK README to point to the hosted `silo.dev` site. It also improves the pre-commit hook's ability to find `pnpm` in various environments (NVM, Homebrew, etc.) and adds an `npx` fallback. Additionally, it removes a redundant `<h1>` from the root README.