### PR TITLE
feat(side-dock): toggle side-panel visibility from the tab context menu

### DIFF
--- a/packages/extension-host/src/layout/SideColumn.tsx
+++ b/packages/extension-host/src/layout/SideColumn.tsx
@@ -4,7 +4,9 @@ import {
   bottomSlot,
   usePanelsForSlot,
   useSideTabDrag,
+  sidePanelVisibilityItems,
 } from "./side-column-helpers";
+import { openMenu } from "../extension-host/menu-controller";
 import { PanelPane } from "./PanelPane";
 import "./SideColumn.css";
 
@@ -22,6 +24,15 @@ function EmptyColumn({ location }: { location: "left" | "right" }) {
     <div
       className={`side-empty-column${over ? " over" : ""}`}
       data-slot={topSlot(location)}
+      onContextMenu={(e) => {
+        // The only entry point back when every panel is hidden — the tab bar
+        // that normally hosts this menu isn't rendered for an empty column.
+        e.preventDefault();
+        void openMenu({
+          items: sidePanelVisibilityItems(),
+          at: { x: e.clientX, y: e.clientY },
+        });
+      }}
     />
   );
 }

--- a/packages/extension-host/src/layout/TabBar.tsx
+++ b/packages/extension-host/src/layout/TabBar.tsx
@@ -17,6 +17,7 @@ import {
   moveGhost,
   removeGhost,
   useSideTabDrag,
+  sidePanelVisibilityItems,
 } from "./side-column-helpers";
 
 interface TabBarProps {
@@ -205,29 +206,45 @@ export function TabBar({
     return result;
   }, [panels, activeDrag, isSameSlot, insertIdx]);
 
-  function showContextMenu(panel: SidePanel, x: number, y: number) {
-    const oppositeColumn: "left" | "right" =
-      location === "left" ? "right" : "left";
-    const isTop = isTopSlot(slot, location);
-    const items: MenuEntry[] = [
-      {
+  function showContextMenu(panel: SidePanel | null, x: number, y: number) {
+    const items: MenuEntry[] = [];
+    // Move actions apply to a specific tab; absent when the bar's empty area
+    // (spacer) is right-clicked — only the visibility list shows then.
+    if (panel) {
+      const oppositeColumn: "left" | "right" =
+        location === "left" ? "right" : "left";
+      const isTop = isTopSlot(slot, location);
+      items.push({
         label: `Move to ${oppositeColumn === "left" ? "Left" : "Right"} Panel`,
         run: () => setSidePanelSlot(panel.id, topSlot(oppositeColumn)),
-      },
-    ];
-    if (isTop && panels.length > 1) {
-      items.push({
-        label: "Move to Bottom Pane",
-        run: () => setSidePanelSlot(panel.id, bottomSlot(location)),
       });
+      if (isTop && panels.length > 1) {
+        items.push({
+          label: "Move to Bottom Pane",
+          run: () => setSidePanelSlot(panel.id, bottomSlot(location)),
+        });
+      }
+      if (!isTop) {
+        items.push({
+          label: "Move to Top Pane",
+          run: () => setSidePanelSlot(panel.id, topSlot(location)),
+        });
+      }
+      items.push({ type: "separator" });
     }
-    if (!isTop) {
-      items.push({
-        label: "Move to Top Pane",
-        run: () => setSidePanelSlot(panel.id, topSlot(location)),
-      });
-    }
+    items.push(...sidePanelVisibilityItems());
     void openMenu({ items, at: { x, y } });
+  }
+
+  function onBarContextMenu(e: React.MouseEvent<HTMLDivElement>) {
+    e.preventDefault();
+    const button = (e.target as HTMLElement).closest<HTMLButtonElement>(
+      "button.tab",
+    );
+    const panel = button?.dataset.panelId
+      ? (panels.find((p) => p.id === button.dataset.panelId) ?? null)
+      : null;
+    showContextMenu(panel, e.clientX, e.clientY);
   }
 
   return (
@@ -238,6 +255,7 @@ export function TabBar({
       onPointerMove={onBarPointerMove}
       onPointerUp={onBarPointerUp}
       onPointerCancel={onBarPointerCancel}
+      onContextMenu={onBarContextMenu}
     >
       {displayPanels.map((p) => (
         <button
@@ -251,10 +269,6 @@ export function TabBar({
           ]
             .filter(Boolean)
             .join(" ")}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            showContextMenu(p, e.clientX, e.clientY);
-          }}
         >
           {p.title}
         </button>

--- a/packages/extension-host/src/layout/side-column-helpers.test.ts
+++ b/packages/extension-host/src/layout/side-column-helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Disposable, MenuItem, SidePanel } from "@silo-code/sdk";
+import { sidePanelRegistry } from "../extension-host/side-panels";
+import { store } from "../state/store";
+import { sidePanelVisibilityItems } from "./side-column-helpers";
+
+function panel(
+  id: string,
+  title: string,
+  location: "left" | "right",
+): SidePanel {
+  return { id, title, location, component: () => null };
+}
+
+describe("sidePanelVisibilityItems", () => {
+  let subs: Disposable[] = [];
+
+  beforeEach(() => {
+    store.sidePanelVisibility = {};
+    subs = [
+      sidePanelRegistry.register(panel("zed", "Zed", "right")),
+      sidePanelRegistry.register(panel("alpha", "Alpha", "left")),
+    ];
+  });
+
+  afterEach(() => {
+    for (const s of subs) s.dispose();
+  });
+
+  it("leads with a 'Side Panels' header", () => {
+    const items = sidePanelVisibilityItems();
+    expect(items[0]).toEqual({ type: "header", label: "Side Panels" });
+  });
+
+  it("lists every registered panel sorted by title, checked when visible", () => {
+    const rows = sidePanelVisibilityItems().slice(1) as MenuItem[];
+    expect(rows.map((r) => r.label)).toEqual(["Alpha", "Zed"]);
+    expect(rows.every((r) => r.checked)).toBe(true);
+  });
+
+  it("unchecks a hidden panel", () => {
+    store.sidePanelVisibility.alpha = false;
+    const rows = sidePanelVisibilityItems().slice(1) as MenuItem[];
+    const alpha = rows.find((r) => r.label === "Alpha");
+    expect(alpha?.checked).toBe(false);
+  });
+
+  it("each row's run toggles that panel's visibility", () => {
+    const rows = sidePanelVisibilityItems().slice(1) as MenuItem[];
+    rows.find((r) => r.label === "Zed")?.run?.();
+    expect(store.sidePanelVisibility.zed).toBe(false);
+  });
+});

--- a/packages/extension-host/src/layout/side-column-helpers.ts
+++ b/packages/extension-host/src/layout/side-column-helpers.ts
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { useSnapshot } from "valtio";
 import { sidePanelRegistry } from "../extension-host/side-panels";
-import type { SidePanel } from "@silo-code/sdk";
+import type { MenuEntry, SidePanel } from "@silo-code/sdk";
 import type { SidePanelSlot } from "../state/types";
-import { store } from "../state/store";
+import {
+  store,
+  isSidePanelVisible,
+  toggleSidePanelVisibility,
+} from "../state/store";
 import { sideTabDrag } from "./drag-state";
 
 // ─── slot helpers ──────────────────────────────────────────────────────────
@@ -90,6 +94,7 @@ export function usePanelsForSlot(slot: SidePanelSlot): SidePanel[] {
     const order = snap.sidePanelOrder;
     const isBottom = slot === "left-bottom" || slot === "right-bottom";
     const filtered = sidePanelRegistry.list().filter((p) => {
+      if (snap.sidePanelVisibility[p.id] === false) return false;
       const effective = overrides[p.id] ?? p.location;
       if (isBottom) {
         return overrides[p.id] === slot;
@@ -101,9 +106,37 @@ export function usePanelsForSlot(slot: SidePanelSlot): SidePanel[] {
     );
     return filtered;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slot, tick, snap.sidePanelLocations, snap.sidePanelOrder]);
+  }, [
+    slot,
+    tick,
+    snap.sidePanelLocations,
+    snap.sidePanelOrder,
+    snap.sidePanelVisibility,
+  ]);
 }
 
 export function useSideTabDrag() {
   return useSyncExternalStore(sideTabDrag.subscribe, sideTabDrag.get);
+}
+
+// ─── side-panel visibility menu ───────────────────────────────────────────────
+
+/**
+ * Menu entries (a "Side Panels" header + one checkable row per registered panel,
+ * sorted by title) for toggling each side panel's visibility. Shared by the tab
+ * bar and the empty-column context menus so a fully-hidden dock can still be
+ * re-populated. Read at open time, so checkmarks reflect the live state.
+ */
+export function sidePanelVisibilityItems(): MenuEntry[] {
+  const items: MenuEntry[] = [{ type: "header", label: "Side Panels" }];
+  for (const sp of [...sidePanelRegistry.list()].sort((a, b) =>
+    a.title.localeCompare(b.title),
+  )) {
+    items.push({
+      label: sp.title,
+      checked: isSidePanelVisible(sp.id),
+      run: () => toggleSidePanelVisibility(sp.id),
+    });
+  }
+  return items;
 }

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -229,10 +229,18 @@ describe("buildIndex", () => {
       activeWorkspaceId: "a",
       editorSettings,
     });
+    const sidePanelVisibility = { explorer: false };
+    const index2 = buildIndex({
+      workspaceOrder: [],
+      activeWorkspaceId: null,
+      sidePanelVisibility,
+    });
     order.push("c");
     editorSettings.tabSize = 8;
+    sidePanelVisibility.explorer = true;
     expect(index.workspaceOrder).toEqual(["a", "b"]);
     expect(index.editorSettings).toEqual({ tabSize: 2 });
+    expect(index2.sidePanelVisibility).toEqual({ explorer: false });
   });
 
   it("preserves undefined optional fields", () => {
@@ -242,6 +250,7 @@ describe("buildIndex", () => {
     expect(index.uiFontSize).toBeUndefined();
     expect(index.leftPanelCollapsed).toBeUndefined();
     expect(index.rightPanelCollapsed).toBeUndefined();
+    expect(index.sidePanelVisibility).toBeUndefined();
   });
 
   it("carries the global side-dock visibility flags through", () => {
@@ -250,8 +259,10 @@ describe("buildIndex", () => {
       activeWorkspaceId: null,
       leftPanelCollapsed: true,
       rightPanelCollapsed: false,
+      sidePanelVisibility: { themes: false },
     });
     expect(index.leftPanelCollapsed).toBe(true);
     expect(index.rightPanelCollapsed).toBe(false);
+    expect(index.sidePanelVisibility).toEqual({ themes: false });
   });
 });

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -29,6 +29,9 @@ export interface PersistedIndex {
   // indexes, hydrated with a per-workspace fallback (see persistence.ts).
   leftPanelCollapsed?: boolean;
   rightPanelCollapsed?: boolean;
+  // Side-panel visibility is global too; absent in pre-this-change indexes, in
+  // which case every panel hydrates as visible (the default).
+  sidePanelVisibility?: Record<string, boolean>;
 }
 
 /** The legacy monolithic blob (one `"state"` key in the app-data store) we
@@ -130,6 +133,9 @@ export function buildIndex(snapshot: PersistedIndex): PersistedIndex {
       : undefined,
     leftPanelCollapsed: snapshot.leftPanelCollapsed,
     rightPanelCollapsed: snapshot.rightPanelCollapsed,
+    sidePanelVisibility: snapshot.sidePanelVisibility
+      ? { ...snapshot.sidePanelVisibility }
+      : undefined,
   };
 }
 

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -198,6 +198,9 @@ export async function hydrate(configDir: string): Promise<void> {
   store.rightPanelCollapsed =
     index?.rightPanelCollapsed ?? legacyWs?.rightPanelCollapsed ?? false;
 
+  // Side-panel visibility is global; absent in older indexes → all visible.
+  store.sidePanelVisibility = index?.sidePanelVisibility ?? {};
+
   store.hydrated = true;
   subscribe(store, schedulePersist);
 }
@@ -265,6 +268,7 @@ async function doPersist(): Promise<void> {
       terminalSettings: { ...store.terminalSettings },
       leftPanelCollapsed: store.leftPanelCollapsed,
       rightPanelCollapsed: store.rightPanelCollapsed,
+      sidePanelVisibility: { ...store.sidePanelVisibility },
     }),
   );
   await indexStore.save();

--- a/packages/extension-host/src/state/store.test.ts
+++ b/packages/extension-host/src/state/store.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { store, isSidePanelVisible, toggleSidePanelVisibility } from "./store";
+
+describe("side-panel visibility", () => {
+  beforeEach(() => {
+    store.sidePanelVisibility = {};
+  });
+
+  it("defaults to visible when no entry is stored", () => {
+    expect(isSidePanelVisible("explorer")).toBe(true);
+  });
+
+  it("reports hidden once an explicit false is stored", () => {
+    store.sidePanelVisibility.explorer = false;
+    expect(isSidePanelVisible("explorer")).toBe(false);
+  });
+
+  it("hiding a visible panel stores an explicit false", () => {
+    toggleSidePanelVisibility("explorer");
+    expect(store.sidePanelVisibility.explorer).toBe(false);
+    expect(isSidePanelVisible("explorer")).toBe(false);
+  });
+
+  it("showing a hidden panel deletes the key (back to default-visible)", () => {
+    store.sidePanelVisibility.explorer = false;
+    toggleSidePanelVisibility("explorer");
+    expect("explorer" in store.sidePanelVisibility).toBe(false);
+    expect(isSidePanelVisible("explorer")).toBe(true);
+  });
+
+  it("toggles back and forth without leaking other keys", () => {
+    toggleSidePanelVisibility("a");
+    toggleSidePanelVisibility("a");
+    expect(store.sidePanelVisibility).toEqual({});
+  });
+});

--- a/packages/extension-host/src/state/store.ts
+++ b/packages/extension-host/src/state/store.ts
@@ -25,6 +25,7 @@ export const store = proxy<AppState>({
   extensionState: {},
   leftPanelCollapsed: false,
   rightPanelCollapsed: false,
+  sidePanelVisibility: {},
 });
 
 export function setSidePanelSlot(panelId: string, slot: SidePanelSlot | null) {
@@ -59,6 +60,21 @@ export function toggleLeftPanel() {
 
 export function toggleRightPanel() {
   store.rightPanelCollapsed = !store.rightPanelCollapsed;
+}
+
+/** Whether a side panel is shown in the dock. Absent = visible (default). */
+export function isSidePanelVisible(panelId: string): boolean {
+  return store.sidePanelVisibility[panelId] !== false;
+}
+
+/** Flip a side panel between shown and hidden. Hiding stores an explicit
+ * `false`; showing deletes the key, returning it to the default-visible state. */
+export function toggleSidePanelVisibility(panelId: string) {
+  if (store.sidePanelVisibility[panelId] === false) {
+    delete store.sidePanelVisibility[panelId];
+  } else {
+    store.sidePanelVisibility[panelId] = false;
+  }
 }
 
 export function setTheme(id: string) {

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -60,6 +60,11 @@ export interface AppState {
   extensionState: Record<string, Record<string, unknown>>;
   leftPanelCollapsed: boolean;
   rightPanelCollapsed: boolean;
+  /**
+   * Global side-panel visibility, keyed by panel id. Shared across workspaces.
+   * Absent = visible (default); only an explicit `false` (hidden) is stored.
+   */
+  sidePanelVisibility: Record<string, boolean>;
 }
 
 export const DEFAULT_UI_FONT_SIZE = 13;


### PR DESCRIPTION
## What

Adds a **Side Panels** section to the side-dock tab context menu: a separator, a header, then one checkable row per registered side panel. Clicking a row shows/hides that panel. Visibility is **global** — shared across every workspace and persisted across restarts.

Right-click a side-dock tab → see the move actions, then the panel list with checkmarks. Hidden panels lose their tab; re-check them to bring them back.

## How

- **State**: new sparse `sidePanelVisibility: Record<string, boolean>` map on `AppState` (absent = visible; only an explicit `false` is stored). Persisted in the `app-state.json` index — modeled exactly on the existing `leftPanelCollapsed`/`rightPanelCollapsed` global fields (`PersistedIndex` → `buildIndex` → hydrate/persist).
- **Filtering**: `usePanelsForSlot` drops hidden panels so their tab disappears. `PanelPane` already re-resolves the active tab when a panel leaves the list, so hiding the active one falls through cleanly.
- **Menu**: extracted a shared `sidePanelVisibilityItems()` helper used by the tab bar **and** the `EmptyColumn` (and the tab bar's empty spacer area) — so a fully-hidden dock can still be re-populated by right-clicking the empty column.

This is host-internal behavior, not a new `ctx`/SDK member, so no SDK barrel or docs-site changes.

## Tests

- `store.test.ts` — `isSidePanelVisible` / `toggleSidePanelVisibility` (default-visible, hide stores `false`, show deletes the key).
- `side-column-helpers.test.ts` — `sidePanelVisibilityItems` (header first, sorted rows, checked reflects visibility, `run` toggles).
- `persistence-model.test.ts` — extended `buildIndex` round-trip + clone + undefined-when-absent.

`pnpm lint` clean; full `pnpm test` green (268 extension-host tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)