### PR TITLE
ci(release-please): author release PR via a GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,13 @@ name: release-please
 # The same GITHUB_TOKEN rule blocks the release PR itself: a PR opened with the
 # default token does NOT fire `pull_request`, so ci.yml never runs on it and its
 # required checks (frontend/rust/pr-title) stay absent — leaving the PR forever
-# BLOCKED by branch protection. We pass a dedicated RELEASE_PLEASE_TOKEN (a PAT
-# or GitHub App token) so the PR is authored by a non-GITHUB_TOKEN identity and
-# CI runs on it normally.
+# BLOCKED by branch protection. We mint a GitHub App installation token and hand
+# it to release-please so the PR is authored by a non-GITHUB_TOKEN identity (the
+# app's bot user), which lets `pull_request` fire and CI run on it normally.
+#
+# Setup (one-time): a GitHub App installed on this repo with Contents:write and
+# Pull requests:write. Its App ID is stored as the `RELEASE_PLEASE_APP_ID` repo
+# variable and its private key as the `RELEASE_PLEASE_APP_PRIVATE_KEY` secret.
 on:
   push:
     branches: [main]
@@ -28,10 +32,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,13 @@ name: release-please
 # made by GITHUB_TOKEN do NOT trigger other workflows — so release.yml's
 # `on: push: tags` would never fire on its own. We bridge it explicitly below
 # with a workflow_dispatch, which IS allowed to run from GITHUB_TOKEN.
+#
+# The same GITHUB_TOKEN rule blocks the release PR itself: a PR opened with the
+# default token does NOT fire `pull_request`, so ci.yml never runs on it and its
+# required checks (frontend/rust/pr-title) stay absent — leaving the PR forever
+# BLOCKED by branch protection. We pass a dedicated RELEASE_PLEASE_TOKEN (a PAT
+# or GitHub App token) so the PR is authored by a non-GITHUB_TOKEN identity and
+# CI runs on it normally.
 on:
   push:
     branches: [main]
@@ -24,6 +31,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Problem

The release-please PR (#2) is permanently `BLOCKED` and looks "hung" — it has **no checks at all** (`statusCheckRollup: []`).

`main`'s branch protection requires `frontend`, `rust`, and `pr-title` (all jobs in `ci.yml`, triggered by `pull_request`). But release-please opens/updates the release PR using the default `GITHUB_TOKEN`, and GitHub deliberately does **not** fire `pull_request` for events caused by `GITHUB_TOKEN` (anti-recursion). So CI never runs on the release PR, the required checks never appear, and branch protection can never be satisfied.

(This is the same `GITHUB_TOKEN` gotcha the workflow header already documents for tag pushes — it just also bites the PR's own required checks.)

## Fix

Mint a GitHub App installation token via `actions/create-github-app-token` and hand it to release-please. A PR authored by the app's bot identity (not `GITHUB_TOKEN`) *does* fire `pull_request`, so CI runs and the required checks populate on every future release PR. An App token is preferred over a PAT: no personal-account dependency and no expiry churn.

## ⚠️ Required before this works (one-time setup)

A GitHub App must exist and be installed on this repo:

1. Create a GitHub App (org or personal) with repo permissions **Contents: Read & write** and **Pull requests: Read & write**.
2. Install it on `silo-code/silo`.
3. Add its credentials to the repo:
   - `RELEASE_PLEASE_APP_ID` — **variable** (App ID is not secret):
     `gh variable set RELEASE_PLEASE_APP_ID --repo silo-code/silo --body "<app-id>"`
   - `RELEASE_PLEASE_APP_PRIVATE_KEY` — **secret** (the generated .pem):
     `gh secret set RELEASE_PLEASE_APP_PRIVATE_KEY --repo silo-code/silo < key.pem`

## Unblocking 0.2.0 right now

PR #2 was already created by `GITHUB_TOKEN`, so it stays BLOCKED until release-please next regenerates it with the app token (next push to main after this merges). To ship 0.2.0 immediately, an admin can bypass:
```
gh pr merge 2 --repo silo-code/silo --squash --admin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)