### PR TITLE
feat(tabs): restyle overflow menu to match Silo context menus

### DIFF
--- a/packages/extension-host/src/panels/CenterDock.css
+++ b/packages/extension-host/src/panels/CenterDock.css
@@ -350,6 +350,99 @@
   border-color: var(--silo-color-border);
 }
 
+/* Overflow tab list: restyle dockview's raw dropdown to match Silo context menus.
+ * The popup is rendered inside .dv-popover-anchor which dockview places outside
+ * .editor-dock, so we scope to .dv-popover-anchor instead. */
+.dv-popover-anchor .dv-tabs-overflow-container {
+  background: var(--silo-menu-bg);
+  border: 1px solid var(--silo-menu-border);
+  border-radius: var(--silo-radius-md);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  color: var(--silo-menu-text);
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+  padding: 4px 0;
+  min-width: 180px;
+}
+
+/* Reset tab-strip chrome (borders, radii, colors) that don't belong in a menu */
+.dv-popover-anchor .dv-tabs-overflow-container .dv-tab,
+.dv-popover-anchor .dv-tabs-overflow-container .dv-tab.dv-active-tab,
+.dv-popover-anchor .dv-tabs-overflow-container .dv-tab.dv-inactive-tab {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--silo-menu-text);
+  padding: 0;
+  margin: 0;
+}
+
+.dv-popover-anchor .dv-tabs-overflow-container .dv-tab:not(:last-child) {
+  border-bottom: none;
+}
+
+.dv-popover-anchor .dv-tabs-overflow-container .dv-tab:hover,
+.dv-popover-anchor .dv-tabs-overflow-container .dv-tab.dv-inactive-tab:hover {
+  background: var(--silo-menu-item-hover-bg);
+  color: var(--silo-menu-text);
+}
+
+/* The DockTab component renders .dv-default-tab — give it menu-item layout */
+.dv-popover-anchor .dv-tabs-overflow-container .dv-default-tab {
+  display: flex;
+  align-items: center;
+  padding: 5px 12px;
+  width: 100%;
+  box-sizing: border-box;
+  gap: 8px;
+}
+
+.dv-popover-anchor .dv-tabs-overflow-container .dv-default-tab-content {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Active tab: brighter text so it reads as the currently open file */
+.dv-popover-anchor
+  .dv-tabs-overflow-container
+  .dv-active-tab
+  .dv-default-tab-content {
+  color: var(--silo-color-text-hi);
+}
+
+/* Close button: dim by default, visible on row hover — matches tab-bar treatment */
+.dv-popover-anchor .dv-tabs-overflow-container .dv-default-tab-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--silo-radius-sm);
+  margin-left: 6px;
+  cursor: pointer;
+  color: transparent;
+  transition:
+    color 0.1s ease,
+    background-color 0.1s ease;
+}
+.dv-popover-anchor
+  .dv-tabs-overflow-container
+  .dv-tab:hover
+  .dv-default-tab-action {
+  color: var(--silo-menu-text);
+}
+.dv-popover-anchor .dv-tabs-overflow-container .dv-default-tab-action:hover {
+  background-color: var(--silo-color-bg-hover);
+}
+.dv-popover-anchor .dv-tabs-overflow-container .dv-default-tab-action svg {
+  fill: currentColor;
+  width: 11px;
+  height: 11px;
+}
+
 /* Dirty-indicator ● — smaller, blue accent, vertically centered */
 .dv-default-tab-content .dvi-dirty-indicator {
   display: inline-block;

--- a/packages/extension-host/src/panels/DockTab.tsx
+++ b/packages/extension-host/src/panels/DockTab.tsx
@@ -63,14 +63,36 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
     (event: React.MouseEvent) => {
       event.preventDefault();
       event.stopPropagation();
+
+      // When closing from inside the overflow popup, stopPropagation prevents
+      // dockview's wrapper click-handler from running (which normally closes the
+      // popup). We handle it here instead: remove the row or close the popup.
+      const closeBtn = event.currentTarget as HTMLElement;
+      const overflowContainer = closeBtn.closest(".dv-tabs-overflow-container");
+
       if (editorId && isDirty) {
         window.dispatchEvent(
           new CustomEvent("app:confirm-close-editor", {
             detail: { panelId, title },
           }),
         );
+        // Close the popup so the confirm modal isn't obscured.
+        if (overflowContainer) {
+          document.body.dispatchEvent(
+            new PointerEvent("pointerdown", { bubbles: true }),
+          );
+        }
       } else {
         api.close();
+        if (overflowContainer) {
+          // Remove this tab's row from the list; close the popup if it's now empty.
+          closeBtn.closest(".dv-tab")?.remove();
+          if (!overflowContainer.querySelector(".dv-tab")) {
+            document.body.dispatchEvent(
+              new PointerEvent("pointerdown", { bubbles: true }),
+            );
+          }
+        }
       }
     },
     [api, editorId, panelId, title, isDirty],


### PR DESCRIPTION
## Summary

- **CSS** (`CenterDock.css`): restyle the dockview tab overflow dropdown to match Silo's context menu treatment — `--silo-menu-bg` background, `--silo-menu-border` border, `--silo-radius-md` corners, drop shadow, and `--silo-menu-item-hover-bg` hover. Tab-strip chrome (borders, radius, dividers) is reset so rows look like menu items, not tabs. The close button is hidden by default and revealed on row hover, matching the tab-bar treatment.
- **Behavior** (`DockTab.tsx`): fix the overflow popup not updating when a tab is closed from inside it. The close button's `stopPropagation` prevented dockview's wrapper click-handler from firing (which normally closes the popup). `onClose` now detects the overflow context via `closest('.dv-tabs-overflow-container')`, removes the closed tab's row directly, and closes the popup via a synthetic `pointerdown` if no rows remain. The dirty-tab path closes the popup immediately so the confirm modal isn't obscured.

The popup anchor (`dv-popover-anchor`) is placed outside `.editor-dock` by dockview, so the CSS is scoped to `.dv-popover-anchor` rather than `.editor-dock`.

## Test plan

- [ ] Open enough files to overflow the tab bar; click the overflow button — dropdown should match context menu styling (background, border, rounded corners, hover highlight)
- [ ] Hover a row — close button (×) appears; mouse-off — it disappears
- [ ] Click × on a clean tab — tab closes and row is removed from the dropdown; if it was the last row, popup closes
- [ ] Click × on a dirty tab — popup closes and the save-changes modal appears
- [ ] Click a row (not the ×) — popup closes and that tab becomes active
- [ ] Verify styling in both Light and Dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)