### PR TITLE
feat(focus): app-wide keyboard focus ring for standalone controls

### DIFF
--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -558,3 +558,21 @@ body.panel-resizing .side-resize-handle {
   outline: 1.5px solid var(--silo-color-accent);
   outline-offset: -1.5px;
 }
+
+/* Fallback ring for standalone interactive controls that aren't part of a focus
+   group (panel header buttons, etc.). Ordinary Tab focus *does* light
+   `:focus-visible` in WebKit — the attribute path above is only needed for the
+   programmatic focus inside roving groups — so keyboard focus on a lone control
+   gets the same accent ring instead of the inconsistent native one. Scoped to
+   interactive elements, and `:not([data-focus-item])` so a group item never
+   double-rings. */
+button:focus-visible:not([data-focus-item]),
+[role="button"]:focus-visible:not([data-focus-item]),
+a:focus-visible:not([data-focus-item]),
+input:focus-visible:not([data-focus-item]),
+select:focus-visible:not([data-focus-item]),
+textarea:focus-visible:not([data-focus-item]),
+[tabindex]:focus-visible:not([data-focus-item]) {
+  outline: 1.5px solid var(--silo-color-accent);
+  outline-offset: -1.5px;
+}


### PR DESCRIPTION
## Summary

The app's styled focus ring (RFC 0012) was only applied to **focus-group** items — `useFocusGroup` marks them with `data-focus-visible` and the host paints the accent ring keyed on that attribute. Standalone Tab-focusable controls that aren't part of a group (side-panel header buttons, etc.) had **no** app styling and fell back to WebKit's native focus outline, so they looked inconsistent with the rest of the app (status bar, lists, menus).

This adds a **scoped `:focus-visible` fallback** in `theme.css` that paints the same `--silo-color-accent` ring on ordinary keyboard focus.

```css
button:focus-visible:not([data-focus-item]),
[role="button"]:focus-visible:not([data-focus-item]),
a:focus-visible:not([data-focus-item]),
input:focus-visible:not([data-focus-item]),
select:focus-visible:not([data-focus-item]),
textarea:focus-visible:not([data-focus-item]),
[tabindex]:focus-visible:not([data-focus-item]) { … }
```

## Why this is safe

- Ordinary Tab focus **does** light `:focus-visible` in WebKit — the attribute-driven path is only needed for the *programmatic* focus the roving focus-group cycle performs (that's the documented reason groups use `data-focus-visible` instead of `:focus`).
- `:not([data-focus-item])` excludes focus-group items, so they never double-ring.
- Scoped to interactive elements (per review preference) rather than a universal `:focus-visible`, to avoid surprising rings on non-interactive nodes.

Relates to the focus model (RFC 0012 / ADR 0021). Pointer interaction is unaffected (`:focus-visible` is keyboard-only). Happy to add an ADR note if we want this recorded as a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)