### PR TITLE
fix(layout): match side-dock resize border to center dock

### DIFF
--- a/packages/extension-host/src/layout/AppShell.css
+++ b/packages/extension-host/src/layout/AppShell.css
@@ -34,6 +34,13 @@
   min-height: 0;
   padding-top: 28px;
   overflow: hidden;
+  /* Contain each column's internal stacking. Without this the center column is
+     a static (non-isolating) box, so dockview's positioned descendants (e.g.
+     .dock-host at z-index 1, .dv-sash at z-index 99) escape into the root
+     stacking context and paint over the resize handle's 1px line — clipping the
+     left handle behind the center dock. Isolating keeps those z-indexes local
+     so the handle (z-index 1, a sibling) always wins at the seam. */
+  isolation: isolate;
 }
 
 .app-col > * {

--- a/packages/extension-host/src/layout/SideColumn.css
+++ b/packages/extension-host/src/layout/SideColumn.css
@@ -94,7 +94,7 @@
   position: relative;
   flex: 0 0 0;
   height: 0;
-  cursor: row-resize;
+  cursor: ns-resize;
 }
 .side-resize-handle::after {
   content: "";
@@ -103,12 +103,11 @@
   right: 0;
   top: -3px;
   bottom: -3px;
-  cursor: row-resize;
+  cursor: ns-resize;
 }
-.side-resize-handle[data-resize-handle-active] {
-  background: var(--silo-color-accent);
-  height: 1px;
-}
+/* The hover/drag accent line is drawn by the shared rrp ::before rule in
+   theme.css (the split handle is a vertical rrp handle), so it stays a single
+   1px line and matches the center dock — no element-level highlight here. */
 
 /* Empty column — invisible but accepts drops to restore panels */
 .side-empty-column {

--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -461,7 +461,7 @@ a {
 [data-panel-resize-handle-enabled="true"][data-panel-group-direction="horizontal"] {
   flex: 0 0 0;
   width: 0;
-  cursor: col-resize;
+  cursor: ew-resize;
 }
 [data-panel-resize-handle-enabled="true"][data-panel-group-direction="horizontal"]::before {
   content: "";
@@ -480,14 +480,14 @@ a {
   bottom: 0;
   left: -3px;
   right: -3px;
-  cursor: col-resize;
+  cursor: ew-resize;
 }
 
 /* Vertical handles (horizontal dividing line between rows) */
 [data-panel-resize-handle-enabled="true"][data-panel-group-direction="vertical"] {
   flex: 0 0 0;
   height: 0;
-  cursor: row-resize;
+  cursor: ns-resize;
 }
 [data-panel-resize-handle-enabled="true"][data-panel-group-direction="vertical"]::before {
   content: "";
@@ -506,7 +506,7 @@ a {
   right: 0;
   top: -3px;
   bottom: -3px;
-  cursor: row-resize;
+  cursor: ns-resize;
 }
 
 /* Disable pointer events on all content during active resize drag so that
@@ -516,15 +516,29 @@ body.panel-resizing * {
   pointer-events: none !important;
   user-select: none !important;
 }
-
-/* Active (dragging) only: render the handle itself as the visible line */
-[data-panel-resize-handle-enabled="true"][data-panel-group-direction="horizontal"][data-resize-handle-active] {
-  flex-basis: 2px;
-  background: var(--silo-color-accent);
-  left: -1px;
+/* ...but keep the resize handles themselves hit-testable. pointer-events is an
+   inherited property, so the rule above would otherwise make the handle inherit
+   `none` from its container even though the drag is in progress. When that
+   happens react-resizable-panels loses the handle as the pointer target,
+   event.target collapses to <body>, and its `buttons === 0` guard force-releases
+   the drag in the webview — so click-and-hold stops dragging. Re-enable them. */
+body.panel-resizing [data-panel-resize-handle-enabled],
+body.panel-resizing .side-resize-handle {
+  pointer-events: auto !important;
 }
-[data-panel-resize-handle-enabled="true"][data-resize-handle-active]::before {
-  display: none;
+
+/* Hover/drag highlight, mirroring the center dock's dockview sash: the 1px
+   divider line fades to the accent color so it reads as draggable, and stays a
+   single 1px line while dragging — it never thickens. The transition (with
+   delay) eases the highlight in after a brief hover and clears instantly on
+   leave (the resting `::before` has no transition). Covers the horizontal column
+   handles and the vertical side-split handle alike (both draw the line via
+   ::before). */
+[data-panel-resize-handle-enabled="true"][data-resize-handle-state="hover"]::before,
+[data-panel-resize-handle-enabled="true"][data-resize-handle-state="drag"]::before {
+  background: var(--silo-color-accent);
+  transition: background-color 0.1s ease-in-out;
+  transition-delay: 0.5s;
 }
 
 /* ── Keyboard focus ring (RFC 0012). The one ring for every keyboard-navigable


### PR DESCRIPTION
## Problem

The side-dock resize borders (left/right dock width + the side-split) use
`react-resizable-panels` and didn't behave like the center dock's dockview
sashes. Four issues:

1. **Click-and-hold released the drag.** During a resize, `body.panel-resizing`
   sets `pointer-events: none` on all content (to stop terminals/Monaco from
   stealing pointer capture). Because `pointer-events` is **inherited**, the
   handle inherited `none` from its container even mid-drag — so rrp lost the
   handle as the pointer target, `event.target` collapsed to `<body>`, and rrp's
   `buttons === 0` guard force-released the drag in the webview.
2. **No hover affordance.** The handles only styled the active-drag state, so
   hovering never highlighted the border.
3. **Mismatched cursor + thickening border.** Side handles used
   `col-/row-resize` and grew to 2px on drag; the center dock uses `ew-/ns-resize`
   and stays a single 1px line.
4. **Left handle clipped behind the center dock.** `.app-col` was a static box, so
   dockview's positioned descendants (`.dock-host` z-index 1, `.dv-sash` z-index
   99) escaped into the root stacking context and painted over the left handle's
   1px line. (The right handle was fine — the right dock has no positive-z
   descendants.)

## Fix (host CSS only, 3 files)

- **`theme.css`** — re-enable `pointer-events` on the handles during resize (an
  explicit re-enable, since excluding them from the rule isn't enough given
  inheritance); add a delayed hover/drag highlight via `data-resize-handle-state`,
  mirroring dockview's `transition-delay`; switch cursors to `ew-/ns-resize`; keep
  the divider a single 1px `::before` line on drag instead of thickening to 2px.
- **`SideColumn.css`** — `ns-resize` cursor; drop the redundant element-level
  active highlight (the shared `::before` rule now covers the side-split).
- **`AppShell.css`** — `isolation: isolate` on `.app-col` so each column contains
  its own stacking and dockview's z-indexes can't paint over the handle.

## Verification

Driven through the dev automation bridge in a sandbox workspace:

- Cursor is `ew-resize`; handle stays width `0` / `flex-basis: 0` with the
  `::before` line exactly `1px` during drag (no thickening).
- Hover/drag recolors the 1px line to the accent after the 0.5s delay.
- During `body.panel-resizing` the handle keeps `pointer-events: auto` while
  content stays `none`; a full synthetic drag (incl. stationary frames) holds
  `data-resize-handle-state="drag"` throughout and resizes the panels.
- Magnified screenshot confirms the left-seam accent line is a clean, continuous
  full-height 1px bar — no longer clipped by the center dock.
- `pnpm lint` + `pnpm test` (217 host tests) green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)