### PR TITLE
feat(terminal): find/search overlay (Cmd+F)

### DIFF
--- a/packages/extensions-core/package.json
+++ b/packages/extensions-core/package.json
@@ -16,6 +16,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",

--- a/packages/extensions-core/src/editor/EditorPanel.css
+++ b/packages/extensions-core/src/editor/EditorPanel.css
@@ -36,3 +36,16 @@
 .editor-panel .placeholder.error {
   color: var(--silo-color-err);
 }
+
+/* Monaco shows UI-control tooltips (the find widget's Close / Match Case / …
+ * buttons) via its hover *service*, rendered as `.monaco-hover.workbench-hover`
+ * inside a `.context-view` overlay. Near the editor's right edge the box is
+ * width-constrained, so "Close (Escape)" wraps to a second line that drops down
+ * over the ✕ — covering the button and triggering a show/hide flicker loop.
+ * Suppress these service tooltips. Editor content/symbol hovers use a plain
+ * `.monaco-hover` WITHOUT `.workbench-hover` (in the content-widget layer), so
+ * they're unaffected. The two-class selector out-specifies Monaco's base
+ * `.monaco-hover` rule, so it wins without `!important`. */
+.monaco-hover.workbench-hover {
+  display: none;
+}

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -8,6 +8,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { SearchAddon } from "@xterm/addon-search";
 import type { IDockviewPanelProps } from "dockview";
 import {
   DND_MIME,
@@ -27,6 +28,7 @@ import {
 } from "@silo-code/extension-host/internal";
 import { xtermThemeFor } from "./xterm-theme";
 import { findFileLinks, getHomeDir } from "./terminal-links";
+import { TerminalSearch } from "./TerminalSearch";
 import { Breadcrumb } from "../editor/Breadcrumb";
 import "@xterm/xterm/css/xterm.css";
 import "./TerminalPanel.css";
@@ -50,6 +52,7 @@ type Lifecycle =
 interface LiveRefs {
   term: XTerm;
   fit: FitAddon;
+  search: SearchAddon;
   session: ProcessSession;
   sessionId: string;
 }
@@ -101,6 +104,14 @@ export function TerminalPanel(
   const [lifecycle, setLifecycle] = useState<Lifecycle>({ kind: "loading" });
   // Bumping this re-runs the attach effect (used by the Recreate button).
   const [version, setVersion] = useState(0);
+  // Find overlay (Cmd+F). `seed` carries the terminal's current selection into
+  // the search box at open time; bumping `nonce` re-focuses the box if Cmd+F is
+  // pressed while it's already open.
+  const [search, setSearch] = useState<{
+    open: boolean;
+    seed: string;
+    nonce: number;
+  }>({ open: false, seed: "", nonce: 0 });
 
   const recreate = useCallback(() => {
     // Read activeWorkspaceId at click time to avoid stale closure.
@@ -176,6 +187,10 @@ export function TerminalPanel(
     // Code uses for terminal "process revive".
     const serializeAddon = new SerializeAddon();
     term.loadAddon(serializeAddon);
+    // Find-in-terminal (Cmd+F). The overlay (TerminalSearch) drives it; the
+    // addon does the matching/highlighting over the scrollback buffer.
+    const searchAddon = new SearchAddon();
+    term.loadAddon(searchAddon);
     term.open(containerRef.current);
     fit.fit();
 
@@ -332,7 +347,13 @@ export function TerminalPanel(
         }
         if (needsCreate) tRec.sessionId = sessionId;
 
-        liveRef.current = { term, fit, session, sessionId };
+        liveRef.current = {
+          term,
+          fit,
+          search: searchAddon,
+          session,
+          sessionId,
+        };
 
         // Persist the serialized buffer (screen + scrollback) on a throttle so a
         // restart can restore it. A timer-driven flush (rather than persisting
@@ -400,10 +421,29 @@ export function TerminalPanel(
         };
         window.addEventListener("pagehide", onPageHide);
 
-        // Make Shift+Enter send ESC+newline like Alt+Enter does for Claude Code
         term.attachCustomKeyEventHandler((event) => {
+          if (event.type !== "keydown") return true;
+          // Cmd+F (Ctrl+F on Windows/Linux) opens the find overlay. This only
+          // fires while the terminal textarea has focus, so it never competes
+          // with Monaco's own Cmd+F or any global keybinding.
           if (
-            event.type === "keydown" &&
+            (isMac
+              ? event.metaKey && !event.ctrlKey
+              : event.ctrlKey && !event.metaKey) &&
+            !event.altKey &&
+            !event.shiftKey &&
+            (event.key === "f" || event.key === "F")
+          ) {
+            event.preventDefault();
+            setSearch((s) => ({
+              open: true,
+              seed: term.getSelection() || s.seed,
+              nonce: s.nonce + 1,
+            }));
+            return false; // don't forward Cmd+F to the PTY
+          }
+          // Make Shift+Enter send ESC+newline like Alt+Enter does for Claude Code
+          if (
             event.key === "Enter" &&
             event.shiftKey &&
             !event.ctrlKey &&
@@ -819,6 +859,16 @@ export function TerminalPanel(
           ref={containerRef}
           className={`terminal-host${lifecycle.kind === "ready" ? " terminal-host--active" : ""}`}
         />
+        {search.open && lifecycle.kind === "ready" && liveRef.current && (
+          <TerminalSearch
+            key={search.nonce}
+            addon={liveRef.current.search}
+            host={containerRef.current}
+            initialQuery={search.seed}
+            onClose={() => setSearch((s) => ({ ...s, open: false }))}
+            onFocusTerminal={() => liveRef.current?.term.focus()}
+          />
+        )}
         {lifecycle.kind === "stale" && (
           <div className="terminal-overlay interactive">
             <div>{lifecycle.message}</div>

--- a/packages/extensions-core/src/terminal/TerminalSearch.css
+++ b/packages/extensions-core/src/terminal/TerminalSearch.css
@@ -1,0 +1,142 @@
+/* Find overlay styled after Monaco's editor find widget: a flat elevated bar
+ * pinned to the top-right of the terminal body, with inline Aa / ab / .* match-
+ * mode toggles, a muted result count, and thin prev/next/close glyph buttons.
+ * Design tokens only — no hard-coded colors/sizes — so it tracks the active
+ * theme and uiFontSize. (Monaco's widget reads editorWidget.background, an
+ * editor-owned token the terminal can't consume, so we approximate it with the
+ * panel background + a strong border + soft shadow.) */
+.terminal-search {
+  position: absolute;
+  top: 0;
+  right: 15px;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px 4px;
+  background: var(--silo-color-bg);
+  border: 1px solid var(--silo-color-border-strong);
+  border-top: none;
+  border-radius: 0 0 var(--silo-radius-sm) var(--silo-radius-sm);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.22);
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+}
+
+/* The input wraps the match-mode toggles on its right, like Monaco's find box. */
+.terminal-search__field {
+  display: flex;
+  align-items: center;
+  /* Light themes: a white card (matching the editor's white find input) via the
+   * terminal surface token (#fff in light). Dark themes override below. */
+  background: var(--silo-content-terminal-bg);
+  /* A visible outline (not the near-invisible --silo-color-border) so the field
+   * reads as a distinct input box against the bar, like Monaco's. */
+  border: 1px solid var(--silo-color-border-strong);
+  border-radius: var(--silo-radius-sm);
+  padding-right: 3px;
+}
+/* Dark themes: match Monaco's dark find input exactly — a #3c3c3c surface with
+ * #ccc foreground on the input + adornments (Monaco's vs-dark input colors).
+ * Literals are intentional here: these mirror Monaco's fixed find-widget colors,
+ * which aren't part of our token palette. */
+[data-theme="dark"] .terminal-search__field {
+  background: #3c3c3c;
+}
+[data-theme="dark"] .terminal-search__input,
+[data-theme="dark"] .terminal-search__count,
+[data-theme="dark"] .terminal-search__toggle,
+[data-theme="dark"] .terminal-search__btn {
+  color: #cccccc;
+}
+[data-theme="dark"] .terminal-search__toggle:hover,
+[data-theme="dark"] .terminal-search__btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}
+[data-theme="dark"] .terminal-search__toggle.is-on {
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+/* Accent focus ring (a single 1px border), matching Monaco's focusBorder. */
+.terminal-search__field:focus-within {
+  border-color: var(--silo-color-accent);
+}
+.terminal-search__field--nomatch,
+.terminal-search__field--nomatch:focus-within {
+  border-color: var(--silo-color-err);
+}
+
+.terminal-search__input {
+  width: 200px;
+  box-sizing: border-box;
+  background: transparent;
+  border: none;
+  color: var(--silo-color-input-text);
+  padding: 4px 8px;
+  font: inherit;
+}
+.terminal-search__input:focus {
+  outline: none;
+}
+
+.terminal-search__toggles {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+}
+
+.terminal-search__count {
+  min-width: 50px;
+  padding: 0 2px 0 6px;
+  text-align: center;
+  color: var(--silo-color-text);
+  font-size: var(--silo-font-size-sm);
+  white-space: nowrap;
+}
+
+/* Match-mode toggles (inside the field) and the prev/next/close buttons share
+ * the same flat, hover-lit treatment Monaco uses. */
+.terminal-search__toggle,
+.terminal-search__btn {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  /* Match Monaco's icon contrast — the darkest text token, not washed-out gray. */
+  color: var(--silo-color-text-hi);
+  border-radius: var(--silo-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  font: inherit;
+}
+.terminal-search__toggle {
+  min-width: 23px;
+  height: 23px;
+  padding: 0 4px;
+  font-size: var(--silo-font-size-sm);
+  line-height: 1;
+}
+.terminal-search__toggle--word {
+  text-decoration: underline;
+}
+.terminal-search__btn {
+  width: 27px;
+  height: 27px;
+  padding: 0;
+}
+.terminal-search__toggle:hover,
+.terminal-search__btn:hover {
+  background: var(--silo-color-bg-hover);
+  color: var(--silo-color-input-text);
+}
+/* Active toggle: accent-tinted box with an accent outline, matching Monaco's
+ * inputOption.activeBackground/activeBorder. */
+.terminal-search__toggle.is-on {
+  background: var(--silo-color-bg-active);
+  border-color: var(--silo-color-accent);
+  color: var(--silo-color-text-hi);
+}

--- a/packages/extensions-core/src/terminal/TerminalSearch.tsx
+++ b/packages/extensions-core/src/terminal/TerminalSearch.tsx
@@ -1,0 +1,231 @@
+// The terminal find overlay (Cmd+F / Ctrl+F). Thin glue around xterm's
+// SearchAddon and the pure helpers in terminal-search.ts. Mounted by
+// TerminalPanel only while the terminal is "ready".
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowUp, ArrowDown, X } from "@phosphor-icons/react";
+import type { SearchAddon } from "@xterm/addon-search";
+import {
+  buildSearchOptions,
+  formatMatchCount,
+  rgbToHex,
+  blendOver,
+  isLightColor,
+  DEFAULT_SEARCH_FLAGS,
+  MONACO_FIND_COLORS,
+  type DecorationColors,
+  type SearchFlags,
+} from "./terminal-search";
+import "./TerminalSearch.css";
+
+const isMac = navigator.platform.toUpperCase().includes("MAC");
+
+// The terminal surface color (#RRGGBB) the match highlights are painted over —
+// needed to pre-blend the translucent orange (the WebGL renderer ignores alpha)
+// and to pick the light/dark active-match fill. Falls back to the dark surface.
+function terminalSurface(host: HTMLElement): string {
+  return rgbToHex(getComputedStyle(host).backgroundColor) ?? "#0f1115";
+}
+
+const DARK_DEFAULT: DecorationColors = {
+  match: blendOver(MONACO_FIND_COLORS.matchHighlight, "#0f1115"),
+  activeMatch: MONACO_FIND_COLORS.activeDark,
+  ruler: MONACO_FIND_COLORS.ruler,
+};
+
+interface Props {
+  addon: SearchAddon;
+  /** The terminal container — used to resolve theme colors for decorations. */
+  host: HTMLElement | null;
+  /** Seed query (the terminal's current selection, if any). */
+  initialQuery: string;
+  onClose: () => void;
+  /** Return focus to the xterm instance (called on close). */
+  onFocusTerminal: () => void;
+}
+
+export function TerminalSearch({
+  addon,
+  host,
+  initialQuery,
+  onClose,
+  onFocusTerminal,
+}: Props) {
+  const [query, setQuery] = useState(initialQuery);
+  const [flags, setFlags] = useState<SearchFlags>(DEFAULT_SEARCH_FLAGS);
+  const [results, setResults] = useState<{
+    resultIndex: number;
+    resultCount: number;
+  } | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Decoration colors mirror Monaco's find palette (translucent orange for all
+  // matches, a neutral fill for the active one), pre-blended/picked for the
+  // terminal's surface so terminal search looks identical to the editor.
+  // Re-resolved if the host (hence theme) changes.
+  const decoRef = useRef<DecorationColors>(DARK_DEFAULT);
+  useEffect(() => {
+    if (!host) return;
+    const surface = terminalSurface(host);
+    decoRef.current = {
+      match: blendOver(MONACO_FIND_COLORS.matchHighlight, surface),
+      activeMatch: isLightColor(surface)
+        ? MONACO_FIND_COLORS.activeLight
+        : MONACO_FIND_COLORS.activeDark,
+      ruler: MONACO_FIND_COLORS.ruler,
+    };
+  }, [host]);
+
+  // Run a search. dir: +1 next, -1 previous, 0 incremental (typing).
+  const run = useCallback(
+    (q: string, dir: -1 | 0 | 1) => {
+      if (!q) {
+        addon.clearDecorations();
+        setResults(null);
+        return;
+      }
+      const opts = buildSearchOptions(flags, decoRef.current, dir === 0);
+      if (dir < 0) addon.findPrevious(q, opts);
+      else addon.findNext(q, opts);
+    },
+    [addon, flags],
+  );
+
+  // The match count rides on onDidChangeResults, which only fires while
+  // decorations are enabled (buildSearchOptions always enables them).
+  useEffect(() => {
+    const sub = addon.onDidChangeResults((e) => setResults(e));
+    return () => sub.dispose();
+  }, [addon]);
+
+  // Focus + select the input on mount so the user can type immediately.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  // Re-search whenever the query or a match-mode flag changes (incremental).
+  useEffect(() => {
+    run(query, 0);
+  }, [query, flags, run]);
+
+  const close = useCallback(() => {
+    addon.clearDecorations();
+    onClose();
+    onFocusTerminal();
+  }, [addon, onClose, onFocusTerminal]);
+
+  // Step to the next/previous match and keep keyboard focus in the input so
+  // Enter / Shift+Enter keep working after a button click.
+  const step = useCallback(
+    (dir: -1 | 1) => {
+      run(query, dir);
+      inputRef.current?.focus();
+    },
+    [run, query],
+  );
+
+  function onInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      step(e.shiftKey ? -1 : 1);
+    } else if (
+      (isMac ? e.metaKey : e.ctrlKey) &&
+      (e.key === "f" || e.key === "F")
+    ) {
+      // Re-pressing the find shortcut while open just reselects the query.
+      e.preventDefault();
+      e.currentTarget.select();
+    }
+  }
+
+  function toggle(k: keyof SearchFlags) {
+    setFlags((f) => ({ ...f, [k]: !f[k] }));
+    inputRef.current?.focus();
+  }
+
+  const label = formatMatchCount(query, results);
+  const noMatch = label === "No results";
+
+  return (
+    <div className="terminal-search" role="search">
+      <div
+        className={`terminal-search__field${noMatch ? " terminal-search__field--nomatch" : ""}`}
+      >
+        <input
+          ref={inputRef}
+          className="terminal-search__input"
+          type="text"
+          placeholder="Find"
+          value={query}
+          spellCheck={false}
+          autoComplete="off"
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onInputKeyDown}
+        />
+        <div className="terminal-search__toggles">
+          <button
+            type="button"
+            className={`terminal-search__toggle${flags.caseSensitive ? " is-on" : ""}`}
+            title="Match Case"
+            aria-label="Match Case"
+            aria-pressed={flags.caseSensitive}
+            onClick={() => toggle("caseSensitive")}
+          >
+            Aa
+          </button>
+          <button
+            type="button"
+            className={`terminal-search__toggle terminal-search__toggle--word${flags.wholeWord ? " is-on" : ""}`}
+            title="Match Whole Word"
+            aria-label="Match Whole Word"
+            aria-pressed={flags.wholeWord}
+            onClick={() => toggle("wholeWord")}
+          >
+            ab
+          </button>
+          <button
+            type="button"
+            className={`terminal-search__toggle${flags.regex ? " is-on" : ""}`}
+            title="Use Regular Expression"
+            aria-label="Use Regular Expression"
+            aria-pressed={flags.regex}
+            onClick={() => toggle("regex")}
+          >
+            .*
+          </button>
+        </div>
+      </div>
+      <span className="terminal-search__count">{label}</span>
+      <button
+        type="button"
+        className="terminal-search__btn"
+        title="Previous Match (⇧⏎)"
+        aria-label="Previous Match"
+        onClick={() => step(-1)}
+      >
+        <ArrowUp size={16} weight="bold" />
+      </button>
+      <button
+        type="button"
+        className="terminal-search__btn"
+        title="Next Match (⏎)"
+        aria-label="Next Match"
+        onClick={() => step(1)}
+      >
+        <ArrowDown size={16} weight="bold" />
+      </button>
+      <button
+        type="button"
+        className="terminal-search__btn"
+        title="Close (Esc)"
+        aria-label="Close"
+        onClick={close}
+      >
+        <X size={16} weight="bold" />
+      </button>
+    </div>
+  );
+}

--- a/packages/extensions-core/src/terminal/terminal-search.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-search.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSearchOptions,
+  formatMatchCount,
+  rgbToHex,
+  blendOver,
+  isLightColor,
+  DEFAULT_SEARCH_FLAGS,
+} from "./terminal-search";
+
+const DECO = { match: "#aabbcc80", activeMatch: "#112233cc", ruler: "#445566" };
+
+describe("formatMatchCount", () => {
+  it("is empty when the query is empty (idle)", () => {
+    expect(formatMatchCount("", null)).toBe("");
+    expect(formatMatchCount("", { resultIndex: 3, resultCount: 9 })).toBe("");
+  });
+
+  it("reports no results when a non-empty query matched nothing", () => {
+    expect(formatMatchCount("foo", null)).toBe("No results");
+    expect(formatMatchCount("foo", { resultIndex: -1, resultCount: 0 })).toBe(
+      "No results",
+    );
+  });
+
+  it("reports the 1-based position of the active match", () => {
+    expect(formatMatchCount("foo", { resultIndex: 0, resultCount: 12 })).toBe(
+      "1 of 12",
+    );
+    expect(formatMatchCount("foo", { resultIndex: 11, resultCount: 12 })).toBe(
+      "12 of 12",
+    );
+  });
+
+  it("reports a bare count when the result set exceeds the threshold", () => {
+    // SearchAddon sets resultIndex to -1 (no single active match) but still
+    // gives a positive count.
+    expect(formatMatchCount("a", { resultIndex: -1, resultCount: 5000 })).toBe(
+      "5000 matches",
+    );
+  });
+});
+
+describe("buildSearchOptions", () => {
+  it("maps the toggle flags straight through", () => {
+    const opts = buildSearchOptions(
+      { caseSensitive: true, wholeWord: true, regex: true },
+      DECO,
+      false,
+    );
+    expect(opts.caseSensitive).toBe(true);
+    expect(opts.wholeWord).toBe(true);
+    expect(opts.regex).toBe(true);
+    expect(opts.incremental).toBe(false);
+  });
+
+  it("defaults are all off", () => {
+    const opts = buildSearchOptions(DEFAULT_SEARCH_FLAGS, DECO, true);
+    expect(opts.caseSensitive).toBe(false);
+    expect(opts.wholeWord).toBe(false);
+    expect(opts.regex).toBe(false);
+    expect(opts.incremental).toBe(true);
+  });
+
+  it("always enables decorations so the count can update", () => {
+    const opts = buildSearchOptions(DEFAULT_SEARCH_FLAGS, DECO, false);
+    expect(opts.decorations).toEqual({
+      matchBackground: "#aabbcc80",
+      matchOverviewRuler: "#445566",
+      activeMatchBackground: "#112233cc",
+      activeMatchColorOverviewRuler: "#445566",
+    });
+  });
+});
+
+describe("rgbToHex", () => {
+  it("passes #RRGGBB through (lowercased)", () => {
+    expect(rgbToHex("#AABBCC")).toBe("#aabbcc");
+    expect(rgbToHex("  #112233 ")).toBe("#112233");
+  });
+
+  it("expands #RGB shorthand", () => {
+    expect(rgbToHex("#abc")).toBe("#aabbcc");
+    expect(rgbToHex("#F0A")).toBe("#ff00aa");
+  });
+
+  it("converts rgb()/rgba() (dropping alpha)", () => {
+    expect(rgbToHex("rgb(170, 187, 204)")).toBe("#aabbcc");
+    expect(rgbToHex("rgba(255, 0, 170, 0.5)")).toBe("#ff00aa");
+    expect(rgbToHex("rgb(0 120 212)")).toBe("#0078d4");
+  });
+
+  it("clamps and rounds out-of-range / fractional channels", () => {
+    expect(rgbToHex("rgb(300, -5, 127.6)")).toBe("#ff0080");
+  });
+
+  it("returns null for anything it can't normalize", () => {
+    expect(rgbToHex("rebeccapurple")).toBeNull();
+    expect(rgbToHex("hsl(200, 50%, 50%)")).toBeNull();
+    expect(rgbToHex("#12")).toBeNull();
+    expect(rgbToHex("")).toBeNull();
+  });
+});
+
+describe("blendOver", () => {
+  it("composites a translucent fg over an opaque bg", () => {
+    // 0x80 alpha ≈ 50%: halfway between fg and bg per channel.
+    expect(blendOver("#ffffff80", "#000000")).toBe("#808080");
+    expect(blendOver("#ff000080", "#0000ff")).toBe("#80007f");
+  });
+
+  it("returns the fg unchanged when it's already opaque", () => {
+    expect(blendOver("#abcdef", "#123456")).toBe("#abcdef");
+    expect(blendOver("#fff", "#000000")).toBe("#ffffff");
+  });
+
+  it("matches Monaco's translucent orange over the dark terminal surface", () => {
+    // #ea5c0055 (alpha 0x55 ≈ 33%) over #0f1115 → a muted brown-orange.
+    expect(blendOver("#ea5c0055", "#0f1115")).toBe("#582a0e");
+  });
+
+  it("falls back to fg when an input can't be parsed", () => {
+    expect(blendOver("rgb(1,2,3)", "#000000")).toBe("rgb(1,2,3)");
+    expect(blendOver("#ea5c0055", "transparent")).toBe("#ea5c0055");
+  });
+});
+
+describe("isLightColor", () => {
+  it("is true for light surfaces, false for dark", () => {
+    expect(isLightColor("#ffffff")).toBe(true);
+    expect(isLightColor("#e5e5e5")).toBe(true);
+    expect(isLightColor("#000000")).toBe(false);
+    expect(isLightColor("#0f1115")).toBe(false);
+  });
+
+  it("returns false for unparseable input", () => {
+    expect(isLightColor("rgb(255,255,255)")).toBe(false);
+    expect(isLightColor("")).toBe(false);
+  });
+});

--- a/packages/extensions-core/src/terminal/terminal-search.ts
+++ b/packages/extensions-core/src/terminal/terminal-search.ts
@@ -1,0 +1,176 @@
+// Pure, unit-testable logic for the terminal find overlay. The React component
+// (TerminalSearch.tsx) is thin glue around these; xterm's SearchAddon does the
+// actual matching.
+import type { ISearchOptions } from "@xterm/addon-search";
+
+/** The three match-mode toggles the overlay exposes (mirrors VS Code's find). */
+export interface SearchFlags {
+  caseSensitive: boolean;
+  wholeWord: boolean;
+  regex: boolean;
+}
+
+export const DEFAULT_SEARCH_FLAGS: SearchFlags = {
+  caseSensitive: false,
+  wholeWord: false,
+  regex: false,
+};
+
+/**
+ * Decoration colors for SearchAddon, mirroring Monaco's editor find-match
+ * palette so terminal search looks identical to the editor's. Monaco uses a
+ * translucent orange for all matches and a neutral fill for the focused one
+ * (the active is distinguished by hue, not a border) — both readable because
+ * the terminal text shows through / contrasts. See {@link MONACO_FIND_COLORS}.
+ */
+export interface DecorationColors {
+  /**
+   * Orange for all matches (Monaco `findMatchHighlightBackground`), pre-blended
+   * over the terminal surface so it looks translucent despite the WebGL
+   * renderer ignoring alpha — see {@link blendOver}.
+   */
+  match: string;
+  /** Neutral fill for the focused match (Monaco `findMatchBackground`). */
+  activeMatch: string;
+  /** Solid color for the overview-ruler ticks. */
+  ruler: string;
+}
+
+/**
+ * Monaco's default find-match colors (the editor doesn't override them, so the
+ * editor renders exactly these). Mirrored here so terminal search matches the
+ * editor in both themes; if the editor ever themes its find colors, update
+ * these to follow.
+ */
+export const MONACO_FIND_COLORS = {
+  /** `editor.findMatchHighlightBackground` — translucent orange, both themes. */
+  matchHighlight: "#ea5c0055",
+  /** `editor.findMatchBackground` — olive-gray (light), blue-gray (dark). */
+  activeLight: "#a8ac94",
+  activeDark: "#515c6a",
+  /** `editor.overviewRulerFindMatchForeground` base. */
+  ruler: "#d18616",
+} as const;
+
+/**
+ * Build xterm's {@link ISearchOptions} from the overlay's toggle state. The
+ * count label only updates when `decorations` is set (that's what makes
+ * SearchAddon count and fire `onDidChangeResults`), so decorations are always
+ * included. `incremental` is only honored by `findNext` — pass it true while
+ * the user types so the selection grows in place instead of jumping.
+ */
+export function buildSearchOptions(
+  flags: SearchFlags,
+  decorations: DecorationColors,
+  incremental: boolean,
+): ISearchOptions {
+  return {
+    regex: flags.regex,
+    wholeWord: flags.wholeWord,
+    caseSensitive: flags.caseSensitive,
+    incremental,
+    decorations: {
+      matchBackground: decorations.match,
+      matchOverviewRuler: decorations.ruler,
+      activeMatchBackground: decorations.activeMatch,
+      activeMatchColorOverviewRuler: decorations.ruler,
+    },
+  };
+}
+
+/**
+ * The label shown next to the input:
+ * - `""` when the query is empty (nothing searched yet),
+ * - `"No results"` when a non-empty query matched nothing,
+ * - `"{n} of {m}"` for a located match (resultIndex is 0-based),
+ * - `"{m} matches"` when the result set exceeds the highlight threshold, in
+ *   which case SearchAddon reports `resultIndex === -1` (no single active one).
+ */
+export function formatMatchCount(
+  query: string,
+  res: { resultIndex: number; resultCount: number } | null,
+): string {
+  if (!query) return "";
+  if (!res || res.resultCount <= 0) return "No results";
+  if (res.resultIndex < 0) return `${res.resultCount} matches`;
+  return `${res.resultIndex + 1} of ${res.resultCount}`;
+}
+
+/**
+ * Normalize a CSS color into the `#RRGGBB` form SearchAddon decorations
+ * require. Accepts `rgb()`/`rgba()` (alpha dropped — decorations don't take it),
+ * `#RGB` shorthand, and `#RRGGBB` (passed through). Returns null for anything
+ * else so the caller can fall back to a known-good hex. DOM-dependent
+ * resolution (CSS vars, named colors) belongs in the component; this stays pure.
+ */
+export function rgbToHex(input: string): string | null {
+  const s = input.trim();
+  const pair = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n)))
+      .toString(16)
+      .padStart(2, "0");
+  if (s.startsWith("#")) {
+    if (/^#[0-9a-f]{6}$/i.test(s)) return s.toLowerCase();
+    const short = s.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+    if (short)
+      return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`.toLowerCase();
+    return null;
+  }
+  const m = s.match(/^rgba?\(\s*(-?[\d.]+)[\s,]+(-?[\d.]+)[\s,]+(-?[\d.]+)/i);
+  if (!m) return null;
+  return `#${pair(Number(m[1]))}${pair(Number(m[2]))}${pair(Number(m[3]))}`;
+}
+
+/** Parse `#RGB` / `#RRGGBB` / `#RRGGBBAA` into channels (`a` in 0..1). */
+function parseHexColor(
+  hex: string,
+): { r: number; g: number; b: number; a: number } | null {
+  const s = hex.trim();
+  const short = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec(s);
+  if (short)
+    return {
+      r: parseInt(short[1] + short[1], 16),
+      g: parseInt(short[2] + short[2], 16),
+      b: parseInt(short[3] + short[3], 16),
+      a: 1,
+    };
+  const full = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?$/i.exec(
+    s,
+  );
+  if (full)
+    return {
+      r: parseInt(full[1], 16),
+      g: parseInt(full[2], 16),
+      b: parseInt(full[3], 16),
+      a: full[4] ? parseInt(full[4], 16) / 255 : 1,
+    };
+  return null;
+}
+
+/**
+ * Alpha-composite a (possibly translucent) `fg` over an opaque `bg`, returning a
+ * solid `#RRGGBB`. xterm's WebGL renderer paints decoration backgrounds onto its
+ * canvas and **ignores their alpha**, so a translucent match color would render
+ * fully opaque. Pre-blending against the terminal surface reproduces the
+ * translucent look as a solid color — exactly the color Monaco ends up showing
+ * when it composites its translucent find highlight over the editor background.
+ * Falls back to `fg` if either input can't be parsed.
+ */
+export function blendOver(fg: string, bg: string): string {
+  const f = parseHexColor(fg);
+  const b = parseHexColor(bg);
+  if (!f || !b) return fg;
+  const h = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n)))
+      .toString(16)
+      .padStart(2, "0");
+  const mix = (fc: number, bc: number) => fc * f.a + bc * (1 - f.a);
+  return `#${h(mix(f.r, b.r))}${h(mix(f.g, b.g))}${h(mix(f.b, b.b))}`;
+}
+
+/** Perceived-luminance test (ITU-R BT.601) used to pick light/dark variants. */
+export function isLightColor(hex: string): boolean {
+  const c = parseHexColor(hex);
+  if (!c) return false;
+  return 0.299 * c.r + 0.587 * c.g + 0.114 * c.b > 140;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-search':
+        specifier: ^0.16.0
+        version: 0.16.0
       '@xterm/addon-serialize':
         specifier: ^0.14.0
         version: 0.14.0
@@ -2214,6 +2217,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-search@0.16.0':
+    resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
 
   '@xterm/addon-serialize@0.14.0':
     resolution: {integrity: sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==}
@@ -5985,6 +5991,8 @@ snapshots:
       - typescript
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-search@0.16.0': {}
 
   '@xterm/addon-serialize@0.14.0': {}
 


### PR DESCRIPTION
## Summary

Adds **find-in-terminal** (Cmd+F / Ctrl+F) to the terminal extension, styled to match the editor's Monaco find widget, plus a fix for the editor find widget's tooltips covering its close button.

### Terminal find overlay (new feature)
- **Trigger**: handled inside xterm's custom key-event handler, so Cmd+F only fires when the terminal textarea has focus — it never competes with Monaco's own Cmd+F or global keybindings. No SDK/host changes; entirely within `extensions-core`.
- **Matching**: `@xterm/addon-search` over the scrollback buffer.
- **Overlay**: input, live match count (`1 of 12` / `No results`), `Aa` / `ab` / `.*` mode toggles, prev/next/close. Enter = next, Shift+Enter = prev, Esc = close + refocus terminal; incremental search as you type.
- **Look**: matches Monaco's find widget — flat bar dropping from the top-right edge, white input card in light themes, `#3c3c3c` input + `#cccccc` foreground in dark themes (Monaco's vs-dark colors), accent focus ring, full ↑/↓ arrows.
- **Match highlights**: mirror Monaco's find palette — translucent orange for all matches, a neutral fill for the active one. Because xterm's WebGL renderer ignores alpha in decoration colors, the orange is **pre-blended over the terminal surface** (`blendOver`) so it looks translucent and the underlying text stays readable, in both light and dark themes.
- **CSS** consumes only design tokens (+ the terminal's own component-token family) per the theming contract; the Monaco-literal dark colors are intentional (they aren't part of the token palette).
- **Tests**: pure logic (`formatMatchCount`, `buildSearchOptions`, `blendOver`, `isLightColor`, `rgbToHex`) extracted to `terminal-search.ts` with unit tests; components stay thin glue.

### Editor find-widget tooltip fix
Monaco renders the find widget's button tooltips as hover-service overlays (`.monaco-hover.workbench-hover`) in a `.context-view`. Near the editor's right edge the box is width-constrained, so "Close (Escape)" wraps to a second line that drops over the ✕ — hiding it and causing a show/hide flicker. Those service tooltips are now suppressed; editor content/symbol hovers (a plain `.monaco-hover` in the content-widget layer) are unaffected.

## Testing
- `pnpm test` — green (32 tests in `extensions-core`, incl. the new pure-logic suite)
- `pnpm --filter silo exec tsc --noEmit` — clean
- `pnpm lint` (eslint + stylelint boundary/token gate) — clean
- Verified in the running dev app: find works end-to-end, match counts + highlights render readably, and both themes match the editor's find widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)