### PR TITLE
fix(editor): free Cmd+Alt+[/] for side-dock toggles when Monaco has focus

### DIFF
--- a/packages/extension-host/src/docked/monaco-setup.ts
+++ b/packages/extension-host/src/docked/monaco-setup.ts
@@ -8,6 +8,7 @@ import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 import type { ThemeBase } from "../state/types";
+import { foldUnbindRules } from "../extension-host/editor-options";
 
 type MonacoLike = typeof monaco;
 
@@ -206,6 +207,12 @@ export function ensureMonaco(): MonacoLike {
     // language-service defaults now live on the top-level `typescript` namespace.
     monaco.typescript.typescriptDefaults.setDiagnosticsOptions(diagnostics);
     monaco.typescript.javascriptDefaults.setDiagnosticsOptions(diagnostics);
+    // Drop Monaco's default fold/unfold keybindings on Cmd+Alt+[ / Cmd+Alt+] so
+    // those keystrokes fall through to Silo's native menu accelerators that
+    // toggle the side docks (see foldUnbindRules).
+    monaco.editor.addKeybindingRules(
+      foldUnbindRules(monaco.KeyMod, monaco.KeyCode),
+    );
     defineMonacoThemes(monaco);
     loader.config({ monaco });
     initialized = true;

--- a/packages/extension-host/src/extension-host/editor-options.test.ts
+++ b/packages/extension-host/src/extension-host/editor-options.test.ts
@@ -9,7 +9,9 @@ import {
   languageFromPath,
   toTextEditorOptions,
   toDiffEditorOptions,
+  foldUnbindRules,
 } from "./editor-options";
+import type { KeyMod, KeyCode } from "monaco-editor";
 import { DEFAULT_EDITOR_SETTINGS, type EditorSettings } from "../state/types";
 
 describe("languageFromPath", () => {
@@ -88,5 +90,28 @@ describe("text vs diff editor options (one core, two modes)", () => {
       renderLineHighlight: "gutter",
       fontSize: 12.5,
     });
+  });
+});
+
+describe("foldUnbindRules (free Cmd+Alt+[/] for the side-dock toggles)", () => {
+  // Stub the runtime enums with bit values shaped like Monaco's real ones so we
+  // can assert the bitwise composition without loading the Monaco runtime.
+  const keyMod = { CtrlCmd: 2048, Alt: 512 } as unknown as typeof KeyMod;
+  const keyCode = {
+    BracketLeft: 87,
+    BracketRight: 88,
+  } as unknown as typeof KeyCode;
+
+  it("unbinds exactly the two bracket combos with command: null", () => {
+    const rules = foldUnbindRules(keyMod, keyCode);
+    expect(rules).toHaveLength(2);
+    for (const r of rules) expect(r.command).toBeNull();
+  });
+
+  it("composes CtrlCmd|Alt with the bracket key codes", () => {
+    const [left, right] = foldUnbindRules(keyMod, keyCode);
+    // 2048 | 512 | 87  and  2048 | 512 | 88
+    expect(left.keybinding).toBe(2048 | 512 | 87);
+    expect(right.keybinding).toBe(2048 | 512 | 88);
   });
 });

--- a/packages/extension-host/src/extension-host/editor-options.ts
+++ b/packages/extension-host/src/extension-host/editor-options.ts
@@ -1,4 +1,4 @@
-import type { editor as MonacoEditor } from "monaco-editor";
+import type { editor as MonacoEditor, KeyMod, KeyCode } from "monaco-editor";
 import { toMonacoOptions } from "../state/editor-settings";
 import type { EditorSettings } from "../state/types";
 
@@ -17,6 +17,35 @@ export const EDITOR_FONT_FAMILY =
  * diff alike) — the editor renders a touch larger than chrome.
  */
 const EDITOR_FONT_BOOST = 0.5;
+
+/**
+ * Monaco's default fold (`Cmd+Alt+[`) and unfold (`Cmd+Alt+]`) keybindings
+ * collide with Silo's global side-dock toggles, which fire via native menu
+ * accelerators on the same keys. When focus is in Monaco it consumes the
+ * keystroke for folding (calling preventDefault) and the accelerator never
+ * fires. Silo exposes no folding affordance, so we unbind both — passing
+ * `command: null` to Monaco's `addKeybindingRules` removes a default — letting
+ * the keystroke fall through to the native menu in every focus context. Bound
+ * with `CtrlCmd|Alt` to match the `CmdOrCtrl+Alt` menu accelerator (so on
+ * non-macOS platforms, where Monaco binds nothing to these combos, it's a
+ * harmless no-op). Takes the runtime `KeyMod`/`KeyCode` enums as arguments so
+ * the rule construction stays pure and unit-testable.
+ */
+export function foldUnbindRules(
+  keyMod: typeof KeyMod,
+  keyCode: typeof KeyCode,
+): MonacoEditor.IKeybindingRule[] {
+  return [
+    {
+      keybinding: keyMod.CtrlCmd | keyMod.Alt | keyCode.BracketLeft,
+      command: null,
+    },
+    {
+      keybinding: keyMod.CtrlCmd | keyMod.Alt | keyCode.BracketRight,
+      command: null,
+    },
+  ];
+}
 
 /**
  * Map a file path to a Monaco language id. Deduplicated from the two


### PR DESCRIPTION
## Problem

`Cmd+Alt+[` and `Cmd+Alt+]` toggle the left/right side docks everywhere **except** when focus is inside a Monaco editor, where they fold/unfold code branches instead.

**Root cause:** The dock-toggle commands (`view.toggleLeftPanel` / `view.toggleRightPanel`) are registered as **native Tauri menu accelerators** (`CmdOrCtrl+Alt+[` / `]`), deliberately *not* through the JS keybinding dispatcher (registering both would toggle twice). On macOS the focused webview gets first crack at a key event; Monaco binds those same keys to `editor.fold`/`editor.unfold`, so it runs the fold and calls `preventDefault()`, and the native accelerator never fires. Outside Monaco nothing consumes the keys — which is why the bug only shows up in the editor.

## Fix

Silo exposes no folding affordance, so drop Monaco's fold/unfold bindings on exactly those combos via `monaco.editor.addKeybindingRules({ command: null })` (the documented way to unbind a default). The keystroke then falls through to the native menu accelerator in every focus context, reusing the existing dock-toggle path unchanged.

- A pure helper `foldUnbindRules(KeyMod, KeyCode)` lives in `editor-options.ts` (the Monaco-runtime-free, unit-testable module). It takes the enums as args so rule construction stays pure.
- `ensureMonaco()` calls it once in its init block.
- Bound with `CtrlCmd|Alt` to match the `CmdOrCtrl+Alt` accelerator — a harmless no-op on platforms where Monaco binds nothing to those combos.

No new command, keybinding, or menu item is added; no public SDK surface changes.

## Tests

Added 2 unit tests in `editor-options.test.ts` pinning the `command: null` unbind and the `CtrlCmd|Alt|Bracket` bitwise composition. Full suite green (`pnpm test`), lint and typecheck clean.

## Manual verification

Not yet run live — the macOS event-ordering assumption (accelerator fires once Monaco stops consuming the key) is best confirmed by running the dev app: focus a `.ts` file in the editor, press `Cmd+Alt+[` / `]`, confirm the docks toggle (and no folding occurs), and confirm no regression outside the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)