### PR TITLE
docs(readme): add Build extensions with Claude Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,43 @@ Open as many project workspaces as you need and tab between them instantly. Each
 - **Extension SDK** — a small stable core with a public API; first-party features ship as extensions (modeled on VS Code / Obsidian)
 - **Local-first** — everything runs on your machine; no cloud required
 
+## Build extensions with Claude Code
+
+Silo ships a Claude Code skill that turns a plain-English description into a working extension — scaffolded, written, compiled, and installed in one session.
+
+**Install the skill once:**
+
+```bash
+mkdir -p ~/.claude/skills/silo-extension-builder && \
+  curl -fsSL -o ~/.claude/skills/silo-extension-builder/SKILL.md \
+  https://raw.githubusercontent.com/silo-code/silo/main/skills/silo-extension-builder/SKILL.md
+```
+
+**Then describe what you want:**
+
+```
+/silo-extension-builder Create a status bar item that shows the current git branch
+and a dot when there are uncommitted changes.
+```
+
+Claude scaffolds the project, writes the TypeScript, compiles it, and asks if you want it installed — all without leaving your terminal. The result is a real extension you own: edit the source, rebuild with `npm run build`, reinstall with `silo install`.
+
+Some things people have built this way in a single session:
+
+- **Git branch status bar** — branch name + dirty indicator, updates on workspace switch
+- **GitHub Issues panel** — lists open issues for the active repo via `gh`, with a refresh button
+- **Scratch pad** — persisted notes panel that survives restarts
+- **Word count** — right-aligned status bar item that tracks the active editor
+
+Extensions install and uninstall live — no restart needed:
+
+```bash
+silo install ~/my-extensions/dave.git-branch
+silo uninstall dave.git-branch
+```
+
+→ [Full guide](https://getsilo.dev/guide/claude-skill) · [Extension API](https://getsilo.dev/api/)
+
 ## Who it's for
 
 - You run Claude Code, Aider, or other AI coding agents and want to keep several going at once


### PR DESCRIPTION
## Summary

- Adds a "Build extensions with Claude Code" section to the README between "How it works" and "Who it's for"
- Shows the skill install one-liner, an example prompt, what Claude does end-to-end, four example extensions, and `silo install`/`silo uninstall` commands
- Links to the full guide and API reference

This was committed to the `feat/extension-distribution` branch but wasn't included in #45 before it was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)