### PR TITLE
feat(layout): roomier caption bar + double-click to zoom

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-toggle-maximize",
     "core:window:allow-set-focus",
     "fs:default",
     "fs:allow-read-text-file",

--- a/packages/extension-host/src/layout/AppShell.css
+++ b/packages/extension-host/src/layout/AppShell.css
@@ -8,15 +8,16 @@
 }
 
 /* macOS uses `titleBarStyle: Overlay`, so the webview extends under the
- * traffic lights. This strip reclaims the top 28px as a Tauri drag region
+ * traffic lights. This strip reclaims the top 36px as a Tauri drag region
  * so the user can reposition the window from any column. The traffic
- * lights are drawn by AppKit above the webview and remain clickable. */
+ * lights are drawn by AppKit above the webview and remain clickable. The
+ * extra height past the lights themselves keeps the tabs from crowding them. */
 .titlebar-drag {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  height: 28px;
+  height: 36px;
   z-index: 5;
 }
 
@@ -32,7 +33,7 @@
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  padding-top: 28px;
+  padding-top: 36px;
   overflow: hidden;
   /* Contain each column's internal stacking. Without this the center column is
      a static (non-isolating) box, so dockview's positioned descendants (e.g.

--- a/packages/extension-host/src/layout/AppShell.tsx
+++ b/packages/extension-host/src/layout/AppShell.tsx
@@ -18,9 +18,49 @@ import "./AppShell.css";
 // Overlay` (Tauri issue #9503 / #4316) — clicks while the window isn't
 // already focused frequently don't initiate a drag. Calling
 // `startDragging()` from a mousedown handler works around it.
+// Calling `startDragging()` on mousedown enters AppKit's modal window-drag
+// loop, which swallows every following pointer event — including the second
+// mousedown of a double-click. So we defer it: arm mousemove/mouseup listeners
+// on mousedown and only start dragging once the pointer travels past a small
+// threshold. A pure click never enters the drag loop, leaving the native
+// `dblclick` (-> zoom) free to fire.
+const DRAG_THRESHOLD_PX = 4;
+
 function onTitlebarMouseDown(e: React.MouseEvent<HTMLDivElement>) {
   if (e.button !== 0) return;
-  void getCurrentWebviewWindow().startDragging();
+  const startX = e.screenX;
+  const startY = e.screenY;
+
+  const cleanup = () => {
+    window.removeEventListener("mousemove", onMove);
+    window.removeEventListener("mouseup", cleanup);
+  };
+  const onMove = (ev: MouseEvent) => {
+    if (
+      Math.abs(ev.screenX - startX) > DRAG_THRESHOLD_PX ||
+      Math.abs(ev.screenY - startY) > DRAG_THRESHOLD_PX
+    ) {
+      cleanup();
+      void getCurrentWebviewWindow().startDragging();
+    }
+  };
+
+  window.addEventListener("mousemove", onMove);
+  window.addEventListener("mouseup", cleanup);
+}
+
+// Double-clicking the title bar zooms the window to fill the screen, matching
+// the native macOS green-button / title-bar behavior. `toggleMaximize` maps to
+// AppKit's zoom, not true fullscreen.
+function onTitlebarDoubleClick(e: React.MouseEvent<HTMLDivElement>) {
+  if (e.button !== 0) return;
+  getCurrentWebviewWindow()
+    .toggleMaximize()
+    .catch((err: unknown) => {
+      // A rejection here is almost always a missing Tauri capability
+      // (`core:window:allow-toggle-maximize`) — surface it rather than swallow.
+      console.error("titlebar double-click: toggleMaximize failed", err);
+    });
 }
 
 function onPanelDragging(isDragging: boolean) {
@@ -74,7 +114,11 @@ export function AppShell() {
 
   return (
     <div className="app-shell">
-      <div className="titlebar-drag" onMouseDown={onTitlebarMouseDown} />
+      <div
+        className="titlebar-drag"
+        onMouseDown={onTitlebarMouseDown}
+        onDoubleClick={onTitlebarDoubleClick}
+      />
       <PanelGroup direction="horizontal" autoSaveId="app:main-cols">
         <Panel
           ref={leftRef}


### PR DESCRIPTION
## What

Two small caption-bar improvements requested while working in that area:

1. **Roomier caption** — bump the title-bar drag strip (`.titlebar-drag`) and the matching column top padding (`.app-col`) from **28px → 36px** so the workspace tabs no longer crowd the macOS traffic lights.
2. **Double-click to zoom** — double-clicking the caption now fills the screen / restores, matching native macOS title-bar behavior.

## Why the double-click was tricky

Calling `startDragging()` on the first `mousedown` enters AppKit's **modal** window-drag loop, which consumes every following pointer event — so neither a native `dblclick` nor a manual second-mousedown check could ever reach the webview.

Fix: **defer `startDragging()` until the pointer actually moves past 4px.** A pure click never enters the drag loop, leaving the native `dblclick` free to fire `toggleMaximize()`.

On top of that, `toggleMaximize()` was being **silently rejected** — the `core:window:allow-toggle-maximize` capability was never granted, and the `void` swallowed the rejection. Added the capability and replaced the `void` with a `.catch` that logs, so a missing permission can't hide again.

> ⚠️ Capabilities compile into the Rust binary at build time — a webview reload won't pick this up; `pnpm dev` must be restarted.

## Files

- `apps/desktop/src-tauri/capabilities/default.json` — grant `core:window:allow-toggle-maximize`
- `packages/extension-host/src/layout/AppShell.css` — 28px → 36px
- `packages/extension-host/src/layout/AppShell.tsx` — deferred drag + double-click zoom + surfaced error

## Testing

- `pnpm --filter silo exec tsc --noEmit` clean
- `pnpm test` green (pre-commit hook)
- Verified by hand in the dev app: tabs sit clear of the traffic lights; double-click zooms and restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)