### PR TITLE
ci(release-please): bump action to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,7 +38,7 @@ jobs:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why

Every release-please run logs a deprecation warning: `googleapis/release-please-action@v4` runs on **Node 20**, which GitHub Actions forces to Node 24 on **2026-06-16** and removes from runners on **2026-09-16**.

## Change

Bump `@v4` → `@v5`. v5.0.0's [only breaking change](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0) is the Node 24 runtime upgrade itself — inputs and outputs are unchanged, so the `token` / `config-file` / `manifest-file` inputs and the `releases_created` output we rely on are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)