### PR TITLE
feat(git): Pull button + background autofetch in the Git panel

### DIFF
--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -147,6 +147,10 @@
   -webkit-animation: branch-push 0.7s ease-in-out infinite;
   animation: branch-push 0.7s ease-in-out infinite;
 }
+.pull-btn.working {
+  -webkit-animation: branch-pull 0.7s ease-in-out infinite;
+  animation: branch-pull 0.7s ease-in-out infinite;
+}
 
 @-webkit-keyframes branch-spin {
   to {
@@ -192,6 +196,46 @@
   }
   41% {
     transform: translateY(5px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@-webkit-keyframes branch-pull {
+  0% {
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+    opacity: 1;
+  }
+  40% {
+    -webkit-transform: translateY(5px);
+    transform: translateY(5px);
+    opacity: 0;
+  }
+  41% {
+    -webkit-transform: translateY(-5px);
+    transform: translateY(-5px);
+    opacity: 0;
+  }
+  100% {
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@keyframes branch-pull {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  40% {
+    transform: translateY(5px);
+    opacity: 0;
+  }
+  41% {
+    transform: translateY(-5px);
     opacity: 0;
   }
   100% {

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -18,6 +18,7 @@ import { buildGitNavItems, navItemKey } from "./git-nav";
 import {
   ICON_CHECK,
   ICON_PUSH,
+  ICON_PULL,
   ICON_PLUS,
   ICON_MINUS,
   ICON_UNDO,
@@ -26,6 +27,9 @@ import { summarizeGitError } from "./notify-error";
 import { BranchManager } from "./BranchManager";
 
 const REFRESH_DEBOUNCE_MS = 400;
+// How often the panel fetches in the background so ↑ahead/↓behind stay roughly
+// accurate without the user acting (matches VS Code's git.autofetchPeriod).
+const AUTOFETCH_INTERVAL_MS = 180_000;
 const statusCache = new Map<string, GitStatus>();
 const messageCache = new Map<string, string>();
 
@@ -55,6 +59,7 @@ export function GitView({
   );
   const [busy, setBusy] = useState(false);
   const [pushing, setPushing] = useState(false);
+  const [pulling, setPulling] = useState(false);
   const [committing, setCommitting] = useState(false);
   // Mirror `committing` into a ref so the file-watch callback (a stable closure)
   // can skip refreshes while a commit runs — commit() does the final refresh.
@@ -64,6 +69,7 @@ export function GitView({
   }, [committing]);
   const [pendingRefresh, setPendingRefresh] = useState(false);
   const [pendingPush, setPendingPush] = useState(false);
+  const [pendingPull, setPendingPull] = useState(false);
   const [stagedOpen, setStagedOpen] = useState(true);
   const [changesOpen, setChangesOpen] = useState(true);
   const [collapsed, setCollapsed] = useState(false);
@@ -178,6 +184,40 @@ export function GitView({
   }, [pendingPush, folder, notifyError, status?.upstream]);
 
   useEffect(() => {
+    if (!pendingPull) return;
+    setPendingPull(false);
+    const min = new Promise<void>((r) => setTimeout(r, 600));
+    setTimeout(() => {
+      const api = getGitApi();
+      if (!api) {
+        notifyError("Pull failed", "Git provider (silo.git) unavailable.");
+        min.then(() => setPulling(false));
+        return;
+      }
+      api
+        .pull(folder)
+        .then(() => {
+          setBusy(true);
+          setPendingRefresh(true);
+        })
+        .catch((err) => {
+          // --ff-only aborts when the branch has diverged; there's no in-panel
+          // conflict resolution, so point the user at a terminal rather than
+          // surfacing git's raw "Not possible to fast-forward".
+          if (/fast-forward|diverged|non-fast-forward/i.test(String(err))) {
+            notifyError(
+              "Pull failed — branch has diverged",
+              "Your branch and its upstream have diverged. Reconcile them in a terminal (e.g. `git pull --rebase`), then refresh.",
+            );
+          } else {
+            notifyError("Pull failed", err);
+          }
+        })
+        .finally(() => min.then(() => setPulling(false)));
+    }, 50);
+  }, [pendingPull, folder, notifyError]);
+
+  useEffect(() => {
     if (paused) return;
     let timer: number | null = null;
     const sub = files.watch(folder, () => {
@@ -192,6 +232,29 @@ export function GitView({
       sub.dispose();
     };
   }, [folder, refresh, paused]);
+
+  // Background autofetch: periodically `git fetch` so ↑ahead/↓behind trend
+  // toward accurate without the user acting. Fetch is read-only on the working
+  // tree (it only updates remote-tracking refs), so it's safe to run unattended;
+  // re-read status quietly (no spinner) so the counts update in place. Failures
+  // (offline, no remote) are swallowed — autofetch must stay silent.
+  useEffect(() => {
+    if (paused) return;
+    const id = window.setInterval(() => {
+      if (committingRef.current) return;
+      const api = getGitApi();
+      if (!api) return;
+      api
+        .fetch(folder)
+        .then(() => api.status(folder))
+        .then((s) => {
+          statusCache.set(cacheKey, s);
+          setStatus(s);
+        })
+        .catch((err) => console.warn("git autofetch failed", err));
+    }, AUTOFETCH_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [folder, cacheKey, paused]);
 
   const stagedFiles = useMemo(
     () => status?.files.filter((f) => f.isStaged) ?? [],
@@ -369,6 +432,11 @@ export function GitView({
     setPendingPush(true);
   }
 
+  function pull() {
+    setPulling(true);
+    setPendingPull(true);
+  }
+
   // Open the branch manager modal. The host owns the chrome; refresh() re-reads
   // status after a switch/create so the header reflects the new branch.
   function openBranchManager() {
@@ -420,6 +488,13 @@ export function GitView({
   // branch with no upstream yet, where the first push publishes it.
   const canPush = !!status?.branch;
   const pushTitle = status?.upstream ? "Push" : "Publish branch";
+  // Pull needs a tracking branch to pull from; disabled (not hidden) otherwise.
+  const canPull = !!status?.upstream;
+  const pullTitle = canPull
+    ? status && status.behind > 0
+      ? `Pull (${status.behind} behind)`
+      : "Pull"
+    : "Pull (no upstream)";
   // A cloud-up glyph marks "publish" (first push, no upstream); the plain
   // up-arrow is a normal push to an existing remote branch.
   const pushIcon = status?.upstream ? ICON_PUSH : <CloudArrowUp size={16} />;
@@ -484,6 +559,13 @@ export function GitView({
               <ArrowsClockwise size={14} />
             </button>
             <button
+              className={`branch-action pull-btn${pulling ? " working" : ""}${!pulling && !canPull ? " disabled" : ""}`}
+              title={pullTitle}
+              onClick={pulling || !canPull ? undefined : pull}
+            >
+              {ICON_PULL}
+            </button>
+            <button
               className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !canPush ? " disabled" : ""}`}
               title={pushTitle}
               onClick={pushing || !canPush ? undefined : push}
@@ -519,6 +601,13 @@ export function GitView({
             onClick={busy ? undefined : refresh}
           >
             <ArrowsClockwise size={16} />
+          </button>
+          <button
+            className={`branch-action pull-btn${pulling ? " working" : ""}${!pulling && !canPull ? " disabled" : ""}`}
+            title={pullTitle}
+            onClick={pulling || !canPull ? undefined : pull}
+          >
+            {ICON_PULL}
           </button>
           <button
             className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !canPush ? " disabled" : ""}`}

--- a/packages/extensions-silo/src/git-explorer/git-icons.tsx
+++ b/packages/extensions-silo/src/git-explorer/git-icons.tsx
@@ -119,3 +119,29 @@ export const ICON_PUSH: ReactNode = (
     />
   </svg>
 );
+// Vertical mirror of ICON_PUSH: a bar at the top (the remote) with an arrow
+// pulling down from it.
+export const ICON_PULL: ReactNode = (
+  <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+    <path
+      d="M3 3h10"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M8 5v8"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M5 10l3 3 3-3"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/packages/extensions-silo/src/git/git-api.ts
+++ b/packages/extensions-silo/src/git/git-api.ts
@@ -109,6 +109,14 @@ export interface GitAPI {
    * that still shows long-deleted remote branches.
    */
   fetch(cwd: string, prune?: boolean): Promise<void>;
+  /**
+   * Fast-forward the current branch from its upstream (`git pull --ff-only`):
+   * fetches, then advances the branch **only if** it can be fast-forwarded.
+   * Rejects (non-zero) when the branch has diverged — there's no in-panel
+   * conflict resolution, so the caller surfaces the failure as a toast rather
+   * than leaving a half-finished merge. Requires a tracking branch.
+   */
+  pull(cwd: string): Promise<void>;
   /** Switch to an existing branch (`git switch <name>`). */
   switchBranch(cwd: string, name: string): Promise<void>;
   /**

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -306,4 +306,73 @@ describe("GitService (against a temp repo)", () => {
       rmSync(remote, { recursive: true, force: true });
     }
   });
+
+  it("pulls (fast-forward) commits added upstream", async () => {
+    await seedCommit();
+    const base = (await git.branches(repo)).find((b) => b.current)!.name;
+    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+    const other = mkdtempSync(join(tmpdir(), "silo-gitclone-"));
+    try {
+      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
+      // Publish base and set tracking, so pull knows its upstream.
+      await git.push(repo, { setUpstream: true });
+
+      // A second clone advances the branch on the remote.
+      await realExec("git", ["clone", "-q", remote, other], {});
+      await realExec("git", ["config", "user.email", "t@t"], { cwd: other });
+      await realExec("git", ["config", "user.name", "t"], { cwd: other });
+      writeFileSync(join(other, "upstream.txt"), "from elsewhere\n");
+      await realExec("git", ["add", "."], { cwd: other });
+      await realExec("git", ["commit", "-q", "-m", "remote commit"], {
+        cwd: other,
+      });
+      await realExec("git", ["push", "-q", "origin", base], { cwd: other });
+
+      // repo is now behind; a fast-forward pull brings the commit in.
+      await git.pull(repo);
+      expect(existsSync(join(repo, "upstream.txt"))).toBe(true);
+      const { stdout } = await realExec("git", ["log", "--oneline"], {
+        cwd: repo,
+      });
+      expect(stdout).toContain("remote commit");
+    } finally {
+      rmSync(remote, { recursive: true, force: true });
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a fast-forward pull when the branch has diverged", async () => {
+    await seedCommit();
+    const base = (await git.branches(repo)).find((b) => b.current)!.name;
+    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+    const other = mkdtempSync(join(tmpdir(), "silo-gitclone-"));
+    try {
+      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
+      await git.push(repo, { setUpstream: true });
+
+      // The remote advances…
+      await realExec("git", ["clone", "-q", remote, other], {});
+      await realExec("git", ["config", "user.email", "t@t"], { cwd: other });
+      await realExec("git", ["config", "user.name", "t"], { cwd: other });
+      writeFileSync(join(other, "remote.txt"), "remote side\n");
+      await realExec("git", ["add", "."], { cwd: other });
+      await realExec("git", ["commit", "-q", "-m", "remote commit"], {
+        cwd: other,
+      });
+      await realExec("git", ["push", "-q", "origin", base], { cwd: other });
+
+      // …while repo makes its own commit — now the histories have diverged.
+      writeFileSync(join(repo, "local.txt"), "local side\n");
+      await git.stage(repo, ["local.txt"]);
+      await git.commit(repo, "local commit");
+
+      // --ff-only can't reconcile a divergence, so it must reject (no merge).
+      await expect(git.pull(repo)).rejects.toThrow();
+    } finally {
+      rmSync(remote, { recursive: true, force: true });
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -160,6 +160,13 @@ export function createGitService(exec: ExecFn): GitAPI {
       return run(cwd, ["fetch", ...(prune ? ["--prune"] : [])]);
     },
 
+    pull(cwd) {
+      // Fast-forward only: never auto-create a merge commit or leave a
+      // half-finished merge the panel can't resolve. A diverged branch makes
+      // this fail, which the caller turns into a "resolve manually" toast.
+      return run(cwd, ["pull", "--ff-only"]);
+    },
+
     switchBranch(cwd, name) {
       return run(cwd, ["switch", name]);
     },


### PR DESCRIPTION
## Summary

The Git panel could push but never get remote changes, and `↑ahead/↓behind` only reflected the last fetch done elsewhere. This adds the missing direction:

- **Pull button** next to Push in the header (both single-root and multi-root layouts). It's **fast-forward only** (`git pull --ff-only`): brings in upstream commits when you're simply behind, and on a diverged branch fails cleanly with a *"branch has diverged — resolve in a terminal"* toast rather than leaving a half-finished merge (the panel has no conflict-resolution UI). Disabled when there's no tracking branch; uses a mirrored down-arrow icon and a downward "working" animation matching Push.
- **Background autofetch** — a `git fetch` every 3 min (matching VS Code's `git.autofetchPeriod`) plus a quiet status re-read, so `↑/↓` trends accurate on its own. **Refresh stays local-only.** Autofetch is read-only on the working tree, skips while committing, and swallows errors (offline is normal).

## Design notes

Mirrors VS Code's split (local Refresh vs. explicit network Pull, plus autofetch), but chooses `--ff-only` over VS Code's merge-default pull because Silo has no in-panel merge-conflict resolution — ff-only keeps a failed pull from stranding you mid-merge.

## Implementation

- `git/git-api.ts` + `git-service.ts`: new `pull(cwd)` verb → `git pull --ff-only`.
- `GitView.tsx`: `pull()` flow mirroring `push()` (pending-state + toast), the autofetch `useEffect`, and Pull buttons in both headers.
- `git-icons.tsx`: `ICON_PULL` (vertical mirror of `ICON_PUSH`); `GitExplorerPanel.css`: `branch-pull` animation.

## Tests

`git-service.test.ts`: fast-forward pull succeeds (commit added upstream lands locally); a diverged branch rejects. Verified locally: `tsc --noEmit` clean, `pnpm lint` clean, `pnpm --filter @silo-code/extensions-silo test` green (80 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)