### PR TITLE
fix(ui): tighten terminal breadcrumb gap and fix tab + menu alignment

### DIFF
--- a/packages/extension-host/src/panels/GroupAddMenu.tsx
+++ b/packages/extension-host/src/panels/GroupAddMenu.tsx
@@ -113,7 +113,7 @@ export function GroupAddMenu(props: IDockviewHeaderActionsProps) {
         run: pickFile,
       },
     ];
-    void openMenu({ items, anchor: btnRef.current, align: "end" });
+    void openMenu({ items, anchor: btnRef.current });
   }
 
   return (

--- a/packages/extensions-core/src/terminal/TerminalPanel.css
+++ b/packages/extensions-core/src/terminal/TerminalPanel.css
@@ -4,7 +4,7 @@
   height: 100%;
   width: 100%;
   /* Painted by TerminalPanel.tsx to match the xterm canvas background so
-   * the 6px padding around the canvas blends in seamlessly. Falls back to
+   * the padding around the canvas blends in seamlessly. Falls back to
    * --bg-0 before the terminal mounts. */
   background: var(--silo-content-terminal-bg);
 }
@@ -20,7 +20,7 @@
 .terminal-host {
   position: absolute;
   inset: 0;
-  padding: 6px 0 0 6px;
+  padding: 3px 0 0 6px;
   user-select: text;
   -webkit-user-select: text;
   background: var(--silo-content-terminal-bg);


### PR DESCRIPTION
## Summary

Two small UI fixes:

- **Terminal breadcrumb gap** — reduce the `.terminal-host` top padding from `6px` to `3px` so the space between the breadcrumb and the terminal text is a little tighter.
- **Content-tabs "+" menu alignment** — drop the `align: "end"` on the `GroupAddMenu` dropdown. The button sits at the far right of the tab strip, so right-aligning a wide menu against the tiny "+" made it spill out entirely to the *left* of the button — unlike every other dropdown. Falling back to start alignment hangs the menu from the button's left edge and drops straight down; the existing viewport clamp in `use-menu-dismiss.ts` keeps it on screen near the edge.

## Testing

- `pnpm test` (all packages green via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)