### PR TITLE
fix(focus): round the keyboard focus ring + stop edge clipping

### DIFF
--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -553,6 +553,11 @@ body.panel-resizing .side-resize-handle {
    so only the state-driven ring shows. */
 [data-focus-item] {
   outline: none;
+  /* The focus ring is an `outline`, which has no radius of its own — it inherits
+     the element's border-radius. Give every focus-group item the controls' small
+     radius so the ring (and the hover/selection highlight it shares a box with)
+     is rounded to match, rather than square on list rows that declare none. */
+  border-radius: var(--silo-radius-sm);
 }
 [data-focus-item][data-focus-visible] {
   outline: 1.5px solid var(--silo-color-accent);

--- a/packages/extensions-silo/src/file-explorer/FileExplorerPanel.css
+++ b/packages/extensions-silo/src/file-explorer/FileExplorerPanel.css
@@ -14,7 +14,9 @@
 
 .file-tree {
   font-family: var(--silo-font-ui);
-  padding: 4px 0 0;
+  /* Small horizontal inset so a row's rounded focus ring / selection floats off
+     the panel edges instead of being clipped flush against them. */
+  padding: 4px 4px 0;
   user-select: none;
   line-height: 1.4;
 }

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -338,7 +338,9 @@
   font-size: var(--silo-font-size-chrome);
   font-weight: 600;
   cursor: pointer;
-  border-radius: 0;
+  /* Match the file rows' rounded keyboard focus ring (the focus group's shared
+     [data-focus-item] radius) instead of forcing square corners here. */
+  border-radius: var(--silo-radius-sm);
 }
 .section-head:hover {
   background: var(--silo-color-bg-hover);


### PR DESCRIPTION
## Summary

Polish for the keyboard focus ring across the workbench. The ring is a CSS `outline`, which has **no radius of its own** — it inherits the focused element's `border-radius` — and at `outline-offset: -1.5px` it sits *inside* the box, so rows that run flush to a panel edge clip it.

1. **Round all focus-group highlights** — `[data-focus-item]` gets `--silo-radius-sm` (4px), so every group item's ring (and the hover/selection highlight sharing its box) is rounded instead of square on rows that declared no radius.
2. **Git section headers** — `.section-head` hard-coded `border-radius: 0`, overriding (1); set it to `--silo-radius-sm` so the CHANGES / STAGED CHANGES rings match the file rows.
3. **File-explorer edge clipping** — `.file-tree` had no horizontal padding and rows have no left padding, so a row's box ran flush to the panel's left edge and the inset ring hugged/clipped it. Add a small horizontal inset on the tree container so the ring floats off both edges.

## Notes

- App-wide for focus-group surfaces (file tree, workspaces, status bar, git panel; the Switch-branches list once #27 lands). Floating menus use state-driven highlight (not `[data-focus-item]`), so they're unaffected.
- No dedicated focus-ring radius token exists — the ring radius *is* the element's `border-radius`, so that (plus edge spacing) is the lever.

Verified: `tsc` clean, `pnpm lint` clean. Pure theming/layout, no logic → no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)