### PR TITLE
feat(file-search): focus without selection, per-workspace state, badge contrast

### DIFF
--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -180,7 +180,7 @@
   padding: 0 6px;
   border-radius: var(--silo-radius-sm);
   background: var(--silo-color-button-bg);
-  color: var(--silo-color-text-lo);
+  color: var(--silo-color-text);
   font-size: calc(1em - 2px);
   text-align: center;
 }

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.tsx
@@ -1,9 +1,11 @@
+import { useRef } from "react";
 import {
   useServiceState,
   type ExtensionContext,
   type ExtensionStorage,
 } from "@silo-code/sdk";
 import { FileSearchView } from "./FileSearchView";
+import type { WorkspaceViewCache } from "./search-model";
 import "./FileSearchPanel.css";
 
 export function FileSearchPanel({
@@ -17,17 +19,23 @@ export function FileSearchPanel({
 }) {
   const wsState = useServiceState(ctx.workspaces);
   const ws = wsState.all.find((w) => w.id === wsState.activeId) ?? null;
+
+  // Per-workspace cache for results, collapse state, and scroll position so
+  // switching workspaces restores the view instead of re-running the search.
+  const viewCacheRef = useRef<Map<string, WorkspaceViewCache>>(new Map());
+
   if (!ws) return <div className="placeholder">No active workspace.</div>;
 
   return (
     <div className="fsearch-panel">
       <FileSearchView
-        // Re-mount the view per workspace so its query/results don't leak across.
         key={ws.id}
         ctx={ctx}
         workspace={ws}
         storage={storage}
         paused={paused}
+        savedState={viewCacheRef.current.get(ws.id) ?? null}
+        onSaveState={(state) => viewCacheRef.current.set(ws.id, state)}
       />
     </div>
   );

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -12,11 +12,11 @@ import {
   summarize,
   EMPTY_UI_STATE,
   type SearchUiState,
+  type WorkspaceViewCache,
 } from "./search-model";
 import { SearchResults } from "./SearchResults";
 import { onSearchRequest, takePendingSearch } from "./search-bus";
 
-const UI_STATE_KEY = "ui";
 const DEBOUNCE_MS = 250;
 
 /** Toggle button for a search modifier (case / word / regex). */
@@ -49,37 +49,89 @@ export function FileSearchView({
   workspace,
   storage,
   paused,
+  savedState,
+  onSaveState,
 }: {
   ctx: ExtensionContext;
   workspace: Workspace;
   storage: ExtensionStorage;
   paused: boolean;
+  savedState: WorkspaceViewCache | null;
+  onSaveState: (state: WorkspaceViewCache) => void;
 }) {
+  // ui (query + toggles) is persisted per workspace so each workspace remembers
+  // its own search independently across sessions.
+  const uiKey = `ui.${workspace.id}`;
   const [ui, setUi] = useState<SearchUiState>(() =>
-    storage.get<SearchUiState>(UI_STATE_KEY, EMPTY_UI_STATE),
+    storage.get<SearchUiState>(uiKey, EMPTY_UI_STATE),
   );
-  const [response, setResponse] = useState<SearchResponse | null>(null);
+  const [response, setResponse] = useState<SearchResponse | null>(
+    () => savedState?.response ?? null,
+  );
   const [searching, setSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(
+    () => savedState?.collapsed ?? new Set(),
+  );
 
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const resultsRef = useRef<HTMLDivElement | null>(null);
   // Monotonic token so a slow earlier search can't overwrite a newer result.
   const runIdRef = useRef(0);
+  // Skip the very first search run when we're restoring saved results so the
+  // workspace switch doesn't wipe and re-fetch what was already there.
+  const skipInitialRef = useRef(savedState?.response != null);
+  // Always-current snapshot used by the unmount cleanup (avoids stale closure).
+  const snapshotRef = useRef<WorkspaceViewCache>({
+    response: savedState?.response ?? null,
+    collapsed: savedState?.collapsed ?? new Set(),
+    scrollTop: savedState?.scrollTop ?? 0,
+  });
+  snapshotRef.current = {
+    response,
+    collapsed,
+    scrollTop: resultsRef.current?.scrollTop ?? snapshotRef.current.scrollTop,
+  };
 
   const patch = (next: Partial<SearchUiState>) =>
     setUi((prev) => {
       const merged = { ...prev, ...next };
-      storage.set(UI_STATE_KEY, merged);
+      storage.set(uiKey, merged);
       return merged;
     });
 
   const folder = workspace.folder;
 
+  // Save state when unmounting (workspace switch) so it can be restored next time.
+  useEffect(
+    () => () => {
+      onSaveState({
+        ...snapshotRef.current,
+        scrollTop:
+          resultsRef.current?.scrollTop ?? snapshotRef.current.scrollTop,
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // Restore scroll position after the saved results paint on mount.
+  useEffect(() => {
+    if (savedState?.scrollTop && resultsRef.current) {
+      resultsRef.current.scrollTop = savedState.scrollTop;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Debounced search whenever the query/options change (and the panel is shown).
   useEffect(() => {
     const query = ui.query;
     if (paused) return;
+    // First run after mount with saved results: show them as-is, don't re-fetch.
+    if (skipInitialRef.current) {
+      skipInitialRef.current = false;
+      return;
+    }
     if (query.trim() === "") {
       setResponse(null);
       setError(null);
@@ -124,11 +176,15 @@ export function FileSearchView({
   useEffect(() => {
     const apply = (req: { query?: string }) => {
       if (req.query != null && req.query !== "") patch({ query: req.query });
-      const el = inputRef.current;
-      if (el) {
-        el.focus();
-        el.select();
-      }
+      // Defer focus so revealSidePanel's state update has been committed and the
+      // panel is visible before the browser processes the focus request.
+      requestAnimationFrame(() => {
+        const el = inputRef.current;
+        if (el) {
+          el.focus();
+          el.select();
+        }
+      });
     };
     const pendingReq = takePendingSearch();
     if (pendingReq) apply(pendingReq);
@@ -227,12 +283,14 @@ export function FileSearchView({
           <div className="fsearch-status">
             {summarize(response.totalMatches, files.length, response.truncated)}
           </div>
-          <SearchResults
-            files={files}
-            collapsed={collapsed}
-            onToggleFile={toggleFile}
-            onOpenMatch={openMatch}
-          />
+          <div className="fsearch-results" ref={resultsRef}>
+            <SearchResults
+              files={files}
+              collapsed={collapsed}
+              onToggleFile={toggleFile}
+              onOpenMatch={openMatch}
+            />
+          </div>
         </>
       ) : null}
     </div>

--- a/packages/extensions-silo/src/file-search/SearchResults.tsx
+++ b/packages/extensions-silo/src/file-search/SearchResults.tsx
@@ -52,7 +52,7 @@ export function SearchResults({
   onOpenMatch: (file: SearchFileResult, match: SearchMatch) => void;
 }) {
   return (
-    <div className="fsearch-results">
+    <>
       {files.map((file) => {
         const { name, dir } = splitPath(file.path);
         const isCollapsed = collapsed.has(file.path);
@@ -86,6 +86,6 @@ export function SearchResults({
           </div>
         );
       })}
-    </div>
+    </>
   );
 }

--- a/packages/extensions-silo/src/file-search/search-model.ts
+++ b/packages/extensions-silo/src/file-search/search-model.ts
@@ -1,8 +1,19 @@
-import type { SearchOptions } from "@silo-code/sdk";
+import type { SearchOptions, SearchResponse } from "@silo-code/sdk";
 
 // Pure, UI-free helpers for the file-search panel — extracted so the search
 // rules (option building, glob parsing, preview highlighting, the summary line)
 // are unit-testable without rendering React.
+
+/**
+ * In-session state cached per workspace so switching back doesn't re-run the
+ * search or lose the collapse and scroll position. Not persisted to disk —
+ * lives in a Map ref in FileSearchPanel for the lifetime of the panel instance.
+ */
+export interface WorkspaceViewCache {
+  response: SearchResponse | null;
+  collapsed: ReadonlySet<string>;
+  scrollTop: number;
+}
 
 /** The panel's query controls, persisted across reloads. */
 export interface SearchUiState {


### PR DESCRIPTION
## Summary

- **Cmd+Shift+F without a selection** now opens the Search panel and focuses the query input so you can type immediately. Previously the `el.focus()` call fired before `revealSidePanel` made the panel visible — the browser silently drops focus on hidden elements. Wrapping it in `requestAnimationFrame` defers the call to the next frame, after the panel is rendered visible.

- **Workspace switch no longer re-runs the search or loses state.** `FileSearchPanel` holds an in-memory `Map` (keyed by workspace ID) of the previous search response, collapse state, and scroll position. `FileSearchView` saves to it on unmount and restores on mount, skipping the initial search-effect run when saved results exist. Any subsequent query change re-searches normally. The `ui` storage key is now scoped to `ui.{workspace.id}` so each workspace also remembers its own query and toggles independently across sessions (previously all workspaces shared one key).

- **Match-count badge contrast fix.** Changed the count badge text from `--silo-color-text-lo` to `--silo-color-text` so the number is legible against the `--silo-color-button-bg` background.

## Test plan

- [ ] Cmd+Shift+F with text selected → panel opens, input focused, query populated
- [ ] Cmd+Shift+F with no selection → panel opens, input focused, ready to type
- [ ] Cmd+Shift+F while panel is already open and visible → input focused
- [ ] Search for something in workspace A, switch to workspace B, switch back → workspace A's results, collapse state, and scroll position are restored without re-fetching
- [ ] Each workspace remembers its own query across sessions (relaunch app)
- [ ] Match-count badges are visibly legible in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)