### PR TITLE
fix(tooltip): dismiss tooltip on pointer down

### DIFF
--- a/packages/extension-host/src/components/Tooltip.tsx
+++ b/packages/extension-host/src/components/Tooltip.tsx
@@ -50,6 +50,7 @@ export function Tooltip({
       className="silo-tooltip-host"
       onMouseEnter={show}
       onMouseLeave={hide}
+      onPointerDown={hide}
     >
       {children}
       {anchor &&


### PR DESCRIPTION
## Summary

- Tooltips on status bar items were staying visible when clicking to open a menu, causing them to overlap the bottom of the menu
- Added `onPointerDown={hide}` to the `Tooltip` host span so the tooltip dismisses the instant the user presses down, before any menu renders

## Test plan

- [ ] Hover a status bar item → tooltip appears after the delay as before
- [ ] Click the item → tooltip disappears immediately, no overlap with the menu
- [ ] Mouse off without clicking → tooltip still hides on mouse leave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)