### PR TITLE
feat(git): rework the Git panel header — publish button, click-to-sync, ⋯ menu

### DIFF
--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -84,8 +84,13 @@
   appearance: none;
   background: transparent;
   border: none;
-  padding: 1px 5px;
-  margin-left: -5px;
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 4px;
+  /* Cancel the padding so the text still sits flush with the panel edge while
+     the hover rect matches the sibling buttons' height + padding. */
+  margin-left: -4px;
   border-radius: var(--silo-radius-sm);
   font: inherit;
   font-weight: 600;
@@ -110,14 +115,56 @@
 .git-branch .spacer {
   flex: 1;
 }
+
+/* Multi-root: wrapper holding the sync/publish control next to the branch. */
+.git-root-remote {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* The ↑/↓ counts double as a Sync (pull, then push) button. Matches the height
+   of the row's icon buttons (.branch-action) so its hover highlight reads the
+   same instead of a thin sliver around the text. */
+.branch-sync {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  font: inherit;
+  color: var(--silo-color-text-lo);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 26px;
+  padding: 0 4px;
+  border-radius: var(--silo-radius-sm);
+  cursor: pointer;
+}
+/* Scoped (0,3,0) so it beats the host's global `button:hover:not(:disabled)`
+   (0,2,1), which would otherwise paint the dark `--silo-button-bg` mix here —
+   the same reason .branch-name-button scopes its hover under .git-branch. */
+.git-branch .branch-sync:hover,
+.git-root-remote .branch-sync:hover {
+  background: var(--silo-color-bg-hover);
+}
+.branch-sync.working {
+  color: var(--silo-color-accent);
+  pointer-events: none;
+}
+
+/* The inline "publish branch" button shown when the branch has no upstream. */
+.branch-publish {
+  color: var(--silo-color-accent);
+}
 .branch-action {
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
   border: none;
   color: var(--silo-color-text-lo);
-  width: 30px;
-  height: 30px;
+  width: 26px;
+  height: 26px;
   border-radius: var(--silo-radius-sm);
   display: inline-flex;
   align-items: center;
@@ -146,10 +193,6 @@
 .push-btn.working {
   -webkit-animation: branch-push 0.7s ease-in-out infinite;
   animation: branch-push 0.7s ease-in-out infinite;
-}
-.pull-btn.working {
-  -webkit-animation: branch-pull 0.7s ease-in-out infinite;
-  animation: branch-pull 0.7s ease-in-out infinite;
 }
 
 @-webkit-keyframes branch-spin {
@@ -196,46 +239,6 @@
   }
   41% {
     transform: translateY(5px);
-    opacity: 0;
-  }
-  100% {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-@-webkit-keyframes branch-pull {
-  0% {
-    -webkit-transform: translateY(0);
-    transform: translateY(0);
-    opacity: 1;
-  }
-  40% {
-    -webkit-transform: translateY(5px);
-    transform: translateY(5px);
-    opacity: 0;
-  }
-  41% {
-    -webkit-transform: translateY(-5px);
-    transform: translateY(-5px);
-    opacity: 0;
-  }
-  100% {
-    -webkit-transform: translateY(0);
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-@keyframes branch-pull {
-  0% {
-    transform: translateY(0);
-    opacity: 1;
-  }
-  40% {
-    transform: translateY(5px);
-    opacity: 0;
-  }
-  41% {
-    transform: translateY(-5px);
     opacity: 0;
   }
   100% {

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -4,25 +4,20 @@ import {
   CaretDown,
   CaretRight,
   CloudArrowUp,
+  DotsThreeVertical,
 } from "@phosphor-icons/react";
 import {
   useFocusGroup,
   type ExtensionContext,
   type FocusGroupItemProps,
+  type MenuEntry,
   type NotifyOptions,
 } from "@silo-code/sdk";
 import type { GitFileStatus, GitStatus } from "../git/git-api";
 import { getGitApi } from "./git-runtime";
 import { Section, FileRow } from "./git-rows";
 import { buildGitNavItems, navItemKey } from "./git-nav";
-import {
-  ICON_CHECK,
-  ICON_PUSH,
-  ICON_PULL,
-  ICON_PLUS,
-  ICON_MINUS,
-  ICON_UNDO,
-} from "./git-icons";
+import { ICON_CHECK, ICON_PLUS, ICON_MINUS, ICON_UNDO } from "./git-icons";
 import { summarizeGitError } from "./notify-error";
 import { BranchManager } from "./BranchManager";
 
@@ -60,6 +55,7 @@ export function GitView({
   const [busy, setBusy] = useState(false);
   const [pushing, setPushing] = useState(false);
   const [pulling, setPulling] = useState(false);
+  const [syncing, setSyncing] = useState(false);
   const [committing, setCommitting] = useState(false);
   // Mirror `committing` into a ref so the file-watch callback (a stable closure)
   // can skip refreshes while a commit runs — commit() does the final refresh.
@@ -437,6 +433,58 @@ export function GitView({
     setPendingPull(true);
   }
 
+  // Sync = bring remote work in, then send ours. Pull is fast-forward only, so a
+  // diverged branch fails here and we never push onto a stale base or strand a
+  // half-finished merge — same posture as the standalone Pull/Push.
+  async function sync() {
+    if (syncing) return;
+    setSyncing(true);
+    try {
+      const api = requireGit();
+      await api.pull(folder);
+      await api.push(folder);
+      refresh();
+    } catch (err) {
+      if (/fast-forward|diverged|non-fast-forward/i.test(String(err))) {
+        notifyError(
+          "Sync failed — branch has diverged",
+          "Your branch and its upstream have diverged. Reconcile them in a terminal (e.g. `git pull --rebase`), then sync.",
+        );
+      } else {
+        notifyError("Sync failed", err);
+      }
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  // Update remote-tracking refs (and thus ↑/↓) without touching the branch.
+  async function fetchRemote() {
+    try {
+      await requireGit().fetch(folder);
+      refresh();
+    } catch (err) {
+      notifyError("Fetch failed", err);
+    }
+  }
+
+  // The "⋯" dropdown: the explicit Push/Pull (folded off the bar), plus Fetch
+  // and a way into the branch manager.
+  function gitMenuItems(): MenuEntry[] {
+    return [
+      { label: pushTitle, disabled: !canPush || pushing, run: push },
+      { label: "Pull", disabled: !canPull || pulling, run: pull },
+      { type: "separator" },
+      { label: "Fetch", run: fetchRemote },
+      { type: "separator" },
+      { label: "Manage branches…", run: openBranchManager },
+    ];
+  }
+
+  function openGitMenu(anchor: HTMLElement) {
+    void ctx.ui.showMenu({ items: gitMenuItems(), anchor, align: "end" });
+  }
+
   // Open the branch manager modal. The host owns the chrome; refresh() re-reads
   // status after a switch/create so the header reflects the new branch.
   function openBranchManager() {
@@ -488,16 +536,9 @@ export function GitView({
   // branch with no upstream yet, where the first push publishes it.
   const canPush = !!status?.branch;
   const pushTitle = status?.upstream ? "Push" : "Publish branch";
-  // Pull needs a tracking branch to pull from; disabled (not hidden) otherwise.
+  // Pull needs a tracking branch to pull from; the menu item is disabled
+  // (not hidden) otherwise.
   const canPull = !!status?.upstream;
-  const pullTitle = canPull
-    ? status && status.behind > 0
-      ? `Pull (${status.behind} behind)`
-      : "Pull"
-    : "Pull (no upstream)";
-  // A cloud-up glyph marks "publish" (first push, no upstream); the plain
-  // up-arrow is a normal push to an existing remote branch.
-  const pushIcon = status?.upstream ? ICON_PUSH : <CloudArrowUp size={16} />;
 
   return (
     <div className="git-panel">
@@ -540,12 +581,31 @@ export function GitView({
             }
           >
             {status ? (status.branch ?? "(detached)") : ""}
-            {status?.upstream && (
-              <span className="branch-tracking">
-                {" "}
+          </span>
+          <span
+            className="git-root-remote"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {status?.upstream ? (
+              <button
+                className={`branch-tracking branch-sync${syncing ? " working" : ""}`}
+                title="Sync (pull, then push)"
+                onClick={syncing ? undefined : sync}
+              >
+                {syncing && (
+                  <ArrowsClockwise className="git-branch-spin" size={12} />
+                )}
                 ↑{status.ahead} ↓{status.behind}
-              </span>
-            )}
+              </button>
+            ) : status?.inRepo && status.branch ? (
+              <button
+                className={`branch-action branch-publish push-btn${pushing ? " working" : ""}`}
+                title="Publish branch"
+                onClick={pushing ? undefined : push}
+              >
+                <CloudArrowUp size={16} />
+              </button>
+            ) : null}
           </span>
           <span
             className="git-root-actions"
@@ -558,20 +618,15 @@ export function GitView({
             >
               <ArrowsClockwise size={14} />
             </button>
-            <button
-              className={`branch-action pull-btn${pulling ? " working" : ""}${!pulling && !canPull ? " disabled" : ""}`}
-              title={pullTitle}
-              onClick={pulling || !canPull ? undefined : pull}
-            >
-              {ICON_PULL}
-            </button>
-            <button
-              className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !canPush ? " disabled" : ""}`}
-              title={pushTitle}
-              onClick={pushing || !canPush ? undefined : push}
-            >
-              {pushIcon}
-            </button>
+            {status?.inRepo && (
+              <button
+                className="branch-action git-menu-btn"
+                title="More actions"
+                onClick={(e) => openGitMenu(e.currentTarget)}
+              >
+                <DotsThreeVertical size={18} weight="bold" />
+              </button>
+            )}
           </span>
         </button>
       ) : (
@@ -589,11 +644,28 @@ export function GitView({
               {status ? (status.branch ?? "(detached)") : "Loading…"}
             </span>
           )}
-          {status?.upstream && (
-            <span className="branch-tracking">
+          {/* Where the remote state lives: published → the ↑/↓ counts double as
+              a Sync button; not yet published → a Publish-branch button. */}
+          {status?.upstream ? (
+            <button
+              className={`branch-tracking branch-sync${syncing ? " working" : ""}`}
+              title="Sync (pull, then push)"
+              onClick={syncing ? undefined : sync}
+            >
+              {syncing && (
+                <ArrowsClockwise className="git-branch-spin" size={12} />
+              )}
               ↑{status.ahead} ↓{status.behind}
-            </span>
-          )}
+            </button>
+          ) : status?.inRepo && status.branch ? (
+            <button
+              className={`branch-action branch-publish push-btn${pushing ? " working" : ""}`}
+              title="Publish branch"
+              onClick={pushing ? undefined : push}
+            >
+              <CloudArrowUp size={16} />
+            </button>
+          ) : null}
           <span className="spacer" />
           <button
             className={`branch-action refresh-btn${busy ? " working" : ""}`}
@@ -602,20 +674,15 @@ export function GitView({
           >
             <ArrowsClockwise size={16} />
           </button>
-          <button
-            className={`branch-action pull-btn${pulling ? " working" : ""}${!pulling && !canPull ? " disabled" : ""}`}
-            title={pullTitle}
-            onClick={pulling || !canPull ? undefined : pull}
-          >
-            {ICON_PULL}
-          </button>
-          <button
-            className={`branch-action push-btn${pushing ? " working" : ""}${!pushing && !canPush ? " disabled" : ""}`}
-            title={pushTitle}
-            onClick={pushing || !canPush ? undefined : push}
-          >
-            {pushIcon}
-          </button>
+          {status?.inRepo && (
+            <button
+              className="branch-action git-menu-btn"
+              title="More actions"
+              onClick={(e) => openGitMenu(e.currentTarget)}
+            >
+              <DotsThreeVertical size={18} weight="bold" />
+            </button>
+          )}
         </div>
       )}
       {!collapsed && (

--- a/packages/extensions-silo/src/git-explorer/git-icons.tsx
+++ b/packages/extensions-silo/src/git-explorer/git-icons.tsx
@@ -119,29 +119,3 @@ export const ICON_PUSH: ReactNode = (
     />
   </svg>
 );
-// Vertical mirror of ICON_PUSH: a bar at the top (the remote) with an arrow
-// pulling down from it.
-export const ICON_PULL: ReactNode = (
-  <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
-    <path
-      d="M3 3h10"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M8 5v8"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M5 10l3 3 3-3"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);


### PR DESCRIPTION
## Summary

Reworks the Git panel's branch row around remote state, building on the pull/autofetch work from #24.

- **No upstream** → a **Publish branch** button sits where the counts go, next to the branch name.
- **Published** → the **`↑/↓` counts become a Sync button**: `git pull --ff-only` then `git push` (behind → fast-forwards; ahead → pushes; diverged → toast, never a half-merge).
- **Push & Pull move off the bar into a `⋯` menu** (plain text rows) alongside **Fetch** and **Manage branches…**. **Refresh stays inline.**

## Layout / polish

- Branch name, sync counts, and the icon buttons share the same height + padding so their hover highlights match.
- The sync button's hover is scoped `(0,3,0)` so it beats the host's global `button:hover:not(:disabled)` (which was otherwise painting the dark `--silo-button-bg` mix instead of `--silo-color-bg-hover`).
- Removed the now-unused bar pull/push buttons, `ICON_PULL`, and the `branch-pull` animation introduced in #24.

## Tests

No behavior in the changed files is unit-tested directly (pure git logic lives in `git-service`/`parse-*`, already covered). Verified `tsc` clean, `pnpm lint` clean, `pnpm --filter @silo-code/extensions-silo test` green (80).

> Note: separately, a global keyboard focus ring for standalone controls is in #25 — these two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)