### PR TITLE
feat(updates): add core.updates status-bar update indicator

### DIFF
--- a/apps/desktop/src/builtins.ts
+++ b/apps/desktop/src/builtins.ts
@@ -11,6 +11,7 @@ import {
   extensions,
   panelToggles,
   settingsButton,
+  updates,
 } from "@silo-code/extensions-core";
 import {
   imageViewer,
@@ -50,6 +51,7 @@ const builtins: Extension[] = [
   themes,
   panelToggles,
   settingsButton,
+  updates,
   keybindings,
   about,
   extensions,

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -7,7 +7,6 @@ import {
   userConfigDir,
   getExtensionManager,
   initUserKeybindings,
-  checkForUpdatesOnLaunch,
 } from "@silo-code/extension-host";
 import { activateBuiltins } from "./builtins";
 
@@ -55,12 +54,6 @@ document.addEventListener("visibilitychange", () => {
 // triggers a menu re-sync via onKeymapChange.
 initUserKeybindings().catch((err) =>
   console.error("initUserKeybindings failed", err),
-);
-
-// Stable app only: quietly check for a new release on launch (no-ops in dev
-// and in the "Silo Dev" build).
-checkForUpdatesOnLaunch().catch((err) =>
-  console.error("update check failed", err),
 );
 
 // Dev-only automation bridge (paired with the Cargo `automation` feature on the

--- a/packages/extension-host/src/extension-host/menu-items.ts
+++ b/packages/extension-host/src/extension-host/menu-items.ts
@@ -15,7 +15,7 @@ import {
   toTauriAccelerator,
 } from "./keymap";
 import type { Disposable, MenuId, MenuItemContribution } from "@silo-code/sdk";
-import { checkForUpdatesInteractive } from "../services/updater";
+import { checkForUpdatesInteractive } from "./update-service";
 
 export const menuItemRegistry = new Registry<MenuItemContribution>();
 

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -46,6 +46,13 @@ export type { ModalProps } from "./Modal";
 export type { AppService } from "./app-service";
 export { getAppService } from "./app-service";
 
+// Reactive auto-update state — privileged because self-updating the installed
+// app (download + install a binary, relaunch) is a host/platform capability only
+// `core.updates` (and the app's "Check for Updates…" menu item) needs; not a
+// public-surface capability. See update-service.ts for the rationale.
+export type { UpdateService, UpdateState, UpdatePhase } from "./update-service";
+export { getUpdateService } from "./update-service";
+
 // The extension manager — install / uninstall / enable / disable / load runtime
 // extensions. Core-only **by design**: loading and unloading other extensions is
 // a privileged host capability that silo.*/third-party extensions must not have.

--- a/packages/extension-host/src/extension-host/update-service.test.ts
+++ b/packages/extension-host/src/extension-host/update-service.test.ts
@@ -1,0 +1,217 @@
+// Unit test for the host UpdateService: the Tauri seam (services/updater) and
+// the native-dialog plugin are mocked, so this stays a fast, app-free unit. The
+// service is a module singleton, so each test re-imports it fresh
+// (`vi.resetModules`) to get clean state.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const seam = vi.hoisted(() => ({
+  isStableApp: vi.fn(),
+  checkForUpdate: vi.fn(),
+  installUpdate: vi.fn(),
+}));
+
+// update-service.ts imports these for its interactive (menu) path. Hoisted +
+// stable so assertions survive `vi.resetModules()`.
+const dialog = vi.hoisted(() => ({
+  ask: vi.fn(),
+  message: vi.fn(),
+}));
+
+vi.mock("../services/updater", () => seam);
+vi.mock("@tauri-apps/plugin-dialog", () => dialog);
+
+beforeEach(() => {
+  vi.resetModules();
+  seam.isStableApp.mockReset();
+  seam.checkForUpdate.mockReset();
+  seam.installUpdate.mockReset();
+  dialog.ask.mockReset();
+  dialog.message.mockReset();
+});
+
+async function freshService() {
+  const mod = await import("./update-service");
+  return mod.getUpdateService();
+}
+
+async function freshModule() {
+  return import("./update-service");
+}
+
+describe("UpdateService.check", () => {
+  it("no-ops (stays idle) outside the packaged stable app", async () => {
+    seam.isStableApp.mockResolvedValue(false);
+    const svc = await freshService();
+
+    await svc.check();
+
+    expect(svc.getState()).toEqual({ phase: "idle", version: null });
+    expect(seam.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("transitions to 'available' and records the version when a release exists", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue({ version: "9.9.9" });
+    const svc = await freshService();
+
+    await svc.check();
+
+    expect(svc.getState()).toEqual({ phase: "available", version: "9.9.9" });
+  });
+
+  it("transitions to 'upToDate' when there is no release", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue(null);
+    const svc = await freshService();
+
+    await svc.check();
+
+    expect(svc.getState()).toEqual({ phase: "upToDate", version: null });
+  });
+
+  it("transitions to 'error' when the check throws", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockRejectedValue(new Error("network"));
+    const svc = await freshService();
+
+    await svc.check();
+
+    expect(svc.getState().phase).toBe("error");
+  });
+
+  it("notifies subscribers on state change", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue({ version: "2.0.0" });
+    const svc = await freshService();
+    const seen: string[] = [];
+    svc.subscribe((s) => seen.push(s.phase));
+
+    await svc.check();
+
+    expect(seen).toContain("available");
+  });
+});
+
+describe("UpdateService.installAndRelaunch", () => {
+  it("installs the release found by the last check", async () => {
+    const update = { version: "9.9.9" };
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue(update);
+    seam.installUpdate.mockResolvedValue(undefined);
+    const svc = await freshService();
+
+    await svc.check();
+    await svc.installAndRelaunch();
+
+    expect(seam.installUpdate).toHaveBeenCalledWith(update);
+  });
+
+  it("is a no-op when no update is pending", async () => {
+    const svc = await freshService();
+
+    await svc.installAndRelaunch();
+
+    expect(seam.installUpdate).not.toHaveBeenCalled();
+  });
+
+  it("marks the phase 'installing' while the install runs", async () => {
+    const update = { version: "9.9.9" };
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue(update);
+    let phaseDuringInstall: string | undefined;
+    const svc = await freshService();
+    seam.installUpdate.mockImplementation(async () => {
+      phaseDuringInstall = svc.getState().phase;
+    });
+
+    await svc.check();
+    await svc.installAndRelaunch();
+
+    expect(phaseDuringInstall).toBe("installing");
+  });
+
+  it("does not start a second install while one is in flight (re-entry guard)", async () => {
+    const update = { version: "9.9.9" };
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue(update);
+    // Never resolves — keeps the first install "in flight".
+    seam.installUpdate.mockReturnValue(new Promise(() => {}));
+    const svc = await freshService();
+
+    await svc.check();
+    void svc.installAndRelaunch();
+    await svc.installAndRelaunch(); // second click
+
+    expect(seam.installUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("reverts to 'available' and re-throws when the install fails", async () => {
+    const update = { version: "9.9.9" };
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue(update);
+    seam.installUpdate.mockRejectedValue(new Error("download failed"));
+    const svc = await freshService();
+
+    await svc.check();
+    await expect(svc.installAndRelaunch()).rejects.toThrow("download failed");
+    expect(svc.getState().phase).toBe("available");
+
+    // The release is still pending, so a retry attempts the install again.
+    seam.installUpdate.mockResolvedValue(undefined);
+    await svc.installAndRelaunch();
+    expect(seam.installUpdate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("checkForUpdatesInteractive (menu path)", () => {
+  it("reports 'latest version' in dev / non-stable builds (no silent no-op)", async () => {
+    seam.isStableApp.mockResolvedValue(false);
+    const { checkForUpdatesInteractive } = await freshModule();
+
+    await checkForUpdatesInteractive();
+
+    expect(dialog.message).toHaveBeenCalledWith(
+      "You're on the latest version.",
+      expect.anything(),
+    );
+  });
+
+  it("reports 'latest version' when up to date", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue(null);
+    const { checkForUpdatesInteractive } = await freshModule();
+
+    await checkForUpdatesInteractive();
+
+    expect(dialog.message).toHaveBeenCalledWith(
+      "You're on the latest version.",
+      expect.anything(),
+    );
+  });
+
+  it("surfaces the underlying error detail when the check fails", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockRejectedValue(new Error("network down"));
+    const { checkForUpdatesInteractive } = await freshModule();
+
+    await checkForUpdatesInteractive();
+
+    const [text] = dialog.message.mock.calls[0];
+    expect(text).toContain("Couldn't check for updates.");
+    expect(text).toContain("network down");
+  });
+
+  it("prompts to install when a release is available", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue({ version: "9.9.9" });
+    dialog.ask.mockResolvedValue(false); // user declines
+    const { checkForUpdatesInteractive } = await freshModule();
+
+    await checkForUpdatesInteractive();
+
+    const [text] = dialog.ask.mock.calls[0];
+    expect(text).toContain("Silo 9.9.9");
+    expect(seam.installUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension-host/src/extension-host/update-service.ts
+++ b/packages/extension-host/src/extension-host/update-service.ts
@@ -1,0 +1,190 @@
+import { proxy, snapshot, subscribe } from "valtio";
+import { ask, message } from "@tauri-apps/plugin-dialog";
+import type { Disposable } from "@silo-code/sdk";
+import {
+  checkForUpdate,
+  installUpdate,
+  isStableApp,
+  type Update,
+} from "../services/updater";
+
+// Reactive auto-update state for **core** extensions, exposed on the PRIVILEGED
+// `@silo-code/extension-host/internal` barrel — core.* only — rather than public
+// `@silo-code/sdk`.
+//
+// Why internal, not public `ctx.updates`: self-updating the installed app is a
+// host/platform capability whose only consumer is `core.updates` (Silo's own
+// status-bar indicator) and the app's "Check for Updates…" menu item. Per the
+// public-first rule (ctx-domains.md → "Extension trust tiers"), a capability
+// only a core extension needs lives on the internal barrel — importing it from
+// `@silo-code/extension-host/internal` is the marked, greppable record of that
+// privileged use. Handing arbitrary extensions the ability to download + install
+// a binary and relaunch the app would be unsafe; if a public need ever appears
+// this graduates to a `ctx.updates` domain instead.
+//
+// Stateless Tauri plumbing lives in the leaf seam `services/updater.ts`; this
+// module owns the *state* (so a status item can react) and the launch-discovered
+// vs. user-invoked policy.
+
+/**
+ * Where the updater is in its check/install lifecycle. The status-bar link
+ * renders for `available` (actionable) and `installing` (disabled, in-flight).
+ *
+ * @internal
+ */
+export type UpdatePhase =
+  | "idle"
+  | "checking"
+  | "available"
+  | "installing"
+  | "upToDate"
+  | "error";
+
+/**
+ * Reactive auto-update state. `version` is the available release's version while
+ * {@link UpdateState.phase | phase} is `"available"`, else `null`.
+ *
+ * @internal
+ */
+export interface UpdateState {
+  readonly phase: UpdatePhase;
+  readonly version: string | null;
+}
+
+/**
+ * Host auto-update service for **core** extensions, exposed via the privileged
+ * `@silo-code/extension-host/internal` barrel (not public `@silo-code/sdk`).
+ * Satisfies the {@link @silo-code/sdk!ReactiveService} contract so a status item
+ * can `useServiceState` it. Obtain the singleton with {@link getUpdateService}.
+ *
+ * @internal
+ */
+export interface UpdateService {
+  /** Current state — a stable, frozen snapshot. */
+  getState(): UpdateState;
+  /** Subscribe to state changes (for `useServiceState`). */
+  subscribe(listener: (s: UpdateState) => void): Disposable;
+  /**
+   * Check the configured endpoint for a newer release and update the state.
+   * No-ops (leaving `phase: "idle"`) outside the packaged stable app, so neither
+   * `tauri dev` nor the "Silo Dev" build ever offers to replace itself.
+   */
+  check(): Promise<void>;
+  /**
+   * Download + install the release found by the last {@link UpdateService.check}
+   * and relaunch into it. No-op when no update is pending or an install is
+   * already in flight (guards against a double-click). Moves `phase` to
+   * `"installing"` for the duration; on failure it reverts to `"available"` and
+   * re-throws so the caller can report it (a successful install never returns —
+   * the app relaunches).
+   */
+  installAndRelaunch(): Promise<void>;
+}
+
+const state = proxy<{ phase: UpdatePhase; version: string | null }>({
+  phase: "idle",
+  version: null,
+});
+
+// The Tauri update handle for the currently-available release. Non-serializable,
+// so kept off the valtio proxy (mirrors modal-service's `pending` map).
+let pending: Update | null = null;
+
+// The last check/install error string, kept off the proxy so the interactive
+// menu path can surface the underlying detail (the state machine only needs the
+// `"error"` phase).
+let lastError: string | null = null;
+
+let service: UpdateService | null = null;
+
+/**
+ * Host factory for {@link UpdateService}, re-exported from
+ * `@silo-code/extension-host/internal` for core extensions (`core.updates`).
+ * Returns a shared singleton.
+ *
+ * @internal
+ */
+export function getUpdateService(): UpdateService {
+  if (service) return service;
+  service = {
+    getState: () => snapshot(state),
+    subscribe(listener) {
+      const unsub = subscribe(state, () => listener(snapshot(state)));
+      return { dispose: unsub };
+    },
+    async check() {
+      if (!(await isStableApp())) return;
+      // Don't clobber an in-flight install (a stray re-check shouldn't reopen
+      // the link mid-download).
+      if (state.phase === "installing") return;
+      state.phase = "checking";
+      try {
+        const update = await checkForUpdate();
+        lastError = null;
+        if (update) {
+          pending = update;
+          state.version = update.version;
+          state.phase = "available";
+        } else {
+          pending = null;
+          state.version = null;
+          state.phase = "upToDate";
+        }
+      } catch (err) {
+        lastError = String(err);
+        console.warn("[updater] check failed", err);
+        state.phase = "error";
+      }
+    },
+    async installAndRelaunch() {
+      // Guard re-entry: no pending release, or an install already running.
+      if (!pending || state.phase === "installing") return;
+      state.phase = "installing";
+      try {
+        await installUpdate(pending);
+        // On success the app relaunches into the new version — control never
+        // returns here.
+      } catch (err) {
+        lastError = String(err);
+        console.warn("[updater] install failed", err);
+        // Revert so the link reappears and the user can retry.
+        state.phase = "available";
+        throw err;
+      }
+    },
+  };
+  return service;
+}
+
+/**
+ * Manual "Check for Updates…" — the macOS app-menu item (`menu-items.ts`). Runs
+ * a check through the shared {@link UpdateService} (so a found update also lights
+ * the status-bar link), then always reports via native dialogs: an install
+ * prompt if a release is available, an error (with detail) if the check failed,
+ * else "up to date". In dev / the "Silo Dev" build the check no-ops (`phase`
+ * stays `"idle"`), which is reported as up-to-date so the menu still gives
+ * feedback.
+ *
+ * @internal
+ */
+export async function checkForUpdatesInteractive(): Promise<void> {
+  const svc = getUpdateService();
+  await svc.check();
+  const { phase, version } = svc.getState();
+  if (phase === "available") {
+    const ok = await ask(
+      `Silo ${version} is available.\n\nInstall it and restart now?`,
+      { title: "Update available", kind: "info" },
+    );
+    if (ok) await svc.installAndRelaunch();
+  } else if (phase === "error") {
+    const detail = lastError ? `\n\n${lastError}` : "";
+    await message(`Couldn't check for updates.${detail}`, {
+      title: "Silo",
+      kind: "error",
+    });
+  } else {
+    // "upToDate", or "idle" in dev / non-stable builds.
+    await message("You're on the latest version.", { title: "Silo" });
+  }
+}

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -34,7 +34,6 @@ export { userConfigDir } from "./services/user-config";
 export { activateExtensions } from "./extension-host/host";
 export { getExtensionManager } from "./extension-host/extension-manager";
 export { initUserKeybindings } from "./extension-host/keymap";
-export { checkForUpdatesOnLaunch } from "./services/updater";
 
 // --- Host services the automation bridge drives directly --------------------
 export { getThemeService } from "./extension-host/theme-service";

--- a/packages/extension-host/src/services/updater.ts
+++ b/packages/extension-host/src/services/updater.ts
@@ -1,16 +1,23 @@
-// Host-side auto-updater glue. This is app-shell infrastructure (not an
-// extension): it talks to the Tauri updater + process plugins directly. The
-// launch check is gated to the *stable* bundle identifier so the side-by-side
-// "Silo Dev" build (com.silo.app.dev) never tries to replace itself.
+// Host-side auto-updater seam — thin, stateless wrappers over the Tauri updater
+// + process plugins. The reactive `UpdateService`
+// (extension-host/update-service.ts) and the `core.updates` extension layer
+// policy, state, and UI on top of these. The stable-app gate keeps the
+// side-by-side "Silo Dev" build (com.silo.app.dev) and `tauri dev` from ever
+// trying to replace themselves.
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { ask, message } from "@tauri-apps/plugin-dialog";
 import { getIdentifier } from "@tauri-apps/api/app";
+
+/**
+ * The Tauri update handle, re-exported so host modules can hold one without
+ * importing the plugin directly.
+ */
+export type { Update };
 
 const STABLE_IDENTIFIER = "com.silo.desktop";
 
-/** True only for the packaged stable app — never the `tauri dev` dev build. */
-async function isStableApp(): Promise<boolean> {
+/** True only for the packaged stable app — never `tauri dev` or the "Silo Dev" build. */
+export async function isStableApp(): Promise<boolean> {
   if (import.meta.env.DEV) return false;
   try {
     return (await getIdentifier()) === STABLE_IDENTIFIER;
@@ -19,48 +26,13 @@ async function isStableApp(): Promise<boolean> {
   }
 }
 
-async function promptAndApply(update: Update): Promise<void> {
-  const ok = await ask(
-    `Silo ${update.version} is available.\n\nInstall it and restart now?`,
-    { title: "Update available", kind: "info" },
-  );
-  if (!ok) return;
+/** Ask the configured endpoint whether a newer release exists (`null` if up to date). */
+export function checkForUpdate(): Promise<Update | null> {
+  return check();
+}
+
+/** Download + install the given update, then restart into the new version. */
+export async function installUpdate(update: Update): Promise<void> {
   await update.downloadAndInstall();
   await relaunch();
-}
-
-/**
- * Manual "Check for Updates…" — always reports a result (up-to-date, error, or
- * an install prompt). Safe to call from any build.
- */
-export async function checkForUpdatesInteractive(): Promise<void> {
-  let update: Update | null = null;
-  try {
-    update = await check();
-  } catch (err) {
-    await message(`Couldn't check for updates.\n\n${String(err)}`, {
-      title: "Silo",
-      kind: "error",
-    });
-    return;
-  }
-  if (!update) {
-    await message("You're on the latest version.", { title: "Silo" });
-    return;
-  }
-  await promptAndApply(update);
-}
-
-/**
- * Silent check on launch. No-ops in dev and in the "Silo Dev" build; only the
- * installed stable app reaches out, and only prompts if an update exists.
- */
-export async function checkForUpdatesOnLaunch(): Promise<void> {
-  if (!(await isStableApp())) return;
-  try {
-    const update = await check();
-    if (update) await promptAndApply(update);
-  } catch (err) {
-    console.warn("[updater] launch check failed", err);
-  }
 }

--- a/packages/extensions-core/src/index.ts
+++ b/packages/extensions-core/src/index.ts
@@ -17,3 +17,4 @@ export { extension as about } from "./about";
 export { extension as extensions } from "./extensions";
 export { extension as panelToggles } from "./panel-toggles";
 export { extension as settingsButton } from "./settings-button";
+export { extension as updates } from "./updates";

--- a/packages/extensions-core/src/updates/UpdatePrompt.tsx
+++ b/packages/extensions-core/src/updates/UpdatePrompt.tsx
@@ -1,0 +1,37 @@
+import { buildUpdateLead } from "./model";
+
+/**
+ * The pre-install prompt, rendered as the content of `ctx.ui.showModal` (the
+ * host owns the card chrome). A dedicated layout — not `ctx.ui.confirm` — so the
+ * "save your work" warning can stand on its own line and be emphasized, and the
+ * sentences get real paragraph spacing. `onLater` / `onInstall` settle the modal.
+ */
+export function UpdatePrompt({
+  version,
+  onLater,
+  onInstall,
+}: {
+  version: string | null;
+  onLater: () => void;
+  onInstall: () => void;
+}) {
+  return (
+    <div className="update-prompt">
+      <div className="update-prompt-title">Update Silo?</div>
+      <div className="update-prompt-body">
+        <p>{buildUpdateLead(version)}</p>
+        <p className="update-prompt-warn">
+          Save your work first — Silo will close and restart to finish updating.
+        </p>
+      </div>
+      <div className="update-prompt-actions">
+        <button className="silo-button" onClick={onLater}>
+          Later
+        </button>
+        <button className="silo-button-primary" onClick={onInstall}>
+          Install &amp; Restart
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-core/src/updates/index.tsx
+++ b/packages/extensions-core/src/updates/index.tsx
@@ -1,0 +1,117 @@
+// `core.updates` — surfaces Silo's auto-updater in the status bar. When a new
+// release is available it shows a small "Update" link; clicking it warns the
+// user to save work, then installs and restarts. Checks run in the background
+// (on activation + on a long interval), gated to the packaged stable app inside
+// the host's UpdateService — so this is inert in `pnpm dev` and the "Silo Dev"
+// build.
+//
+// Like `core.about`, this is a core extension: it reaches the host-owned update
+// capability through the privileged `@silo-code/extension-host/internal` barrel
+// (self-updating a binary is not a public-SDK capability), and touches the
+// running app only through `ctx`.
+
+import type { Extension } from "@silo-code/sdk";
+import { useServiceState } from "@silo-code/sdk";
+import { getUpdateService } from "@silo-code/extension-host/internal";
+import { updateLinkLabel, isUpdateActionable } from "./model";
+import { UpdatePrompt } from "./UpdatePrompt";
+import "./updates.css";
+
+const updates = getUpdateService();
+
+// Re-check cadence for long-running sessions, so a window left open for days
+// still notices a release without a restart.
+const RECHECK_INTERVAL_MS = 3 * 60 * 60 * 1000;
+
+export const extension: Extension = {
+  id: "core.updates",
+  activate(ctx) {
+    // The component closes over `ctx`; identity is stable (activate runs once).
+    function UpdateLink() {
+      const snap = useServiceState(updates);
+      const label = updateLinkLabel(snap.phase);
+      if (!label) return null;
+      const actionable = isUpdateActionable(snap.phase);
+
+      async function promptAndInstall(): Promise<void> {
+        const ok = await ctx.ui.showModal<boolean>(
+          (close) => (
+            <UpdatePrompt
+              version={snap.version}
+              onLater={() => close(false)}
+              onInstall={() => close(true)}
+            />
+          ),
+          { size: "sm", dismissible: true, ariaLabel: "Update Silo" },
+        );
+        if (!ok) return;
+        try {
+          await updates.installAndRelaunch();
+        } catch {
+          // The service reverts to "available" so the link returns for a retry;
+          // tell the user the install didn't take (it otherwise relaunches).
+          ctx.ui.notify(
+            "error",
+            "Couldn't install the update. Please try again.",
+          );
+        }
+      }
+
+      // Wrapped so the nested `.update-status .update-link` selector outweighs
+      // the host's `.status-bar button { color }` rule — letting the link keep
+      // the accent color instead of the muted status-bar text color. While the
+      // install is in flight the button is disabled (shows "Installing…"), which
+      // — together with the service's re-entry guard — prevents a double install.
+      return (
+        <span className="update-status">
+          <button
+            className="update-link"
+            title={
+              actionable
+                ? "A new version of Silo is available"
+                : "Installing the update…"
+            }
+            disabled={!actionable}
+            onClick={() => void promptAndInstall()}
+          >
+            {label}
+          </button>
+        </span>
+      );
+    }
+
+    ctx.registerStatusItem({
+      id: "updates",
+      alignment: "right",
+      // Leftmost of the right cluster (theme picker is -10) so the rare link
+      // reads as prominent.
+      priority: -20,
+      component: UpdateLink,
+    });
+
+    // User-invoked check (palette / future menu): reports the outcome via a
+    // toast, where the background check stays silent.
+    ctx.registerCommand({
+      id: "core.updates.check",
+      label: "Check for Updates",
+      run: () => {
+        void (async () => {
+          await updates.check();
+          const { phase, version } = updates.getState();
+          if (phase === "available") {
+            ctx.ui.notify("info", `Silo ${version} is available.`);
+          } else if (phase === "upToDate") {
+            ctx.ui.notify("info", "You're on the latest version.");
+          } else if (phase === "error") {
+            ctx.ui.notify("error", "Couldn't check for updates.");
+          }
+        })();
+      },
+    });
+
+    // Background checks: once shortly after activation, then on a long interval.
+    void updates.check();
+    const timer = setInterval(() => void updates.check(), RECHECK_INTERVAL_MS);
+    ctx.subscriptions.push({ dispose: () => clearInterval(timer) });
+  },
+};

--- a/packages/extensions-core/src/updates/model.test.ts
+++ b/packages/extensions-core/src/updates/model.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import type { UpdatePhase } from "@silo-code/extension-host/internal";
+import { updateLinkLabel, isUpdateActionable, buildUpdateLead } from "./model";
+
+describe("updateLinkLabel", () => {
+  it("shows the actionable link when an update is available", () => {
+    expect(updateLinkLabel("available")).toBe("Update Silo");
+    expect(isUpdateActionable("available")).toBe(true);
+  });
+
+  it("shows a disabled 'Installing…' label while installing", () => {
+    expect(updateLinkLabel("installing")).toBe("Installing…");
+    expect(isUpdateActionable("installing")).toBe(false);
+  });
+
+  it("renders nothing (and is not actionable) for every other phase", () => {
+    const hidden: UpdatePhase[] = ["idle", "checking", "upToDate", "error"];
+    for (const phase of hidden) {
+      expect(updateLinkLabel(phase)).toBeNull();
+      expect(isUpdateActionable(phase)).toBe(false);
+    }
+  });
+});
+
+describe("buildUpdateLead", () => {
+  it("names the version when known", () => {
+    expect(buildUpdateLead("1.2.3")).toBe("Silo 1.2.3 is ready to install.");
+  });
+
+  it("falls back to a generic phrase when the version is unknown", () => {
+    expect(buildUpdateLead(null)).toBe(
+      "A new version of Silo is ready to install.",
+    );
+  });
+});

--- a/packages/extensions-core/src/updates/model.ts
+++ b/packages/extensions-core/src/updates/model.ts
@@ -1,0 +1,32 @@
+// Pure, unit-testable rules for the `core.updates` status-bar indicator,
+// extracted from index.tsx so the component stays thin glue (cf.
+// view-switcher-model.ts). No React, no `ctx`.
+
+import type { UpdatePhase } from "@silo-code/extension-host/internal";
+
+/**
+ * Label for the status-bar indicator, or `null` when it should render nothing.
+ * It's visible only once a release is waiting (`available`) and while that
+ * release is installing (`installing`, shown disabled); every other phase
+ * (idle / checking / up-to-date / error) stays invisible.
+ */
+export function updateLinkLabel(phase: UpdatePhase): string | null {
+  if (phase === "available") return "Update Silo";
+  if (phase === "installing") return "Installing…";
+  return null;
+}
+
+/** Whether the indicator is the actionable "Update Silo" link (vs. disabled "Installing…"). */
+export function isUpdateActionable(phase: UpdatePhase): boolean {
+  return phase === "available";
+}
+
+/**
+ * Lead sentence for the pre-install prompt — names the release when known, else
+ * a generic fallback. The "save your work" warning is rendered separately (and
+ * emphasized) by the prompt component, so it isn't part of this string.
+ */
+export function buildUpdateLead(version: string | null): string {
+  const release = version ? `Silo ${version}` : "A new version of Silo";
+  return `${release} is ready to install.`;
+}

--- a/packages/extensions-core/src/updates/updates.css
+++ b/packages/extensions-core/src/updates/updates.css
@@ -1,0 +1,64 @@
+/* Always-on link look: accent color + underline at rest. The hover surface is
+   the host's shared `.status-bar button:hover` background — the only thing hover
+   changes. The nested selector outweighs `.status-bar button { color }` so the
+   accent color wins (the host otherwise forces the muted status-bar text color). */
+/* Pre-install prompt content (rendered inside the host modal card via
+   ctx.ui.showModal). Own classes for layout/text + the host `silo-button*`
+   classes for the buttons, mirroring PermissionConsent. */
+.update-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.update-prompt-title {
+  font-weight: 600;
+  font-size: var(--silo-font-size-base);
+  color: var(--silo-color-text-hi);
+}
+.update-prompt-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text);
+  line-height: 1.55;
+}
+.update-prompt-body p {
+  margin: 0;
+}
+.update-prompt-warn {
+  font-weight: 600;
+  color: var(--silo-color-text-hi);
+}
+.update-prompt-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.update-status .update-link {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  border: none;
+  padding: 0 6px;
+  border-radius: var(--silo-radius-sm);
+  cursor: pointer;
+  font: inherit;
+}
+
+/* Actionable "Update Silo": accent link look. The nested selector out-specifies
+   the host's `.status-bar button { color }` so the accent color wins. */
+.update-status .update-link:not(:disabled) {
+  color: var(--silo-color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* In-flight install ("Installing…"): non-interactive, and deliberately styles no
+   color/decoration so it falls through to the host's normal status-bar text
+   color — matching the other status-bar items. */
+.update-status .update-link:disabled {
+  cursor: default;
+}


### PR DESCRIPTION
## What

Surfaces Silo's (already-configured) Tauri auto-updater in the UI. A new bundled **`core.updates`** extension shows an accent **"Update Silo"** link in the status bar when a release is available; clicking it opens an in-app prompt — warning the user to save work — and then installs and relaunches.

Before this, updates were only reachable via the macOS **"Check for Updates…"** menu item and a silent launch check that popped a native modal; there was no persistent, non-intrusive indicator.

## How

- **New host-internal reactive `UpdateService`** (`extension-host/update-service.ts`), exposed on the privileged `@silo-code/extension-host/internal` barrel — modeled on `getAppService` for `core.about` (self-updating a binary is a host/platform capability, not public-SDK surface). It's a valtio-backed state machine (`idle → checking → available → installing → upToDate / error`) satisfying the `ReactiveService` contract so the status item can `useServiceState` it.
  - `installAndRelaunch()` guards against a double-click (no-op if already `installing`) and, on failure, reverts to `available` and re-throws so the caller can report it.
- **`services/updater.ts` reduced to a stateless Tauri seam** (`isStableApp` / `checkForUpdate` / `installUpdate`). The launch check moved out of `main.tsx` into the extension's activation (on launch + a 3 h re-check). The "Check for Updates…" menu now routes through the shared service and still reports up-to-date / error (with detail) natively.
- **`core.updates` extension** (`extensions-core/src/updates/`): the status item (disabled **"Installing…"** in the normal status-bar color during install), a custom `ctx.ui.showModal` install prompt so the save-work warning stands out, a `core.updates.check` command, and the background checks. Wired into `builtins.ts`.

## Tests

- `update-service.test.ts` — state transitions, stable-app gating, the install re-entry guard, error revert + re-throw, and interactive-menu reporting (up-to-date / error-with-detail / install prompt).
- `updates/model.test.ts` — the pure status-item helpers (`updateLinkLabel` / `isUpdateActionable`) and the prompt lead-sentence builder.

## Verification

`pnpm test` (all packages green), `pnpm lint` (boundary + design-token CSS gates), and `pnpm --filter silo exec tsc --noEmit` all pass. The real install flow only runs in a packaged stable build; it was smoke-tested in dev by temporarily faking the Tauri seam (removed before this commit).

## Notes

- Internal-barrel only, so no public `apps/docs/api` page / `pnpm docs:api` is required.
- Incidental: `Cargo.lock` syncs the `silo` crate `0.1.0 → 0.2.0` (matching `tauri.conf.json` / `package.json`), picked up by a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)