### PR TITLE
feat(git): Git panel branch management + keyboard tab navigation

### DIFF
--- a/packages/extensions-silo/src/git-explorer/BranchManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/BranchManager.tsx
@@ -1,0 +1,401 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowsClockwise,
+  Cloud,
+  CloudArrowUp,
+  GitBranch as GitBranchIcon,
+  PencilSimple,
+  Plus,
+  Trash,
+} from "@phosphor-icons/react";
+import type { ExtensionContext } from "@silo-code/sdk";
+import type { GitBranch, GitLogEntry } from "../git/git-api";
+import { getGitApi } from "./git-runtime";
+import {
+  filterBranches,
+  isPublished,
+  localNameFor,
+  orderBranches,
+  remoteBranchNames,
+} from "./branch-model";
+import { ForceDeleteDialog } from "./ForceDeleteDialog";
+import { BranchNameDialog } from "./BranchNameDialog";
+import { ICON_PUSH } from "./git-icons";
+
+export interface BranchManagerProps {
+  ctx: ExtensionContext;
+  /** The repo working directory whose branches are managed. */
+  folder: string;
+  /** Close the host modal. */
+  close: () => void;
+  /** Called after a switch/create so the panel re-reads status. */
+  onSwitched: () => void;
+  /** Surface a git failure as a toast (reuses the view's helper). */
+  notifyError: (title: string, err: unknown) => void;
+}
+
+/**
+ * Content of the branch manager modal (`ctx.ui.showModal`). A searchable list of
+ * local + remote branches with inline actions: click a row to switch (or check
+ * out a remote as a new local tracking branch), hover a local branch for rename
+ * / delete, and create a new branch from the input at the top. The host owns the
+ * surrounding modal chrome.
+ */
+export function BranchManager({
+  ctx,
+  folder,
+  close,
+  onSwitched,
+  notifyError,
+}: BranchManagerProps) {
+  const [branches, setBranches] = useState<GitBranch[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [fetching, setFetching] = useState(false);
+  const [pushing, setPushing] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  const reload = useCallback(async () => {
+    const api = getGitApi();
+    if (!api) {
+      notifyError("Branches", "Git provider (silo.git) unavailable.");
+      return;
+    }
+    try {
+      setBranches(await api.branches(folder));
+    } catch (err) {
+      notifyError("Listing branches failed", err);
+    }
+  }, [folder, notifyError]);
+
+  useEffect(() => {
+    void reload();
+    searchRef.current?.focus();
+  }, [reload]);
+
+  const visible = useMemo(
+    () => orderBranches(filterBranches(branches ?? [], query)),
+    [branches, query],
+  );
+  // Remote-tracking refs that actually exist — used to tell a published branch
+  // (plain push) from one whose upstream is gone/never-pushed (publish).
+  const remoteNames = useMemo(
+    () => remoteBranchNames(branches ?? []),
+    [branches],
+  );
+
+  // The live provider, or a notify + null so handlers can bail gracefully.
+  function api() {
+    const a = getGitApi();
+    if (!a) notifyError("Branches", "Git provider (silo.git) unavailable.");
+    return a;
+  }
+
+  // Push a local branch. With no upstream this is a first push that publishes
+  // the branch and sets tracking (`-u`); otherwise it pushes to its upstream's
+  // remote (defaulting to origin).
+  async function pushBranch(b: GitBranch) {
+    const a = api();
+    if (!a || pushing) return;
+    setPushing(b.name);
+    try {
+      const published = isPublished(b, remoteNames);
+      const remote = b.upstream ? b.upstream.split("/")[0] : "origin";
+      await a.push(folder, {
+        branch: b.name,
+        remote,
+        // Re-establish tracking when the branch isn't actually published (never
+        // pushed, or its remote branch was deleted) so it republishes cleanly.
+        setUpstream: !published,
+      });
+      ctx.ui.notify("info", `Pushed ${b.name}`);
+      await reload();
+    } catch (err) {
+      notifyError(`Push "${b.name}" failed`, err);
+    } finally {
+      setPushing(null);
+    }
+  }
+
+  // Fetch + prune: reconciles the list with the remote, dropping stale
+  // remote-tracking branches (deleted upstream) that would otherwise linger.
+  async function runFetch() {
+    const a = api();
+    if (!a || fetching) return;
+    setFetching(true);
+    try {
+      await a.fetch(folder, true);
+      await reload();
+    } catch (err) {
+      notifyError("Fetch failed", err);
+    } finally {
+      setFetching(false);
+    }
+  }
+
+  // Prompt for a branch name via a custom dialog (no autocapitalize/autocorrect,
+  // unlike ctx.ui.prompt). Resolves the trimmed name, or undefined if cancelled.
+  function promptName(opts: {
+    title: string;
+    label?: string;
+    initialValue?: string;
+    placeholder?: string;
+    confirmLabel: string;
+  }) {
+    return ctx.ui.showModal<string>(
+      (close) => (
+        <BranchNameDialog
+          label={opts.label}
+          initialValue={opts.initialValue}
+          placeholder={opts.placeholder}
+          confirmLabel={opts.confirmLabel}
+          close={close}
+        />
+      ),
+      { title: opts.title, dismissible: true, size: "sm" },
+    );
+  }
+
+  async function create() {
+    const name = await promptName({
+      title: "Create branch",
+      label: "New branch name",
+      placeholder: "feature/my-branch",
+      confirmLabel: "Create",
+    });
+    const a = api();
+    if (!name || !a || busy) return;
+    setBusy(true);
+    try {
+      await a.createBranch(folder, name);
+      onSwitched();
+      close();
+    } catch (err) {
+      notifyError(`Create "${name}" failed`, err);
+      setBusy(false);
+    }
+  }
+
+  async function switchTo(b: GitBranch) {
+    const a = api();
+    if (b.current || !a || busy) return;
+    setBusy(true);
+    try {
+      if (b.remote) await a.createBranch(folder, localNameFor(b.name), b.name);
+      else await a.switchBranch(folder, b.name);
+      onSwitched();
+      close();
+    } catch (err) {
+      notifyError(`Switch to "${b.name}" failed`, err);
+      setBusy(false);
+    }
+  }
+
+  async function rename(b: GitBranch) {
+    const next = await promptName({
+      title: "Rename branch",
+      label: `New name for "${b.name}"`,
+      initialValue: b.name,
+      confirmLabel: "Rename",
+    });
+    const a = api();
+    if (!next || !a) return;
+    const trimmed = next.trim();
+    if (!trimmed || trimmed === b.name) return;
+    try {
+      await a.renameBranch(folder, b.name, trimmed);
+      if (b.current) onSwitched();
+      await reload();
+    } catch (err) {
+      notifyError(`Rename "${b.name}" failed`, err);
+    }
+  }
+
+  // The force-delete modal — lists the commits at risk (a plain confirm body
+  // would crunch them onto one line). Resolves true if the user confirms.
+  function confirmForceDelete(b: GitBranch, commits: GitLogEntry[]) {
+    return ctx.ui
+      .showModal<boolean>(
+        (close) => (
+          <ForceDeleteDialog
+            branchName={b.name}
+            upstream={b.upstream}
+            commits={commits}
+            close={close}
+          />
+        ),
+        { title: `Force-delete "${b.name}"?`, dismissible: true, size: "lg" },
+      )
+      .then((r) => r === true);
+  }
+
+  async function del(b: GitBranch) {
+    const a = api();
+    if (!a) return;
+
+    // Detect up front whether the branch is fully merged. If not, the same
+    // commits `git branch -d` would refuse to discard become a preview in a
+    // single force-delete confirmation — no second dialog. Merged → a simple
+    // confirm.
+    let unmerged: GitLogEntry[] = [];
+    try {
+      unmerged = await a.unmergedCommits(folder, b.name, b.upstream);
+    } catch {
+      // Couldn't compute the range — fall back to a plain delete; the safety
+      // net below still catches git's own `-d` refusal.
+    }
+    const force = unmerged.length > 0;
+    const confirmed = force
+      ? await confirmForceDelete(b, unmerged)
+      : await ctx.ui.confirm({
+          title: `Delete branch "${b.name}"?`,
+          confirmLabel: "Delete",
+          danger: true,
+        });
+    if (!confirmed) return;
+
+    try {
+      await a.deleteBranch(folder, b.name, force);
+      await reload();
+    } catch (err) {
+      // Safety net: if a plain `-d` still trips git's "not fully merged" guard
+      // (a merge-rule edge our check missed), offer the force-delete modal
+      // rather than surfacing the raw error.
+      if (!force && /not fully merged/i.test(String(err))) {
+        let commits: GitLogEntry[] = [];
+        try {
+          commits = await a.unmergedCommits(folder, b.name, b.upstream);
+        } catch {
+          // The dialog handles an empty list.
+        }
+        if (!(await confirmForceDelete(b, commits))) return;
+        try {
+          await a.deleteBranch(folder, b.name, true);
+          await reload();
+        } catch (forceErr) {
+          notifyError(`Delete "${b.name}" failed`, forceErr);
+        }
+        return;
+      }
+      notifyError(`Delete "${b.name}" failed`, err);
+    }
+  }
+
+  return (
+    <div className="git-branch-modal">
+      <input
+        ref={searchRef}
+        className="git-branch-search"
+        placeholder="Filter branches…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        spellCheck={false}
+      />
+
+      <div className="git-branch-list">
+        {branches === null && (
+          <div className="git-branch-loader">
+            <ArrowsClockwise size={22} className="git-branch-spin" />
+            <span>Loading branches…</span>
+          </div>
+        )}
+        {branches !== null && visible.length === 0 && (
+          <div className="git-branch-empty">No matching branches.</div>
+        )}
+        {(branches ?? []).length > 0 &&
+          visible.map((b) => (
+            <div
+              key={(b.remote ? "r:" : "l:") + b.name}
+              className={`git-branch-row${b.current ? " current" : ""}`}
+              role="button"
+              tabIndex={0}
+              title={b.current ? "Current branch" : `Switch to ${b.name}`}
+              onClick={() => void switchTo(b)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  void switchTo(b);
+                }
+              }}
+            >
+              <span className="git-branch-glyph">
+                {b.remote ? <Cloud size={15} /> : <GitBranchIcon size={15} />}
+              </span>
+              <span className="git-branch-name">{b.name}</span>
+              {b.current && <span className="git-branch-badge">current</span>}
+              {!b.remote && (
+                <span
+                  className="git-branch-actions"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    type="button"
+                    className={`git-branch-action${pushing === b.name ? " working" : ""}`}
+                    title={
+                      isPublished(b, remoteNames)
+                        ? `Push ${b.name}`
+                        : `Publish ${b.name}`
+                    }
+                    disabled={pushing === b.name}
+                    onClick={() => void pushBranch(b)}
+                  >
+                    {isPublished(b, remoteNames) ? (
+                      ICON_PUSH
+                    ) : (
+                      <CloudArrowUp size={16} />
+                    )}
+                  </button>
+                  {!b.current && (
+                    <>
+                      <button
+                        type="button"
+                        className="git-branch-action"
+                        title="Rename branch"
+                        onClick={() => void rename(b)}
+                      >
+                        <PencilSimple size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        className="git-branch-action danger"
+                        title="Delete branch"
+                        onClick={() => void del(b)}
+                      >
+                        <Trash size={14} />
+                      </button>
+                    </>
+                  )}
+                </span>
+              )}
+            </div>
+          ))}
+      </div>
+
+      <div className="git-branch-footer">
+        <button
+          type="button"
+          className="silo-button-primary"
+          onClick={() => void create()}
+          disabled={busy}
+        >
+          <Plus size={14} weight="bold" /> Create branch
+        </button>
+        <button
+          type="button"
+          className="silo-button"
+          onClick={() => void runFetch()}
+          disabled={fetching}
+        >
+          <ArrowsClockwise
+            size={15}
+            className={fetching ? "git-branch-spin" : undefined}
+          />{" "}
+          Fetch
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/BranchNameDialog.tsx
+++ b/packages/extensions-silo/src/git-explorer/BranchNameDialog.tsx
@@ -1,0 +1,72 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+export interface BranchNameDialogProps {
+  /** Optional label above the input. */
+  label?: string;
+  /** Pre-fills the input (selected on open) — used by rename. */
+  initialValue?: string;
+  /** Placeholder shown when empty. */
+  placeholder?: string;
+  /** Confirm button label, e.g. "Create" / "Rename". */
+  confirmLabel: string;
+  /** Resolve the host modal with the entered name, or `undefined` to cancel. */
+  close: (name?: string) => void;
+}
+
+/**
+ * A single-line branch-name input rendered as `ctx.ui.showModal` content, used
+ * for both create and rename. Unlike `ctx.ui.prompt`, its input opts out of
+ * autocapitalize / autocorrect / spellcheck — branch names are literal text.
+ * The host owns the surrounding modal chrome and title.
+ */
+export function BranchNameDialog({
+  label,
+  initialValue,
+  placeholder,
+  confirmLabel,
+  close,
+}: BranchNameDialogProps) {
+  const [name, setName] = useState(initialValue ?? "");
+  const ref = useRef<HTMLInputElement | null>(null);
+
+  useLayoutEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+
+  const trimmed = name.trim();
+  return (
+    <form
+      className="silo-modal-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (trimmed) close(trimmed);
+      }}
+    >
+      {label && <label className="silo-modal-label">{label}</label>}
+      <input
+        ref={ref}
+        className="silo-modal-input"
+        value={name}
+        placeholder={placeholder}
+        onChange={(e) => setName(e.target.value)}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <div className="silo-modal-actions">
+        <button type="button" className="silo-button" onClick={() => close()}>
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="silo-button-primary"
+          disabled={!trimmed}
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/ForceDeleteDialog.tsx
+++ b/packages/extensions-silo/src/git-explorer/ForceDeleteDialog.tsx
@@ -1,0 +1,73 @@
+import type { GitLogEntry } from "../git/git-api";
+
+export interface ForceDeleteDialogProps {
+  branchName: string;
+  /** Where the commits are missing from — the branch's upstream, or HEAD. */
+  upstream: string | null | undefined;
+  /** The unmerged commits that a force-delete would discard (most recent first). */
+  commits: GitLogEntry[];
+  /** Settle the host modal: `true` to force-delete, `false`/dismiss to cancel. */
+  close: (confirmed?: boolean) => void;
+}
+
+/**
+ * Content of the force-delete confirmation (`ctx.ui.showModal`). Unlike
+ * `ctx.ui.confirm` (a single plain-text line), this lays the unmerged commits
+ * out as a scrollable list so the work at risk is legible. The host owns the
+ * surrounding modal chrome and title.
+ */
+export function ForceDeleteDialog({
+  branchName,
+  upstream,
+  commits,
+  close,
+}: ForceDeleteDialogProps) {
+  const one = commits.length === 1;
+  const target = upstream ? `"${upstream}"` : "the current branch";
+  return (
+    <div className="git-force-delete">
+      {commits.length === 0 ? (
+        <p className="git-force-delete-lead">
+          <strong>{branchName}</strong> isn&apos;t fully merged and may have
+          commits that aren&apos;t reachable from any other branch.
+          Force-deleting it could <strong>permanently discard</strong> that
+          work.
+        </p>
+      ) : (
+        <>
+          <p className="git-force-delete-lead">
+            {one ? "1 commit" : `${commits.length} commits`} on{" "}
+            <strong>{branchName}</strong> {one ? "isn't" : "aren't"} merged into{" "}
+            {target} and will be <strong>permanently lost</strong>:
+          </p>
+          <ul className="git-force-delete-list">
+            {commits.map((c) => (
+              <li key={c.hash} className="git-force-delete-commit">
+                <code className="git-force-delete-hash">{c.shortHash}</code>
+                <span className="git-force-delete-subject" title={c.subject}>
+                  {c.subject}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      <div className="silo-modal-actions">
+        <button
+          type="button"
+          className="silo-button"
+          onClick={() => close(false)}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="silo-button-danger"
+          onClick={() => close(true)}
+        >
+          Force delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -78,6 +78,32 @@
   font-weight: 600;
   color: var(--silo-color-text-hi);
 }
+/* The clickable branch name (single-root) — a button styled like the text. */
+.git-branch .branch-name-button {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 1px 5px;
+  margin-left: -5px;
+  border-radius: var(--silo-radius-sm);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+.git-branch .branch-name-button:hover {
+  background: var(--silo-color-bg-hover);
+}
+/* The clickable branch name (multi-root). */
+.git-root-branch.clickable {
+  cursor: pointer;
+  padding: 1px 5px;
+  border-radius: var(--silo-radius-sm);
+}
+.git-root-branch.clickable:hover {
+  background: var(--silo-color-bg-hover);
+  color: var(--silo-color-text-hi);
+}
 .git-branch .branch-tracking {
   color: var(--silo-color-text-lo);
 }
@@ -210,6 +236,10 @@
 .commit-area textarea::placeholder {
   color: color-mix(in srgb, var(--silo-color-input-text) 40%, transparent);
 }
+.commit-area textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 .commit-btn {
   display: inline-flex;
   align-items: center;
@@ -240,6 +270,13 @@
   flex-direction: column;
 }
 
+/* While a commit (with its pre-commit hooks) is in flight, dim and disable the
+   file lists so an interaction can't race the locked index. */
+.git-sections.busy {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .section-head {
   display: flex;
   align-items: center;
@@ -260,12 +297,26 @@
   background: var(--silo-color-bg-hover);
   color: var(--silo-color-text-hi);
 }
+/* Bulk-action cluster (stage/unstage/discard all), sitting next to the title
+ * and revealed on hover; the count badge stays pinned to the right edge. */
+.section-actions {
+  display: inline-flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 80ms ease-out;
+}
+.section-head:hover .section-actions {
+  opacity: 1;
+}
 .section-head .section-add {
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
   border: none;
   color: var(--silo-color-text);
+  /* The header text is chrome-sized; bump the em-based icons back up to the
+     base UI size so they don't read as undersized next to the row actions. */
+  font-size: var(--silo-font-size-base);
   width: 24px;
   height: 24px;
   border-radius: var(--silo-radius-sm);
@@ -275,12 +326,6 @@
   padding: 0;
   cursor: pointer;
   flex-shrink: 0;
-  margin-right: -6px;
-  opacity: 0;
-  transition: opacity 80ms ease-out;
-}
-.section-head:hover .section-add {
-  opacity: 1;
 }
 .section-add:hover {
   background: transparent;
@@ -362,16 +407,25 @@
   min-width: 0;
 }
 
+/* Actions are taken out of the flex flow and overlaid on the right edge so the
+ * file name / path can use the full row width. They fade in over the text on
+ * hover, masked by the row's hover background. */
 .row-actions {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   gap: 0;
-  margin-left: auto;
   opacity: 0;
+  pointer-events: none;
+  background: var(--silo-color-bg-hover);
   transition: opacity 100ms ease-out;
 }
 .git-file-row:hover .row-actions {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .row-action {
@@ -422,4 +476,198 @@
  * disappears under the action cluster on hover. */
 .git-file-row:hover .status-glyph {
   display: none;
+}
+
+/* Branch manager modal (ctx.ui.showModal content). */
+.git-branch-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-family: var(--silo-font-ui);
+}
+.git-branch-search {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--silo-color-input-bg);
+  color: var(--silo-color-input-text);
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm);
+  padding: 6px 8px;
+  font: inherit;
+}
+.git-branch-search::placeholder {
+  color: color-mix(in srgb, var(--silo-color-input-text) 40%, transparent);
+}
+.git-branch-list {
+  display: flex;
+  flex-direction: column;
+  /* Fixed height so the modal doesn't resize as branches load or filter. */
+  height: 340px;
+  overflow-y: auto;
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm);
+}
+.git-branch-empty {
+  color: var(--silo-color-text-lo);
+  font-style: italic;
+  padding: 10px 12px;
+}
+.git-branch-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 100%;
+  color: var(--silo-color-text-lo);
+}
+.git-branch-spin {
+  -webkit-animation: branch-spin 0.8s linear infinite;
+  animation: branch-spin 0.8s linear infinite;
+}
+.git-branch-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.git-branch-footer button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.git-branch-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  color: var(--silo-color-text);
+}
+.git-branch-row + .git-branch-row {
+  border-top: 1px solid var(--silo-color-border);
+}
+.git-branch-row:hover {
+  background: var(--silo-color-bg-hover);
+}
+.git-branch-row.current {
+  cursor: default;
+}
+.git-branch-glyph {
+  display: inline-flex;
+  align-items: center;
+  color: var(--silo-color-text-lo);
+  flex-shrink: 0;
+}
+.git-branch-row.current .git-branch-glyph {
+  color: var(--silo-color-accent);
+}
+.git-branch-name {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.git-branch-row.current .git-branch-name {
+  font-weight: 600;
+  color: var(--silo-color-text-hi);
+}
+.git-branch-badge {
+  flex-shrink: 0;
+  font-size: var(--silo-font-size-chrome);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--silo-color-accent);
+  background: color-mix(in srgb, var(--silo-color-accent) 16%, transparent);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+.git-branch-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 100ms ease-out;
+}
+.git-branch-row:hover .git-branch-actions {
+  opacity: 1;
+}
+.git-branch-action {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--silo-color-text-lo);
+  width: 26px;
+  height: 26px;
+  border-radius: var(--silo-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+}
+.git-branch-action:hover {
+  background: var(--silo-color-bg-active);
+  color: var(--silo-color-text-hi);
+}
+.git-branch-action.danger:hover {
+  color: var(--silo-color-err);
+}
+.git-branch-action:disabled {
+  cursor: default;
+}
+.git-branch-action.working {
+  color: var(--silo-color-accent);
+  -webkit-animation: branch-push 0.7s ease-in-out infinite;
+  animation: branch-push 0.7s ease-in-out infinite;
+}
+
+/* Force-delete confirmation (ctx.ui.showModal content) — lists the unmerged
+ * commits as proper rows instead of one crunched line of confirm-body text. */
+.git-force-delete {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: var(--silo-font-ui);
+}
+.git-force-delete-lead {
+  margin: 0;
+  font-size: var(--silo-font-size-sm);
+  line-height: 1.5;
+  color: var(--silo-color-text);
+}
+.git-force-delete-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 40vh;
+  overflow-y: auto;
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm);
+}
+.git-force-delete-commit {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 10px;
+}
+.git-force-delete-commit + .git-force-delete-commit {
+  border-top: 1px solid var(--silo-color-border);
+}
+.git-force-delete-hash {
+  font-family: var(--silo-font-mono);
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+  flex-shrink: 0;
+}
+.git-force-delete-subject {
+  min-width: 0;
+  /* Wrap full commit subjects instead of truncating, so nothing is hidden. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  color: var(--silo-color-text);
 }

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -1,11 +1,23 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { ArrowsClockwise, CaretDown, CaretRight } from "@phosphor-icons/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowsClockwise,
+  CaretDown,
+  CaretRight,
+  CloudArrowUp,
+} from "@phosphor-icons/react";
 import type { ExtensionContext, NotifyOptions } from "@silo-code/sdk";
 import type { GitFileStatus, GitStatus } from "../git/git-api";
 import { getGitApi } from "./git-runtime";
 import { Section, FileRow } from "./git-rows";
-import { ICON_CHECK, ICON_PUSH } from "./git-icons";
+import {
+  ICON_CHECK,
+  ICON_PUSH,
+  ICON_PLUS,
+  ICON_MINUS,
+  ICON_UNDO,
+} from "./git-icons";
 import { summarizeGitError } from "./notify-error";
+import { BranchManager } from "./BranchManager";
 
 const REFRESH_DEBOUNCE_MS = 400;
 const statusCache = new Map<string, GitStatus>();
@@ -37,6 +49,13 @@ export function GitView({
   );
   const [busy, setBusy] = useState(false);
   const [pushing, setPushing] = useState(false);
+  const [committing, setCommitting] = useState(false);
+  // Mirror `committing` into a ref so the file-watch callback (a stable closure)
+  // can skip refreshes while a commit runs — commit() does the final refresh.
+  const committingRef = useRef(false);
+  useEffect(() => {
+    committingRef.current = committing;
+  }, [committing]);
   const [pendingRefresh, setPendingRefresh] = useState(false);
   const [pendingPush, setPendingPush] = useState(false);
   const [stagedOpen, setStagedOpen] = useState(true);
@@ -139,8 +158,10 @@ export function GitView({
         min.then(() => setPushing(false));
         return;
       }
+      // No upstream yet → first push publishes the branch and sets tracking.
+      const opts = status?.upstream ? undefined : { setUpstream: true };
       api
-        .push(folder)
+        .push(folder, opts)
         .then(() => {
           setBusy(true);
           setPendingRefresh(true);
@@ -148,12 +169,15 @@ export function GitView({
         .catch((err) => notifyError("Push failed", err))
         .finally(() => min.then(() => setPushing(false)));
     }, 50);
-  }, [pendingPush, folder, notifyError]);
+  }, [pendingPush, folder, notifyError, status?.upstream]);
 
   useEffect(() => {
     if (paused) return;
     let timer: number | null = null;
     const sub = files.watch(folder, () => {
+      // Don't poll mid-commit — the commit (and its pre-commit hooks) churn
+      // `.git`, and commit() refreshes once when it's done.
+      if (committingRef.current) return;
       if (timer) window.clearTimeout(timer);
       timer = window.setTimeout(refresh, REFRESH_DEBOUNCE_MS);
     });
@@ -207,11 +231,65 @@ export function GitView({
       notifyError("Unstage failed", err);
     }
   }
-  async function revert(file: GitFileStatus) {
-    if (!confirm(`Discard changes to "${file.path}"? This cannot be undone.`))
-      return;
+  async function unstageAll() {
+    const paths = stagedFiles.map((f) => f.path);
+    if (paths.length === 0) return;
     try {
-      await requireGit().revertFile(folder, [file.path]);
+      await requireGit().unstage(folder, paths);
+      refresh();
+    } catch (err) {
+      notifyError("Unstage failed", err);
+    }
+  }
+  // Discard a file's changes. A tracked file is restored to HEAD; an untracked
+  // (new) file has no committed version, so "discard" deletes it. Uses
+  // ctx.ui.confirm — the webview's window.confirm is async, so `if (!confirm())`
+  // never gates and would run the discard unconfirmed.
+  async function revert(file: GitFileStatus) {
+    const untracked = file.isUntracked;
+    const ok = await ctx.ui.confirm({
+      title: untracked
+        ? `Delete "${file.path}"?`
+        : `Discard changes to "${file.path}"?`,
+      body: untracked
+        ? "This file is new and untracked — discarding it deletes it permanently."
+        : "This restores the file to the last commit and can't be undone.",
+      confirmLabel: untracked ? "Delete" : "Discard",
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      if (untracked) await requireGit().clean(folder, [file.path]);
+      else await requireGit().revertFile(folder, [file.path]);
+      refresh();
+    } catch (err) {
+      notifyError("Discard failed", err);
+    }
+  }
+  // Discard every working-tree change at once: tracked files restored to HEAD,
+  // untracked files deleted. Both paths are confirmed by a single dialog.
+  async function revertAll() {
+    const tracked = changedFiles
+      .filter((f) => !f.isUntracked)
+      .map((f) => f.path);
+    const untracked = changedFiles
+      .filter((f) => f.isUntracked)
+      .map((f) => f.path);
+    const total = tracked.length + untracked.length;
+    if (total === 0) return;
+    const ok = await ctx.ui.confirm({
+      title: `Discard all changes to ${total} file${total === 1 ? "" : "s"}?`,
+      body:
+        untracked.length > 0
+          ? "Tracked files are restored to the last commit; untracked files are deleted permanently. This can't be undone."
+          : "This restores the files to the last commit and can't be undone.",
+      confirmLabel: "Discard All",
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      if (tracked.length > 0) await requireGit().revertFile(folder, tracked);
+      if (untracked.length > 0) await requireGit().clean(folder, untracked);
       refresh();
     } catch (err) {
       notifyError("Discard failed", err);
@@ -242,14 +320,38 @@ export function GitView({
     setPendingPush(true);
   }
 
+  // Open the branch manager modal. The host owns the chrome; refresh() re-reads
+  // status after a switch/create so the header reflects the new branch.
+  function openBranchManager() {
+    ctx.ui.showModal(
+      (close) => (
+        <BranchManager
+          ctx={ctx}
+          folder={folder}
+          close={close}
+          onSwitched={refresh}
+          notifyError={notifyError}
+        />
+      ),
+      { title: "Switch branches", size: "lg", dismissible: true },
+    );
+  }
+
   async function commit() {
-    if (!message.trim()) return;
+    if (!message.trim() || committing) return;
+    // Reflect the in-flight commit immediately — pre-commit hooks can take a
+    // while, so disable the inputs and show progress until it resolves.
+    setCommitting(true);
     try {
       await requireGit().commit(folder, message.trim());
       setMessage("");
-      refresh();
     } catch (err) {
       notifyError("Commit failed", err);
+    } finally {
+      setCommitting(false);
+      // Refresh once, after the commit settles — both to show the result and to
+      // catch any working-tree changes a (failed) pre-commit hook left behind.
+      refresh();
     }
   }
 
@@ -265,6 +367,13 @@ export function GitView({
   }
 
   const canCommit = stagedFiles.length > 0 && message.trim().length > 0;
+  // Push is allowed whenever there's a branch (not detached) — including a
+  // branch with no upstream yet, where the first push publishes it.
+  const canPush = !!status?.branch;
+  const pushTitle = status?.upstream ? "Push" : "Publish branch";
+  // A cloud-up glyph marks "publish" (first push, no upstream); the plain
+  // up-arrow is a normal push to an existing remote branch.
+  const pushIcon = status?.upstream ? ICON_PUSH : <CloudArrowUp size={16} />;
 
   return (
     <div className="git-panel">
@@ -281,7 +390,31 @@ export function GitView({
             )}
           </span>
           <span className="git-root-name">{rootLabel.toUpperCase()}</span>
-          <span className="git-root-branch">
+          <span
+            className={`git-root-branch${status?.inRepo ? " clickable" : ""}`}
+            role={status?.inRepo ? "button" : undefined}
+            tabIndex={status?.inRepo ? 0 : undefined}
+            title={status?.inRepo ? "Manage branches" : undefined}
+            onClick={
+              status?.inRepo
+                ? (e) => {
+                    e.stopPropagation();
+                    openBranchManager();
+                  }
+                : undefined
+            }
+            onKeyDown={
+              status?.inRepo
+                ? (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      openBranchManager();
+                    }
+                  }
+                : undefined
+            }
+          >
             {status ? (status.branch ?? "(detached)") : ""}
             {status?.upstream && (
               <span className="branch-tracking">
@@ -302,19 +435,29 @@ export function GitView({
               <ArrowsClockwise size={14} />
             </button>
             <button
-              className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !status?.upstream ? " disabled" : ""}`}
-              title="Push"
-              onClick={pushing || !status?.upstream ? undefined : push}
+              className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !canPush ? " disabled" : ""}`}
+              title={pushTitle}
+              onClick={pushing || !canPush ? undefined : push}
             >
-              {ICON_PUSH}
+              {pushIcon}
             </button>
           </span>
         </button>
       ) : (
         <div className="git-branch">
-          <span className="branch-name">
-            {status ? (status.branch ?? "(detached)") : "Loading…"}
-          </span>
+          {status?.inRepo ? (
+            <button
+              className="branch-name branch-name-button"
+              title="Manage branches"
+              onClick={openBranchManager}
+            >
+              {status.branch ?? "(detached)"}
+            </button>
+          ) : (
+            <span className="branch-name">
+              {status ? (status.branch ?? "(detached)") : "Loading…"}
+            </span>
+          )}
           {status?.upstream && (
             <span className="branch-tracking">
               ↑{status.ahead} ↓{status.behind}
@@ -329,11 +472,11 @@ export function GitView({
             <ArrowsClockwise size={16} />
           </button>
           <button
-            className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !status?.upstream ? " disabled" : ""}`}
-            title="Push"
-            onClick={pushing || !status?.upstream ? undefined : push}
+            className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !canPush ? " disabled" : ""}`}
+            title={pushTitle}
+            onClick={pushing || !canPush ? undefined : push}
           >
-            {ICON_PUSH}
+            {pushIcon}
           </button>
         </div>
       )}
@@ -346,63 +489,102 @@ export function GitView({
               onChange={(e) => setMessage(e.target.value)}
               onKeyDown={onCommitKeyDown}
               rows={2}
+              disabled={committing}
+              autoCapitalize="off"
+              autoCorrect="off"
+              autoComplete="off"
+              spellCheck={false}
             />
             <button
               className="commit-btn silo-button-primary"
-              disabled={!canCommit}
+              disabled={!canCommit || committing}
               onClick={commit}
             >
-              {ICON_CHECK} <span>Commit</span>
-              {stagedFiles.length > 0 && (
+              {committing ? (
+                <ArrowsClockwise size={16} className="git-branch-spin" />
+              ) : (
+                ICON_CHECK
+              )}{" "}
+              <span>{committing ? "Committing…" : "Commit"}</span>
+              {!committing && stagedFiles.length > 0 && (
                 <span className="commit-count">{stagedFiles.length}</span>
               )}
             </button>
           </div>
 
-          {stagedFiles.length > 0 && (
+          {/* Disable file actions while a commit (incl. pre-commit hooks) runs,
+              so an interaction can't race the locked index. */}
+          <div
+            className={`git-sections${committing ? " busy" : ""}`}
+            aria-busy={committing}
+          >
+            {stagedFiles.length > 0 && (
+              <Section
+                title="Staged Changes"
+                count={stagedFiles.length}
+                open={stagedOpen}
+                onToggle={() => setStagedOpen((v) => !v)}
+                actions={[
+                  {
+                    icon: ICON_MINUS,
+                    title: "Unstage all changes",
+                    onClick: () => unstageAll(),
+                  },
+                ]}
+              >
+                {stagedFiles.map((f) => (
+                  <FileRow
+                    key={`s-${f.path}`}
+                    file={f}
+                    folder={folder}
+                    kind="staged"
+                    onRowClick={() => openFileDiff(f, "staged")}
+                    onOpen={() => openFile(f)}
+                    onUnstage={() => unstage(f)}
+                  />
+                ))}
+              </Section>
+            )}
+
             <Section
-              title="Staged Changes"
-              count={stagedFiles.length}
-              open={stagedOpen}
-              onToggle={() => setStagedOpen((v) => !v)}
+              title="Changes"
+              count={changedFiles.length}
+              open={changesOpen}
+              onToggle={() => setChangesOpen((v) => !v)}
+              actions={
+                changedFiles.length > 0
+                  ? [
+                      {
+                        icon: ICON_UNDO,
+                        title: "Discard all changes",
+                        onClick: () => revertAll(),
+                      },
+                      {
+                        icon: ICON_PLUS,
+                        title: "Stage all changes",
+                        onClick: () => stageAll(),
+                      },
+                    ]
+                  : undefined
+              }
             >
-              {stagedFiles.map((f) => (
+              {changedFiles.length === 0 && (
+                <div className="empty">No changes.</div>
+              )}
+              {changedFiles.map((f) => (
                 <FileRow
-                  key={`s-${f.path}`}
+                  key={`c-${f.path}`}
                   file={f}
                   folder={folder}
-                  kind="staged"
-                  onRowClick={() => openFileDiff(f, "staged")}
+                  kind="changes"
+                  onRowClick={() => openFileDiff(f, "workingTree")}
                   onOpen={() => openFile(f)}
-                  onUnstage={() => unstage(f)}
+                  onStage={() => stage(f)}
+                  onRevert={() => revert(f)}
                 />
               ))}
             </Section>
-          )}
-
-          <Section
-            title="Changes"
-            count={changedFiles.length}
-            open={changesOpen}
-            onToggle={() => setChangesOpen((v) => !v)}
-            onAdd={changedFiles.length > 0 ? () => stageAll() : undefined}
-          >
-            {changedFiles.length === 0 && (
-              <div className="empty">No changes.</div>
-            )}
-            {changedFiles.map((f) => (
-              <FileRow
-                key={`c-${f.path}`}
-                file={f}
-                folder={folder}
-                kind="changes"
-                onRowClick={() => openFileDiff(f, "workingTree")}
-                onOpen={() => openFile(f)}
-                onStage={() => stage(f)}
-                onRevert={() => revert(f)}
-              />
-            ))}
-          </Section>
+          </div>
         </>
       )}
     </div>

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -5,10 +5,16 @@ import {
   CaretRight,
   CloudArrowUp,
 } from "@phosphor-icons/react";
-import type { ExtensionContext, NotifyOptions } from "@silo-code/sdk";
+import {
+  useFocusGroup,
+  type ExtensionContext,
+  type FocusGroupItemProps,
+  type NotifyOptions,
+} from "@silo-code/sdk";
 import type { GitFileStatus, GitStatus } from "../git/git-api";
 import { getGitApi } from "./git-runtime";
 import { Section, FileRow } from "./git-rows";
+import { buildGitNavItems, navItemKey } from "./git-nav";
 import {
   ICON_CHECK,
   ICON_PUSH,
@@ -195,6 +201,49 @@ export function GitView({
     () => status?.files.filter((f) => f.isModified && !f.isStaged) ?? [],
     [status],
   );
+
+  // The flat, in-render-order list of keyboard-navigable items (section headers
+  // + file rows) and a key→index map, so each header/row can claim its focus-
+  // group slot. Mirrors the file Tree's flat/indexOfPath pattern.
+  const navItems = useMemo(
+    () =>
+      buildGitNavItems({ stagedFiles, changedFiles, stagedOpen, changesOpen }),
+    [stagedFiles, changedFiles, stagedOpen, changesOpen],
+  );
+  const navIndex = useMemo(() => {
+    const m = new Map<string, number>();
+    navItems.forEach((it, i) => m.set(navItemKey(it), i));
+    return m;
+  }, [navItems]);
+
+  // Roving keyboard focus, the WebKit-safe ring, and the single Tab stop are
+  // owned by useFocusGroup (same as the file Tree): the headers + file rows are
+  // one Tab stop, ↑/↓/Home/End move between them, and Enter/Space toggles a
+  // header or opens a row's diff.
+  const group = useFocusGroup({
+    count: navItems.length,
+    orientation: "vertical",
+    onActivate: (i) => {
+      const it = navItems[i];
+      if (!it) return;
+      if (it.kind === "header") {
+        if (it.section === "staged") setStagedOpen((v) => !v);
+        else setChangesOpen((v) => !v);
+      } else {
+        openFileDiff(
+          it.file,
+          it.section === "staged" ? "staged" : "workingTree",
+        );
+      }
+    },
+  });
+
+  // Focus-group props for the header/row identified by `key`, or undefined when
+  // it isn't a current nav item (e.g. a collapsed section's rows aren't rendered).
+  function focusPropsFor(key: string): FocusGroupItemProps | undefined {
+    const idx = navIndex.get(key);
+    return idx === undefined ? undefined : group.getItemProps(idx);
+  }
 
   // The live git provider, or a thrown error the handlers' catch turns into an
   // error toast — keeps "provider absent" from crashing an action.
@@ -517,6 +566,7 @@ export function GitView({
           <div
             className={`git-sections${committing ? " busy" : ""}`}
             aria-busy={committing}
+            {...group.containerProps}
           >
             {stagedFiles.length > 0 && (
               <Section
@@ -524,6 +574,7 @@ export function GitView({
                 count={stagedFiles.length}
                 open={stagedOpen}
                 onToggle={() => setStagedOpen((v) => !v)}
+                focusProps={focusPropsFor("h:staged")}
                 actions={[
                   {
                     icon: ICON_MINUS,
@@ -541,6 +592,7 @@ export function GitView({
                     onRowClick={() => openFileDiff(f, "staged")}
                     onOpen={() => openFile(f)}
                     onUnstage={() => unstage(f)}
+                    focusProps={focusPropsFor(`r:staged:${f.path}`)}
                   />
                 ))}
               </Section>
@@ -551,6 +603,7 @@ export function GitView({
               count={changedFiles.length}
               open={changesOpen}
               onToggle={() => setChangesOpen((v) => !v)}
+              focusProps={focusPropsFor("h:changes")}
               actions={
                 changedFiles.length > 0
                   ? [
@@ -581,6 +634,7 @@ export function GitView({
                   onOpen={() => openFile(f)}
                   onStage={() => stage(f)}
                   onRevert={() => revert(f)}
+                  focusProps={focusPropsFor(`r:changes:${f.path}`)}
                 />
               ))}
             </Section>

--- a/packages/extensions-silo/src/git-explorer/branch-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/branch-model.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import type { GitBranch } from "../git/git-api";
+import {
+  filterBranches,
+  isPublished,
+  localNameFor,
+  orderBranches,
+  remoteBranchNames,
+} from "./branch-model";
+
+const local = (name: string, current = false): GitBranch => ({
+  name,
+  current,
+  remote: false,
+  upstream: null,
+});
+const remote = (name: string): GitBranch => ({
+  name,
+  current: false,
+  remote: true,
+  upstream: null,
+});
+
+describe("filterBranches", () => {
+  const branches = [local("main"), local("feature"), remote("origin/feature")];
+
+  it("returns all branches for a blank query", () => {
+    expect(filterBranches(branches, "")).toHaveLength(3);
+    expect(filterBranches(branches, "   ")).toHaveLength(3);
+  });
+
+  it("matches case-insensitively on a substring", () => {
+    expect(filterBranches(branches, "FEAT").map((b) => b.name)).toEqual([
+      "feature",
+      "origin/feature",
+    ]);
+  });
+
+  it("returns nothing when no name matches", () => {
+    expect(filterBranches(branches, "nope")).toEqual([]);
+  });
+});
+
+describe("orderBranches", () => {
+  it("puts the current branch first, then locals, then remotes — alphabetical", () => {
+    const ordered = orderBranches([
+      remote("origin/zeta"),
+      local("zeta"),
+      local("alpha"),
+      local("main", true),
+      remote("origin/alpha"),
+    ]);
+    expect(ordered.map((b) => b.name)).toEqual([
+      "main", // current first
+      "alpha", // then locals, alphabetical
+      "zeta",
+      "origin/alpha", // then remotes, alphabetical
+      "origin/zeta",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [local("b"), local("a")];
+    orderBranches(input);
+    expect(input.map((b) => b.name)).toEqual(["b", "a"]);
+  });
+});
+
+describe("localNameFor", () => {
+  it("strips the leading remote segment", () => {
+    expect(localNameFor("origin/feat/x")).toBe("feat/x");
+    expect(localNameFor("upstream/main")).toBe("main");
+  });
+
+  it("returns names without a slash unchanged", () => {
+    expect(localNameFor("main")).toBe("main");
+  });
+});
+
+describe("isPublished / remoteBranchNames", () => {
+  const localWith = (name: string, upstream: string | null): GitBranch => ({
+    name,
+    current: false,
+    remote: false,
+    upstream,
+  });
+  const branches: GitBranch[] = [
+    localWith("main", "origin/main"), // upstream exists remotely
+    localWith("feature", "origin/feature"), // upstream configured but pruned
+    localWith("scratch", null), // never pushed
+    remote("origin/main"),
+  ];
+  const names = remoteBranchNames(branches);
+
+  it("collects only the remote-tracking branch names", () => {
+    expect([...names]).toEqual(["origin/main"]);
+  });
+
+  it("is published only when the upstream ref still exists", () => {
+    expect(isPublished(localWith("main", "origin/main"), names)).toBe(true);
+    // configured upstream, but the remote ref is gone (pruned) → unpublished
+    expect(isPublished(localWith("feature", "origin/feature"), names)).toBe(
+      false,
+    );
+    // never pushed → unpublished
+    expect(isPublished(localWith("scratch", null), names)).toBe(false);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/branch-model.ts
+++ b/packages/extensions-silo/src/git-explorer/branch-model.ts
@@ -1,0 +1,57 @@
+import type { GitBranch } from "../git/git-api";
+
+// Pure presentation logic for the branch manager modal — filtering, ordering,
+// and remote→local name derivation. Extracted from BranchManager.tsx so the
+// rules are unit-testable without rendering React (per the repo's testing
+// convention; see view-switcher-model.ts).
+
+/** Case-insensitive substring filter over branch names. Blank query → all. */
+export function filterBranches(
+  branches: GitBranch[],
+  query: string,
+): GitBranch[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return branches;
+  return branches.filter((b) => b.name.toLowerCase().includes(q));
+}
+
+/**
+ * Order for display: the current branch first, then the remaining local
+ * branches, then remote-tracking branches — each group alphabetical. Stable and
+ * non-mutating (returns a new array).
+ */
+export function orderBranches(branches: GitBranch[]): GitBranch[] {
+  const rank = (b: GitBranch) => (b.current ? 0 : b.remote ? 2 : 1);
+  return [...branches].sort(
+    (a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name),
+  );
+}
+
+/**
+ * The local branch name to create when checking out a remote-tracking branch —
+ * strips the leading `<remote>/` segment (`origin/feat/x` → `feat/x`). Names
+ * without a `/` are returned unchanged.
+ */
+export function localNameFor(remoteBranchName: string): string {
+  const slash = remoteBranchName.indexOf("/");
+  return slash === -1 ? remoteBranchName : remoteBranchName.slice(slash + 1);
+}
+
+/** The set of remote-tracking branch names in a list (e.g. `"origin/main"`). */
+export function remoteBranchNames(branches: GitBranch[]): Set<string> {
+  return new Set(branches.filter((b) => b.remote).map((b) => b.name));
+}
+
+/**
+ * Whether a local branch is **published** — its configured upstream actually
+ * exists as a remote-tracking ref. A configured-but-missing upstream (the remote
+ * branch was deleted/pruned, or never really pushed) counts as unpublished, so
+ * the UI offers "publish" (cloud-up) rather than a plain push. `remoteNames`
+ * comes from {@link remoteBranchNames} over the same branch list.
+ */
+export function isPublished(
+  branch: GitBranch,
+  remoteNames: Set<string>,
+): boolean {
+  return branch.upstream != null && remoteNames.has(branch.upstream);
+}

--- a/packages/extensions-silo/src/git-explorer/git-nav.test.ts
+++ b/packages/extensions-silo/src/git-explorer/git-nav.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import type { GitFileStatus } from "../git/git-api";
+import { buildGitNavItems, navItemKey, type GitNavItem } from "./git-nav";
+
+const file = (path: string): GitFileStatus => ({
+  path,
+  staged: ".",
+  worktree: "M",
+  isStaged: false,
+  isModified: true,
+  isUntracked: false,
+  isRenamed: false,
+});
+
+const keys = (items: GitNavItem[]): string[] => items.map(navItemKey);
+
+describe("buildGitNavItems", () => {
+  const staged = [file("a.ts"), file("b.ts")];
+  const changed = [file("c.ts")];
+
+  it("orders staged header + rows before changes header + rows when both open", () => {
+    const items = buildGitNavItems({
+      stagedFiles: staged,
+      changedFiles: changed,
+      stagedOpen: true,
+      changesOpen: true,
+    });
+    expect(keys(items)).toEqual([
+      "h:staged",
+      "r:staged:a.ts",
+      "r:staged:b.ts",
+      "h:changes",
+      "r:changes:c.ts",
+    ]);
+  });
+
+  it("keeps a collapsed staged header but drops its rows", () => {
+    const items = buildGitNavItems({
+      stagedFiles: staged,
+      changedFiles: changed,
+      stagedOpen: false,
+      changesOpen: true,
+    });
+    expect(keys(items)).toEqual(["h:staged", "h:changes", "r:changes:c.ts"]);
+  });
+
+  it("keeps a collapsed changes header but drops its rows", () => {
+    const items = buildGitNavItems({
+      stagedFiles: staged,
+      changedFiles: changed,
+      stagedOpen: true,
+      changesOpen: false,
+    });
+    expect(keys(items)).toEqual([
+      "h:staged",
+      "r:staged:a.ts",
+      "r:staged:b.ts",
+      "h:changes",
+    ]);
+  });
+
+  it("omits the staged header entirely when there are no staged files", () => {
+    const items = buildGitNavItems({
+      stagedFiles: [],
+      changedFiles: changed,
+      stagedOpen: true,
+      changesOpen: true,
+    });
+    expect(keys(items)).toEqual(["h:changes", "r:changes:c.ts"]);
+  });
+
+  it("always renders the changes header even with zero changed files", () => {
+    const items = buildGitNavItems({
+      stagedFiles: [],
+      changedFiles: [],
+      stagedOpen: true,
+      changesOpen: true,
+    });
+    expect(keys(items)).toEqual(["h:changes"]);
+  });
+});
+
+describe("navItemKey", () => {
+  it("distinguishes headers from rows and namespaces by section", () => {
+    expect(navItemKey({ kind: "header", section: "staged" })).toBe("h:staged");
+    expect(navItemKey({ kind: "header", section: "changes" })).toBe(
+      "h:changes",
+    );
+    expect(
+      navItemKey({ kind: "row", section: "staged", file: file("src/x.ts") }),
+    ).toBe("r:staged:src/x.ts");
+    expect(
+      navItemKey({ kind: "row", section: "changes", file: file("src/x.ts") }),
+    ).toBe("r:changes:src/x.ts");
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/git-nav.ts
+++ b/packages/extensions-silo/src/git-explorer/git-nav.ts
@@ -1,0 +1,56 @@
+import type { GitFileStatus } from "../git/git-api";
+
+/** Which section an item belongs to. */
+export type GitSection = "staged" | "changes";
+
+/**
+ * One keyboard-navigable element in the Git panel's file area — either a
+ * collapsible section header or a file row. The flat list of these is the index
+ * space {@link useFocusGroup} roves over, so it must be built in the exact order
+ * `GitView` renders (see {@link buildGitNavItems}).
+ */
+export type GitNavItem =
+  | { kind: "header"; section: GitSection }
+  | { kind: "row"; section: GitSection; file: GitFileStatus };
+
+/**
+ * The flat list of navigable items in render order: the "Staged Changes" header
+ * (only when there are staged files) and, when that section is open, its rows;
+ * then the always-present "Changes" header and, when open, its rows. A collapsed
+ * section contributes only its header (its rows aren't rendered, so they aren't
+ * navigable). Kept in lockstep with `GitView`'s JSX so arrow movement lands on
+ * the adjacent on-screen element.
+ */
+export function buildGitNavItems(opts: {
+  stagedFiles: GitFileStatus[];
+  changedFiles: GitFileStatus[];
+  stagedOpen: boolean;
+  changesOpen: boolean;
+}): GitNavItem[] {
+  const { stagedFiles, changedFiles, stagedOpen, changesOpen } = opts;
+  const items: GitNavItem[] = [];
+  if (stagedFiles.length > 0) {
+    items.push({ kind: "header", section: "staged" });
+    if (stagedOpen) {
+      for (const file of stagedFiles)
+        items.push({ kind: "row", section: "staged", file });
+    }
+  }
+  items.push({ kind: "header", section: "changes" });
+  if (changesOpen) {
+    for (const file of changedFiles)
+      items.push({ kind: "row", section: "changes", file });
+  }
+  return items;
+}
+
+/**
+ * A stable lookup key for a nav item, so the renderer can map a header or a file
+ * row back to its focus-group index (mirrors the Tree's `indexOfPath` map):
+ * `h:<section>` for a header, `r:<section>:<path>` for a row.
+ */
+export function navItemKey(it: GitNavItem): string {
+  return it.kind === "header"
+    ? `h:${it.section}`
+    : `r:${it.section}:${it.file.path}`;
+}

--- a/packages/extensions-silo/src/git-explorer/git-rows.tsx
+++ b/packages/extensions-silo/src/git-explorer/git-rows.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { File as FileIcon } from "@phosphor-icons/react";
 import type { GitFileStatus } from "../git/git-api";
 import {
@@ -9,24 +10,31 @@ import {
   ICON_MINUS,
 } from "./git-icons";
 
+/** A bulk action shown in a section header (e.g. "Stage all", "Unstage all"). */
+export type SectionAction = {
+  icon: ReactNode;
+  title: string;
+  onClick: () => void;
+};
+
 export function Section({
   title,
   count,
   open,
   onToggle,
-  onAdd,
+  actions,
   children,
 }: {
   title: string;
   count: number;
   open: boolean;
   onToggle: () => void;
-  onAdd?: () => void;
+  actions?: SectionAction[];
   children: React.ReactNode;
 }) {
   return (
     <div className="git-section">
-      {/* Not a <button>: it contains the "stage all" button, and a button
+      {/* Not a <button>: it contains the header action buttons, and a button
           cannot nest a button. Use a div with button semantics instead. */}
       <div
         className="section-head"
@@ -44,17 +52,25 @@ export function Section({
           {open ? ICON_CHEV_DOWN : ICON_CHEV_RIGHT}
         </span>
         <span className="section-title">{title}</span>
-        {onAdd && (
-          <button
-            className="section-add"
-            title="Stage all changes"
-            onClick={(e) => {
-              e.stopPropagation();
-              onAdd();
-            }}
+        {actions && actions.length > 0 && (
+          <span
+            className="section-actions"
+            onClick={(e) => e.stopPropagation()}
           >
-            {ICON_PLUS}
-          </button>
+            {actions.map((a) => (
+              <button
+                key={a.title}
+                className="section-add"
+                title={a.title}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  a.onClick();
+                }}
+              >
+                {a.icon}
+              </button>
+            ))}
+          </span>
         )}
         <span className="section-count">{count}</span>
       </div>

--- a/packages/extensions-silo/src/git-explorer/git-rows.tsx
+++ b/packages/extensions-silo/src/git-explorer/git-rows.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { File as FileIcon } from "@phosphor-icons/react";
+import type { FocusGroupItemProps } from "@silo-code/sdk";
 import type { GitFileStatus } from "../git/git-api";
 import {
   ICON_CHEV_DOWN,
@@ -23,6 +24,7 @@ export function Section({
   open,
   onToggle,
   actions,
+  focusProps,
   children,
 }: {
   title: string;
@@ -30,6 +32,13 @@ export function Section({
   open: boolean;
   onToggle: () => void;
   actions?: SectionAction[];
+  /**
+   * Roving-focus props from the panel's `useFocusGroup` — the single-tab-stop
+   * `tabIndex`, the arrow/Enter key handler (Enter toggles the section via the
+   * group's `onActivate`), and the keyboard-ring markers. The header keeps its
+   * own `onClick` for mouse toggling.
+   */
+  focusProps?: FocusGroupItemProps;
   children: React.ReactNode;
 }) {
   return (
@@ -39,14 +48,8 @@ export function Section({
       <div
         className="section-head"
         role="button"
-        tabIndex={0}
         onClick={onToggle}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onToggle();
-          }
-        }}
+        {...focusProps}
       >
         <span className="section-chev">
           {open ? ICON_CHEV_DOWN : ICON_CHEV_RIGHT}
@@ -62,6 +65,7 @@ export function Section({
                 key={a.title}
                 className="section-add"
                 title={a.title}
+                tabIndex={-1}
                 onClick={(e) => {
                   e.stopPropagation();
                   a.onClick();
@@ -112,6 +116,7 @@ export function FileRow({
   onStage,
   onUnstage,
   onRevert,
+  focusProps,
 }: {
   file: GitFileStatus;
   folder: string;
@@ -121,24 +126,42 @@ export function FileRow({
   onStage?: () => void;
   onUnstage?: () => void;
   onRevert?: () => void;
+  /**
+   * Roving-focus props from the panel's `useFocusGroup` — the single-tab-stop
+   * `tabIndex`, the arrow/Enter key handler (Enter opens the diff via the group's
+   * `onActivate`), and the keyboard-ring markers. The row keeps its own `onClick`
+   * for mouse activation; the hover action buttons stay out of the Tab order.
+   */
+  focusProps?: FocusGroupItemProps;
 }) {
   const { name, dir } = splitNameAndDir(file.path);
   const glyph = statusGlyph(file);
   return (
-    <div className="git-file-row" onClick={onRowClick} title={file.path}>
+    <div
+      className="git-file-row"
+      onClick={onRowClick}
+      title={file.path}
+      {...focusProps}
+    >
       <span className="ico file">
         <FileIcon size="1.3em" weight="regular" aria-hidden="true" />
       </span>
       <span className="file-name">{name}</span>
       {dir && <span className="file-dir">{dir}</span>}
       <span className="row-actions" onClick={(e) => e.stopPropagation()}>
-        <button className="row-action" title="Open file" onClick={onOpen}>
+        <button
+          className="row-action"
+          title="Open file"
+          tabIndex={-1}
+          onClick={onOpen}
+        >
           {ICON_OPEN}
         </button>
         {kind === "changes" && onRevert && (
           <button
             className="row-action"
             title="Discard changes"
+            tabIndex={-1}
             onClick={onRevert}
           >
             {ICON_UNDO}
@@ -148,6 +171,7 @@ export function FileRow({
           <button
             className="row-action"
             title="Stage changes"
+            tabIndex={-1}
             onClick={onStage}
           >
             {ICON_PLUS}
@@ -157,6 +181,7 @@ export function FileRow({
           <button
             className="row-action"
             title="Unstage changes"
+            tabIndex={-1}
             onClick={onUnstage}
           >
             {ICON_MINUS}

--- a/packages/extensions-silo/src/git-explorer/notify-error.test.ts
+++ b/packages/extensions-silo/src/git-explorer/notify-error.test.ts
@@ -10,13 +10,38 @@ describe("summarizeGitError", () => {
     expect(detail).toBe("fatal: nothing to commit");
   });
 
-  it("uses the first line as the summary and flags the rest as more detail", () => {
+  it("prefers a native git fatal:/error: line over surrounding lines", () => {
     const { summary, hasMore } = summarizeGitError(
-      "pre-commit: lint failed\n  src/foo.ts:1:1 error\ncommit aborted",
+      "→ Running boundary lint…\nfatal: not a git repository\nmore noise",
+      "Status failed",
+    );
+    expect(summary).toBe("fatal: not a git repository");
+    expect(hasMore).toBe(true);
+  });
+
+  it("surfaces the conclusive failure line from hook output, not the first progress line", () => {
+    const detail = [
+      "→ Running boundary lint…",
+      "→ Formatting staged files…",
+      "→ Running unit tests…",
+      "✖   subject may not be empty [subject-empty]",
+      "✖   found 2 problems, 0 warnings",
+      "✖ Commit blocked: message must follow Conventional Commits",
+      "  e.g. 'feat(terminal): add split pane'",
+    ].join("\n");
+    const { summary, hasMore } = summarizeGitError(detail, "Commit failed");
+    expect(summary).toBe(
+      "✖ Commit blocked: message must follow Conventional Commits",
+    );
+    expect(hasMore).toBe(true);
+  });
+
+  it("falls back to the last line when nothing looks like an error marker", () => {
+    const { summary } = summarizeGitError(
+      "step one\nstep two\nstep three",
       "Commit failed",
     );
-    expect(summary).toBe("pre-commit: lint failed");
-    expect(hasMore).toBe(true);
+    expect(summary).toBe("step three");
   });
 
   it("reports no extra detail for a single-line error", () => {

--- a/packages/extensions-silo/src/git-explorer/notify-error.ts
+++ b/packages/extensions-silo/src/git-explorer/notify-error.ts
@@ -8,10 +8,34 @@
 export interface GitErrorSummary {
   /** Full error text — git's stderr, with a leading `Error:` and whitespace trimmed. */
   detail: string;
-  /** First line of {@link GitErrorSummary.detail}, or `fallback` when it's empty. */
+  /** The most relevant line of {@link GitErrorSummary.detail}, or `fallback` when it's empty. */
   summary: string;
   /** True when `detail` has more than the `summary` line — i.e. a details modal is worth showing. */
   hasMore: boolean;
+}
+
+/** A line that reads like a conclusive failure (commitlint/lint/test output). */
+const ERROR_MARKER = /(✖|✗|\b(?:failed|blocked|error|fatal)\b)/i;
+
+/**
+ * Pick the line that best explains the failure. Plain git errors put the reason
+ * on a `fatal:`/`error:` line, so prefer that. Hook output (lint, commitlint,
+ * tests) buries the reason under progress lines like "→ Running boundary lint…",
+ * so fall back to the *last* line that reads like a failure, then to the last
+ * line overall.
+ */
+function pickSummaryLine(detail: string): string | undefined {
+  const lines = detail
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return undefined;
+  const native = lines.find((l) => /^(?:fatal|error):/i.test(l));
+  if (native) return native;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (ERROR_MARKER.test(lines[i])) return lines[i];
+  }
+  return lines[lines.length - 1];
 }
 
 /**
@@ -25,7 +49,7 @@ export function summarizeGitError(
   const detail = String(err)
     .replace(/^Error:\s*/, "")
     .trim();
-  const summary = detail.split("\n")[0] || fallback;
+  const summary = pickSummaryLine(detail) ?? fallback;
   const hasMore = detail.length > summary.length;
   return { detail, summary, hasMore };
 }

--- a/packages/extensions-silo/src/git/git-api.ts
+++ b/packages/extensions-silo/src/git/git-api.ts
@@ -40,6 +40,18 @@ export interface GitLogEntry {
   subject: string;
 }
 
+/** One branch, as listed by {@link GitAPI.branches}. */
+export interface GitBranch {
+  /** Short name — `main` for a local branch, `origin/feat/x` for a remote one. */
+  name: string;
+  /** True for the currently checked-out branch. */
+  current: boolean;
+  /** True for a remote-tracking branch (`refs/remotes/*`). */
+  remote: boolean;
+  /** Upstream this branch tracks, e.g. `origin/main`; `null` for none / remotes. */
+  upstream: string | null;
+}
+
 /**
  * The typed API the `silo.git` provider publishes. All methods take the repo
  * working directory (`cwd`) as their first argument and run `git` off the UI
@@ -65,8 +77,65 @@ export interface GitAPI {
    * revision (e.g. an untracked file's HEAD version).
    */
   show(cwd: string, reference: string): Promise<string>;
-  /** Discard working-tree + staged changes for paths (`git restore`). */
+  /**
+   * Discard working-tree + staged changes for **tracked** paths, restoring them
+   * to `HEAD` (`git restore --source=HEAD --staged --worktree`). Errors on
+   * untracked paths (git has nothing to restore) — delete those with
+   * {@link GitAPI.clean}.
+   */
   revertFile(cwd: string, paths: string[]): Promise<void>;
-  /** Push the current branch (`git push`). */
-  push(cwd: string): Promise<void>;
+  /**
+   * Delete untracked files from the working tree (`git clean -f`). This is how
+   * a new (untracked) file is "discarded" — there's no committed version to
+   * restore, so discarding removes it.
+   */
+  clean(cwd: string, paths: string[]): Promise<void>;
+  /**
+   * Push to a remote. With no options, pushes the current branch to its
+   * configured upstream (`git push`). Pass `branch` to push a specific local
+   * branch, `remote` to target a remote other than `origin`, and `setUpstream`
+   * to create the tracking link on a first push (`git push --set-upstream`).
+   */
+  push(
+    cwd: string,
+    options?: { branch?: string; remote?: string; setUpstream?: boolean },
+  ): Promise<void>;
+  /** All local and remote-tracking branches (see {@link GitBranch}). */
+  branches(cwd: string): Promise<GitBranch[]>;
+  /**
+   * Fetch from the default remote (`git fetch`). With `prune`, also drops local
+   * remote-tracking refs (`refs/remotes/*`) for branches deleted on the remote
+   * (`git fetch --prune`) — the way to reconcile a {@link GitAPI.branches} list
+   * that still shows long-deleted remote branches.
+   */
+  fetch(cwd: string, prune?: boolean): Promise<void>;
+  /** Switch to an existing branch (`git switch <name>`). */
+  switchBranch(cwd: string, name: string): Promise<void>;
+  /**
+   * Create a branch and switch to it (`git switch -c <name> [startPoint]`).
+   * `startPoint` defaults to the current `HEAD`; pass a remote-tracking branch
+   * (e.g. `origin/feat/x`) to check it out as a new local tracking branch.
+   */
+  createBranch(cwd: string, name: string, startPoint?: string): Promise<void>;
+  /**
+   * Delete a local branch (`git branch -d`, or `-D` when `force`). Without
+   * `force`, git refuses to delete a branch that isn't fully merged.
+   */
+  deleteBranch(cwd: string, name: string, force?: boolean): Promise<void>;
+  /** Rename a local branch (`git branch -m <oldName> <newName>`). */
+  renameBranch(cwd: string, oldName: string, newName: string): Promise<void>;
+  /**
+   * Commits on `branch` not yet merged into its delete target — its `upstream`
+   * if set, otherwise `HEAD` — i.e. exactly the commits `git branch -d` would
+   * refuse to discard (it would need `-D`). An **empty array means the branch is
+   * safe to delete** with `-d`; a non-empty array is the work that a force-delete
+   * would throw away (most recent first). If the `upstream` ref can't be resolved
+   * (e.g. a pruned remote-tracking branch), falls back to comparing against
+   * `HEAD` rather than reporting the branch as merged.
+   */
+  unmergedCommits(
+    cwd: string,
+    branch: string,
+    upstream?: string | null,
+  ): Promise<GitLogEntry[]>;
 }

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFile } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createGitService, type ExecFn } from "./git-service";
@@ -110,5 +110,200 @@ describe("GitService (against a temp repo)", () => {
 
     await git.revertFile(repo, ["a.txt"]);
     expect((await git.status(repo)).files).toEqual([]); // change discarded
+  });
+
+  it("clean deletes an untracked file (discarding a new file)", async () => {
+    writeFileSync(join(repo, "a.txt"), "v1\n");
+    await git.stage(repo, ["a.txt"]);
+    await git.commit(repo, "init");
+    writeFileSync(join(repo, "junk.txt"), "scratch\n");
+    expect(
+      (await git.status(repo)).files.find((f) => f.path === "junk.txt"),
+    ).toMatchObject({ isUntracked: true });
+
+    await git.clean(repo, ["junk.txt"]);
+    expect(existsSync(join(repo, "junk.txt"))).toBe(false);
+    expect((await git.status(repo)).files).toEqual([]);
+  });
+
+  it("revertFile errors on an untracked path (use clean instead)", async () => {
+    writeFileSync(join(repo, "a.txt"), "v1\n");
+    await git.stage(repo, ["a.txt"]);
+    await git.commit(repo, "init");
+    writeFileSync(join(repo, "new.txt"), "untracked\n");
+    // git restore can't act on a path it doesn't know — the panel routes
+    // untracked discards to clean() for exactly this reason.
+    await expect(git.revertFile(repo, ["new.txt"])).rejects.toThrow(
+      /did not match any file/i,
+    );
+  });
+
+  // A repo needs one commit before branches exist / can be created.
+  async function seedCommit() {
+    writeFileSync(join(repo, "a.txt"), "v1\n");
+    await git.stage(repo, ["a.txt"]);
+    await git.commit(repo, "init");
+  }
+
+  it("creates, lists, switches between, and deletes branches", async () => {
+    await seedCommit();
+    const initial = await git.branches(repo);
+    expect(initial).toHaveLength(1);
+    const base = initial[0].name; // "main" or "master" depending on git config
+    expect(initial[0]).toMatchObject({ current: true, remote: false });
+
+    // createBranch checks out the new branch.
+    await git.createBranch(repo, "feature");
+    let branches = await git.branches(repo);
+    expect(branches.find((b) => b.name === "feature")).toMatchObject({
+      current: true,
+    });
+    expect(branches.find((b) => b.name === base)).toMatchObject({
+      current: false,
+    });
+
+    // switchBranch moves HEAD back.
+    await git.switchBranch(repo, base);
+    branches = await git.branches(repo);
+    expect(branches.find((b) => b.name === base)).toMatchObject({
+      current: true,
+    });
+
+    // deleteBranch removes a (merged) branch.
+    await git.deleteBranch(repo, "feature");
+    expect((await git.branches(repo)).map((b) => b.name)).toEqual([base]);
+  });
+
+  it("renames a branch", async () => {
+    await seedCommit();
+    await git.createBranch(repo, "old-name");
+    await git.renameBranch(repo, "old-name", "new-name");
+    const names = (await git.branches(repo)).map((b) => b.name);
+    expect(names).toContain("new-name");
+    expect(names).not.toContain("old-name");
+  });
+
+  it("refuses to delete an unmerged branch without force", async () => {
+    await seedCommit();
+    const base = (await git.branches(repo)).find((b) => b.current)!.name;
+
+    // Commit something only on the side branch so it isn't merged into base.
+    await git.createBranch(repo, "wip");
+    writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
+    await git.stage(repo, ["b.txt"]);
+    await git.commit(repo, "wip work");
+    await git.switchBranch(repo, base);
+
+    await expect(git.deleteBranch(repo, "wip")).rejects.toThrow(
+      /not fully merged/i,
+    );
+    // Force succeeds.
+    await git.deleteBranch(repo, "wip", true);
+    expect((await git.branches(repo)).map((b) => b.name)).not.toContain("wip");
+  });
+
+  it("reports unmerged commits for a branch (empty when merged)", async () => {
+    await seedCommit();
+    const base = (await git.branches(repo)).find((b) => b.current)!.name;
+
+    // A branch with no extra commits is fully merged → nothing at risk.
+    await git.createBranch(repo, "merged");
+    await git.switchBranch(repo, base);
+    expect(await git.unmergedCommits(repo, "merged")).toEqual([]);
+
+    // A branch with a unique commit reports it as unmerged (vs HEAD/base).
+    await git.createBranch(repo, "wip");
+    writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
+    await git.stage(repo, ["b.txt"]);
+    await git.commit(repo, "wip work");
+    await git.switchBranch(repo, base);
+
+    const unmerged = await git.unmergedCommits(repo, "wip");
+    expect(unmerged).toHaveLength(1);
+    expect(unmerged[0].subject).toBe("wip work");
+  });
+
+  it("falls back to HEAD when the branch's upstream ref can't be resolved", async () => {
+    await seedCommit();
+    const base = (await git.branches(repo)).find((b) => b.current)!.name;
+    await git.createBranch(repo, "wip");
+    writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
+    await git.stage(repo, ["b.txt"]);
+    await git.commit(repo, "wip work");
+    await git.switchBranch(repo, base);
+
+    // A dangling upstream (e.g. a pruned remote-tracking branch) makes
+    // `<upstream>..wip` error; we must fall back to HEAD and still surface the
+    // unmerged commit rather than reporting the branch as safe to delete.
+    const unmerged = await git.unmergedCommits(repo, "wip", "origin/gone");
+    expect(unmerged).toHaveLength(1);
+    expect(unmerged[0].subject).toBe("wip work");
+  });
+
+  it("fetch --prune drops remote-tracking branches deleted upstream", async () => {
+    await seedCommit();
+    const base = (await git.branches(repo)).find((b) => b.current)!.name;
+    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+    try {
+      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
+      await realExec("git", ["push", "-q", "origin", base], { cwd: repo });
+
+      // Push a branch, then fetch so its remote-tracking ref exists locally.
+      await git.createBranch(repo, "temp");
+      await realExec("git", ["push", "-q", "origin", "temp"], { cwd: repo });
+      await git.switchBranch(repo, base);
+      await git.fetch(repo, false);
+      expect((await git.branches(repo)).map((b) => b.name)).toContain(
+        "origin/temp",
+      );
+
+      // Delete it directly on the remote (as another clone would) so this
+      // clone's `origin/temp` tracking ref is now stale — still listed…
+      await realExec("git", ["branch", "-D", "temp"], { cwd: remote });
+      expect((await git.branches(repo)).map((b) => b.name)).toContain(
+        "origin/temp",
+      );
+
+      // …until fetch --prune reconciles and removes it.
+      await git.fetch(repo, true);
+      expect((await git.branches(repo)).map((b) => b.name)).not.toContain(
+        "origin/temp",
+      );
+    } finally {
+      rmSync(remote, { recursive: true, force: true });
+    }
+  });
+
+  it("pushes a branch and sets its upstream on first push", async () => {
+    await seedCommit();
+    const base = (await git.branches(repo)).find((b) => b.current)!.name;
+    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+    try {
+      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
+
+      // First push of the current branch: publishes it and sets tracking.
+      await git.push(repo, { setUpstream: true });
+      expect(
+        (await git.branches(repo)).find((b) => b.name === base)?.upstream,
+      ).toBe(`origin/${base}`);
+
+      // Push a different local branch by name (without checking it out).
+      await git.createBranch(repo, "feature");
+      writeFileSync(join(repo, "f.txt"), "x\n");
+      await git.stage(repo, ["f.txt"]);
+      await git.commit(repo, "feature work");
+      await git.switchBranch(repo, base);
+      await git.push(repo, {
+        branch: "feature",
+        remote: "origin",
+        setUpstream: true,
+      });
+      const { stdout } = await realExec("git", ["branch"], { cwd: remote });
+      expect(stdout).toContain("feature");
+    } finally {
+      rmSync(remote, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -1,5 +1,6 @@
 import type { GitAPI, GitLogEntry } from "./git-api";
 import { parseGitStatus } from "./parse-status";
+import { parseBranches } from "./parse-branches";
 
 // The GitAPI implementation, built on a generic one-shot `exec` (ctx.process.exec
 // in the app; a real-git wrapper in the contract test). This is the whole point
@@ -35,7 +36,14 @@ function parseLog(raw: string): GitLogEntry[] {
 
 /** Build a {@link GitAPI} backed by the given one-shot `exec`. */
 export function createGitService(exec: ExecFn): GitAPI {
-  const git = (cwd: string, args: string[]) => exec("git", args, { cwd });
+  // `--no-optional-locks` keeps background reads (status/log/diff/branches),
+  // which the panel polls on a file-watch, from taking git's *optional* index
+  // lock — so a poll mid-commit can't collide with the lock the commit (and its
+  // pre-commit hooks) hold and fail with "Unable to create index.lock". It's a
+  // top-level flag, harmless on the mutating commands (they use required locks),
+  // so it's applied to every invocation.
+  const git = (cwd: string, args: string[]) =>
+    exec("git", ["--no-optional-locks", ...args], { cwd });
 
   // Mutating commands: succeed silently, throw the stderr on failure (the old
   // run_git rejected on non-zero, and the view surfaces the message).
@@ -121,8 +129,78 @@ export function createGitService(exec: ExecFn): GitAPI {
       ]);
     },
 
-    push(cwd) {
-      return run(cwd, ["push"]);
+    clean(cwd, paths) {
+      return run(cwd, ["clean", "-f", "--", ...paths]);
+    },
+
+    push(cwd, options) {
+      // No options → push the current branch to its configured upstream.
+      if (!options?.branch && !options?.remote && !options?.setUpstream) {
+        return run(cwd, ["push"]);
+      }
+      const args = ["push"];
+      if (options.setUpstream) args.push("--set-upstream");
+      args.push(options.remote ?? "origin", options.branch ?? "HEAD");
+      return run(cwd, args);
+    },
+
+    async branches(cwd) {
+      const { stdout, code } = await git(cwd, [
+        "for-each-ref",
+        "--format=%(refname)%09%(HEAD)%09%(upstream:short)",
+        "refs/heads",
+        "refs/remotes",
+      ]);
+      // Any error (e.g. an empty repo with no refs yet) → no branches.
+      if (code !== 0) return [];
+      return parseBranches(stdout);
+    },
+
+    fetch(cwd, prune) {
+      return run(cwd, ["fetch", ...(prune ? ["--prune"] : [])]);
+    },
+
+    switchBranch(cwd, name) {
+      return run(cwd, ["switch", name]);
+    },
+
+    createBranch(cwd, name, startPoint) {
+      return run(cwd, [
+        "switch",
+        "-c",
+        name,
+        ...(startPoint ? [startPoint] : []),
+      ]);
+    },
+
+    deleteBranch(cwd, name, force) {
+      return run(cwd, ["branch", force ? "-D" : "-d", name]);
+    },
+
+    renameBranch(cwd, oldName, newName) {
+      return run(cwd, ["branch", "-m", oldName, newName]);
+    },
+
+    async unmergedCommits(cwd, branch, upstream) {
+      // `<target>..<branch>` lists commits reachable from branch but not target;
+      // empty ⇔ branch is fully merged into target ⇔ `git branch -d` would
+      // succeed. Mirror git's delete-safety check: prefer the upstream, but if
+      // that ref can't be resolved (a pruned/renamed remote-tracking branch
+      // whose `branch.*.merge` config lingers) fall back to HEAD — otherwise
+      // we'd report "nothing at risk", pick `-d`, and hit git's raw "not fully
+      // merged" error instead of offering a force-delete.
+      const ranges = upstream
+        ? [`${upstream}..${branch}`, `HEAD..${branch}`]
+        : [`HEAD..${branch}`];
+      for (const range of ranges) {
+        const { stdout, code } = await git(cwd, [
+          "log",
+          "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%s",
+          range,
+        ]);
+        if (code === 0) return parseLog(stdout);
+      }
+      return [];
     },
   };
 }

--- a/packages/extensions-silo/src/git/parse-branches.test.ts
+++ b/packages/extensions-silo/src/git/parse-branches.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { parseBranches } from "./parse-branches";
+
+// Fixtures mimic `git for-each-ref --format=%(refname)%09%(HEAD)%09%(upstream:short)`.
+const T = "\t";
+
+describe("parseBranches", () => {
+  it("parses the current local branch with an upstream", () => {
+    const raw = `refs/heads/main${T}*${T}origin/main`;
+    expect(parseBranches(raw)).toEqual([
+      { name: "main", current: true, remote: false, upstream: "origin/main" },
+    ]);
+  });
+
+  it("parses a non-current local branch without an upstream", () => {
+    const raw = `refs/heads/feature${T} ${T}`;
+    expect(parseBranches(raw)).toEqual([
+      { name: "feature", current: false, remote: false, upstream: null },
+    ]);
+  });
+
+  it("keeps slashes in branch names", () => {
+    const raw = `refs/heads/feat/core-updates${T} ${T}`;
+    expect(parseBranches(raw)[0].name).toBe("feat/core-updates");
+  });
+
+  it("parses remote-tracking branches and skips the symbolic HEAD pointer", () => {
+    const raw = [
+      `refs/heads/main${T}*${T}origin/main`,
+      `refs/remotes/origin/HEAD${T} ${T}`,
+      `refs/remotes/origin/main${T} ${T}`,
+      `refs/remotes/origin/feat/x${T} ${T}`,
+    ].join("\n");
+    expect(parseBranches(raw)).toEqual([
+      { name: "main", current: true, remote: false, upstream: "origin/main" },
+      { name: "origin/main", current: false, remote: true, upstream: null },
+      { name: "origin/feat/x", current: false, remote: true, upstream: null },
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseBranches("")).toEqual([]);
+    expect(parseBranches("\n")).toEqual([]);
+  });
+});

--- a/packages/extensions-silo/src/git/parse-branches.ts
+++ b/packages/extensions-silo/src/git/parse-branches.ts
@@ -1,0 +1,36 @@
+import type { GitBranch } from "./git-api";
+
+// Pure parser for `git for-each-ref --format=%(refname)%09%(HEAD)%09%(upstream:short)
+// refs/heads refs/remotes`. Kept a pure string→GitBranch[] function (no exec) so
+// it's unit-testable against captured fixtures, the same way parse-status.ts is.
+
+const TAB = "\t";
+
+/**
+ * Parse the tab-delimited `for-each-ref` lines into {@link GitBranch} entries.
+ * Each line is `<refname>\t<HEAD marker>\t<upstream short>`, where the HEAD
+ * marker is `*` for the current branch. `refs/remotes/<remote>/HEAD` (the
+ * symbolic default-branch pointer, not a real branch) is skipped.
+ */
+export function parseBranches(raw: string): GitBranch[] {
+  const branches: GitBranch[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    const [refname = "", head = "", upstream = ""] = line.split(TAB);
+
+    if (refname.startsWith("refs/heads/")) {
+      branches.push({
+        name: refname.slice("refs/heads/".length),
+        current: head === "*",
+        remote: false,
+        upstream: upstream || null,
+      });
+    } else if (refname.startsWith("refs/remotes/")) {
+      const name = refname.slice("refs/remotes/".length);
+      // Skip the symbolic `<remote>/HEAD` pointer — it aliases another branch.
+      if (name.endsWith("/HEAD")) continue;
+      branches.push({ name, current: false, remote: true, upstream: null });
+    }
+  }
+  return branches;
+}


### PR DESCRIPTION
## Summary

Brings the Git side-panel up to a full source-control surface, in three logical commits:

1. **Branch-listing provider APIs** — extends the `silo.git` provider with branch list (porcelain parse), switch/create/delete/rename, fetch (+prune), push/publish (sets upstream on first push), and unmerged-commit lookup for safe-delete.
2. **Branch management, push/publish & bulk actions in the panel** — a Switch-branches modal (`BranchManager`) with create/rename/switch and a guarded force-delete (`ForceDeleteDialog` listing unmerged commits), a branch-name dialog, header push/publish, unstage-all / discard-all section actions, and a clearer commit-progress + error-summary flow.
3. **Keyboard tab navigation** — adopts the shared `useFocusGroup` hook (as the Workspaces panel and file Tree do): section headers + file rows become one roving group / single Tab stop, with arrow-key movement, the WebKit-safe keyboard-only focus ring, and Enter/Space activation (toggle a header, open a row's diff). Stage/unstage/discard stay mouse-only hover buttons, kept out of the Tab order.

## Scope

Touches only `packages/extensions-silo/src/git/` and `.../git-explorer/` (17 files). `index.ts`/`index.tsx` are untouched, so main's diff-provider `manifest` + `ctx.subscriptions` lifecycle are preserved. No wiring change needed — `git`/`gitExplorer` are already activated in `builtins.ts`.

## Tests

New/extended unit tests: `parse-branches`, `branch-model`, `git-nav`, and additional `git-service` + `notify-error` coverage. Verified locally: `tsc --noEmit` clean, `pnpm lint` clean, `pnpm --filter @silo-code/extensions-silo test` green (78 tests).

## Note on history

This work was originally developed on a branch that shared no common ancestor with `main` (an old, re-rooted timeline), so it couldn't be PR'd directly. The feature was replayed cleanly onto a fresh branch off `origin/main` via a 3-way apply of the pure feature diff — preserving main's independent changes — and re-grouped into the three commits above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)