### PR TITLE
feat(editor): show strikethrough tab when an open file is deleted

### DIFF
--- a/apps/desktop/src/automation/file-watch-reload.it.test.ts
+++ b/apps/desktop/src/automation/file-watch-reload.it.test.ts
@@ -5,6 +5,10 @@
 // watch-ownership move (file-explorer-owned watch -> host-owned, ref-counted)
 // must NOT regress — written against current behavior so it pins it.
 //
+// Also covers the deleted-file tab treatment: when the watched file is removed
+// from disk, the tab gets the `deleted-title` class (VS Code's strikethrough
+// tab) and clears it once the file reappears — see TextViewer/DockTab.
+//
 // Requires the dev app running (`npm run app:dev`). When none is reachable the
 // suite skips, so `npm test` stays green without it; `npm run test:it` expects
 // a live app.
@@ -42,6 +46,21 @@ async function waitFor<T>(
     last = await fn();
   }
   return last;
+}
+
+// The tab's class list, for the editor whose title contains `name` — ground
+// truth for the deleted-file strikethrough (`deleted-title`, see CenterDock.css).
+// Null if no matching tab is mounted.
+function tabClassName(name: string): Promise<string | null> {
+  return silo.eval<string | null>(
+    `(() => {
+      const spans = [...document.querySelectorAll(
+        '[data-testid="dockview-dv-default-tab"] .dv-default-tab-content'
+      )];
+      const span = spans.find((s) => s.textContent.includes(${JSON.stringify(name)}));
+      return span ? span.className : null;
+    })()`,
+  );
 }
 
 describe.skipIf(!available)("file-watch -> editor reload", () => {
@@ -88,5 +107,36 @@ describe.skipIf(!available)("file-watch -> editor reload", () => {
     );
     expect(model?.value).toContain("changed-on-disk");
     expect(model?.value).not.toContain("original");
+  });
+
+  it("marks the tab deleted when the file is removed from disk", async () => {
+    await rm(filePath);
+
+    const className = await waitFor(
+      () => tabClassName(fileName),
+      (c) => !!c?.includes("deleted-title"),
+    );
+    expect(className).toContain("deleted-title");
+
+    // The buffer itself is untouched — still shows the last-known content,
+    // not cleared out just because the file vanished.
+    const model = await silo.editorContent(fileName);
+    expect(model?.value).toContain("changed-on-disk");
+  });
+
+  it("clears the deleted mark once the file reappears on disk", async () => {
+    await writeFile(filePath, "recreated\n");
+
+    const className = await waitFor(
+      () => tabClassName(fileName),
+      (c) => !!c && !c.includes("deleted-title"),
+    );
+    expect(className).not.toContain("deleted-title");
+
+    const model = await waitFor(
+      () => silo.editorContent(fileName),
+      (m) => !!m && m.value.includes("recreated"),
+    );
+    expect(model?.value).toContain("recreated");
   });
 });

--- a/packages/extension-host/src/panels/CenterDock.css
+++ b/packages/extension-host/src/panels/CenterDock.css
@@ -360,6 +360,13 @@
   color: var(--silo-color-accent);
 }
 
+/* Deleted-on-disk tab title — strikethrough + error color, mirroring VS
+ * Code's treatment of a file removed out from under an open editor. */
+.dv-default-tab-content.deleted-title {
+  color: var(--silo-color-err);
+  text-decoration: line-through;
+}
+
 /* Tab close button: subtle background on hover, click feedback.
  * We include .dockview-theme-* classes to match the library's specificity
  * and avoid the need for !important. */

--- a/packages/extension-host/src/panels/DockTab.tsx
+++ b/packages/extension-host/src/panels/DockTab.tsx
@@ -25,6 +25,11 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
   const [isDirty, setIsDirty] = useState(
     () => !!api.getParameters<{ dirty?: boolean }>().dirty,
   );
+  // True when the viewer's backing file no longer exists on disk (deleted
+  // externally). Same params channel as `dirty` — see TextViewer.
+  const [isDeleted, setIsDeleted] = useState(
+    () => !!api.getParameters<{ deleted?: boolean }>().deleted,
+  );
   const snap = useSnapshot(store);
 
   useEffect(() => {
@@ -36,8 +41,14 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
   // Re-read getParameters() on each change rather than trusting the event
   // payload, which only carries the keys that changed in that update.
   useEffect(() => {
-    const read = () =>
-      setIsDirty(!!api.getParameters<{ dirty?: boolean }>().dirty);
+    const read = () => {
+      const params = api.getParameters<{
+        dirty?: boolean;
+        deleted?: boolean;
+      }>();
+      setIsDirty(!!params.dirty);
+      setIsDeleted(!!params.deleted);
+    };
     read();
     const sub = api.onDidParametersChange(read);
     return () => sub.dispose();
@@ -126,7 +137,7 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
       onContextMenu={onTabContextMenu}
     >
       <span
-        className={`dv-default-tab-content${isPreview ? " preview-title" : ""}`}
+        className={`dv-default-tab-content${isPreview ? " preview-title" : ""}${isDeleted ? " deleted-title" : ""}`}
       >
         {isDirty && <span className="dvi-dirty-indicator">●</span>}
         {title}

--- a/packages/extensions-core/src/editor/TextViewer.tsx
+++ b/packages/extensions-core/src/editor/TextViewer.tsx
@@ -77,6 +77,11 @@ export function TextViewer({
   // steals keyboard focus back to the previously-active editor.
   const [content, setContent] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  // True when the backing file no longer exists on disk (deleted externally,
+  // e.g. `rm`, a git checkout, or another tool). The buffer stays editable —
+  // we just stop treating disk as the source of truth and flag the tab (VS
+  // Code's strikethrough-tab behavior).
+  const [deleted, setDeleted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -158,6 +163,7 @@ export function TextViewer({
         dockApi.setTitle(path.split("/").pop() ?? path);
       }
       setDirty(false);
+      setDeleted(false); // the write just (re)created the file
       void clearEditorBackup(editorId);
     } catch (err) {
       setError(String(err));
@@ -205,16 +211,28 @@ export function TextViewer({
     if (!filePath) return;
     if (loadedPathRef.current === filePath) return;
     let cancelled = false;
-    // Read the file and any hot-exit backup together. If a backup differs from
-    // disk, it's the user's unsaved work — restore it and mark the tab dirty;
-    // otherwise show the disk content (and drop a stale backup that matched).
-    Promise.all([files.readText(filePath), readEditorBackup(editorId)])
-      .then(([text, backup]) => {
-        if (cancelled) return;
-        savedContentRef.current = text;
-        loadedPathRef.current = filePath;
-        applyRestoredBuffer(text, backup?.content ?? null);
-      })
+    // Check existence first so a file deleted between session-restore and
+    // mount falls back to its hot-exit backup (or an empty buffer) instead of
+    // a hard error — same "missing on disk" treatment as the live-watch path
+    // below, just evaluated once up front.
+    files
+      .pathExists(filePath)
+      .then((exists) =>
+        // Read the file and any hot-exit backup together. If a backup differs
+        // from disk, it's the user's unsaved work — restore it and mark the
+        // tab dirty; otherwise show the disk content (and drop a stale backup
+        // that matched).
+        Promise.all([
+          exists ? files.readText(filePath) : Promise.resolve(null),
+          readEditorBackup(editorId),
+        ]).then(([text, backup]) => {
+          if (cancelled) return;
+          savedContentRef.current = text ?? "";
+          loadedPathRef.current = filePath;
+          setDeleted(!exists);
+          applyRestoredBuffer(text, backup?.content ?? null);
+        }),
+      )
       .catch((err) => {
         if (cancelled) return;
         setError(String(err));
@@ -229,21 +247,32 @@ export function TextViewer({
   // we don't want to silently clobber the user's work. Echoes of our own
   // save are filtered by the disk-vs-savedContentRef equality check. The watch
   // is scoped to this file, so we don't re-check the changed path ourselves.
+  //
+  // A change event fires for deletes too (the backend's `Remove` kind), so we
+  // re-check existence on every event rather than trust `kind` — it's the
+  // OS-level Debug string, not a stable contract. Once gone, leave the buffer
+  // exactly as it was (still editable) and just flag the tab; don't reload
+  // until the path exists again.
   useEffect(() => {
     if (!filePath) return;
     let cancelled = false;
     const sub = files.watch(filePath, () => {
       if (cancelled) return;
       files
-        .readText(filePath)
-        .then((text) => {
+        .pathExists(filePath)
+        .then((exists) => {
           if (cancelled) return;
-          if (text === savedContentRef.current) return;
-          if (dirtyRef.current) return;
-          savedContentRef.current = text;
-          loadedPathRef.current = filePath;
-          setContent(text);
-          setDirty(false);
+          setDeleted(!exists);
+          if (!exists) return;
+          return files.readText(filePath).then((text) => {
+            if (cancelled) return;
+            if (text === savedContentRef.current) return;
+            if (dirtyRef.current) return;
+            savedContentRef.current = text;
+            loadedPathRef.current = filePath;
+            setContent(text);
+            setDirty(false);
+          });
         })
         .catch(() => {});
     });
@@ -253,13 +282,13 @@ export function TextViewer({
     };
   }, [filePath]);
 
-  // Surface dirty state to the tab via dockview panel params; DockTab renders
-  // the indicator. Reset on unmount so a recycled panel id never shows stale
-  // dirt. (Merges with existing params, so editorId is preserved.)
+  // Surface dirty/deleted state to the tab via dockview panel params; DockTab
+  // renders the indicator. Reset on unmount so a recycled panel id never shows
+  // stale state. (Merges with existing params, so editorId is preserved.)
   useEffect(() => {
-    dockApi.updateParameters({ dirty });
-    return () => dockApi.updateParameters({ dirty: false });
-  }, [dirty, dockApi]);
+    dockApi.updateParameters({ dirty, deleted });
+    return () => dockApi.updateParameters({ dirty: false, deleted: false });
+  }, [dirty, deleted, dockApi]);
 
   async function saveAs() {
     const ed = editorRef.current;
@@ -278,6 +307,7 @@ export function TextViewer({
       setEditorFilePath(ws, editorId, picked);
       dockApi.setTitle(picked.split("/").pop() ?? picked);
       setDirty(false);
+      setDeleted(false);
       void clearEditorBackup(editorId);
     } catch (err) {
       setError(String(err));


### PR DESCRIPTION
## What

When a file open in an editor is removed from disk (externally — `rm`, a `git checkout`, another tool), the tab now mirrors VS Code: the title renders with a red strikethrough while the buffer keeps its last-known content fully editable.

## How

- `TextViewer` tracks a `deleted` flag alongside `dirty`, surfaced through the same dockview panel-params channel (`DockTab` already reads `dirty` this way).
- Existence is checked via `files.pathExists()` — on initial load (handles a file deleted while the app was closed) and on every live watch event — rather than parsing the watcher's OS-level `kind` string, which isn't a stable cross-platform contract.
- While deleted, the live-reload effect skips re-reading the file and leaves the buffer untouched. `deleted` clears automatically once the path exists again (recreated externally, or the user saves — which recreates the file).
- `DockTab` adds a `deleted-title` class when the flag is set; `CenterDock.css` styles it with `--silo-color-err` + `text-decoration: line-through`.
- Extended `file-watch-reload.it.test.ts` with delete/recreate cases.

## Verification

Drove the real dev app via the automation RPC in a sandbox workspace: opened a file, deleted it from disk, confirmed the tab got `deleted-title` (red strikethrough) while `editorContent` still returned the original text, then recreated the file and confirmed the class cleared and content reloaded.

| Before delete | After delete | After recreate |
| --- | --- | --- |
| normal tab | strikethrough tab, content intact | normal tab, content reloaded |

`pnpm test` (282 tests) and `pnpm lint` pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)