### PR TITLE
feat(layout): make side-dock visibility and widths global, not per-workspace

### DIFF
--- a/apps/docs/api/types/interfaces/CustomTheme.md
+++ b/apps/docs/api/types/interfaces/CustomTheme.md
@@ -1,6 +1,6 @@
 # Interface: CustomTheme
 
-Defined in: [packages/sdk/src/domain-types.ts:232](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L232)
+Defined in: [packages/sdk/src/domain-types.ts:230](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L230)
 
 A persisted custom theme.
 
@@ -12,7 +12,7 @@ A persisted custom theme.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:233](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L233)
+Defined in: [packages/sdk/src/domain-types.ts:231](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L231)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [packages/sdk/src/domain-types.ts:233](https://github.com/silo-code/
 version: 2;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:238](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L238)
+Defined in: [packages/sdk/src/domain-types.ts:236](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L236)
 
 `2` since the `--silo-*` token rename (theming-contract.md › Migration).
 v1 themes used the legacy bare names (`--bg`, `--text-hi`, …).
@@ -35,7 +35,7 @@ v1 themes used the legacy bare names (`--bg`, `--text-hi`, …).
 name: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:239](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L239)
+Defined in: [packages/sdk/src/domain-types.ts:237](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L237)
 
 ***
 
@@ -45,7 +45,7 @@ Defined in: [packages/sdk/src/domain-types.ts:239](https://github.com/silo-code/
 base: ThemeBase;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:240](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L240)
+Defined in: [packages/sdk/src/domain-types.ts:238](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L238)
 
 ***
 
@@ -55,7 +55,7 @@ Defined in: [packages/sdk/src/domain-types.ts:240](https://github.com/silo-code/
 colorScheme: "dark" | "light";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:241](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L241)
+Defined in: [packages/sdk/src/domain-types.ts:239](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L239)
 
 ***
 
@@ -65,4 +65,4 @@ Defined in: [packages/sdk/src/domain-types.ts:241](https://github.com/silo-code/
 vars: Partial<ThemeVars>;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:242](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L242)
+Defined in: [packages/sdk/src/domain-types.ts:240](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L240)

--- a/apps/docs/api/types/interfaces/ThemeVars.md
+++ b/apps/docs/api/types/interfaces/ThemeVars.md
@@ -1,6 +1,6 @@
 # Interface: ThemeVars
 
-Defined in: [packages/sdk/src/domain-types.ts:162](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L162)
+Defined in: [packages/sdk/src/domain-types.ts:160](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L160)
 
 The full theme-override surface, in type form: every `--silo-*` token a theme
 preset's `vars` may recolor. Per the theming contract it spans **the design
@@ -21,7 +21,7 @@ docs/architecture-audit/theming-contract.md
 --silo-color-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:164](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L164)
+Defined in: [packages/sdk/src/domain-types.ts:162](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L162)
 
 ***
 
@@ -31,7 +31,7 @@ Defined in: [packages/sdk/src/domain-types.ts:164](https://github.com/silo-code/
 --silo-color-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L165)
+Defined in: [packages/sdk/src/domain-types.ts:163](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L163)
 
 ***
 
@@ -41,7 +41,7 @@ Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/
 --silo-color-bg-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L166)
+Defined in: [packages/sdk/src/domain-types.ts:164](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L164)
 
 ***
 
@@ -51,7 +51,7 @@ Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/
 --silo-color-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L167)
+Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L165)
 
 ***
 
@@ -61,7 +61,7 @@ Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/
 --silo-color-text-hi: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L168)
+Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L166)
 
 ***
 
@@ -71,7 +71,7 @@ Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/
 --silo-color-text-lo: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L169)
+Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L167)
 
 ***
 
@@ -81,7 +81,7 @@ Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/
 --silo-color-accent: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L170)
+Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L168)
 
 ***
 
@@ -91,7 +91,7 @@ Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/
 --silo-color-accent-2: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L171)
+Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L169)
 
 ***
 
@@ -101,7 +101,7 @@ Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/
 --silo-color-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L172)
+Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L170)
 
 ***
 
@@ -111,7 +111,7 @@ Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/
 --silo-color-border-strong: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:173](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L173)
+Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L171)
 
 ***
 
@@ -121,7 +121,7 @@ Defined in: [packages/sdk/src/domain-types.ts:173](https://github.com/silo-code/
 --silo-color-ok: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L174)
+Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L172)
 
 ***
 
@@ -131,7 +131,7 @@ Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/
 --silo-color-warn: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L175)
+Defined in: [packages/sdk/src/domain-types.ts:173](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L173)
 
 ***
 
@@ -141,7 +141,7 @@ Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/
 --silo-color-err: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L176)
+Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L174)
 
 ***
 
@@ -151,7 +151,7 @@ Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/
 --silo-color-input-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L177)
+Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L175)
 
 ***
 
@@ -161,7 +161,7 @@ Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/
 --silo-color-input-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:178](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L178)
+Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L176)
 
 ***
 
@@ -171,7 +171,7 @@ Defined in: [packages/sdk/src/domain-types.ts:178](https://github.com/silo-code/
 --silo-color-button-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:179](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L179)
+Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L177)
 
 ***
 
@@ -181,7 +181,7 @@ Defined in: [packages/sdk/src/domain-types.ts:179](https://github.com/silo-code/
 --silo-color-button-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L180)
+Defined in: [packages/sdk/src/domain-types.ts:178](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L178)
 
 ***
 
@@ -191,7 +191,7 @@ Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/
 optional --silo-font-ui?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:182](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L182)
+Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L180)
 
 ***
 
@@ -201,7 +201,7 @@ Defined in: [packages/sdk/src/domain-types.ts:182](https://github.com/silo-code/
 optional --silo-font-mono?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L183)
+Defined in: [packages/sdk/src/domain-types.ts:181](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L181)
 
 ***
 
@@ -211,7 +211,7 @@ Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/
 --silo-content-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L185)
+Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L183)
 
 ***
 
@@ -221,7 +221,7 @@ Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/
 --silo-content-terminal-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L186)
+Defined in: [packages/sdk/src/domain-types.ts:184](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L184)
 
 ***
 
@@ -231,7 +231,7 @@ Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/
 --silo-content-editor-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:187](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L187)
+Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L185)
 
 ***
 
@@ -241,7 +241,7 @@ Defined in: [packages/sdk/src/domain-types.ts:187](https://github.com/silo-code/
 --silo-content-editor-selection: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L188)
+Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L186)
 
 ***
 
@@ -251,7 +251,7 @@ Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/
 --silo-content-editor-selection-inactive: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L189)
+Defined in: [packages/sdk/src/domain-types.ts:187](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L187)
 
 ***
 
@@ -261,7 +261,7 @@ Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/
 --silo-content-editor-text-dim: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:190](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L190)
+Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L188)
 
 ***
 
@@ -271,7 +271,7 @@ Defined in: [packages/sdk/src/domain-types.ts:190](https://github.com/silo-code/
 --silo-content-editor-text-faint: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L191)
+Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L189)
 
 ***
 
@@ -281,7 +281,7 @@ Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/
 --silo-content-tab-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L192)
+Defined in: [packages/sdk/src/domain-types.ts:190](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L190)
 
 ***
 
@@ -291,7 +291,7 @@ Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/
 --silo-content-tab-tray-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:193](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L193)
+Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L191)
 
 ***
 
@@ -301,7 +301,7 @@ Defined in: [packages/sdk/src/domain-types.ts:193](https://github.com/silo-code/
 --silo-content-tab-tray-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L194)
+Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L192)
 
 ***
 
@@ -311,7 +311,7 @@ Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/
 --silo-content-tab-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L195)
+Defined in: [packages/sdk/src/domain-types.ts:193](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L193)
 
 ***
 
@@ -321,7 +321,7 @@ Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/
 --silo-content-tab-text-inactive: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:196](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L196)
+Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L194)
 
 ***
 
@@ -331,7 +331,7 @@ Defined in: [packages/sdk/src/domain-types.ts:196](https://github.com/silo-code/
 --silo-content-tab-text-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L197)
+Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L195)
 
 ***
 
@@ -341,7 +341,7 @@ Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/
 --silo-breadcrumb-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L199)
+Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L197)
 
 ***
 
@@ -351,7 +351,7 @@ Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/
 --silo-breadcrumb-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L200)
+Defined in: [packages/sdk/src/domain-types.ts:198](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L198)
 
 ***
 
@@ -361,7 +361,7 @@ Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/
 --silo-breadcrumb-text-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L201)
+Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L199)
 
 ***
 
@@ -371,7 +371,7 @@ Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/
 --silo-breadcrumb-icon: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:202](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L202)
+Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L200)
 
 ***
 
@@ -381,7 +381,7 @@ Defined in: [packages/sdk/src/domain-types.ts:202](https://github.com/silo-code/
 --silo-statusbar-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:204](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L204)
+Defined in: [packages/sdk/src/domain-types.ts:202](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L202)
 
 ***
 
@@ -391,7 +391,7 @@ Defined in: [packages/sdk/src/domain-types.ts:204](https://github.com/silo-code/
 --silo-statusbar-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L205)
+Defined in: [packages/sdk/src/domain-types.ts:203](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L203)
 
 ***
 
@@ -401,7 +401,7 @@ Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/
 --silo-statusbar-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L206)
+Defined in: [packages/sdk/src/domain-types.ts:204](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L204)
 
 ***
 
@@ -411,7 +411,7 @@ Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/
 --silo-tab-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:208](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L208)
+Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L206)
 
 ***
 
@@ -421,7 +421,7 @@ Defined in: [packages/sdk/src/domain-types.ts:208](https://github.com/silo-code/
 --silo-tab-text-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L209)
+Defined in: [packages/sdk/src/domain-types.ts:207](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L207)
 
 ***
 
@@ -431,7 +431,7 @@ Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/
 --silo-tab-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:210](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L210)
+Defined in: [packages/sdk/src/domain-types.ts:208](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L208)
 
 ***
 
@@ -441,7 +441,7 @@ Defined in: [packages/sdk/src/domain-types.ts:210](https://github.com/silo-code/
 --silo-tab-border-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L211)
+Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L209)
 
 ***
 
@@ -451,7 +451,7 @@ Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/
 --silo-menu-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L213)
+Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L211)
 
 ***
 
@@ -461,7 +461,7 @@ Defined in: [packages/sdk/src/domain-types.ts:213](https://github.com/silo-code/
 --silo-menu-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L214)
+Defined in: [packages/sdk/src/domain-types.ts:212](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L212)
 
 ***
 
@@ -471,7 +471,7 @@ Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/
 --silo-menu-item-hover-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:215](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L215)
+Defined in: [packages/sdk/src/domain-types.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L213)
 
 ***
 
@@ -481,7 +481,7 @@ Defined in: [packages/sdk/src/domain-types.ts:215](https://github.com/silo-code/
 --silo-menu-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L216)
+Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L214)
 
 ***
 
@@ -491,7 +491,7 @@ Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/
 --silo-modal-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:218](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L218)
+Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L216)
 
 ***
 
@@ -501,7 +501,7 @@ Defined in: [packages/sdk/src/domain-types.ts:218](https://github.com/silo-code/
 --silo-modal-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:219](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L219)
+Defined in: [packages/sdk/src/domain-types.ts:217](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L217)
 
 ***
 
@@ -511,7 +511,7 @@ Defined in: [packages/sdk/src/domain-types.ts:219](https://github.com/silo-code/
 --silo-notify-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:221](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L221)
+Defined in: [packages/sdk/src/domain-types.ts:219](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L219)
 
 ***
 
@@ -521,7 +521,7 @@ Defined in: [packages/sdk/src/domain-types.ts:221](https://github.com/silo-code/
 --silo-notify-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L222)
+Defined in: [packages/sdk/src/domain-types.ts:220](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L220)
 
 ***
 
@@ -531,4 +531,4 @@ Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/
 --silo-notify-text-hi: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:223](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L223)
+Defined in: [packages/sdk/src/domain-types.ts:221](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L221)

--- a/apps/docs/api/types/interfaces/Workspace.md
+++ b/apps/docs/api/types/interfaces/Workspace.md
@@ -182,32 +182,12 @@ Defined in: [packages/sdk/src/domain-types.ts:135](https://github.com/silo-code/
 
 ***
 
-### leftPanelCollapsed?
-
-```ts
-optional leftPanelCollapsed?: boolean;
-```
-
-Defined in: [packages/sdk/src/domain-types.ts:136](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L136)
-
-***
-
-### rightPanelCollapsed?
-
-```ts
-optional rightPanelCollapsed?: boolean;
-```
-
-Defined in: [packages/sdk/src/domain-types.ts:137](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L137)
-
-***
-
 ### previewEditorId?
 
 ```ts
 optional previewEditorId?: string | null;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:139](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L139)
+Defined in: [packages/sdk/src/domain-types.ts:137](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L137)
 
 ID of the current preview (temporary) editor, if any.

--- a/apps/docs/api/types/type-aliases/ThemeBase.md
+++ b/apps/docs/api/types/type-aliases/ThemeBase.md
@@ -4,6 +4,6 @@
 type ThemeBase = "dark" | "light";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:148](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L148)
+Defined in: [packages/sdk/src/domain-types.ts:146](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L146)
 
 Light or dark theme base.

--- a/apps/docs/api/types/type-aliases/ThemeExport.md
+++ b/apps/docs/api/types/type-aliases/ThemeExport.md
@@ -4,7 +4,7 @@
 type ThemeExport = Omit<CustomTheme, "id">;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:252](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L252)
+Defined in: [packages/sdk/src/domain-types.ts:250](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L250)
 
 A [CustomTheme](../interfaces/CustomTheme.md) without its `id` — the shape exported/imported as a
 shareable theme file.

--- a/packages/extension-host/src/layout/AppShell.tsx
+++ b/packages/extension-host/src/layout/AppShell.tsx
@@ -75,14 +75,7 @@ export function AppShell() {
   return (
     <div className="app-shell">
       <div className="titlebar-drag" onMouseDown={onTitlebarMouseDown} />
-      <PanelGroup
-        direction="horizontal"
-        autoSaveId={
-          snap.activeWorkspaceId
-            ? `app:main-cols:${snap.activeWorkspaceId}`
-            : "app:main-cols"
-        }
-      >
+      <PanelGroup direction="horizontal" autoSaveId="app:main-cols">
         <Panel
           ref={leftRef}
           defaultSize={18}

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -31,8 +31,6 @@ const PANEL: PanelState = {
   activeSidePanelTabs: { left: "explorer" },
   sidePanelScrollPositions: { explorer: 12 },
   extensionState: { "silo.explorer": { expanded: ["/a"] } },
-  leftPanelCollapsed: false,
-  rightPanelCollapsed: true,
 };
 
 describe("splitPersistedState", () => {
@@ -114,8 +112,6 @@ describe("withActivePanelState", () => {
     expect(merged.extensionState).toEqual({
       "silo.explorer": { expanded: ["/a"] },
     });
-    expect(merged.leftPanelCollapsed).toBe(false);
-    expect(merged.rightPanelCollapsed).toBe(true);
   });
 
   it("does not mutate the source workspace and isolates the extension-state bag", () => {
@@ -244,5 +240,18 @@ describe("buildIndex", () => {
     expect(index.editorSettings).toBeUndefined();
     expect(index.terminalSettings).toBeUndefined();
     expect(index.uiFontSize).toBeUndefined();
+    expect(index.leftPanelCollapsed).toBeUndefined();
+    expect(index.rightPanelCollapsed).toBeUndefined();
+  });
+
+  it("carries the global side-dock visibility flags through", () => {
+    const index = buildIndex({
+      workspaceOrder: [],
+      activeWorkspaceId: null,
+      leftPanelCollapsed: true,
+      rightPanelCollapsed: false,
+    });
+    expect(index.leftPanelCollapsed).toBe(true);
+    expect(index.rightPanelCollapsed).toBe(false);
   });
 });

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -24,6 +24,11 @@ export interface PersistedIndex {
   activeThemeId?: string;
   editorSettings?: Partial<EditorSettings>;
   terminalSettings?: Partial<TerminalSettings>;
+  // Side-dock visibility is global (shared across workspaces), so it lives in
+  // the index rather than per-workspace. Optional: absent in pre-this-change
+  // indexes, hydrated with a per-workspace fallback (see persistence.ts).
+  leftPanelCollapsed?: boolean;
+  rightPanelCollapsed?: boolean;
 }
 
 /** The legacy monolithic blob (one `"state"` key in the app-data store) we
@@ -52,8 +57,6 @@ export interface PanelState {
   activeSidePanelTabs: Record<string, string>;
   sidePanelScrollPositions: Record<string, number>;
   extensionState: Record<string, Record<string, unknown>>;
-  leftPanelCollapsed: boolean;
-  rightPanelCollapsed: boolean;
 }
 
 /** Deep-clone the two-level extension-state bag so a stored snapshot can't alias
@@ -125,6 +128,8 @@ export function buildIndex(snapshot: PersistedIndex): PersistedIndex {
     terminalSettings: snapshot.terminalSettings
       ? { ...snapshot.terminalSettings }
       : undefined,
+    leftPanelCollapsed: snapshot.leftPanelCollapsed,
+    rightPanelCollapsed: snapshot.rightPanelCollapsed,
   };
 }
 
@@ -141,8 +146,6 @@ export function withActivePanelState(
     activeSidePanelTabs: { ...panel.activeSidePanelTabs },
     sidePanelScrollPositions: { ...panel.sidePanelScrollPositions },
     extensionState: cloneExtensionState(panel.extensionState),
-    leftPanelCollapsed: panel.leftPanelCollapsed,
-    rightPanelCollapsed: panel.rightPanelCollapsed,
   };
 }
 

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -176,6 +176,19 @@ export async function hydrate(configDir: string): Promise<void> {
     : null;
   if (activeWs) loadPanelStateFromWorkspace(activeWs);
 
+  // Side-dock visibility is global, so it comes from the index. Pre-this-change
+  // installs stored it per-workspace; the field is gone from the Workspace type,
+  // so read it off the raw active record as a one-time fallback — the user's
+  // current collapse state carries over instead of resetting on first launch.
+  const legacyWs = activeWs as {
+    leftPanelCollapsed?: boolean;
+    rightPanelCollapsed?: boolean;
+  } | null;
+  store.leftPanelCollapsed =
+    index?.leftPanelCollapsed ?? legacyWs?.leftPanelCollapsed ?? false;
+  store.rightPanelCollapsed =
+    index?.rightPanelCollapsed ?? legacyWs?.rightPanelCollapsed ?? false;
+
   store.hydrated = true;
   subscribe(store, schedulePersist);
 }
@@ -187,8 +200,6 @@ function snapshotPanelState(): PanelState {
     activeSidePanelTabs: { ...store.activeSidePanelTabs },
     sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
     extensionState: cloneExtensionState(store.extensionState),
-    leftPanelCollapsed: store.leftPanelCollapsed,
-    rightPanelCollapsed: store.rightPanelCollapsed,
   };
 }
 
@@ -243,6 +254,8 @@ async function doPersist(): Promise<void> {
       activeThemeId: store.activeThemeId,
       editorSettings: { ...store.editorSettings },
       terminalSettings: { ...store.terminalSettings },
+      leftPanelCollapsed: store.leftPanelCollapsed,
+      rightPanelCollapsed: store.rightPanelCollapsed,
     }),
   );
   await indexStore.save();

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -57,8 +57,6 @@ export function savePanelStateToWorkspace(wsId: string): void {
   for (const k of Object.keys(store.extensionState))
     ext[k] = { ...store.extensionState[k] };
   ws.extensionState = ext;
-  ws.leftPanelCollapsed = store.leftPanelCollapsed;
-  ws.rightPanelCollapsed = store.rightPanelCollapsed;
 }
 
 /** Restore the global panel state from a workspace object. */
@@ -71,8 +69,6 @@ export function loadPanelStateFromWorkspace(ws: Workspace): void {
   for (const k of Object.keys(ws.extensionState ?? {}))
     ext[k] = { ...ws.extensionState![k] };
   store.extensionState = ext;
-  store.leftPanelCollapsed = ws.leftPanelCollapsed ?? false;
-  store.rightPanelCollapsed = ws.rightPanelCollapsed ?? false;
 }
 
 export function activateWorkspace(id: string): void {

--- a/packages/sdk/src/domain-types.ts
+++ b/packages/sdk/src/domain-types.ts
@@ -133,8 +133,6 @@ export interface Workspace {
   activeSidePanelTabs?: Record<string, string>;
   sidePanelScrollPositions?: Record<string, number>;
   extensionState?: Record<string, Record<string, unknown>>;
-  leftPanelCollapsed?: boolean;
-  rightPanelCollapsed?: boolean;
   /** ID of the current preview (temporary) editor, if any. */
   previewEditorId?: string | null;
 }


### PR DESCRIPTION
## What

Side-dock **collapsed state** and **column widths** were effectively per-workspace, so switching workspaces reshuffled the layout. This makes both a single app-wide setting that stays put across workspace switches and restarts.

## Why

Dock visibility/width is workbench chrome, not workspace content — users expect it to be stable as they hop between workspaces, the way the editor's other global prefs (font size, theme) are.

## Changes

- **Widths** (`AppShell.tsx`): the main 3-column `PanelGroup` now uses a constant `app:main-cols` `autoSaveId` instead of one keyed per workspace, so `react-resizable-panels` persists one global width set. (Matches how the vertical side-split already behaves.)
- **Visibility**: `leftPanelCollapsed` / `rightPanelCollapsed` move from the per-workspace file to the global `app-state.json` index, alongside `uiFontSize` / `activeThemeId`.
  - Removed from the public `Workspace` type and the per-workspace save/load path (`workspaces.ts`, `PanelState`).
  - Carried through `PersistedIndex` / `buildIndex`; written in `doPersist` and read in `hydrate`.
  - **Migration:** hydration falls back to the active workspace's old stored value once, so an existing user's collapse state carries over instead of resetting on first launch.
- The runtime home stays the global valtio `store`; toggle commands, hotkeys, and the `ctx.layout` service are unchanged.

## Tests & docs

- Updated `persistence-model.test.ts` (dropped the collapse fields from the `PanelState` fixture; added `buildIndex` coverage for the new index flags).
- Regenerated the API type reference — `Workspace` lost two public fields; the `CustomTheme` / `ThemeVars` / `ThemeBase` / `ThemeExport` doc touches are pure source-line-number drift.
- `pnpm test`, `pnpm lint`, and `tsc --noEmit` all green (pre-commit hook ran the full suite).

## Not covered here

Runtime GUI verification (open two workspaces, confirm shared collapse/width across switch + restart) — worth a manual pass before merge.

Note: widths still live in the `react-resizable-panels` / `localStorage` layer (now globally keyed), consistent with the side-split. Moving them into `app-state.json` too would be a separate follow-up (a custom PanelGroup `storage` adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)