### PR TITLE
fix(release): sync Cargo.lock to released version + stop it drifting each release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,6 +45,45 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # release-please bumps the version in Cargo.toml (the `generic` extra-file
+      # updater) but never regenerates Cargo.lock, so the lock's own `silo` entry
+      # drifts a version behind on every release. Nothing builds with --locked, so
+      # this doesn't break CI — but it leaves a dirty Cargo.lock in the tree the
+      # moment anyone builds locally, which then rides into unrelated PRs.
+      #
+      # When a release PR is open, sync the lock on its branch and push the fix
+      # back onto the PR so the merged release commit is self-consistent. This
+      # runs in the same job right after release-please, so even though
+      # release-please force-pushes (and re-bumps) that branch on every reconcile,
+      # the branch always ends each run with the lock in sync. Pushing to the
+      # release branch (not main) re-runs the PR's CI but does NOT re-trigger this
+      # workflow, so there's no loop. `cargo update -p silo` touches only the silo
+      # lock entry — no dependency churn.
+      - uses: actions/checkout@v6
+        if: ${{ steps.release.outputs.pr }}
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: dtolnay/rust-toolchain@stable
+        if: ${{ steps.release.outputs.pr }}
+      - name: sync Cargo.lock on the release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          cargo update --manifest-path apps/desktop/src-tauri/Cargo.toml -p silo
+          if git diff --quiet -- apps/desktop/src-tauri/Cargo.lock; then
+            echo "Cargo.lock already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/desktop/src-tauri/Cargo.lock
+          git commit -m "chore: sync Cargo.lock to released version"
+          git push origin "$BRANCH"
+
       # When a release was just created, kick off the installer build. main HEAD
       # is the release commit (version already bumped), so release.yml reads the
       # correct version from tauri.conf.json.

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "silo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "core-graphics",


### PR DESCRIPTION
## Summary

release-please bumps `apps/desktop/src-tauri/Cargo.toml` (via its `generic` extra-file updater) but never regenerates `Cargo.lock`, so the lockfile's own `silo` entry drifts a version behind on **every** release. Nothing builds with `--locked`, so it doesn't break CI — but it leaves a dirty `Cargo.lock` in the tree the moment anyone builds locally, which then rides into unrelated PRs.

This PR does two things:

1. **Sync today's drift** — bump the `silo` entry in `Cargo.lock` from `0.1.0` to `0.2.0` to match the manifest (release-please bumped the manifest at 0.2.0 but missed the lock).
2. **Stop it recurring** — add a step to `release-please.yml` that, while a release PR is open, runs `cargo update -p silo` on the PR branch and pushes the synced lockfile back. The merged release commit is then self-consistent and no dirty lock leaks out.

### Notes on the CI step

- Runs in the same job right after release-please. release-please force-pushes (and re-bumps) its release branch on every reconcile, but our step runs after it within the same run, so the branch always ends each run with the lock in sync — self-healing.
- Pushes to the **release branch** (not `main`), which re-runs the PR's CI but does **not** re-trigger `release-please.yml` (`on: push: branches: [main]`), so there's no loop.
- `cargo update -p silo` touches only the `silo` lock entry — no dependency churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)