### PR TITLE
docs(roadmap): correct stale status for shipped capabilities

### DIFF
--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -48,16 +48,19 @@ designed. As a primitive ships, its badge flips from
 Features that ship built-in but are implemented as **extensions** on the
 primitives above — so a third party could build the same.
 
-| Feature                | Status                               | Built on                            | Publishes     |
-| ---------------------- | ------------------------------------ | ----------------------------------- | ------------- |
-| Git                    | <Badge type="tip" text="stable" />   | `process.exec` + `files`            | `GitAPI`      |
-| Markdown Preview       | <Badge type="tip" text="stable" />   | `registerEditor` + `files`          | —             |
-| Terminal               | <Badge type="info" text="planned" /> | `process` sessions + panel          | `TerminalAPI` |
-| Theme management       | <Badge type="info" text="planned" /> | `theme`-read + `files` + `settings` | `ThemeAPI`    |
-| Search (find-in-files) | <Badge type="tip" text="stable" />   | `search` + `editors`                | —             |
+| Feature                | Status                             | Built on                        | Publishes |
+| ---------------------- | ---------------------------------- | ------------------------------- | --------- |
+| Git                    | <Badge type="tip" text="stable" /> | `process.exec` + `files`        | `GitAPI`  |
+| Markdown Preview       | <Badge type="tip" text="stable" /> | `registerEditor` + `files`      | —         |
+| Terminal               | <Badge type="tip" text="stable" /> | `process` sessions + dock panel | —         |
+| Theme management       | <Badge type="tip" text="stable" /> | `theme` + `files` + `ui`        | —         |
+| Search (find-in-files) | <Badge type="tip" text="stable" /> | `search` + `editors`            | —         |
 
-> Today these still live partly inside the host; the work to move them out is
-> tracked in the repo. The decisions behind the model are recorded as ADRs in
+> Each ships as a real extension package (`core.*` / `silo.*`) that touches the
+> app only through `ctx` — the same surface a third party gets. The core
+> primitives they lean on (the terminal's `process` sessions, the theme domain
+> service) still live in the host; that split is by design. The decisions behind
+> the model are recorded as ADRs in
 > [`docs/decisions/`](https://github.com/silo-code/silo/tree/main/docs/decisions).
 
 ## Extension distribution <a id="extension-distribution"></a>
@@ -67,7 +70,7 @@ How a third-party extension gets from a package into the running app. See
 
 | Capability                                           | Status                               |                                                                     |
 | ---------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------- |
-| Author against `@silo-code/sdk` from npm             | <Badge type="info" text="planned" /> | [docs](/guide/publishing-an-extension#the-build-contract-externals) |
+| Author against `@silo-code/sdk` from npm             | <Badge type="tip" text="stable" />   | [docs](/guide/publishing-an-extension#the-build-contract-externals) |
 | Install from local folder                            | <Badge type="tip" text="stable" />   | [docs](/guide/publishing-an-extension)                              |
 | Enable / disable / uninstall (runtime)               | <Badge type="tip" text="stable" />   | [docs](/guide/publishing-an-extension)                              |
 | First-party built-ins listed (disable-only, branded) | <Badge type="tip" text="stable" />   | [docs](/guide/publishing-an-extension#install-enable-uninstall)     |


### PR DESCRIPTION
## What

Audited `apps/docs/roadmap.md` against the actual code. Three entries were stale and are now corrected.

### Fixed

- **Terminal** and **Theme management** — were marked `planned` / "still in host", but both ship today as real extensions (`core.terminal`, `core.themes`) that touch the app only through `ctx`, exactly like the other `stable` bundled extensions. Flipped both to `stable`.
  - Fixed their **Built on** columns — themes is built on `theme` + `files` + `ui` (not the nonexistent `ctx.settings`); terminal on `process` sessions + dock panel.
  - Dropped the unimplemented `TerminalAPI` / `ThemeAPI` **Publishes** claims — neither `activate()` returns an API today.
  - Refreshed the trailing note that claimed these features "still live partly inside the host."
- **"Author against `@silo-code/sdk` from npm"** → `stable`. The package is published (`registry.npmjs.org/@silo-code/sdk@0.6.0`) and the publishing guide documents `npm i -D @silo-code/sdk` as the authoring workflow.
  - This stays distinct from **"Install from npm registry"**, which remains `planned` — the host loader only does `installFromFolder`.

### Verified accurate (no change)

Re-checked every other `planned` row against runtime behavior, not just code presence: replace-in-files, `quickPick`/`inputBox`/`progress`, `ctx.settings`, `ctx.storage`, typed `ctx` events, remote install (URL/npm/npx), extension update checking, `engine` enforcement, sandbox, declarative `contributes`, and failed-load surfacing are all genuinely unimplemented. The permission model and automation RPC are real and correctly marked.

### Note (not addressed here)

App self-update (`update-service.ts` + `core.updates` status item + "Check for Updates…" menu) is shipped but absent from the roadmap. It's deliberately off the extension SDK surface (a host/platform capability, not a public `ctx.updates` domain). Could add a row under **Tooling** for completeness if desired — left out for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)