### PR TITLE
ci(release-please): guard fromJSON against an empty pr output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,7 +68,11 @@ jobs:
       - name: sync Cargo.lock on the release PR
         if: ${{ steps.release.outputs.pr }}
         env:
-          BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          # Short-circuit: GitHub evaluates this `env` expression eagerly (even
+          # though the step's `if` is false when there's no open release PR), and
+          # `fromJSON("")` hard-errors ("Error reading JToken ... Path ''"). The
+          # `&&` skips fromJSON entirely when `pr` is empty.
+          BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName }}
         run: |
           set -euo pipefail
           git fetch origin "$BRANCH"


### PR DESCRIPTION
## Problem

The `release-please` workflow job fails (e.g. [run 27419112502](https://github.com/silo-code/silo/actions/runs/27419112502)) whenever release-please leaves **no open release PR** — such as the run that finalizes a release (`✔ No commits for path: ., skipping`).

The release itself succeeds (it tagged `silo-v0.3.0`); the job then dies at the `sync Cargo.lock on the release PR` step:

```
.github/workflows/release-please.yml (Line: 71, Col: 19):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

## Cause

That line is:

```yaml
env:
  BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
```

The step is gated with `if: ${{ steps.release.outputs.pr }}`, but GitHub evaluates step **`env:` expressions eagerly**, even when the `if` is false. When there's no open PR, `steps.release.outputs.pr` is `""` and **`fromJSON("")` hard-errors** — that's the "JToken / Path ''" message — failing the job.

## Fix

Short-circuit so `fromJSON` is only called when `pr` is non-empty:

```yaml
BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName }}
```

When `pr` is empty the `&&` resolves to `""` and `fromJSON` is never invoked; when it's real PR JSON, behavior is unchanged. The existing `if:` guards stay as-is.

One-line change to the workflow only — no code/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)