### PR TITLE
feat: Switch-branches modal — close button + keyboard list navigation

### DIFF
--- a/packages/extension-host/src/extension-host/Modal.tsx
+++ b/packages/extension-host/src/extension-host/Modal.tsx
@@ -14,6 +14,7 @@ import {
   pushModal,
   removeModal,
 } from "./modal-service";
+import { getMenu } from "./menu-controller";
 import { TABBABLE } from "./focus-dom";
 
 // The SDK `<Modal>` — host-owned dialog chrome for arbitrary custom content,
@@ -120,6 +121,11 @@ export function Modal({
     if (!isTop) return;
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape" && dismissible) {
+        // A menu open on top of the modal owns Escape — let it close first, and
+        // the modal closes on the next Escape. Both listen on document/capture
+        // and the modal's listener was registered first, so without this the
+        // modal would close out from under the open menu.
+        if (getMenu()) return;
         e.preventDefault();
         onClose();
         return;

--- a/packages/extension-host/src/extension-host/Modal.tsx
+++ b/packages/extension-host/src/extension-host/Modal.tsx
@@ -169,6 +169,27 @@ export function Modal({
       >
         {title != null && <div className="silo-modal-title">{title}</div>}
         {children}
+        {/* Close affordance for dismissible modals — last in the DOM so it
+            never steals the initial focus from the modal's real first control,
+            but visually pinned to the top-right corner. Bare modals own their
+            own chrome, so they opt out. */}
+        {dismissible && !bare && (
+          <button
+            type="button"
+            className="silo-modal-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+              <path
+                d="M4 4l8 8M12 4l-8 8"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        )}
       </div>
     </div>,
     document.body,

--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -358,6 +358,7 @@ button.silo-button-sm {
   /* z-index set inline (var(--silo-z-modal-base) + stack index) */
 }
 .silo-modal {
+  position: relative;
   background: var(--silo-modal-bg);
   border: 1px solid var(--silo-modal-border);
   border-radius: var(--silo-modal-radius);
@@ -367,6 +368,29 @@ button.silo-button-sm {
   gap: 12px;
   padding: 20px;
   font-family: var(--silo-font-ui);
+}
+/* Corner close button (dismissible modals). Scoped under .silo-modal so the
+   hover beats the global `button:hover:not(:disabled)` and paints the themed
+   --silo-color-bg-hover rather than the dark button mix. */
+.silo-modal .silo-modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--silo-radius-sm);
+  color: var(--silo-color-text-lo);
+  cursor: pointer;
+}
+.silo-modal .silo-modal-close:hover {
+  background: var(--silo-color-bg-hover);
+  color: var(--silo-color-text-hi);
 }
 .silo-modal-sm {
   width: 300px;
@@ -386,6 +410,8 @@ button.silo-button-sm {
   font-weight: 600;
   font-size: var(--silo-font-size-base);
   color: var(--silo-color-text-hi);
+  /* Leave room for the corner close button so a long title never runs under it. */
+  padding-right: 24px;
 }
 .silo-modal-body {
   font-size: var(--silo-font-size-sm);

--- a/packages/extensions-silo/src/git-explorer/BranchManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/BranchManager.tsx
@@ -8,10 +8,15 @@ import {
   Plus,
   Trash,
 } from "@phosphor-icons/react";
-import { useFocusGroup, type ExtensionContext } from "@silo-code/sdk";
+import {
+  useFocusGroup,
+  type ExtensionContext,
+  type MenuEntry,
+} from "@silo-code/sdk";
 import type { GitBranch, GitLogEntry } from "../git/git-api";
 import { getGitApi } from "./git-runtime";
 import {
+  branchActions,
   filterBranches,
   isPublished,
   localNameFor,
@@ -95,6 +100,11 @@ export function BranchManager({
     onActivate: (i) => {
       const b = visible[i];
       if (b) void switchTo(b);
+    },
+    // ContextMenu key / Shift+F10 → the row's action menu, anchored to the row.
+    onMenu: (i, anchor) => {
+      const b = visible[i];
+      if (b) openBranchMenu(b, { anchor });
     },
   });
 
@@ -295,6 +305,47 @@ export function BranchManager({
     }
   }
 
+  // The row context menu — the keyboard path to the row actions (ContextMenu
+  // key / Shift+F10 via the focus group, or right-click), mirroring the hover
+  // buttons so keyboard users aren't locked out of push/rename/delete.
+  function branchMenuItems(b: GitBranch): MenuEntry[] {
+    const acts = branchActions(b, isPublished(b, remoteNames));
+    const items: MenuEntry[] = [];
+    if (acts.includes("switch")) {
+      items.push({
+        label: b.remote ? "Check out as local branch" : "Switch to branch",
+        run: () => void switchTo(b),
+      });
+    }
+    if (acts.includes("push")) {
+      items.push({ label: "Push", run: () => void pushBranch(b) });
+    }
+    if (acts.includes("publish")) {
+      items.push({ label: "Publish", run: () => void pushBranch(b) });
+    }
+    if (acts.includes("rename") || acts.includes("delete")) {
+      items.push({ type: "separator" });
+      if (acts.includes("rename")) {
+        items.push({ label: "Rename…", run: () => void rename(b) });
+      }
+      if (acts.includes("delete")) {
+        items.push({ label: "Delete", danger: true, run: () => void del(b) });
+      }
+    }
+    return items;
+  }
+
+  // Open a row's menu — at the cursor for a right-click, anchored to the row for
+  // a keyboard invocation (`toggle: false` so a stray duplicate event re-opens).
+  function openBranchMenu(
+    b: GitBranch,
+    placement: { at?: { x: number; y: number }; anchor?: HTMLElement | null },
+  ) {
+    const items = branchMenuItems(b);
+    if (items.length === 0) return;
+    void ctx.ui.showMenu({ items, toggle: false, ...placement });
+  }
+
   return (
     <div className="git-branch-modal">
       <input
@@ -333,6 +384,16 @@ export function BranchManager({
               role="button"
               title={b.current ? "Current branch" : `Switch to ${b.name}`}
               onClick={() => void switchTo(b)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                // Right-click opens at the cursor; a keyboard-invoked
+                // contextmenu (button !== 2) anchors to the row instead.
+                if (e.button === 2) {
+                  openBranchMenu(b, { at: { x: e.clientX, y: e.clientY } });
+                } else {
+                  openBranchMenu(b, { anchor: e.currentTarget });
+                }
+              }}
               {...list.getItemProps(i)}
             >
               <span className="git-branch-glyph">

--- a/packages/extensions-silo/src/git-explorer/BranchManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/BranchManager.tsx
@@ -8,7 +8,7 @@ import {
   Plus,
   Trash,
 } from "@phosphor-icons/react";
-import type { ExtensionContext } from "@silo-code/sdk";
+import { useFocusGroup, type ExtensionContext } from "@silo-code/sdk";
 import type { GitBranch, GitLogEntry } from "../git/git-api";
 import { getGitApi } from "./git-runtime";
 import {
@@ -83,6 +83,20 @@ export function BranchManager({
     () => remoteBranchNames(branches ?? []),
     [branches],
   );
+
+  // Roving keyboard nav over the list (same as the side panels): the list is a
+  // single Tab stop, ↑/↓/Home/End move between rows, and Enter switches. Entry
+  // parks on the current branch. ArrowDown from the filter box drops into it.
+  const currentIndex = visible.findIndex((b) => b.current);
+  const list = useFocusGroup({
+    count: visible.length,
+    start: currentIndex >= 0 ? currentIndex : 0,
+    orientation: "vertical",
+    onActivate: (i) => {
+      const b = visible[i];
+      if (b) void switchTo(b);
+    },
+  });
 
   // The live provider, or a notify + null so handlers can bail gracefully.
   function api() {
@@ -289,13 +303,19 @@ export function BranchManager({
         placeholder="Filter branches…"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            list.focusItem(currentIndex >= 0 ? currentIndex : 0);
+          }
+        }}
         autoCapitalize="off"
         autoCorrect="off"
         autoComplete="off"
         spellCheck={false}
       />
 
-      <div className="git-branch-list">
+      <div className="git-branch-list" {...list.containerProps}>
         {branches === null && (
           <div className="git-branch-loader">
             <ArrowsClockwise size={22} className="git-branch-spin" />
@@ -306,20 +326,14 @@ export function BranchManager({
           <div className="git-branch-empty">No matching branches.</div>
         )}
         {(branches ?? []).length > 0 &&
-          visible.map((b) => (
+          visible.map((b, i) => (
             <div
               key={(b.remote ? "r:" : "l:") + b.name}
               className={`git-branch-row${b.current ? " current" : ""}`}
               role="button"
-              tabIndex={0}
               title={b.current ? "Current branch" : `Switch to ${b.name}`}
               onClick={() => void switchTo(b)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  void switchTo(b);
-                }
-              }}
+              {...list.getItemProps(i)}
             >
               <span className="git-branch-glyph">
                 {b.remote ? <Cloud size={15} /> : <GitBranchIcon size={15} />}
@@ -339,6 +353,7 @@ export function BranchManager({
                         ? `Push ${b.name}`
                         : `Publish ${b.name}`
                     }
+                    tabIndex={-1}
                     disabled={pushing === b.name}
                     onClick={() => void pushBranch(b)}
                   >
@@ -354,6 +369,7 @@ export function BranchManager({
                         type="button"
                         className="git-branch-action"
                         title="Rename branch"
+                        tabIndex={-1}
                         onClick={() => void rename(b)}
                       >
                         <PencilSimple size={14} />
@@ -362,6 +378,7 @@ export function BranchManager({
                         type="button"
                         className="git-branch-action danger"
                         title="Delete branch"
+                        tabIndex={-1}
                         onClick={() => void del(b)}
                       >
                         <Trash size={14} />

--- a/packages/extensions-silo/src/git-explorer/branch-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/branch-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { GitBranch } from "../git/git-api";
 import {
+  branchActions,
   filterBranches,
   isPublished,
   localNameFor,
@@ -104,5 +105,31 @@ describe("isPublished / remoteBranchNames", () => {
     );
     // never pushed → unpublished
     expect(isPublished(localWith("scratch", null), names)).toBe(false);
+  });
+});
+
+describe("branchActions", () => {
+  it("offers only checkout for a remote-tracking branch", () => {
+    expect(branchActions(remote("origin/feature"), false)).toEqual(["switch"]);
+  });
+
+  it("gives a non-current local the full set, push vs publish by published", () => {
+    expect(branchActions(local("feature"), true)).toEqual([
+      "switch",
+      "push",
+      "rename",
+      "delete",
+    ]);
+    expect(branchActions(local("feature"), false)).toEqual([
+      "switch",
+      "publish",
+      "rename",
+      "delete",
+    ]);
+  });
+
+  it("limits the current branch to push/publish (no switch/rename/delete)", () => {
+    expect(branchActions(local("main", true), true)).toEqual(["push"]);
+    expect(branchActions(local("main", true), false)).toEqual(["publish"]);
   });
 });

--- a/packages/extensions-silo/src/git-explorer/branch-model.ts
+++ b/packages/extensions-silo/src/git-explorer/branch-model.ts
@@ -55,3 +55,25 @@ export function isPublished(
 ): boolean {
   return branch.upstream != null && remoteNames.has(branch.upstream);
 }
+
+/** A row action offered for a branch (drives the row context menu). */
+export type BranchAction = "switch" | "push" | "publish" | "rename" | "delete";
+
+/**
+ * The actions that apply to a branch, in display order. A **remote-tracking**
+ * branch only offers `switch` (check it out as a local branch). The **current**
+ * branch can't switch/rename/delete — only push/publish. Any other **local**
+ * branch gets the full set. `published` (see {@link isPublished}) picks `push`
+ * vs `publish`.
+ */
+export function branchActions(
+  branch: GitBranch,
+  published: boolean,
+): BranchAction[] {
+  if (branch.remote) return ["switch"];
+  const actions: BranchAction[] = [];
+  if (!branch.current) actions.push("switch");
+  actions.push(published ? "push" : "publish");
+  if (!branch.current) actions.push("rename", "delete");
+  return actions;
+}


### PR DESCRIPTION
## Summary

Three improvements to the Switch-branches modal (the close button is host-wide):

1. **Close button (host chrome)** — `Modal.tsx` now renders a corner **✕** on every *dismissible*, non-bare modal (branch switcher, workspace properties, force-delete, confirm/prompt — consistent close affordance, not just Escape/backdrop). Last in the DOM so it never steals the modal's initial focus; pinned top-right; hover scoped under `.silo-modal` to beat the global `button:hover` and paint the themed `--silo-color-bg-hover`.

2. **Keyboard list navigation** — the branch list uses the shared **`useFocusGroup`** (like the file tree / workspaces / status bar): a **single Tab stop**, **↑/↓/Home/End** rove, **Enter** switches, entry **parks on the current branch**, and **ArrowDown** from the filter box drops into the list.

3. **Row context menu** — keeps the per-row push/rename/delete out of the Tab order (so the list reads as one stop) but restores keyboard access via the **ContextMenu key / Shift+F10** (the focus group's `onMenu`) and **right-click**: a per-row menu of Switch / Push|Publish / Rename / Delete, mirroring the hover buttons. Which actions appear is the pure `branchActions()` helper (remote → checkout only; current → push/publish; other locals → full set), unit-tested.

Commits split by layer (host modal vs. git-explorer) — easy to separate into two PRs if preferred.

## Tests

The modal close button and list wiring are thin glue over already-tested primitives (`Modal`, `useFocusGroup`). The new `branchActions()` action-set logic is covered in `branch-model.test.ts`. Verified: `tsc` clean, `pnpm lint` clean, host suite (282) + extensions-silo (83) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)