### PR TITLE
feat(cli): `silo <path>` opens/activates a workspace or file from the terminal

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4443,6 +4443,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
@@ -4943,6 +4944,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -64,7 +64,10 @@ pty-host = { path = "../../../crates/pty-host" }
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.25"
 
-# Auto-updater — desktop only (no mobile update channel).
+# Auto-updater + single-instance — desktop only (no mobile update channel; no
+# second-launch model on mobile). Single-instance powers the `silo <path>` CLI:
+# a second launch is forwarded to the running app (see commands/cli.rs).
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
+tauri-plugin-single-instance = "2"
 

--- a/apps/desktop/src-tauri/src/commands/cli.rs
+++ b/apps/desktop/src-tauri/src/commands/cli.rs
@@ -1,0 +1,158 @@
+//! `silo <path>` terminal entry point.
+//!
+//! Launching the `silo` binary a second time is forwarded to the already-running
+//! instance by `tauri-plugin-single-instance` (registered in `lib.rs`): the
+//! plugin hands us the second process's `argv` + `cwd`, we focus the window and
+//! emit a `cli:open` event the webview acts on. A *cold* launch (no instance yet)
+//! stashes the resolved arg in [`PendingLaunchArg`] for the webview to drain via
+//! [`cli_consume_launch_args`] once it's ready — avoiding the race where the emit
+//! lands before any listener exists.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tauri::{AppHandle, Manager, State};
+
+/// A resolved CLI path argument handed to the webview. `kind` is `"dir"`,
+/// `"file"`, or `"missing"`.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct CliOpenRequest {
+    pub path: String,
+    pub kind: String,
+}
+
+/// Cold-launch holding cell: the path arg parsed in `setup`, kept until the
+/// webview pulls it via [`cli_consume_launch_args`]. Warm launches go straight
+/// through the `cli:open` event and never touch this.
+#[derive(Default)]
+pub struct PendingLaunchArg(pub Mutex<Option<CliOpenRequest>>);
+
+/// Resolve the first positional CLI argument into an absolute path + kind.
+///
+/// Skips `argv[0]` (the program path) and any `-`/`--flag` tokens (the
+/// `--session-host` daemon fork never reaches here, but we stay defensive).
+/// Returns `None` when no path was given — bare `silo`, which should only focus
+/// the window. Relative paths are joined against `cwd`; existing paths are
+/// canonicalized so `.`/`..`/symlinks resolve to the same string a stored
+/// workspace folder would have.
+pub fn resolve_cli_arg(argv: &[String], cwd: &str) -> Option<CliOpenRequest> {
+    let raw = argv.iter().skip(1).find(|a| !a.starts_with('-'))?;
+    let p = Path::new(raw);
+    let abs: PathBuf = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        Path::new(cwd).join(p)
+    };
+    let resolved = std::fs::canonicalize(&abs).unwrap_or(abs);
+    let kind = match std::fs::metadata(&resolved) {
+        Ok(meta) if meta.is_dir() => "dir",
+        Ok(_) => "file",
+        Err(_) => "missing",
+    };
+    Some(CliOpenRequest {
+        path: resolved.to_string_lossy().into_owned(),
+        kind: kind.to_string(),
+    })
+}
+
+/// Bring the main window to the foreground (best-effort; ignores errors).
+pub fn focus_main_window(app: &AppHandle) {
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.unminimize();
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+}
+
+/// Drain the cold-launch path arg. The webview calls this once on startup; the
+/// `take` makes a later reload not replay the open.
+#[tauri::command]
+pub fn cli_consume_launch_args(state: State<'_, PendingLaunchArg>) -> Option<CliOpenRequest> {
+    state.0.lock().ok().and_then(|mut guard| guard.take())
+}
+
+/// Install a `silo` shim onto the user's PATH (`~/.local/bin/silo`) that execs
+/// the running app binary, so `silo <path>` works from any shell. Returns a
+/// human-readable status string (with a PATH hint when `~/.local/bin` isn't on
+/// `$PATH`). Backs the in-app "Install `silo` command" action.
+#[tauri::command]
+pub fn cli_install_shim() -> Result<String, String> {
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let home = dirs::home_dir().ok_or("could not resolve home directory")?;
+    let bin_dir = home.join(".local").join("bin");
+    std::fs::create_dir_all(&bin_dir).map_err(|e| e.to_string())?;
+
+    let shim = bin_dir.join("silo");
+    let script = format!("#!/bin/sh\nexec \"{}\" \"$@\"\n", exe.display());
+    std::fs::write(&shim, script).map_err(|e| e.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| e.to_string())?;
+    }
+
+    let on_path = std::env::var("PATH")
+        .map(|p| std::env::split_paths(&p).any(|d| d == bin_dir))
+        .unwrap_or(false);
+    if on_path {
+        Ok(format!("Installed the `silo` command to {}.", shim.display()))
+    } else {
+        Ok(format!(
+            "Installed `silo` to {} — add {} to your PATH to use it.",
+            shim.display(),
+            bin_dir.display()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(args: &[&str]) -> Vec<String> {
+        std::iter::once("/Applications/Silo.app/Contents/MacOS/silo")
+            .chain(args.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn bare_invocation_has_no_request() {
+        assert!(resolve_cli_arg(&argv(&[]), "/tmp").is_none());
+    }
+
+    #[test]
+    fn skips_leading_flags() {
+        assert!(resolve_cli_arg(&argv(&["--foo", "-x"]), "/tmp").is_none());
+    }
+
+    #[test]
+    fn joins_relative_path_against_cwd() {
+        // A path that doesn't exist on disk falls through to the lexical join and
+        // is reported as "missing" — but it's still resolved relative to cwd.
+        let req = resolve_cli_arg(&argv(&["sub/dir"]), "/tmp/some-cwd").unwrap();
+        assert_eq!(req.path, "/tmp/some-cwd/sub/dir");
+        assert_eq!(req.kind, "missing");
+    }
+
+    #[test]
+    fn keeps_absolute_path() {
+        let req = resolve_cli_arg(&argv(&["/no/such/path"]), "/tmp").unwrap();
+        assert_eq!(req.path, "/no/such/path");
+        assert_eq!(req.kind, "missing");
+    }
+
+    #[test]
+    fn classifies_existing_dir_and_file() {
+        let dir = std::env::temp_dir();
+        let dir_req = resolve_cli_arg(&argv(&[&dir.to_string_lossy()]), "/").unwrap();
+        assert_eq!(dir_req.kind, "dir");
+
+        let file = dir.join("silo-cli-test-marker.txt");
+        std::fs::write(&file, b"x").unwrap();
+        let file_req = resolve_cli_arg(&argv(&[&file.to_string_lossy()]), "/").unwrap();
+        assert_eq!(file_req.kind, "file");
+        let _ = std::fs::remove_file(&file);
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod app_paths;
 #[cfg(feature = "automation")]
 pub mod automation;
+pub mod cli;
 pub mod devtools;
 pub mod fs;
 pub mod process;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,8 +2,7 @@ mod commands;
 #[cfg(target_os = "macos")]
 mod mac_keys;
 
-#[cfg(target_os = "macos")]
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -37,7 +36,22 @@ pub fn run() {
         );
     }
 
-    let builder = tauri::Builder::default()
+    let builder = tauri::Builder::default();
+
+    // Single-instance must be the FIRST plugin (per its docs). A second `silo
+    // <path>` launch is forwarded here instead of opening a new window: we focus
+    // the running window and emit `cli:open` for the webview to act on. Desktop
+    // only — there is no second-launch model on mobile. The instance lock keys
+    // off the bundle identifier, so "Silo Dev" and "Silo" stay independent.
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+        commands::cli::focus_main_window(app);
+        if let Some(req) = commands::cli::resolve_cli_arg(&argv, &cwd) {
+            let _ = app.emit("cli:open", req);
+        }
+    }));
+
+    let builder = builder
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
@@ -52,8 +66,26 @@ pub fn run() {
 
     builder
         .manage(commands::terminal::TerminalState::new())
+        .manage(commands::cli::PendingLaunchArg::default())
         .setup(|app| {
             commands::watch::register(app.handle());
+
+            // Cold start: stash the `silo <path>` arg from *this* process's argv
+            // so the webview can drain it once it's listening (warm launches go
+            // through the single-instance `cli:open` emit instead).
+            {
+                let argv: Vec<String> = std::env::args().collect();
+                let cwd = std::env::current_dir()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                if let Some(req) = commands::cli::resolve_cli_arg(&argv, &cwd) {
+                    if let Ok(mut guard) =
+                        app.state::<commands::cli::PendingLaunchArg>().0.lock()
+                    {
+                        *guard = Some(req);
+                    }
+                }
+            }
 
             // Dev-only automation RPC (Cargo feature `automation` + the
             // SILO_AUTOMATION env var both required). Excluded from release.
@@ -86,6 +118,8 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            commands::cli::cli_consume_launch_args,
+            commands::cli::cli_install_shim,
             commands::devtools::open_devtools,
             commands::fs::fs_read_text,
             commands::fs::fs_read_bytes,

--- a/apps/desktop/src/builtins.ts
+++ b/apps/desktop/src/builtins.ts
@@ -8,6 +8,7 @@ import {
   themes,
   keybindings,
   about,
+  cliInstall,
   extensions,
   panelToggles,
   settingsButton,
@@ -56,6 +57,7 @@ const builtins: Extension[] = [
   updates,
   keybindings,
   about,
+  cliInstall,
   extensions,
 ];
 

--- a/apps/desktop/src/cli/index.ts
+++ b/apps/desktop/src/cli/index.ts
@@ -1,0 +1,26 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { applyCliOpen, type CliOpenRequest } from "./open-handler";
+
+/**
+ * Wire the `silo <path>` CLI entry point into the running webview.
+ *
+ * Two delivery paths (see `src-tauri/src/commands/cli.rs`):
+ * - **warm** — a second launch is forwarded by `tauri-plugin-single-instance`,
+ *   which emits `cli:open`; we listen for it for the app's lifetime.
+ * - **cold** — the launching process's arg was stashed before the webview
+ *   existed; we drain it once via `cli_consume_launch_args`.
+ *
+ * Must run *after* workspace hydration so a directory open matches an existing
+ * workspace instead of creating a duplicate (see the boot chain in `main.tsx`).
+ */
+export async function initCliOpenHandler(): Promise<void> {
+  await listen<CliOpenRequest>("cli:open", (event) => {
+    if (event.payload) applyCliOpen(event.payload);
+  });
+
+  const pending = await invoke<CliOpenRequest | null>(
+    "cli_consume_launch_args",
+  );
+  if (pending) applyCliOpen(pending);
+}

--- a/apps/desktop/src/cli/open-handler.test.ts
+++ b/apps/desktop/src/cli/open-handler.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Workspace } from "@silo-code/sdk";
+import { store } from "@silo-code/extension-host";
+import {
+  applyCliOpen,
+  findWorkspaceByFolder,
+  normalizeFolder,
+  dirname,
+  basename,
+} from "./open-handler";
+
+// Drives the CLI open logic against the real (in-memory) workspace store —
+// the unit layer (jsdom, Tauri boundary mocked), same style as the host's
+// editor-service tests.
+
+function makeWorkspace(
+  id: string,
+  folder: string,
+  extra?: string[],
+): Workspace {
+  return {
+    id,
+    name: id,
+    folder,
+    extraFolders: extra,
+    createdAt: "",
+    lastOpenedAt: "",
+    terminals: [],
+    editors: [],
+    dockLayout: null,
+    previewEditorId: null,
+  };
+}
+
+beforeEach(() => {
+  store.workspaces = {};
+  store.workspaceOrder = [];
+  store.activeWorkspaceId = null;
+});
+
+describe("path helpers", () => {
+  it("normalizes trailing slashes but keeps root", () => {
+    expect(normalizeFolder("/a/b/")).toBe("/a/b");
+    expect(normalizeFolder("/a/b///")).toBe("/a/b");
+    expect(normalizeFolder("/a/b")).toBe("/a/b");
+    expect(normalizeFolder("/")).toBe("/");
+  });
+
+  it("derives dirname and basename of an absolute path", () => {
+    expect(dirname("/Users/me/proj/readme.md")).toBe("/Users/me/proj");
+    expect(basename("/Users/me/proj/readme.md")).toBe("readme.md");
+    expect(basename("/Users/me/proj/")).toBe("proj");
+    expect(dirname("/top")).toBe("/");
+  });
+});
+
+describe("findWorkspaceByFolder", () => {
+  it("matches the primary folder, normalizing trailing slashes", () => {
+    const ws = makeWorkspace("a", "/code/foo");
+    const found = findWorkspaceByFolder({ a: ws }, "/code/foo/");
+    expect(found?.id).toBe("a");
+  });
+
+  it("matches an extra folder", () => {
+    const ws = makeWorkspace("a", "/code/foo", ["/code/bar"]);
+    expect(findWorkspaceByFolder({ a: ws }, "/code/bar")?.id).toBe("a");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    const ws = makeWorkspace("a", "/code/foo");
+    expect(findWorkspaceByFolder({ a: ws }, "/code/other")).toBeUndefined();
+  });
+});
+
+describe("applyCliOpen — directory", () => {
+  it("activates an existing workspace without creating a new one", () => {
+    store.workspaces = { a: makeWorkspace("a", "/code/foo") };
+    store.workspaceOrder = ["a"];
+
+    applyCliOpen({ path: "/code/foo", kind: "dir" });
+
+    expect(Object.keys(store.workspaces)).toEqual(["a"]);
+    expect(store.activeWorkspaceId).toBe("a");
+  });
+
+  it("creates and activates a workspace when none matches", () => {
+    applyCliOpen({ path: "/code/new-proj", kind: "dir" });
+
+    const all = Object.values(store.workspaces);
+    expect(all).toHaveLength(1);
+    expect(all[0].folder).toBe("/code/new-proj");
+    expect(all[0].name).toBe("new-proj");
+    expect(store.activeWorkspaceId).toBe(all[0].id);
+  });
+});
+
+describe("applyCliOpen — file", () => {
+  it("opens the file in the active workspace, creating nothing", () => {
+    store.workspaces = { a: makeWorkspace("a", "/code/foo") };
+    store.workspaceOrder = ["a"];
+    store.activeWorkspaceId = "a";
+
+    applyCliOpen({ path: "/code/foo/readme.md", kind: "file" });
+
+    expect(Object.keys(store.workspaces)).toEqual(["a"]);
+    const editors = store.workspaces.a.editors;
+    expect(editors.some((e) => e.filePath === "/code/foo/readme.md")).toBe(
+      true,
+    );
+  });
+
+  it("creates a parent-folder workspace when none is active", () => {
+    applyCliOpen({ path: "/code/loose/notes.txt", kind: "file" });
+
+    const all = Object.values(store.workspaces);
+    expect(all).toHaveLength(1);
+    expect(all[0].folder).toBe("/code/loose");
+    expect(store.activeWorkspaceId).toBe(all[0].id);
+    expect(
+      all[0].editors.some((e) => e.filePath === "/code/loose/notes.txt"),
+    ).toBe(true);
+  });
+});
+
+describe("applyCliOpen — missing", () => {
+  it("is a no-op", () => {
+    applyCliOpen({ path: "/no/such/thing", kind: "missing" });
+    expect(Object.keys(store.workspaces)).toHaveLength(0);
+    expect(store.activeWorkspaceId).toBeNull();
+  });
+});

--- a/apps/desktop/src/cli/open-handler.ts
+++ b/apps/desktop/src/cli/open-handler.ts
@@ -1,0 +1,91 @@
+import type { Workspace } from "@silo-code/sdk";
+import {
+  store,
+  createWorkspace,
+  activateWorkspace,
+  openEditor,
+} from "@silo-code/extension-host";
+
+/**
+ * A resolved `silo <path>` argument from the host (see `src-tauri`'s
+ * `commands/cli.rs`). `path` is absolute; `kind` says what's there.
+ */
+export interface CliOpenRequest {
+  path: string;
+  kind: "dir" | "file" | "missing";
+}
+
+/** Strip trailing separators so `/a/b` and `/a/b/` compare equal (keeps root). */
+export function normalizeFolder(p: string): string {
+  return p.length > 1 ? p.replace(/\/+$/, "") : p;
+}
+
+/** POSIX dirname of an absolute path (the host always hands us absolute paths). */
+export function dirname(p: string): string {
+  const norm = normalizeFolder(p);
+  const idx = norm.lastIndexOf("/");
+  if (idx <= 0) return "/";
+  return norm.slice(0, idx);
+}
+
+/** Last path segment, e.g. `/Users/me/proj` → `proj`. Falls back to the path. */
+export function basename(p: string): string {
+  const norm = normalizeFolder(p);
+  const idx = norm.lastIndexOf("/");
+  return idx >= 0 && idx < norm.length - 1 ? norm.slice(idx + 1) : norm;
+}
+
+/**
+ * Find an existing workspace rooted at `folder` (its primary folder or one of
+ * its `extraFolders`), comparing normalized paths. Returns `undefined` if none.
+ */
+export function findWorkspaceByFolder(
+  workspaces: Record<string, Workspace>,
+  folder: string,
+): Workspace | undefined {
+  const target = normalizeFolder(folder);
+  return Object.values(workspaces).find(
+    (w) =>
+      normalizeFolder(w.folder) === target ||
+      (w.extraFolders ?? []).some((f) => normalizeFolder(f) === target),
+  );
+}
+
+/**
+ * Act on a resolved CLI request against the live workspace store:
+ *
+ * - **dir** — activate the existing workspace for that folder, else create one
+ *   rooted there and activate it.
+ * - **file** — open the file in the active workspace; if none is active, create
+ *   a workspace rooted at the file's parent folder first.
+ * - **missing** — no-op (warn).
+ *
+ * The window is already being foregrounded by the host; this only drives state.
+ */
+export function applyCliOpen(req: CliOpenRequest): void {
+  if (req.kind === "missing") {
+    console.warn(`[silo cli] path not found: ${req.path}`);
+    return;
+  }
+
+  if (req.kind === "dir") {
+    const existing = findWorkspaceByFolder(store.workspaces, req.path);
+    const id =
+      existing?.id ??
+      createWorkspace({ folder: req.path, name: basename(req.path) }).id;
+    activateWorkspace(id);
+    return;
+  }
+
+  // file
+  let workspaceId = store.activeWorkspaceId;
+  if (!workspaceId) {
+    const parent = dirname(req.path);
+    workspaceId = createWorkspace({
+      folder: parent,
+      name: basename(parent),
+    }).id;
+    activateWorkspace(workspaceId);
+  }
+  openEditor(workspaceId, req.path);
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -9,6 +9,7 @@ import {
   initUserKeybindings,
 } from "@silo-code/extension-host";
 import { activateBuiltins } from "./builtins";
+import { initCliOpenHandler } from "./cli";
 
 // Activate built-ins synchronously, before render — the dock needs their panel
 // kinds present when it deserializes the saved layout.
@@ -30,7 +31,10 @@ mgr
 
 userConfigDir()
   .then(hydrate)
-  .catch((err) => console.error("hydrate failed", err));
+  // After hydration so a `silo <dir>` open matches an existing workspace
+  // instead of creating a duplicate (warm re-launches also funnel through here).
+  .then(() => initCliOpenHandler())
+  .catch((err) => console.error("hydrate / cli handler failed", err));
 
 // Best-effort flush of unsaved-edit backups + workspace/layout state when the
 // window is being hidden or torn down. We deliberately do NOT intercept the close

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -1,3 +1,10 @@
 // Global test setup — adds jest-dom matchers (toBeInTheDocument, etc.) and
 // runs before every test file (see vitest.config.ts `setupFiles`).
 import "@testing-library/jest-dom/vitest";
+
+// jsdom omits `document.queryCommandSupported`, which Monaco's clipboard contrib
+// probes at import time. Any unit test that imports the `@silo-code/extension-host`
+// barrel pulls Monaco in transitively, so stub it to keep the import from throwing.
+if (typeof document !== "undefined" && !document.queryCommandSupported) {
+  document.queryCommandSupported = () => false;
+}

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -101,6 +101,10 @@ export default withMermaid(
       sidebar: {
         "/guide/": [
           {
+            text: "Using Silo",
+            items: [{ text: "The `silo` command", link: "/guide/cli" }],
+          },
+          {
             text: "Building Extensions",
             items: [
               { text: "What is an extension?", link: "/guide/" },

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -1,0 +1,52 @@
+# The `silo` command
+
+Open Silo from the terminal. `silo <path>` brings the running app to the
+foreground (launching it first if it isn't running) and then opens what you
+pointed it at — mirroring VS Code's `code` command.
+
+## What it does
+
+```sh
+silo .                 # open/activate a workspace for the current directory
+silo ~/code/my-project # open/activate a workspace for that directory
+silo ./README.md       # open a file in the active workspace
+silo                   # just bring Silo to the foreground
+```
+
+- **A directory** — if a workspace already exists for that folder, Silo
+  activates it; otherwise it creates a new workspace rooted there and activates
+  it. Relative paths (`.`, `./sub`) resolve against your shell's working
+  directory.
+- **A file** — Silo opens the file in the **active** workspace. If no workspace
+  is active, it first creates one rooted at the file's parent folder.
+- **No argument** — Silo is simply brought to the foreground (or launched).
+
+A second `silo` invocation never opens a new window: it's forwarded to the
+already-running instance, which focuses and handles the path. Silo Dev and a
+release install are independent instances, each with its own command target.
+
+## Installing the command
+
+The binary ships inside the app bundle but isn't on your `PATH` by default. The
+easiest way to add it:
+
+**From inside Silo** — run **File → Install `silo` Command in PATH**. This writes
+a small shim to `~/.local/bin/silo` pointing at the app binary. If
+`~/.local/bin` isn't already on your `PATH`, the notification tells you to add
+it:
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"   # add to ~/.zshrc or ~/.bashrc
+```
+
+**Manually** — point a shim or symlink at the app binary directly:
+
+```sh
+ln -sf "/Applications/Silo.app/Contents/MacOS/silo" /usr/local/bin/silo
+```
+
+For a dev build, the binary lives under the **Silo Dev** app
+(`Silo Dev.app/Contents/MacOS/silo`); symlink that instead to drive the dev
+instance. Because the command works by launching the real binary (which is then
+forwarded to the running instance), pointing `open -a Silo` at the app won't
+pass the path — use the binary path or the installed shim.

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -127,7 +127,17 @@ Not part of the extension SDK — host-side developer/test surfaces.
 
 | Surface              | Status                                       |                                                                          |
 | -------------------- | -------------------------------------------- | ------------------------------------------------------------------------ |
+| `silo <path>` CLI    | <Badge type="tip" text="stable" />           | [docs](/guide/cli)                                                       |
 | Automation RPC (dev) | <Badge type="warning" text="experimental" /> | [design](https://github.com/silo-code/silo/blob/main/docs/automation.md) |
+
+### `silo <path>` CLI <Badge type="tip" text="stable" />
+
+A terminal entry point: `silo <dir>` foregrounds (or launches) Silo and
+opens/activates a workspace for that folder; `silo <file>` opens the file in the
+active workspace. Built on `tauri-plugin-single-instance` — a second launch is
+forwarded to the running instance rather than opening a new window. Install the
+command from **File → Install `silo` Command in PATH**. See
+[the `silo` command](/guide/cli).
 
 ### Automation RPC <Badge type="warning" text="experimental" />
 

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -46,6 +46,12 @@ export type { ModalProps } from "./Modal";
 export type { AppService } from "./app-service";
 export { getAppService } from "./app-service";
 
+// Install the `silo` shell command — privileged because it writes an executable
+// onto the user's PATH that points at the host binary; only the core
+// "Install `silo` command" action (`core.cli-install`) needs it, never a
+// silo.*/third-party extension. See services/tauri-cli.ts.
+export { installCliShim } from "../services/tauri-cli";
+
 // Reactive auto-update state — privileged because self-updating the installed
 // app (download + install a binary, relaunch) is a host/platform capability only
 // `core.updates` (and the app's "Check for Updates…" menu item) needs; not a

--- a/packages/extension-host/src/services/tauri-cli.ts
+++ b/packages/extension-host/src/services/tauri-cli.ts
@@ -1,0 +1,15 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// Thin wrapper over the host's `cli_install_shim` command — the leaf-layer seam
+// for installing the `silo` shell command, mirroring `tauri-app`/`tauri-watch`.
+// Consumed by `core.cli-install` via the privileged internal barrel; never
+// imported by extensions directly.
+
+/**
+ * Install a `silo` shim onto the user's PATH (`~/.local/bin/silo`) pointing at
+ * the running app binary. Resolves to a human-readable status string; rejects
+ * with the host error message on failure.
+ */
+export function installCliShim(): Promise<string> {
+  return invoke<string>("cli_install_shim");
+}

--- a/packages/extensions-core/src/cli-install/index.ts
+++ b/packages/extensions-core/src/cli-install/index.ts
@@ -1,0 +1,38 @@
+import type { Extension } from "@silo-code/sdk";
+import { installCliShim } from "@silo-code/extension-host/internal";
+
+/**
+ * `core.cli-install` — the in-app "Install `silo` command" action.
+ *
+ * Writes a `silo` shim onto the user's PATH (via the host's `cli_install_shim`,
+ * exposed on the privileged internal barrel) so `silo <path>` works from any
+ * shell, mirroring VS Code's "Install 'code' command in PATH". Surfaced as a
+ * File-menu item; the privileged binary-path resolution + file write happen in
+ * the host, so this extension only touches `ctx`.
+ */
+export const extension: Extension = {
+  id: "core.cli-install",
+  activate(ctx) {
+    ctx.registerCommand({
+      id: "core.cli.install",
+      label: "Install `silo` Command in PATH",
+      run: () => {
+        installCliShim()
+          .then((message) => ctx.ui.notify("info", message))
+          .catch((err) =>
+            ctx.ui.notify(
+              "error",
+              `Could not install the silo command: ${String(err)}`,
+            ),
+          );
+      },
+    });
+    ctx.registerMenuItem({
+      id: "core.cli-install.menu",
+      menu: "file",
+      command: "core.cli.install",
+      group: "8_cli",
+      order: 1,
+    });
+  },
+};

--- a/packages/extensions-core/src/index.ts
+++ b/packages/extensions-core/src/index.ts
@@ -17,6 +17,7 @@ export { extension as workspaces } from "./workspaces";
 export { extension as themes } from "./themes";
 export { extension as keybindings } from "./keybindings";
 export { extension as about } from "./about";
+export { extension as cliInstall } from "./cli-install";
 export { extension as extensions } from "./extensions";
 export { extension as panelToggles } from "./statusbar/panel-toggles";
 export { extension as settingsButton } from "./statusbar/settings-button";


### PR DESCRIPTION
## What

Adds a terminal entry point: `silo <path>` brings Silo to the foreground (or launches it) and opens what you point it at — mirroring VS Code's `code`.

- **`silo <dir>`** (`silo .`, `silo ~/code/foo`) — activate the existing workspace for that folder, else create one rooted there and activate it.
- **`silo <file>`** (`silo ./README.md`) — open the file in the **active** workspace; if none is active, create a workspace rooted at the file's parent folder first.
- **`silo`** — just foreground/launch.

## How

- **Single-instance forwarding.** Registers `tauri-plugin-single-instance` as the first plugin. A second `silo` launch is forwarded to the running instance instead of opening a new window: the host focuses the window and emits `cli:open`.
- **No cold-start race.** A cold launch stashes the resolved arg in Rust (`PendingLaunchArg`); the webview drains it once via `cli_consume_launch_args`, while warm relaunches go through the `cli:open` event. The frontend handler resolves dir/file against the live workspace store, wired **after hydration** so a directory open matches an existing workspace instead of duplicating it.
- **In-app installer.** **File → "Install `silo` Command in PATH"** (`core.cli-install`) writes a shim to `~/.local/bin/silo` via the host `cli_install_shim` command. The extension touches the app only through `ctx`; the privileged binary-path resolution + file write stay in the host (exposed on the internal barrel), keeping the architecture boundary intact.

## Files

- **Rust** — `Cargo.toml` (+`tauri-plugin-single-instance`, desktop-only), `commands/cli.rs` (new: arg resolution, focus, the two commands, unit tests), `lib.rs` (plugin + cold-start stash + command registration).
- **Frontend** — `src/cli/open-handler.ts` (pure helpers + `applyCliOpen`), `src/cli/index.ts` (Tauri wiring), `main.tsx` (post-hydration wiring), `test/setup.ts` (one-line jsdom stub so the host barrel's Monaco import survives).
- **Boundary plumbing** — host `services/tauri-cli.ts` + internal-barrel export; `core.cli-install` extension + barrel/`builtins.ts`.
- **Docs** — new guide `/guide/cli` + "Using Silo" sidebar group; roadmap entry (`stable`).

## Testing

- `cargo test commands::cli` — 5 Rust unit tests (path resolution, flag-skipping, dir/file/missing).
- Vitest — 10 unit tests for the path helpers + `applyCliOpen` (dir activate-vs-create, file active-vs-parent workspace, missing no-op).
- `pnpm lint`, full `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm docs:build` all green.
- Manually verified the real warm path in dev (second `target/debug/silo <path>` invocation forwards to the running instance and opens/activates correctly).

> Note: single-instance forwarding only triggers across real processes — fully verified in dev; cold-start from a packaged bundle is the one path that needs a release build to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)