### PR TITLE
feat(storage): per-workspace files in an identity-keyed config root

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -2,6 +2,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import {
   hydrate,
+  userConfigDir,
   getExtensionManager,
   initUserKeybindings,
   checkForUpdatesOnLaunch,
@@ -26,7 +27,9 @@ mgr
       .catch((err) => console.error("loadInstalled failed", err));
   });
 
-hydrate().catch((err) => console.error("hydrate failed", err));
+userConfigDir()
+  .then(hydrate)
+  .catch((err) => console.error("hydrate failed", err));
 
 // Load keybindings.json overrides and live-reload on save. Runs after
 // activateBuiltins so menu defaults are recorded first; loading overrides

--- a/crates/pty-host/src/discovery.rs
+++ b/crates/pty-host/src/discovery.rs
@@ -55,22 +55,32 @@ mod tests {
     use std::path::PathBuf;
 
     // These tests bind real sockets but in a private temp dir, overriding the
-    // session dir via XDG_RUNTIME_DIR. They serialize on that env var.
+    // session dir via XDG_RUNTIME_DIR. They serialize on a guard, recovering
+    // from a poisoned lock so one failure doesn't cascade into the others. We
+    // also neutralize SILO_PTY_NS for the duration: if it's set in the ambient
+    // environment (e.g. a dev shell exports SILO_PTY_NS=prod), `sock_dir()`
+    // would append that namespace subdir and miss the sockets these tests write
+    // at the un-namespaced base.
     fn with_temp_dir<T>(tag: &str, f: impl FnOnce(&Path) -> T) -> T {
         use std::sync::Mutex;
         static GUARD: Mutex<()> = Mutex::new(());
-        let _g = GUARD.lock().unwrap();
+        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
         // Short base under /tmp — Unix socket paths are capped (~104 bytes on
         // macOS), so the deeper `std::env::temp_dir()` can overflow `sun_path`.
         let dir = PathBuf::from("/tmp").join(format!("ph-{}-{}", std::process::id(), tag));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(dir.join("silo-pty")).unwrap();
-        let prev = std::env::var("XDG_RUNTIME_DIR").ok();
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        let prev_ns = std::env::var("SILO_PTY_NS").ok();
         std::env::set_var("XDG_RUNTIME_DIR", &dir);
+        std::env::remove_var("SILO_PTY_NS");
         let out = f(&dir.join("silo-pty"));
-        match prev {
+        match prev_xdg {
             Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
             None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+        if let Some(v) = prev_ns {
+            std::env::set_var("SILO_PTY_NS", v);
         }
         let _ = std::fs::remove_dir_all(&dir);
         out

--- a/crates/pty-host/src/paths.rs
+++ b/crates/pty-host/src/paths.rs
@@ -11,18 +11,32 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 /// The un-namespaced base for session sockets. These are **ephemeral runtime
-/// state, not editable config**, so prefer the OS runtime dir
-/// (`$XDG_RUNTIME_DIR/silo-pty` — a 0700 tmpfs auto-cleared on logout on Linux);
-/// otherwise fall back to a dedicated `pty/` subdir of Silo's config root
-/// (`~/.config/silo/pty`) so everything stays under one tree on macOS.
+/// state, not editable config** (ADR 0022, tier 3), so they live in the OS
+/// runtime/temp dir — never under `~/.config/silo`. Prefer `$XDG_RUNTIME_DIR`
+/// (Linux — a 0700 tmpfs auto-cleared on logout); otherwise the per-user temp
+/// dir `$TMPDIR` (the macOS analog, `/var/folders/…/T`), which is auto-cleaned
+/// and short enough to keep socket paths under `sockaddr_un`'s ~104-byte
+/// `sun_path` limit; failing both, `/tmp`.
 fn base_dir() -> PathBuf {
-    if let Ok(x) = std::env::var("XDG_RUNTIME_DIR") {
+    resolve_base(
+        std::env::var("XDG_RUNTIME_DIR").ok(),
+        std::env::var("TMPDIR").ok(),
+    )
+}
+
+/// Pick the runtime base from env values. Pure, for testing.
+fn resolve_base(xdg_runtime_dir: Option<String>, tmpdir: Option<String>) -> PathBuf {
+    if let Some(x) = xdg_runtime_dir {
         if !x.is_empty() {
             return PathBuf::from(x).join("silo-pty");
         }
     }
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(home).join(".config/silo/pty")
+    if let Some(t) = tmpdir {
+        if !t.is_empty() {
+            return PathBuf::from(t).join("silo-pty");
+        }
+    }
+    PathBuf::from("/tmp").join("silo-pty")
 }
 
 /// Apply an optional namespace as a subdir of the base. Pure, for testing.
@@ -75,5 +89,30 @@ mod tests {
         let base = PathBuf::from("/run/silo-pty");
         assert_eq!(namespaced(base.clone(), None), base.clone());
         assert_eq!(namespaced(base.clone(), Some(String::new())), base);
+    }
+
+    #[test]
+    fn base_prefers_xdg_then_tmpdir_then_tmp() {
+        // XDG_RUNTIME_DIR wins (Linux).
+        assert_eq!(
+            resolve_base(Some("/run/user/1000".into()), Some("/var/T".into())),
+            PathBuf::from("/run/user/1000/silo-pty")
+        );
+        // No XDG → TMPDIR (macOS).
+        assert_eq!(
+            resolve_base(None, Some("/var/folders/ab/cd/T".into())),
+            PathBuf::from("/var/folders/ab/cd/T/silo-pty")
+        );
+        // Empty values are treated as unset.
+        assert_eq!(
+            resolve_base(Some(String::new()), Some("/var/T".into())),
+            PathBuf::from("/var/T/silo-pty")
+        );
+        // Neither set → /tmp.
+        assert_eq!(resolve_base(None, None), PathBuf::from("/tmp/silo-pty"));
+        assert_eq!(
+            resolve_base(None, Some(String::new())),
+            PathBuf::from("/tmp/silo-pty")
+        );
     }
 }

--- a/docs/decisions/0022-on-disk-storage-layout.md
+++ b/docs/decisions/0022-on-disk-storage-layout.md
@@ -1,0 +1,98 @@
+---
+status: accepted
+date: 2026-06-10
+---
+
+# 0022. On-disk storage layout: a three-tier config / app-state / runtime split
+
+## Context
+
+Silo writes several kinds of state to disk, and they had drifted across unrelated
+roots with no stated rule: workspaces + global prefs in a single `app-state.json`
+under the Tauri app-data dir; themes and keybindings under `~/.config/silo`; the
+terminal session registry, scrollback buffers, and backend log in a legacy
+`~/.app-editor` dotfile (since moved to the app-data dir); and PTY-host sockets
+under `~/.config/silo/pty`. Going open source, where these live — and whether a
+user can find, hand-edit, and back them up — is a public surface that deserves a
+rule, not ad-hoc placement.
+
+The forces:
+
+- Some state is **user data** the user should be able to read, edit, and copy
+  (workspaces, keybindings, themes, installed extensions).
+- Some state is **app-managed**: it should survive a restart but isn't meant to be
+  edited (terminal session registry, buffers, logs).
+- Some state is **purely ephemeral** — meaningless once the process/login ends —
+  and has OS-specific placement constraints (Unix socket paths are length-capped).
+
+Cutting across all three: a dev build and a production install must not collide —
+not just for opaque runtime state, but for workspaces too, because a workspace's
+terminal `sessionId`s only resolve against its own build-identity's session
+registry. So **every tier is keyed by build identity**; "Silo Dev" is a fully
+separate install on disk.
+
+## Decision
+
+Place each on-disk artifact in one of three tiers by its nature — **every tier
+keyed by build identity**:
+
+1. **Config (user data)** → `~/.config/silo` for the production identity
+   (`com.silo.desktop`), `~/.config/silo-<suffix>` for any other build
+   (`~/.config/silo-dev` for "Silo Dev", `com.silo.desktop.dev`). Hand-editable,
+   human-readable, inspectable/backup-able. The single resolver (`userConfigDir`)
+   is identity-keyed, so **everything beneath it splits per build**. _Workspaces
+   (one JSON file per workspace), keybindings, themes, installed extensions._
+2. **Persistent app-state** → the OS app-data dir keyed by bundle identifier
+   (`~/Library/Application Support/com.silo.desktop[.dev]` on macOS); survives app
+   restart; not for hand-editing. _Terminal session registry, scrollback buffers,
+   backend logs._
+3. **Ephemeral runtime** → the OS runtime/temp dir (`$XDG_RUNTIME_DIR` on Linux,
+   `$TMPDIR` on macOS, `/tmp` failing both), namespaced per identity via
+   `SILO_PTY_NS`; recreatable, cleared with the process/login, and short enough to
+   keep Unix socket paths under `sockaddr_un`'s ~104-byte limit. _PTY-host sockets
+   and per-session daemon logs._
+
+## Consequences
+
+- A clear home for every artifact, and a test for new ones: _is it user data,
+  app state, or runtime?_
+- Workspaces become inspectable / backup-able / copyable files alongside themes and
+  keybindings. Keying the config root by identity means a dev build and a prod
+  install never share a workspace, theme, keybinding, or extension — so a
+  workspace's terminal `sessionId`s always line up with the same build's session
+  registry (tier 2) and PTY namespace (tier 3). No cross-build clobbering of the
+  shared file, no orphaned daemons, no two-writers race. The cost is that the
+  builds don't share config (set your theme/keybindings once per build) — a fair
+  trade, and config is plain files you can copy between roots if you want.
+- The one-time migration from the old monolithic app-data blob runs **per
+  identity**: each build reads its own app-data legacy blob (the same identity
+  Tauri's store already used) into its own config root. Because the roots are
+  separate, dev and prod migrate independently and never contend.
+- Sockets gain a narrow loss case: a detached session left idle past the
+  runtime-dir reap window won't reattach (the daemon process _is_ the session; the
+  socket is only its reconnect address). This already matches the Linux
+  `$XDG_RUNTIME_DIR` contract, so it unifies the two platforms rather than adding
+  a macOS-only quirk.
+- [0010](./0010-persistent-process-sessions.md)'s persistent process sessions
+  (tier 2) are why the split has to reach tier 1: workspaces embed references to
+  them, so workspaces must be keyed by the same identity.
+
+## Alternatives considered
+
+- **One root for everything** (all app-data, or all `~/.config/silo`) — rejected:
+  app-data buries user data under an OS identifier path users can't find, while
+  `~/.config/silo` is the wrong home for ephemeral sockets (long path risks the
+  `sun_path` limit) and for per-identity-isolated runtime state.
+- **Two tiers (config vs app-data), sockets in app-data** — rejected: the macOS
+  app-data base is long enough to risk overflowing the Unix socket path limit, and
+  sockets are genuinely a third, ephemeral kind of state.
+
+## References
+
+- [0010](./0010-persistent-process-sessions.md) — persistent process sessions (the
+  tier-2 / tier-3 state this governs).
+- Terminal runtime state moved out of the legacy `~/.app-editor` dotfile into the
+  identity-keyed app-data dir (2026). The workspace-storage move to
+  `~/.config/silo` and the PTY-host socket relocation to the runtime dir landed
+  alongside this ADR. The PTY-host daemon design RFC covers tier-3 socket/daemon
+  lifetime.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -33,26 +33,27 @@ A small, obvious choice needs neither.
 
 ## Index
 
-| ADR                                                     | Title                                               | Date       | Status   |
-| ------------------------------------------------------- | --------------------------------------------------- | ---------- | -------- |
-| [0001](./0001-in-process-extension-architecture.md)     | In-process, registry-based extension architecture   | 2026-05-23 | accepted |
-| [0002](./0002-imperative-registration-no-manifest.md)   | Imperative registration; no static manifest (v1)    | 2026-05-23 | accepted |
-| [0003](./0003-monorepo-pnpm.md)                         | Monorepo with pnpm workspaces                       | 2026-05-29 | accepted |
-| [0004](./0004-sdk-types-first.md)                       | Public `@silo-code/sdk` is types-first              | 2026-05-29 | accepted |
-| [0005](./0005-ui-library-internal.md)                   | Component library (`@silo-code/ui`) stays internal  | 2026-05-29 | accepted |
-| [0006](./0006-open-platform-licensing.md)               | Open-platform MIT licensing                         | 2026-05-30 | accepted |
-| [0007](./0007-core-primitive-vs-extension-test.md)      | Core-primitive vs extension-feature test            | 2026-05-31 | accepted |
-| [0008](./0008-extension-decomposition-provider-view.md) | Extension decomposition; provider/view split        | 2026-05-31 | accepted |
-| [0009](./0009-extension-communication-and-events.md)    | Extension communication: typed APIs + domain events | 2026-05-31 | accepted |
-| [0010](./0010-persistent-process-sessions.md)           | Persistent process sessions as a core primitive     | 2026-05-31 | accepted |
-| [0011](./0011-editor-and-terminal-are-core.md)          | Editor and terminal are core surfaces               | 2026-05-31 | accepted |
-| [0012](./0012-dev-automation-rpc.md)                    | Dev-only automation RPC                             | 2026-06-01 | accepted |
-| [0013](./0013-trust-tiers-two-barrel-sdk.md)            | Extension trust tiers + two-barrel SDK              | 2026-06-02 | accepted |
-| [0014](./0014-per-extension-enablement.md)              | Per-extension enablement config (Obsidian-style)    | 2026-06-02 | accepted |
-| [0015](./0015-phased-security-model.md)                 | Phased security model for privileged primitives     | 2026-06-02 | accepted |
-| [0016](./0016-ctx-dnd-primitive.md)                     | First-class drag-and-drop primitive (`ctx.dnd`)     | 2026-06-02 | accepted |
-| [0017](./0017-css-theming-contract.md)                  | CSS theming contract (`--silo-*` token tiers)       | 2026-06-02 | accepted |
-| [0018](./0018-host-owned-chrome.md)                     | Host-owned UI chrome: modals + unified menu         | 2026-06-03 | accepted |
-| [0019](./0019-runtime-extension-loading.md)             | Runtime extension loading + manifest validation     | 2026-06-04 | accepted |
-| [0020](./0020-silo-extensions-bundled.md)               | Ship `silo.*` bundled, surfaced as disable-able     | 2026-06-04 | accepted |
-| [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model   | 2026-06-08 | accepted |
+| ADR                                                     | Title                                                | Date       | Status   |
+| ------------------------------------------------------- | ---------------------------------------------------- | ---------- | -------- |
+| [0001](./0001-in-process-extension-architecture.md)     | In-process, registry-based extension architecture    | 2026-05-23 | accepted |
+| [0002](./0002-imperative-registration-no-manifest.md)   | Imperative registration; no static manifest (v1)     | 2026-05-23 | accepted |
+| [0003](./0003-monorepo-pnpm.md)                         | Monorepo with pnpm workspaces                        | 2026-05-29 | accepted |
+| [0004](./0004-sdk-types-first.md)                       | Public `@silo-code/sdk` is types-first               | 2026-05-29 | accepted |
+| [0005](./0005-ui-library-internal.md)                   | Component library (`@silo-code/ui`) stays internal   | 2026-05-29 | accepted |
+| [0006](./0006-open-platform-licensing.md)               | Open-platform MIT licensing                          | 2026-05-30 | accepted |
+| [0007](./0007-core-primitive-vs-extension-test.md)      | Core-primitive vs extension-feature test             | 2026-05-31 | accepted |
+| [0008](./0008-extension-decomposition-provider-view.md) | Extension decomposition; provider/view split         | 2026-05-31 | accepted |
+| [0009](./0009-extension-communication-and-events.md)    | Extension communication: typed APIs + domain events  | 2026-05-31 | accepted |
+| [0010](./0010-persistent-process-sessions.md)           | Persistent process sessions as a core primitive      | 2026-05-31 | accepted |
+| [0011](./0011-editor-and-terminal-are-core.md)          | Editor and terminal are core surfaces                | 2026-05-31 | accepted |
+| [0012](./0012-dev-automation-rpc.md)                    | Dev-only automation RPC                              | 2026-06-01 | accepted |
+| [0013](./0013-trust-tiers-two-barrel-sdk.md)            | Extension trust tiers + two-barrel SDK               | 2026-06-02 | accepted |
+| [0014](./0014-per-extension-enablement.md)              | Per-extension enablement config (Obsidian-style)     | 2026-06-02 | accepted |
+| [0015](./0015-phased-security-model.md)                 | Phased security model for privileged primitives      | 2026-06-02 | accepted |
+| [0016](./0016-ctx-dnd-primitive.md)                     | First-class drag-and-drop primitive (`ctx.dnd`)      | 2026-06-02 | accepted |
+| [0017](./0017-css-theming-contract.md)                  | CSS theming contract (`--silo-*` token tiers)        | 2026-06-02 | accepted |
+| [0018](./0018-host-owned-chrome.md)                     | Host-owned UI chrome: modals + unified menu          | 2026-06-03 | accepted |
+| [0019](./0019-runtime-extension-loading.md)             | Runtime extension loading + manifest validation      | 2026-06-04 | accepted |
+| [0020](./0020-silo-extensions-bundled.md)               | Ship `silo.*` bundled, surfaced as disable-able      | 2026-06-04 | accepted |
+| [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model    | 2026-06-08 | accepted |
+| [0022](./0022-on-disk-storage-layout.md)                | On-disk storage layout: config / app-state / runtime | 2026-06-10 | accepted |

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -29,6 +29,7 @@ export { Menus } from "./components/Menus";
 
 // --- Boot sequence (main.tsx) -----------------------------------------------
 export { hydrate } from "./state/persistence";
+export { userConfigDir } from "./services/user-config";
 export { activateExtensions } from "./extension-host/host";
 export { getExtensionManager } from "./extension-host/extension-manager";
 export { initUserKeybindings } from "./extension-host/keymap";

--- a/packages/extension-host/src/services/user-config.test.ts
+++ b/packages/extension-host/src/services/user-config.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { configRootName } from "./user-config";
+
+describe("configRootName", () => {
+  it("maps the production identity to the bare 'silo' root", () => {
+    expect(configRootName("com.silo.desktop")).toBe("silo");
+  });
+
+  it("maps a build-suffixed identity to silo-<suffix>", () => {
+    expect(configRootName("com.silo.desktop.dev")).toBe("silo-dev");
+  });
+
+  it("falls back to silo-<identifier> for an unexpected identity", () => {
+    expect(configRootName("com.example.other")).toBe("silo-com.example.other");
+  });
+});

--- a/packages/extension-host/src/services/user-config.ts
+++ b/packages/extension-host/src/services/user-config.ts
@@ -1,21 +1,39 @@
 import { homeDir } from "@tauri-apps/api/path";
+import { getIdentifier } from "@tauri-apps/api/app";
 import { fsCreateDir } from "./tauri-fs";
 
-// The silo user-config root: ~/.config/silo. Home for all hand-editable config
-// (keybindings.json, and anything else users are meant to edit directly).
-// Deliberately independent of the Tauri app identifier / appConfigDir, so it
-// stays stable across renames and is easy to find.
+// The silo user-config root, home for all hand-editable / user-owned config:
+// workspaces, themes, keybindings, installed extensions.
+//
+// **Identity-keyed** (ADR 0022): each build is a fully isolated install, so the
+// production identity (com.silo.desktop) uses ~/.config/silo and any other build
+// — e.g. "Silo Dev" (com.silo.desktop.dev) — uses ~/.config/silo-<suffix>
+// (~/.config/silo-dev). Everything beneath this root splits with it, which keeps
+// a dev build from sharing workspaces (and their per-identity terminal sessions),
+// themes, or extensions with a production install. Mirrors the app-data
+// (SILO_DATA_DIR) and PTY-socket (SILO_PTY_NS) identity splits.
 //
 // Uses the Rust-backed fs commands rather than plugin-fs: the plugin-fs scope
 // glob ("$HOME/**") does not match the hidden ".config" directory, so plugin-fs
 // would silently deny access here. The std::fs-backed commands have no scope.
+
+const STABLE_IDENTIFIER = "com.silo.desktop";
+
+/** Map a bundle identifier to its config-root folder name under ~/.config. */
+export function configRootName(identifier: string): string {
+  if (identifier === STABLE_IDENTIFIER) return "silo";
+  const suffix = identifier.startsWith(`${STABLE_IDENTIFIER}.`)
+    ? identifier.slice(STABLE_IDENTIFIER.length + 1)
+    : identifier;
+  return `silo-${suffix}`;
+}
 
 let cached: string | null = null;
 
 export async function userConfigDir(): Promise<string> {
   if (cached) return cached;
   const home = (await homeDir()).replace(/\/+$/, "");
-  const dir = `${home}/.config/silo`;
+  const dir = `${home}/.config/${configRootName(await getIdentifier())}`;
   await fsCreateDir(dir);
   cached = dir;
   return dir;

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import type { Workspace } from "@silo-code/sdk";
+import {
+  buildIndex,
+  diffWorkspaceWrites,
+  reconcileWorkspaceListing,
+  splitPersistedState,
+  withActivePanelState,
+  type LegacyPersisted,
+  type PanelState,
+  type PersistedIndex,
+} from "./persistence-model";
+
+function makeWorkspace(id: string, extra: Partial<Workspace> = {}): Workspace {
+  return {
+    id,
+    name: id,
+    folder: `/ws/${id}`,
+    createdAt: "",
+    lastOpenedAt: "",
+    terminals: [],
+    editors: [],
+    dockLayout: null,
+    ...extra,
+  };
+}
+
+const PANEL: PanelState = {
+  sidePanelLocations: { explorer: "left" },
+  sidePanelOrder: { explorer: 0 },
+  activeSidePanelTabs: { left: "explorer" },
+  sidePanelScrollPositions: { explorer: 12 },
+  extensionState: { "silo.explorer": { expanded: ["/a"] } },
+  leftPanelCollapsed: false,
+  rightPanelCollapsed: true,
+};
+
+describe("splitPersistedState", () => {
+  it("extracts workspaces and carries order/active/settings into the index", () => {
+    const legacy: LegacyPersisted = {
+      workspaces: { a: makeWorkspace("a"), b: makeWorkspace("b") },
+      workspaceOrder: ["b", "a"],
+      activeWorkspaceId: "a",
+      uiFontSize: 15,
+      activeThemeId: "light",
+      editorSettings: { tabSize: 4 },
+      terminalSettings: { cursorStyle: "bar" },
+    };
+    const { index, workspaces } = splitPersistedState(legacy);
+    expect(Object.keys(workspaces).sort()).toEqual(["a", "b"]);
+    expect(index.workspaceOrder).toEqual(["b", "a"]);
+    expect(index.activeWorkspaceId).toBe("a");
+    expect(index.uiFontSize).toBe(15);
+    expect(index.activeThemeId).toBe("light");
+    expect(index.editorSettings).toEqual({ tabSize: 4 });
+    expect(index.terminalSettings).toEqual({ cursorStyle: "bar" });
+  });
+
+  it("falls back order to the workspace keys when absent", () => {
+    const legacy = {
+      workspaces: { a: makeWorkspace("a") },
+      activeWorkspaceId: null,
+    } as unknown as LegacyPersisted;
+    const { index } = splitPersistedState(legacy);
+    expect(index.workspaceOrder).toEqual(["a"]);
+    expect(index.activeWorkspaceId).toBeNull();
+  });
+
+  it("handles an empty/missing workspaces map", () => {
+    const { index, workspaces } = splitPersistedState({
+      activeWorkspaceId: null,
+    } as unknown as LegacyPersisted);
+    expect(workspaces).toEqual({});
+    expect(index.workspaceOrder).toEqual([]);
+  });
+
+  it("carries legacy top-level panel state onto the active workspace only when it lacks its own", () => {
+    const legacy: LegacyPersisted = {
+      workspaces: { a: makeWorkspace("a"), b: makeWorkspace("b") },
+      workspaceOrder: ["a", "b"],
+      activeWorkspaceId: "a",
+      sidePanelLocations: { explorer: "right" },
+      sidePanelOrder: { explorer: 2 },
+      activeSidePanelTabs: { right: "explorer" },
+      sidePanelScrollPositions: { explorer: 9 },
+      extensionState: { "silo.x": { k: 1 } },
+    };
+    const { workspaces } = splitPersistedState(legacy);
+    expect(workspaces.a.sidePanelLocations).toEqual({ explorer: "right" });
+    expect(workspaces.a.extensionState).toEqual({ "silo.x": { k: 1 } });
+    // The non-active workspace is untouched.
+    expect(workspaces.b.sidePanelLocations).toBeUndefined();
+  });
+
+  it("does not overwrite a workspace that already has its own panel state", () => {
+    const legacy: LegacyPersisted = {
+      workspaces: {
+        a: makeWorkspace("a", { sidePanelLocations: { explorer: "left" } }),
+      },
+      workspaceOrder: ["a"],
+      activeWorkspaceId: "a",
+      sidePanelLocations: { explorer: "right" },
+    };
+    const { workspaces } = splitPersistedState(legacy);
+    expect(workspaces.a.sidePanelLocations).toEqual({ explorer: "left" });
+  });
+});
+
+describe("withActivePanelState", () => {
+  it("merges the live panel state onto the workspace", () => {
+    const merged = withActivePanelState(makeWorkspace("a"), PANEL);
+    expect(merged.sidePanelLocations).toEqual({ explorer: "left" });
+    expect(merged.sidePanelScrollPositions).toEqual({ explorer: 12 });
+    expect(merged.extensionState).toEqual({
+      "silo.explorer": { expanded: ["/a"] },
+    });
+    expect(merged.leftPanelCollapsed).toBe(false);
+    expect(merged.rightPanelCollapsed).toBe(true);
+  });
+
+  it("does not mutate the source workspace and isolates the extension-state bag", () => {
+    const ws = makeWorkspace("a");
+    const merged = withActivePanelState(ws, PANEL);
+    expect(ws.sidePanelLocations).toBeUndefined();
+    // Two-level isolation: adding/replacing entries in the merged bag (or a
+    // per-extension object) must not bleed back into PANEL's bag.
+    merged.extensionState!["silo.new"] = { added: true };
+    merged.extensionState!["silo.explorer"] = { replaced: true };
+    expect(PANEL.extensionState["silo.new"]).toBeUndefined();
+    expect(PANEL.extensionState["silo.explorer"]).toEqual({ expanded: ["/a"] });
+  });
+});
+
+describe("diffWorkspaceWrites", () => {
+  it("flags new and changed ids to write, removed ids to delete, leaves unchanged", () => {
+    const prev = new Map([
+      ["a", "1"],
+      ["b", "2"],
+      ["c", "3"],
+    ]);
+    const next = new Map([
+      ["a", "1"], // unchanged
+      ["b", "9"], // changed
+      ["d", "4"], // new
+    ]);
+    const { toWrite, toDelete } = diffWorkspaceWrites(prev, next);
+    expect(toWrite.sort()).toEqual(["b", "d"]);
+    expect(toDelete).toEqual(["c"]);
+  });
+
+  it("is a no-op when snapshots match", () => {
+    const m = new Map([["a", "1"]]);
+    expect(diffWorkspaceWrites(m, new Map([["a", "1"]]))).toEqual({
+      toWrite: [],
+      toDelete: [],
+    });
+  });
+
+  it("writes everything from empty and deletes everything to empty", () => {
+    const full = new Map([["a", "1"]]);
+    expect(diffWorkspaceWrites(new Map(), full).toWrite).toEqual(["a"]);
+    expect(diffWorkspaceWrites(full, new Map()).toDelete).toEqual(["a"]);
+  });
+});
+
+describe("reconcileWorkspaceListing", () => {
+  const idx = (over: Partial<PersistedIndex>): PersistedIndex => ({
+    workspaceOrder: [],
+    activeWorkspaceId: null,
+    ...over,
+  });
+
+  it("keeps the index order for listed workspaces and the active id", () => {
+    const r = reconcileWorkspaceListing(
+      idx({ workspaceOrder: ["b", "a"], activeWorkspaceId: "a" }),
+      ["a", "b"],
+    );
+    expect(r.workspaceOrder).toEqual(["b", "a"]);
+    expect(r.activeWorkspaceId).toBe("a");
+  });
+
+  it("recovers on-disk workspaces missing from the index order (self-healing)", () => {
+    // A lost/empty index order must NOT hide workspace files that exist on disk;
+    // they're appended back rather than orphaned.
+    const r = reconcileWorkspaceListing(
+      idx({ workspaceOrder: [], activeWorkspaceId: null }),
+      ["a", "b", "c", "d"],
+    );
+    expect(r.workspaceOrder).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("appends orphans after the ordered entries, preserving index order first", () => {
+    const r = reconcileWorkspaceListing(
+      idx({ workspaceOrder: ["b"], activeWorkspaceId: "b" }),
+      ["a", "b", "c"],
+    );
+    // "b" keeps its index position; "a" and "c" (on disk, not in order) follow.
+    expect(r.workspaceOrder).toEqual(["b", "a", "c"]);
+    expect(r.activeWorkspaceId).toBe("b");
+  });
+
+  it("drops ordered ids whose file didn't load, and reseats a dangling active", () => {
+    const r = reconcileWorkspaceListing(
+      idx({ workspaceOrder: ["a", "gone", "b"], activeWorkspaceId: "gone" }),
+      ["a", "b"],
+    );
+    expect(r.workspaceOrder).toEqual(["a", "b"]);
+    expect(r.activeWorkspaceId).toBe("a");
+  });
+
+  it("active falls to null when nothing is left", () => {
+    const r = reconcileWorkspaceListing(
+      idx({ workspaceOrder: ["gone"], activeWorkspaceId: "gone" }),
+      [],
+    );
+    expect(r.workspaceOrder).toEqual([]);
+    expect(r.activeWorkspaceId).toBeNull();
+  });
+
+  it("with no index, derives order from loaded ids and leaves active null", () => {
+    const r = reconcileWorkspaceListing(null, ["a", "b"]);
+    expect(r.workspaceOrder).toEqual(["a", "b"]);
+    expect(r.activeWorkspaceId).toBeNull();
+  });
+});
+
+describe("buildIndex", () => {
+  it("copies containers so the result doesn't alias the input", () => {
+    const order = ["a", "b"];
+    const editorSettings = { tabSize: 2 };
+    const index = buildIndex({
+      workspaceOrder: order,
+      activeWorkspaceId: "a",
+      editorSettings,
+    });
+    order.push("c");
+    editorSettings.tabSize = 8;
+    expect(index.workspaceOrder).toEqual(["a", "b"]);
+    expect(index.editorSettings).toEqual({ tabSize: 2 });
+  });
+
+  it("preserves undefined optional fields", () => {
+    const index = buildIndex({ workspaceOrder: [], activeWorkspaceId: null });
+    expect(index.editorSettings).toBeUndefined();
+    expect(index.terminalSettings).toBeUndefined();
+    expect(index.uiFontSize).toBeUndefined();
+  });
+});

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -1,0 +1,198 @@
+// Pure persistence logic, factored out of `persistence.ts` so it can be unit
+// tested without Tauri/`plugin-store` (the I/O glue stays in persistence.ts).
+//
+// Storage layout (ADR 0022, tier 1 "config"): under the identity-keyed config
+// root (`~/.config/silo[-<id>]`), workspaces live one-per-file at
+// `<root>/workspaces/<id>.json`, with global prefs + order/active in a single
+// `<root>/app-state.json` index. These helpers own the migration
+// fan-out from the legacy monolithic blob, the index shape, the active-workspace
+// panel-state merge, and the write/delete reconciliation.
+
+import type {
+  EditorSettings,
+  SidePanelSlot,
+  TerminalSettings,
+  Workspace,
+} from "./types";
+
+/** The global index blob — everything in the old store *except* the workspaces
+ * map (which is now one file per workspace). */
+export interface PersistedIndex {
+  workspaceOrder: string[];
+  activeWorkspaceId: string | null;
+  uiFontSize?: number;
+  activeThemeId?: string;
+  editorSettings?: Partial<EditorSettings>;
+  terminalSettings?: Partial<TerminalSettings>;
+}
+
+/** The legacy monolithic blob (one `"state"` key in the app-data store) we
+ * migrate *from*. Workspaces + global prefs + top-level panel state together. */
+export interface LegacyPersisted {
+  workspaces: Record<string, Workspace>;
+  workspaceOrder: string[];
+  activeWorkspaceId: string | null;
+  uiFontSize?: number;
+  activeThemeId?: string;
+  editorSettings?: Partial<EditorSettings>;
+  terminalSettings?: Partial<TerminalSettings>;
+  // Pre-per-workspace blobs kept panel state at the top level.
+  sidePanelLocations?: Record<string, SidePanelSlot>;
+  sidePanelOrder?: Record<string, number>;
+  activeSidePanelTabs?: Record<string, string>;
+  sidePanelScrollPositions?: Record<string, number>;
+  extensionState?: Record<string, Record<string, unknown>>;
+}
+
+/** The active-workspace panel-state snapshot merged in at save time (the live
+ * global store fields, which aren't mirrored onto the workspace until then). */
+export interface PanelState {
+  sidePanelLocations: Record<string, SidePanelSlot>;
+  sidePanelOrder: Record<string, number>;
+  activeSidePanelTabs: Record<string, string>;
+  sidePanelScrollPositions: Record<string, number>;
+  extensionState: Record<string, Record<string, unknown>>;
+  leftPanelCollapsed: boolean;
+  rightPanelCollapsed: boolean;
+}
+
+/** Deep-clone the two-level extension-state bag so a stored snapshot can't alias
+ * (and later mutate via) the live store. */
+export function cloneExtensionState(
+  src: Record<string, Record<string, unknown>>,
+): Record<string, Record<string, unknown>> {
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const k of Object.keys(src)) out[k] = { ...src[k] };
+  return out;
+}
+
+/**
+ * Split the legacy monolithic blob into the new index + per-workspace map.
+ *
+ * Also performs the one-time carry of *top-level* panel state onto the active
+ * workspace: the oldest blobs stored panel state globally rather than
+ * per-workspace, so a workspace that predates that migration gets the global
+ * fields folded in here (mirrors the old runtime fallback, now done once at
+ * migration time so each workspace file is self-contained).
+ */
+export function splitPersistedState(legacy: LegacyPersisted): {
+  index: PersistedIndex;
+  workspaces: Record<string, Workspace>;
+} {
+  const workspaces: Record<string, Workspace> = {
+    ...(legacy.workspaces ?? {}),
+  };
+  const activeId = legacy.activeWorkspaceId ?? null;
+
+  if (
+    activeId &&
+    workspaces[activeId] &&
+    workspaces[activeId].sidePanelLocations === undefined
+  ) {
+    workspaces[activeId] = {
+      ...workspaces[activeId],
+      sidePanelLocations: { ...(legacy.sidePanelLocations ?? {}) },
+      sidePanelOrder: { ...(legacy.sidePanelOrder ?? {}) },
+      activeSidePanelTabs: { ...(legacy.activeSidePanelTabs ?? {}) },
+      sidePanelScrollPositions: { ...(legacy.sidePanelScrollPositions ?? {}) },
+      extensionState: cloneExtensionState(legacy.extensionState ?? {}),
+    };
+  }
+
+  const index: PersistedIndex = buildIndex({
+    workspaceOrder: legacy.workspaceOrder ?? Object.keys(workspaces),
+    activeWorkspaceId: activeId,
+    uiFontSize: legacy.uiFontSize,
+    activeThemeId: legacy.activeThemeId,
+    editorSettings: legacy.editorSettings,
+    terminalSettings: legacy.terminalSettings,
+  });
+
+  return { index, workspaces };
+}
+
+/** Assemble the index blob from a store-shaped snapshot, copying containers so
+ * the result doesn't alias live state. */
+export function buildIndex(snapshot: PersistedIndex): PersistedIndex {
+  return {
+    workspaceOrder: [...snapshot.workspaceOrder],
+    activeWorkspaceId: snapshot.activeWorkspaceId,
+    uiFontSize: snapshot.uiFontSize,
+    activeThemeId: snapshot.activeThemeId,
+    editorSettings: snapshot.editorSettings
+      ? { ...snapshot.editorSettings }
+      : undefined,
+    terminalSettings: snapshot.terminalSettings
+      ? { ...snapshot.terminalSettings }
+      : undefined,
+  };
+}
+
+/** Return a copy of `ws` with the live panel state merged in — used for the
+ * active workspace at save time. Non-active workspaces are persisted as-is. */
+export function withActivePanelState(
+  ws: Workspace,
+  panel: PanelState,
+): Workspace {
+  return {
+    ...ws,
+    sidePanelLocations: { ...panel.sidePanelLocations },
+    sidePanelOrder: { ...panel.sidePanelOrder },
+    activeSidePanelTabs: { ...panel.activeSidePanelTabs },
+    sidePanelScrollPositions: { ...panel.sidePanelScrollPositions },
+    extensionState: cloneExtensionState(panel.extensionState),
+    leftPanelCollapsed: panel.leftPanelCollapsed,
+    rightPanelCollapsed: panel.rightPanelCollapsed,
+  };
+}
+
+/**
+ * Reconcile the persisted order/active against the workspaces that actually
+ * loaded from disk, **self-healingly**.
+ *
+ * The index's `workspaceOrder` sets the order for the workspaces it lists (so the
+ * user's arrangement is preserved), but it is not the sole authority on
+ * existence: a soft-closed workspace stays in the order (closing never removes
+ * it), so any workspace *file on disk* that the index order omits is treated as
+ * an **orphan and appended** rather than left invisible. This means a transient
+ * read failure (or a partial/empty index) can't permanently hide workspaces —
+ * the next clean boot pulls them back in. Order entries whose file didn't load
+ * are dropped; the active id is kept unless its workspace is gone, in which case
+ * it falls to the first workspace (or null).
+ */
+export function reconcileWorkspaceListing(
+  index: PersistedIndex | null,
+  loadedIds: string[],
+): { workspaceOrder: string[]; activeWorkspaceId: string | null } {
+  const have = new Set(loadedIds);
+  const ordered = (index?.workspaceOrder ?? []).filter((id) => have.has(id));
+  const inOrder = new Set(ordered);
+  const orphans = loadedIds.filter((id) => !inOrder.has(id));
+  const workspaceOrder = [...ordered, ...orphans];
+
+  let activeWorkspaceId = index?.activeWorkspaceId ?? null;
+  if (activeWorkspaceId && !have.has(activeWorkspaceId)) {
+    activeWorkspaceId = workspaceOrder[0] ?? null;
+  }
+  return { workspaceOrder, activeWorkspaceId };
+}
+
+/**
+ * Reconcile two snapshots of serialized workspace JSON keyed by id: which files
+ * to (re)write (new or changed) and which to delete (present before, gone now).
+ * Unchanged ids appear in neither list, so a flush only touches what moved.
+ */
+export function diffWorkspaceWrites(
+  prev: Map<string, string>,
+  next: Map<string, string>,
+): { toWrite: string[]; toDelete: string[] } {
+  const toWrite: string[] = [];
+  for (const [id, json] of next) {
+    if (prev.get(id) !== json) toWrite.push(id);
+  }
+  const toDelete: string[] = [];
+  for (const id of prev.keys()) {
+    if (!next.has(id)) toDelete.push(id);
+  }
+  return { toWrite, toDelete };
+}

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -1,4 +1,5 @@
 import { load, Store } from "@tauri-apps/plugin-store";
+import { invoke } from "@tauri-apps/api/core";
 import { subscribe } from "valtio";
 import { store } from "./store";
 import {
@@ -6,84 +7,254 @@ import {
   DEFAULT_EDITOR_SETTINGS,
   DEFAULT_TERMINAL_SETTINGS,
 } from "./types";
-import type {
-  EditorSettings,
-  TerminalSettings,
-  SidePanelSlot,
-  Workspace,
-} from "./types";
+import type { Workspace } from "./types";
 import { loadPanelStateFromWorkspace } from "./workspaces";
+import {
+  buildIndex,
+  cloneExtensionState,
+  diffWorkspaceWrites,
+  reconcileWorkspaceListing,
+  splitPersistedState,
+  withActivePanelState,
+  type LegacyPersisted,
+  type PanelState,
+  type PersistedIndex,
+} from "./persistence-model";
 
-const STORE_FILE = "app-state.json";
+// Persistence (ADR 0022, tier 1 "config"): under the identity-keyed config root
+// (`~/.config/silo[-<id>]`, resolved by the caller), workspaces are stored
+// one-per-file at `<root>/workspaces/<id>.json`, with global prefs + order/active
+// in a single `<root>/app-state.json` index. We use `@tauri-apps/plugin-store`
+// — one Store instance per file — pointed at absolute paths under the config dir;
+// it serializes pretty-printed JSON and is the proven I/O path the app already
+// ran on, and `save()` creates parent dirs for us. `persistence-model.ts` owns
+// the pure logic; this module is the glue.
+//
+// `state/` is a leaf layer that must not import `services/` (the host's one-way
+// dependency rule), so the identity-keyed config root is resolved by the caller
+// (`userConfigDir()` in main.tsx) and passed into `hydrate`. We still talk to the
+// platform directly for `invoke` (the two Rust fs commands plugin-store doesn't
+// cover — directory listing + delete).
 
-interface Persisted {
-  workspaces: Record<string, Workspace>;
-  workspaceOrder: string[];
-  activeWorkspaceId: string | null;
-  uiFontSize?: number;
-  activeThemeId?: string;
-  editorSettings?: Partial<EditorSettings>;
-  terminalSettings?: Partial<TerminalSettings>;
-  sidePanelLocations?: Record<string, SidePanelSlot>;
-  sidePanelOrder?: Record<string, number>;
-  activeSidePanelTabs?: Record<string, string>;
-  sidePanelScrollPositions?: Record<string, number>;
-  extensionState?: Record<string, Record<string, unknown>>;
-}
-
-let backing: Store | null = null;
-let saveTimer: number | null = null;
+const LEGACY_STORE_FILE = "app-state.json"; // legacy monolithic blob in app-data
+const INDEX_KEY = "state";
+const WORKSPACE_KEY = "workspace";
 const SAVE_DEBOUNCE_MS = 250;
+// We manage save timing ourselves (debounce + quit-flush), so disable the
+// plugin's own autosave. Empty `defaults` injects nothing into existing files.
+const STORE_OPTS = { defaults: {}, autoSave: false } as const;
 
-async function getStore(): Promise<Store> {
-  if (!backing) backing = await load(STORE_FILE);
-  return backing;
+let wsDir = "";
+let indexStore: Store | null = null;
+const wsStores = new Map<string, Store>();
+let lastWritten = new Map<string, string>();
+let saveTimer: number | null = null;
+
+function workspacePath(id: string): string {
+  return `${wsDir}/${id}.json`;
 }
 
-export async function hydrate(): Promise<void> {
-  const s = await getStore();
-  const data = (await s.get<Persisted>("state")) ?? null;
-  if (data) {
-    store.workspaces = data.workspaces ?? {};
-    // Legacy diff tabs lived in a separate `ws.diffs` array (a `DiffRecord`
-    // type); diffs are now editor records with `mode: "diff"` in `ws.editors`.
-    // We don't migrate old `ws.diffs` — diffs are transient views (content is
-    // recomputed by the provider), so any open at upgrade time is simply dropped
-    // and reopened on demand. The stale field is ignored by the new type.
-    store.workspaceOrder = data.workspaceOrder ?? Object.keys(store.workspaces);
-    store.activeWorkspaceId = data.activeWorkspaceId ?? null;
-    store.uiFontSize = data.uiFontSize ?? DEFAULT_UI_FONT_SIZE;
-    store.activeThemeId = data.activeThemeId ?? "dark";
-    // Merge over defaults so settings added in later versions hydrate sanely
-    // from an older persisted blob.
+interface RawDirEntry {
+  name: string;
+  path: string;
+  is_dir: boolean;
+}
+
+/** List `~/.config/silo/workspaces`; `[]` if it doesn't exist yet. */
+async function listWorkspaceFiles(): Promise<RawDirEntry[]> {
+  try {
+    return await invoke<RawDirEntry[]>("fs_read_dir", { path: wsDir });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One-time, non-destructive migration from the legacy monolithic blob (in the
+ * app-data dir) to per-workspace files under `~/.config/silo`. Runs only when the
+ * config index has no state yet. The legacy file is left untouched (trivial
+ * rollback); the index is written last, so a crash mid-migration just re-runs it
+ * (idempotent from the same source blob).
+ */
+async function migrateLegacyBlob(indexStore: Store): Promise<void> {
+  let legacy: LegacyPersisted | null = null;
+  try {
+    const legacyStore = await load(LEGACY_STORE_FILE, STORE_OPTS);
+    legacy = (await legacyStore.get<LegacyPersisted>(INDEX_KEY)) ?? null;
+    await legacyStore.close();
+  } catch {
+    return; // no legacy store / unreadable — nothing to migrate
+  }
+  if (!legacy) return;
+
+  const { index, workspaces } = splitPersistedState(legacy);
+  for (const [id, ws] of Object.entries(workspaces)) {
+    try {
+      const s = await load(workspacePath(id), STORE_OPTS);
+      await s.set(WORKSPACE_KEY, ws);
+      await s.save();
+      await s.close();
+    } catch (err) {
+      console.error(`migrate workspace ${id} failed`, err);
+    }
+  }
+  await indexStore.set(INDEX_KEY, index);
+  await indexStore.save();
+}
+
+/** @param configDir the identity-keyed user-config root (see `userConfigDir`). */
+export async function hydrate(configDir: string): Promise<void> {
+  wsDir = `${configDir}/workspaces`;
+  const indexPath = `${configDir}/${LEGACY_STORE_FILE}`;
+
+  // Index: global prefs + order/active. A new/absent index reads as null — that's
+  // either a fresh install or a pre-migration app-data blob, so attempt the
+  // one-time migration (a no-op when there's no legacy blob) and re-read.
+  indexStore = await load(indexPath, STORE_OPTS);
+  let index = (await indexStore.get<PersistedIndex>(INDEX_KEY)) ?? null;
+  if (index === null) {
+    await migrateLegacyBlob(indexStore);
+    index = (await indexStore.get<PersistedIndex>(INDEX_KEY)) ?? null;
+  }
+
+  // Merge settings over defaults so settings added in later versions hydrate
+  // sanely from an older blob. (Order/active are reconciled below, after we know
+  // which workspace files actually loaded.)
+  if (index) {
+    store.uiFontSize = index.uiFontSize ?? DEFAULT_UI_FONT_SIZE;
+    store.activeThemeId = index.activeThemeId ?? "dark";
     store.editorSettings = {
       ...DEFAULT_EDITOR_SETTINGS,
-      ...data.editorSettings,
+      ...index.editorSettings,
     };
     store.terminalSettings = {
       ...DEFAULT_TERMINAL_SETTINGS,
-      ...data.terminalSettings,
+      ...index.terminalSettings,
     };
-
-    // Load panel state from the active workspace.
-    // If the workspace has no panel state yet (first run with new format),
-    // fall back to the legacy top-level fields for a one-time migration.
-    const activeWs = store.activeWorkspaceId
-      ? store.workspaces[store.activeWorkspaceId]
-      : null;
-    if (activeWs && activeWs.sidePanelLocations !== undefined) {
-      loadPanelStateFromWorkspace(activeWs);
-    } else {
-      // Legacy / migration path
-      store.sidePanelLocations = data.sidePanelLocations ?? {};
-      store.sidePanelOrder = data.sidePanelOrder ?? {};
-      store.activeSidePanelTabs = data.activeSidePanelTabs ?? {};
-      store.sidePanelScrollPositions = data.sidePanelScrollPositions ?? {};
-      store.extensionState = data.extensionState ?? {};
-    }
   }
+
+  // One file per workspace. Invalid files are skipped (like the theme loader),
+  // so a hand-edit that breaks JSON drops one workspace rather than failing boot.
+  const workspaces: Record<string, Workspace> = {};
+  const entries = await listWorkspaceFiles();
+  await Promise.all(
+    entries
+      .filter((e) => !e.is_dir && e.name.endsWith(".json"))
+      .map(async (e) => {
+        try {
+          const s = await load(e.path, STORE_OPTS);
+          const ws = await s.get<Workspace>(WORKSPACE_KEY);
+          if (ws && typeof ws.id === "string") {
+            workspaces[ws.id] = ws;
+            wsStores.set(ws.id, s);
+          } else {
+            await s.close();
+          }
+        } catch {
+          // skip invalid file
+        }
+      }),
+  );
+  store.workspaces = workspaces;
+
+  // Order/active come from the index, but any workspace file on disk that the
+  // index omits is appended (self-healing) so a lost/partial index can't hide
+  // real workspaces; entries whose file didn't load are dropped.
+  const listing = reconcileWorkspaceListing(index, Object.keys(workspaces));
+  store.workspaceOrder = listing.workspaceOrder;
+  store.activeWorkspaceId = listing.activeWorkspaceId;
+
+  // Seed lastWritten from the loaded files so the first flush only rewrites what
+  // actually changes afterward.
+  lastWritten = new Map(
+    Object.entries(workspaces).map(([id, ws]) => [id, JSON.stringify(ws)]),
+  );
+
+  // Hydrate the global panel-state fields from the active workspace.
+  const activeWs = store.activeWorkspaceId
+    ? workspaces[store.activeWorkspaceId]
+    : null;
+  if (activeWs) loadPanelStateFromWorkspace(activeWs);
+
   store.hydrated = true;
   subscribe(store, schedulePersist);
+}
+
+function snapshotPanelState(): PanelState {
+  return {
+    sidePanelLocations: { ...store.sidePanelLocations },
+    sidePanelOrder: { ...store.sidePanelOrder },
+    activeSidePanelTabs: { ...store.activeSidePanelTabs },
+    sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
+    extensionState: cloneExtensionState(store.extensionState),
+    leftPanelCollapsed: store.leftPanelCollapsed,
+    rightPanelCollapsed: store.rightPanelCollapsed,
+  };
+}
+
+async function doPersist(): Promise<void> {
+  if (!indexStore) return;
+
+  // Build each workspace's record, merging the active workspace's live panel
+  // state (it isn't mirrored onto the workspace object until save time).
+  const activeId = store.activeWorkspaceId;
+  const panel = snapshotPanelState();
+  const records = new Map<string, Workspace>();
+  const next = new Map<string, string>();
+  for (const [id, ws] of Object.entries(store.workspaces)) {
+    const rec = id === activeId ? withActivePanelState(ws, panel) : { ...ws };
+    records.set(id, rec);
+    next.set(id, JSON.stringify(rec));
+  }
+
+  const { toWrite, toDelete } = diffWorkspaceWrites(lastWritten, next);
+
+  for (const id of toWrite) {
+    let s = wsStores.get(id);
+    if (!s) {
+      s = await load(workspacePath(id), STORE_OPTS);
+      wsStores.set(id, s);
+    }
+    await s.set(WORKSPACE_KEY, records.get(id));
+    await s.save();
+  }
+
+  for (const id of toDelete) {
+    const s = wsStores.get(id);
+    if (s) {
+      await s.close();
+      wsStores.delete(id);
+    }
+    try {
+      await invoke("fs_delete", { path: workspacePath(id) });
+    } catch {
+      // already gone
+    }
+  }
+
+  lastWritten = next;
+
+  await indexStore.set(
+    INDEX_KEY,
+    buildIndex({
+      workspaceOrder: [...store.workspaceOrder],
+      activeWorkspaceId: store.activeWorkspaceId,
+      uiFontSize: store.uiFontSize,
+      activeThemeId: store.activeThemeId,
+      editorSettings: { ...store.editorSettings },
+      terminalSettings: { ...store.terminalSettings },
+    }),
+  );
+  await indexStore.save();
+}
+
+// Serialize persists so a debounce that fires mid-write can't interleave
+// set/save on the same Store. Each run reads the latest store state, so coalesced
+// runs converge.
+let chain: Promise<void> = Promise.resolve();
+function persistNow(): Promise<void> {
+  chain = chain.catch(() => {}).then(() => doPersist());
+  return chain;
 }
 
 function schedulePersist() {
@@ -93,52 +264,6 @@ function schedulePersist() {
     saveTimer = null;
     persistNow().catch((err) => console.error("persist failed", err));
   }, SAVE_DEBOUNCE_MS);
-}
-
-async function persistNow(): Promise<void> {
-  const s = await getStore();
-
-  // Build a workspace snapshot that includes the current panel state for the
-  // active workspace. We do this without mutating the store (which would
-  // trigger another persist cycle).
-  const activeId = store.activeWorkspaceId;
-  const workspacesSnapshot: Record<string, Workspace> = {};
-  for (const [id, ws] of Object.entries(store.workspaces)) {
-    if (id === activeId) {
-      workspacesSnapshot[id] = {
-        ...ws,
-        sidePanelLocations: { ...store.sidePanelLocations },
-        sidePanelOrder: { ...store.sidePanelOrder },
-        activeSidePanelTabs: { ...store.activeSidePanelTabs },
-        sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
-        extensionState: deepCloneExtensionState(store.extensionState),
-        leftPanelCollapsed: store.leftPanelCollapsed,
-        rightPanelCollapsed: store.rightPanelCollapsed,
-      };
-    } else {
-      workspacesSnapshot[id] = { ...ws };
-    }
-  }
-
-  const snapshot: Persisted = {
-    workspaces: workspacesSnapshot,
-    workspaceOrder: [...store.workspaceOrder],
-    activeWorkspaceId: store.activeWorkspaceId,
-    uiFontSize: store.uiFontSize,
-    activeThemeId: store.activeThemeId,
-    editorSettings: { ...store.editorSettings },
-    terminalSettings: { ...store.terminalSettings },
-  };
-  await s.set("state", snapshot);
-  await s.save();
-}
-
-function deepCloneExtensionState(
-  src: Record<string, Record<string, unknown>>,
-): Record<string, Record<string, unknown>> {
-  const out: Record<string, Record<string, unknown>> = {};
-  for (const k of Object.keys(src)) out[k] = { ...src[k] };
-  return out;
 }
 
 export function persistImmediately(): Promise<void> {


### PR DESCRIPTION
## Summary

Moves workspace persistence out of the opaque monolithic `app-state.json` blob into **one human-readable JSON file per workspace**, and keys the whole config root by **build identity** so dev and prod are fully isolated installs. Codifies the resulting model as **ADR 0022**.

## What changed

- **Per-workspace files.** Workspaces persist one-per-file at `<root>/workspaces/<id>.json` via `@tauri-apps/plugin-store` (pretty-printed, inspectable, backup-able), with global prefs + order/active in a `<root>/app-state.json` index. Reuses the proven store crate (no fork) pointed at absolute paths.
  - Non-destructive one-time **migration** from the legacy app-data blob (legacy file left intact).
  - **Diff-based flush** — only changed workspace files are rewritten; deleted ones are removed.
  - **Self-healing hydrate** — a workspace file on disk that's missing from the index order is recovered (appended) rather than orphaned, so a transient read failure can't permanently hide workspaces.
- **Identity-keyed config root.** `userConfigDir()` now resolves `~/.config/silo` for the production identity and `~/.config/silo-dev` for the dev build, so workspaces, themes, keybindings, and installed extensions all split per build. This keeps a workspace's terminal `sessionId`s aligned with their own build's session registry — no cross-build clobbering or orphaned PTY daemons.
- **pty-host sockets → runtime tier.** Sockets move off `~/.config/silo/pty` to the OS runtime/temp dir (`$XDG_RUNTIME_DIR` on Linux, `$TMPDIR` on macOS), matching the ephemeral tier and keeping Unix socket paths under the `sun_path` limit.
- **ADR 0022** documents the three-tier storage model — config / app-state / runtime, all identity-keyed.

## Why

Workspaces were buried in a single opaque blob under the Tauri app-data dir — not inspectable, backup-able, or copyable. They're user data and belong in `~/.config/silo` alongside themes/keybindings. But workspaces embed per-identity terminal `sessionId`s, so the config root must be keyed by build identity (the same isolation principle the app-data dir and `SILO_PTY_NS` already use); otherwise a dev build and a prod install would share workspace files whose sessions only resolve under one identity.

## Testing

- Pure logic extracted (`persistence-model.ts`; `user-config`'s `configRootName`) and unit-tested; pty-host path selection gains a unit test (plus a fix for a `SILO_PTY_NS`-fragile `discovery` test).
- `pnpm test` green (238 extension-host tests), `cargo test -p pty-host` green (19), `tsc --noEmit` + `pnpm lint` clean.
- Verified end-to-end against real data: dev workspaces re-migrate into `~/.config/silo-dev` with correct order + active; create/delete writes and removes the per-workspace file and updates the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)