### PR TITLE
docs: user-facing guides, AI skill section, and nav improvements

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -96,21 +96,28 @@ export default withMermaid(
           text: "Download",
           link: "https://github.com/silo-code/silo/releases/latest",
         },
-        { text: "Guide", link: "/guide/" },
+        { text: "Guides", link: "/guide/" },
         { text: "API Reference", link: "/api/" },
         { text: "Roadmap", link: "/roadmap" },
       ],
 
       sidebar: {
         "/guide/": [
+          { text: "Getting Started", link: "/guide/" },
           {
             text: "Using Silo",
-            items: [{ text: "The `silo` command", link: "/guide/cli" }],
+            items: [
+              { text: "Workspaces", link: "/guide/workspaces" },
+              { text: "The `silo` command", link: "/guide/cli" },
+            ],
           },
           {
             text: "Building Extensions",
             items: [
-              { text: "What is an extension?", link: "/guide/" },
+              {
+                text: "What is an extension?",
+                link: "/guide/what-is-an-extension",
+              },
               { text: "Your first extension", link: "/guide/getting-started" },
               { text: "Build with Claude Code", link: "/guide/claude-skill" },
               { text: "Styling your extension", link: "/guide/styling" },

--- a/apps/docs/guide/index.md
+++ b/apps/docs/guide/index.md
@@ -1,79 +1,18 @@
-# What is an extension?
+# Getting Started
 
-A Silo extension is a small object with an `id` and an `activate` function. The
-host calls `activate` once at startup and hands it an
-[`ExtensionContext`](/api/) — usually called `ctx`. Everything
-your extension adds to the app, it adds through `ctx`.
+Silo is a terminal-first workspace manager built for the multi-agent workflow.
+It keeps multiple projects open at once — each with live terminals and a
+preserved layout — and switches between them instantly.
 
-```ts
-import type { Extension } from "@silo-code/sdk";
+## Using Silo
 
-export const extension: Extension = {
-  id: "acme.hello",
-  activate(ctx) {
-    // register viewers, commands, panels… against ctx here
-  },
-};
-```
+Start with **[Workspaces](/guide/workspaces)** — the core model behind how Silo
+organizes your work. The **[`silo` command](/guide/cli)** covers the terminal
+integration for opening and switching workspaces from the shell.
 
-That's the whole contract ([`Extension`](/api/types/interfaces/Extension)). There's an optional
-`deactivate()` for cleanup, reserved for when dynamic load/unload lands.
+## Building extensions
 
-## The one rule
-
-> An extension touches the running app **only** through `ctx` and the
-> [`@silo-code/sdk`](/api/) **types**. It never imports app internals.
-
-This isn't a style preference — it's enforced (a lint rule fails the build if an
-extension reaches into the app's state, services, or UI directly). The payoff is
-that extensions stay decoupled from the app's internals, so the app can evolve
-without breaking them. The status-bar toggle below — a complete extension —
-imports nothing but SDK types.
-
-```ts
-import type { Extension } from "@silo-code/sdk";
-import { useServiceState } from "@silo-code/sdk";
-
-export const extension: Extension = {
-  id: "acme.panel-toggle",
-  activate(ctx) {
-    const { layout } = ctx;
-
-    function PanelToggles() {
-      const state = useServiceState(layout);       // read state via a typed service
-      return (
-        <button
-          className={state.left.collapsed ? "" : "active"}
-          onClick={() => ctx.executeCommand("view.toggleLeftPanel")}  // act via a command
-        >
-          ▢
-        </button>
-      );
-    }
-
-    ctx.registerStatusItem({ id: "panel-toggles", alignment: "right", component: PanelToggles });
-  },
-};
-```
-
-It **reads** state through a typed service (`ctx.layout`) and **acts** by
-invoking a command (`ctx.executeCommand`) — never by importing the app's store.
-
-## How `ctx` is organized
-
-Everything `ctx` offers falls into three groups:
-
-| Group            | What it's for                                                                                                                                                                                                                     |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Registration** | `register*` methods that add things to the app — viewers, side panels, status items, commands, keybindings, menu items, file types, dock panels, settings pages. Each returns a [`Disposable`](/api/types/interfaces/Disposable). |
-| **State**        | typed services that read & drive app state — [`ctx.workspaces`](/api/state/workspaces) (workspaces and editor tabs) and [`ctx.layout`](/api/state/layout) (side-panel collapse) — so you never reach into the store.              |
-| **Other**        | [`ctx.executeCommand(id)`](/api/other/execute-command) to invoke any registered command, plus `ctx.extensionId` and `ctx.subscriptions`.                                                                                          |
-
-The **[API Reference](/api/)** walks through every member of each group, with
-signatures, examples, and links to the type definitions.
-
-## Next
-
-- **[Your first extension](/guide/getting-started)** — a complete, working
-  status-bar item, step by step.
-- **[API Reference](/api/)** — `ctx` member by member, then the generated types.
+Silo's features are built as extensions, and you can add your own. Start with
+**[What is an extension?](/guide/what-is-an-extension)** to understand the
+model, then **[Your first extension](/guide/getting-started)** for a
+step-by-step build. The **[API Reference](/api/)** documents every `ctx` member.

--- a/apps/docs/guide/what-is-an-extension.md
+++ b/apps/docs/guide/what-is-an-extension.md
@@ -1,0 +1,79 @@
+# What is an extension?
+
+A Silo extension is a small object with an `id` and an `activate` function. The
+host calls `activate` once at startup and hands it an
+[`ExtensionContext`](/api/) — usually called `ctx`. Everything
+your extension adds to the app, it adds through `ctx`.
+
+```ts
+import type { Extension } from "@silo-code/sdk";
+
+export const extension: Extension = {
+  id: "acme.hello",
+  activate(ctx) {
+    // register viewers, commands, panels… against ctx here
+  },
+};
+```
+
+That's the whole contract ([`Extension`](/api/types/interfaces/Extension)). There's an optional
+`deactivate()` for cleanup, reserved for when dynamic load/unload lands.
+
+## The one rule
+
+> An extension touches the running app **only** through `ctx` and the
+> [`@silo-code/sdk`](/api/) **types**. It never imports app internals.
+
+This isn't a style preference — it's enforced (a lint rule fails the build if an
+extension reaches into the app's state, services, or UI directly). The payoff is
+that extensions stay decoupled from the app's internals, so the app can evolve
+without breaking them. The status-bar toggle below — a complete extension —
+imports nothing but SDK types.
+
+```ts
+import type { Extension } from "@silo-code/sdk";
+import { useServiceState } from "@silo-code/sdk";
+
+export const extension: Extension = {
+  id: "acme.panel-toggle",
+  activate(ctx) {
+    const { layout } = ctx;
+
+    function PanelToggles() {
+      const state = useServiceState(layout);       // read state via a typed service
+      return (
+        <button
+          className={state.left.collapsed ? "" : "active"}
+          onClick={() => ctx.executeCommand("view.toggleLeftPanel")}  // act via a command
+        >
+          ▢
+        </button>
+      );
+    }
+
+    ctx.registerStatusItem({ id: "panel-toggles", alignment: "right", component: PanelToggles });
+  },
+};
+```
+
+It **reads** state through a typed service (`ctx.layout`) and **acts** by
+invoking a command (`ctx.executeCommand`) — never by importing the app's store.
+
+## How `ctx` is organized
+
+Everything `ctx` offers falls into three groups:
+
+| Group            | What it's for                                                                                                                                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Registration** | `register*` methods that add things to the app — viewers, side panels, status items, commands, keybindings, menu items, file types, dock panels, settings pages. Each returns a [`Disposable`](/api/types/interfaces/Disposable). |
+| **State**        | typed services that read & drive app state — [`ctx.workspaces`](/api/state/workspaces) (workspaces and editor tabs) and [`ctx.layout`](/api/state/layout) (side-panel collapse) — so you never reach into the store.              |
+| **Other**        | [`ctx.executeCommand(id)`](/api/other/execute-command) to invoke any registered command, plus `ctx.extensionId` and `ctx.subscriptions`.                                                                                          |
+
+The **[API Reference](/api/)** walks through every member of each group, with
+signatures, examples, and links to the type definitions.
+
+## Next
+
+- **[Your first extension](/guide/getting-started)** — a complete, working
+  status-bar item, step by step.
+- **[API Reference](/api/)** — `ctx` member by member, then the generated types.

--- a/apps/docs/guide/workspaces.md
+++ b/apps/docs/guide/workspaces.md
@@ -1,0 +1,44 @@
+# Workspaces
+
+A workspace is a named project rooted at a folder. Silo runs all your open
+workspaces simultaneously — each keeps its terminals, editors, and layout alive
+in the background. Switching is instant, with no reload.
+
+## Opening a workspace
+
+From the terminal, run `silo` with a path:
+
+```sh
+silo .                  # current directory
+silo ~/code/my-project  # any folder
+```
+
+If a workspace already exists for that folder, Silo brings it to the foreground.
+Otherwise it creates one and activates it.
+
+From inside Silo, click the active workspace name in the status bar, then choose
+**Open** to pick a folder or reopen a recently closed workspace.
+
+## Switching between workspaces
+
+**Status bar** — the active workspace name sits at the bottom-left of the
+window. Click it to open a menu listing every open workspace; click any entry
+to switch immediately.
+
+**Keyboard** — press <kbd>⌘`</kbd> to cycle forward through open workspaces, or
+<kbd>⌘~</kbd> to cycle backward. A small popup floats above the status bar while
+the modifier is held — release to land on the highlighted workspace.
+
+**Workspaces panel** — click the workspace icon in the left dock to open the
+Workspaces panel. The panel lists every open workspace; click a row or press
+Enter on the focused row to activate it.
+
+## Closing and reopening
+
+**Close** hides a workspace without losing its state. Closed workspaces appear
+in the Workspaces panel's closed list and in the **Open** submenu of the status
+bar menu. Reopen one to bring it back exactly as you left it — terminals,
+editors, and all.
+
+**Delete** removes a workspace permanently. Its terminals end and any unsaved
+editors are closed.

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -28,7 +28,10 @@ features:
     details: Everything runs on your machine. No cloud sync, no telemetry, no account required.
   - icon: 🧩
     title: Extension SDK
-    details: A small stable core with a public API. First-party features — terminal, editor, git, themes — ship as extensions against the same SDK you get.
+    details: A small stable core with a public API. First-party features — terminal, file explorer, git, themes — ship as extensions against the same SDK you get.
+  - icon: 🤖
+    title: Build with Claude
+    details: The silo-extension-builder Claude Code skill scaffolds, writes, and installs a working extension from a plain-English description. From prompt to installed extension in one session.
   - icon: "📄"
     title: MIT licensed
     details: 100% open source. Build on it, fork it, contribute to it.
@@ -48,14 +51,34 @@ Now you're coordinating multiple AI coding agents simultaneously across differen
 
 ## Download
 
-**macOS** (v0.4.0) — Windows and Linux coming soon.
+**macOS** — Windows and Linux coming soon.
 
-| Build                    | Link                                                                        |
-| ------------------------ | --------------------------------------------------------------------------- |
-| Apple Silicon (M1/M2/M3) | [Silo_0.4.0_aarch64.dmg](https://github.com/silo-code/silo/releases/latest) |
-| Intel Mac                | [Silo_0.4.0_x64.dmg](https://github.com/silo-code/silo/releases/latest)     |
+| Build                    | Link                                                                       |
+| ------------------------ | -------------------------------------------------------------------------- |
+| Apple Silicon (M1/M2/M3) | [Download .dmg](https://github.com/silo-code/silo/releases/latest)         |
+| Intel Mac                | [Download .dmg (Intel)](https://github.com/silo-code/silo/releases/latest) |
 
 Or build from source — see the [GitHub repo](https://github.com/silo-code/silo).
+
+---
+
+## Build extensions with AI
+
+The `silo-extension-builder` Claude Code skill turns a plain-English description
+into a working Silo extension — it scaffolds the project, writes the source,
+compiles it, and installs it into Silo in one session. You don't need to know
+the SDK to build your first extension.
+
+Open Claude Code in any directory and run:
+
+```
+/silo-extension-builder Create a status bar item that shows the current git branch.
+```
+
+The skill handles the scaffold, implementation, compile step, and `silo install`
+for you. From description to installed extension in minutes.
+
+**[Install the skill and get started →](/guide/claude-skill)**
 
 ---
 
@@ -63,8 +86,9 @@ Or build from source — see the [GitHub repo](https://github.com/silo-code/silo
 
 Silo has a public extension SDK (`@silo-code/sdk`), modeled on VS Code and Obsidian. Every first-party feature — terminal, file explorer, git, themes — is built as an extension against the same API you get. If a built-in can do it, so can you.
 
-- **[What is an extension?](/guide/)** — start here
+- **[What is an extension?](/guide/what-is-an-extension)** — start here
 - **[Your first extension](/guide/getting-started)** — 5-minute walkthrough
+- **[Build with Claude Code](/guide/claude-skill)** — scaffold and install via AI
 - **[API Reference](/api/)** — the full `ctx` surface
 - **[Roadmap](/roadmap)** — what's stable, what's planned
 


### PR DESCRIPTION
## Summary

- Rename nav **Guide → Guides**
- Add **Getting Started** landing page (`guide/index.md`) as the guide index — brief intro pointing to both the Using Silo and Building Extensions tracks
- Add **Workspaces** guide covering the workspace model and all four switching methods: status bar menu, ⌘\`/⌘~ keyboard cycle, Workspaces panel, and `silo <path>` from the terminal
- Move **What is an extension?** to its own page (`guide/what-is-an-extension.md`) so the index can be the Getting Started page; sidebar and home-page links updated
- Add **Build with AI** feature tile and prose section to the home page, covering the `silo-extension-builder` Claude Code skill
- Remove stale version number from the Download section (links already resolve to `/releases/latest`)

## Test plan

- [ ] `pnpm docs:dev` — confirm nav shows "Guides", sidebar shows Getting Started + Workspaces under Using Silo
- [ ] Visit `/guide/` — Getting Started page loads
- [ ] Visit `/guide/workspaces` — Workspaces guide loads
- [ ] Visit `/guide/what-is-an-extension` — content loads (old `/guide/` content)
- [ ] Home page — "Build with AI" section visible, Download table has no version numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)