### PR TITLE
feat(error-handling): error boundaries to prevent blank screen on render errors

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Toasts,
   Menus,
   ThemeInjector,
+  ErrorBoundary,
   reloadCustomThemes,
 } from "@silo-code/extension-host";
 
@@ -16,7 +17,7 @@ export default function App() {
   }, []);
 
   return (
-    <>
+    <ErrorBoundary name="app">
       <ThemeInjector />
       <Shortcuts />
       <AppShell />
@@ -24,6 +25,6 @@ export default function App() {
       <ModalHost />
       <Toasts />
       <Menus />
-    </>
+    </ErrorBoundary>
   );
 }

--- a/examples/extensions/error-boundary-demo/build.mjs
+++ b/examples/extensions/error-boundary-demo/build.mjs
@@ -1,0 +1,14 @@
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.tsx"],
+  outfile: "dist/index.js",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2020",
+  jsx: "automatic",
+  minify: false,
+  external: ["react", "react/jsx-runtime", "@silo-code/sdk"],
+  logLevel: "info",
+});

--- a/examples/extensions/error-boundary-demo/package.json
+++ b/examples/extensions/error-boundary-demo/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "error-boundary-demo",
+  "displayName": "Error Boundary Demo",
+  "version": "0.1.0",
+  "description": "Interactively trigger render crashes to test Silo's error boundaries.",
+  "private": true,
+  "type": "module",
+  "silo": {
+    "id": "silo.error-boundary-demo",
+    "engine": "^0.1",
+    "main": "dist/index.js"
+  },
+  "scripts": {
+    "build": "node build.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@silo-code/sdk": "workspace:*",
+    "@types/react": "^19.0.0",
+    "esbuild": "^0.24.0",
+    "react": "^19.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/extensions/error-boundary-demo/src/index.tsx
+++ b/examples/extensions/error-boundary-demo/src/index.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import type { Extension } from "@silo-code/sdk";
+
+const STYLE_ID = "silo-error-boundary-demo-styles";
+const STYLES = `
+.eb-demo {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--silo-color-text);
+  font-size: var(--silo-font-size-sm);
+}
+.eb-demo__title {
+  margin: 0;
+  font-size: var(--silo-font-size-base);
+  font-weight: 600;
+}
+.eb-demo__desc {
+  margin: 0;
+  line-height: 1.5;
+  opacity: 0.8;
+}
+.eb-demo__btn {
+  align-self: flex-start;
+  padding: 4px 12px;
+  background: var(--silo-color-err);
+  color: #fff;
+  border: none;
+  border-radius: var(--silo-radius-sm);
+  font-size: var(--silo-font-size-sm);
+  cursor: pointer;
+  opacity: 1;
+}
+.eb-demo__btn:hover { opacity: 0.85; }
+`;
+
+function injectStyles(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement("style");
+  el.id = STYLE_ID;
+  el.textContent = STYLES;
+  document.head.appendChild(el);
+}
+
+function removeStyles(): void {
+  document.getElementById(STYLE_ID)?.remove();
+}
+
+function Crasher(): null {
+  throw new Error("Intentional render crash from Error Boundary Demo");
+}
+
+function ErrorBoundaryDemoPanel() {
+  const [crashed, setCrashed] = useState(false);
+
+  return (
+    <div className="eb-demo">
+      <h2 className="eb-demo__title">Error Boundary Demo</h2>
+      <p className="eb-demo__desc">
+        Click the button below to simulate a render crash inside this side
+        panel. The per-panel error boundary will catch it and show a fallback —
+        other panels stay unaffected. Use the Retry button in the fallback to
+        reset.
+      </p>
+      <button className="eb-demo__btn" onClick={() => setCrashed(true)}>
+        Crash this panel
+      </button>
+      {crashed && <Crasher />}
+    </div>
+  );
+}
+
+export const extension: Extension = {
+  id: "silo.error-boundary-demo",
+  manifest: {
+    name: "Error Boundary Demo",
+    description:
+      "Interactively trigger render crashes to test Silo's error boundaries.",
+  },
+  activate(ctx) {
+    injectStyles();
+    ctx.registerSidePanel({
+      id: "silo.error-boundary-demo",
+      location: "left",
+      title: "EB Demo",
+      order: 99,
+      component: ErrorBoundaryDemoPanel,
+    });
+  },
+  deactivate() {
+    removeStyles();
+  },
+};

--- a/examples/extensions/error-boundary-demo/tsconfig.json
+++ b/examples/extensions/error-boundary-demo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["react"]
+  },
+  "include": ["src"]
+}

--- a/packages/extension-host/src/components/ErrorBoundary.css
+++ b/packages/extension-host/src/components/ErrorBoundary.css
@@ -1,0 +1,60 @@
+.error-boundary-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 16px;
+  height: 100%;
+  box-sizing: border-box;
+  color: var(--silo-color-err);
+  font-size: var(--silo-font-size-sm, 12px);
+  overflow: auto;
+}
+
+.error-boundary-fallback__icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.error-boundary-fallback__message {
+  margin: 0;
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.error-boundary-fallback__name {
+  opacity: 0.6;
+  font-weight: 400;
+}
+
+.error-boundary-fallback__details {
+  width: 100%;
+}
+
+.error-boundary-fallback__details summary {
+  cursor: pointer;
+  opacity: 0.7;
+  font-size: var(--silo-font-size-xs, 11px);
+}
+
+.error-boundary-fallback__stack {
+  margin: 6px 0 0;
+  font-size: var(--silo-font-size-xs, 11px);
+  white-space: pre-wrap;
+  word-break: break-all;
+  opacity: 0.8;
+}
+
+.error-boundary-fallback__retry {
+  padding: 3px 10px;
+  font-size: var(--silo-font-size-sm, 12px);
+  background: var(--silo-button-bg);
+  color: var(--silo-button-fg);
+  border: 1px solid var(--silo-button-border, transparent);
+  border-radius: var(--silo-radius-sm, 4px);
+  cursor: pointer;
+}
+
+.error-boundary-fallback__retry:hover {
+  background: var(--silo-button-hover-bg);
+}

--- a/packages/extension-host/src/components/ErrorBoundary.test.tsx
+++ b/packages/extension-host/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+beforeEach(() => {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+function Thrower({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("test render error");
+  return <span>ok</span>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error", () => {
+    act(() => {
+      root!.render(
+        <ErrorBoundary name="test">
+          <span>hello</span>
+        </ErrorBoundary>,
+      );
+    });
+    expect(host!.textContent).toContain("hello");
+  });
+
+  it("renders fallback when child throws", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => {
+      root!.render(
+        <ErrorBoundary name="test">
+          <Thrower shouldThrow />
+        </ErrorBoundary>,
+      );
+    });
+    expect(host!.textContent).toContain("test render error");
+    spy.mockRestore();
+  });
+
+  it("renders custom fallback prop when provided", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => {
+      root!.render(
+        <ErrorBoundary fallback={<span>custom</span>}>
+          <Thrower shouldThrow />
+        </ErrorBoundary>,
+      );
+    });
+    expect(host!.textContent).toBe("custom");
+    spy.mockRestore();
+  });
+
+  it("renders null fallback prop without crashing", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => {
+      root!.render(
+        <ErrorBoundary fallback={null}>
+          <Thrower shouldThrow />
+        </ErrorBoundary>,
+      );
+    });
+    expect(host!.textContent).toBe("");
+    spy.mockRestore();
+  });
+
+  it("retrying resets the boundary and re-renders children", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => {
+      root!.render(
+        <ErrorBoundary name="test">
+          <Thrower shouldThrow />
+        </ErrorBoundary>,
+      );
+    });
+
+    const retryBtn = host!.querySelector<HTMLButtonElement>(
+      ".error-boundary-fallback__retry",
+    );
+    expect(retryBtn).not.toBeNull();
+
+    act(() => {
+      root!.render(
+        <ErrorBoundary name="test">
+          <Thrower shouldThrow={false} />
+        </ErrorBoundary>,
+      );
+      retryBtn!.click();
+    });
+
+    expect(host!.textContent).toContain("ok");
+    spy.mockRestore();
+  });
+
+  it("logs to console with the boundary name", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => {
+      root!.render(
+        <ErrorBoundary name="my-panel">
+          <Thrower shouldThrow />
+        </ErrorBoundary>,
+      );
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("[ErrorBoundary:my-panel]"),
+      expect.any(Error),
+      expect.anything(),
+    );
+    spy.mockRestore();
+  });
+});

--- a/packages/extension-host/src/components/ErrorBoundary.tsx
+++ b/packages/extension-host/src/components/ErrorBoundary.tsx
@@ -1,0 +1,78 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { pushToast } from "../extension-host/ui-service";
+import "./ErrorBoundary.css";
+
+interface Props {
+  children: ReactNode;
+  /** Label used in console output to identify where the error occurred. */
+  name?: string;
+  /** Override the default fallback UI entirely. */
+  fallback?: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    const label = this.props.name ? `:${this.props.name}` : "";
+    console.error(`[ErrorBoundary${label}]`, error, info.componentStack);
+    pushToast("error", error.message, {
+      title: `Render error${this.props.name ? ` in ${this.props.name}` : ""}`,
+      dedupKey: `error-boundary:${error.message}`,
+    });
+  }
+
+  retry = () => this.setState({ error: null });
+
+  render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+    if (this.props.fallback !== undefined) return this.props.fallback;
+    return (
+      <DefaultFallback
+        error={this.state.error}
+        name={this.props.name}
+        onRetry={this.retry}
+      />
+    );
+  }
+}
+
+function DefaultFallback({
+  error,
+  name,
+  onRetry,
+}: {
+  error: Error;
+  name?: string;
+  onRetry: () => void;
+}) {
+  const isDev = import.meta.env.DEV;
+  return (
+    <div className="error-boundary-fallback">
+      <div className="error-boundary-fallback__icon">⚠</div>
+      <p className="error-boundary-fallback__message">
+        {isDev ? error.message : "Something went wrong"}
+        {name && (
+          <span className="error-boundary-fallback__name"> ({name})</span>
+        )}
+      </p>
+      {isDev && error.stack && (
+        <details className="error-boundary-fallback__details">
+          <summary>Stack trace</summary>
+          <pre className="error-boundary-fallback__stack">{error.stack}</pre>
+        </details>
+      )}
+      <button className="error-boundary-fallback__retry" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/packages/extension-host/src/components/StatusBar.tsx
+++ b/packages/extension-host/src/components/StatusBar.tsx
@@ -3,6 +3,7 @@ import { statusItemRegistry } from "../extension-host/status-items";
 import { enterRegionOnPointer } from "../extension-host/focus-regions";
 import type { StatusItem } from "@silo-code/sdk";
 import { Tooltip } from "./Tooltip";
+import { ErrorBoundary } from "./ErrorBoundary";
 import "./StatusBar.css";
 
 function useStatusItems(): StatusItem[] {
@@ -96,12 +97,17 @@ function useStatusBarFocus(ref: React.RefObject<HTMLDivElement | null>) {
 }
 
 function renderItem(item: StatusItem) {
-  return item.tooltip ? (
-    <Tooltip key={item.id} content={item.tooltip}>
+  const inner = item.tooltip ? (
+    <Tooltip content={item.tooltip}>
       <item.component />
     </Tooltip>
   ) : (
-    <item.component key={item.id} />
+    <item.component />
+  );
+  return (
+    <ErrorBoundary key={item.id} name={`status:${item.id}`} fallback={null}>
+      {inner}
+    </ErrorBoundary>
   );
 }
 

--- a/packages/extension-host/src/extension-host/ui-service.test.ts
+++ b/packages/extension-host/src/extension-host/ui-service.test.ts
@@ -65,6 +65,25 @@ describe("toast store", () => {
     expect(a.id).not.toBe(b.id);
   });
 
+  it("deduplicates: a second push with the same dedupKey is a no-op while the first toast is alive", () => {
+    pushToast("error", "boom", { dedupKey: "eb:panel-a" });
+    pushToast("error", "boom", { dedupKey: "eb:panel-a" });
+    expect(toastStore.toasts).toHaveLength(1);
+  });
+
+  it("allows a new toast after the original dedup-keyed toast is dismissed", () => {
+    pushToast("error", "boom", { dedupKey: "eb:panel-a" });
+    dismissToast(toastStore.toasts[0].id);
+    pushToast("error", "boom", { dedupKey: "eb:panel-a" });
+    expect(toastStore.toasts).toHaveLength(1);
+  });
+
+  it("different dedup keys don't block each other", () => {
+    pushToast("error", "boom", { dedupKey: "eb:panel-a" });
+    pushToast("error", "boom", { dedupKey: "eb:panel-b" });
+    expect(toastStore.toasts).toHaveLength(2);
+  });
+
   it("stores a title and serializable action metadata, not the run callback", () => {
     const run = vi.fn();
     getUiService().notify("info", "msg", {

--- a/packages/extension-host/src/extension-host/ui-service.ts
+++ b/packages/extension-host/src/extension-host/ui-service.ts
@@ -42,6 +42,14 @@ export interface Toast {
    * {@link runToastAction}.
    */
   actions?: { label: string; keepOpen?: boolean }[];
+  /** Dedup key — if set, a second push with the same key is a no-op while this toast is alive. */
+  dedupKey?: string;
+}
+
+/** Internal options for {@link pushToast} — extends the public {@link NotifyOptions} with host-only fields. */
+interface PushToastOptions extends NotifyOptions {
+  /** If set, skip pushing if an active toast with this key already exists. */
+  dedupKey?: string;
 }
 
 /**
@@ -70,11 +78,17 @@ const toastActions = new Map<number, NotifyAction[]>();
 export function pushToast(
   level: "info" | "warn" | "error",
   message: string,
-  options?: NotifyOptions,
+  options?: PushToastOptions,
 ): void {
+  if (
+    options?.dedupKey &&
+    toastStore.toasts.some((t) => t.dedupKey === options.dedupKey)
+  )
+    return;
   const id = nextToastId++;
   const actions = options?.actions;
   const toast: Toast = { id, level, message };
+  if (options?.dedupKey) toast.dedupKey = options.dedupKey;
   if (options?.title) toast.title = options.title;
   if (actions?.length) {
     toast.actions = actions.map((a) => ({

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -18,6 +18,7 @@
 import "./layout/theme.css";
 
 // --- App shell + chrome (rendered by App.tsx) -------------------------------
+export { ErrorBoundary } from "./components/ErrorBoundary";
 export { AppShell } from "./layout/AppShell";
 export { ThemeInjector } from "./layout/ThemeInjector";
 export { reloadCustomThemes } from "./layout/ThemeLoader";

--- a/packages/extension-host/src/layout/AppShell.tsx
+++ b/packages/extension-host/src/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { CenterDock } from "../panels/CenterDock";
 import { SideColumn } from "./SideColumn";
 import { StatusBar } from "../components/StatusBar";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 import { store } from "../state/store";
 import {
   restoreRegionFocus,
@@ -135,11 +136,15 @@ export function AppShell() {
           }}
           className="app-col"
         >
-          <SideColumn location="left" />
+          <ErrorBoundary name="side-left">
+            <SideColumn location="left" />
+          </ErrorBoundary>
         </Panel>
         <PanelResizeHandle onDragging={onPanelDragging} tabIndex={-1} />
         <Panel defaultSize={58} minSize={30} className="app-col">
-          <CenterDock />
+          <ErrorBoundary name="center-dock">
+            <CenterDock />
+          </ErrorBoundary>
         </Panel>
         <PanelResizeHandle onDragging={onPanelDragging} tabIndex={-1} />
         <Panel
@@ -157,7 +162,9 @@ export function AppShell() {
           }}
           className="app-col"
         >
-          <SideColumn location="right" />
+          <ErrorBoundary name="side-right">
+            <SideColumn location="right" />
+          </ErrorBoundary>
         </Panel>
       </PanelGroup>
       <StatusBar />

--- a/packages/extension-host/src/layout/PanelPane.tsx
+++ b/packages/extension-host/src/layout/PanelPane.tsx
@@ -8,6 +8,7 @@ import { useSideTabDrag } from "./side-column-helpers";
 import { registerSidePane } from "./side-pane-registry";
 import { enterRegionOnPointer } from "../extension-host/focus-regions";
 import { TabBar } from "./TabBar";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 
 interface PanelPaneProps {
   panels: SidePanel[];
@@ -261,11 +262,13 @@ export function PanelPane({
               data-active={isActive ? "true" : "false"}
             >
               {shouldMount ? (
-                <Comp
-                  active={isActive}
-                  storage={getExtensionStorage(p.id)}
-                  hydrated={snap.hydrated}
-                />
+                <ErrorBoundary name={p.id}>
+                  <Comp
+                    active={isActive}
+                    storage={getExtensionStorage(p.id)}
+                    hydrated={snap.hydrated}
+                  />
+                </ErrorBoundary>
               ) : null}
             </div>
           );

--- a/packages/extension-host/src/panels/WorkspaceDock.tsx
+++ b/packages/extension-host/src/panels/WorkspaceDock.tsx
@@ -18,6 +18,7 @@ import {
 } from "../state/workspaces";
 import { tauriTerminalClient } from "../services/tauri-terminal-client";
 import { getDockComponents } from "../extension-host/dock-panel-kinds";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 import { setActiveDockApi } from "../docked/dock-api-registry";
 import { getDndService, resolveDndMode } from "../extension-host/dnd-service";
 import { DND_MIME } from "@silo-code/sdk";
@@ -443,7 +444,7 @@ export function WorkspaceDock({
       ? "dockview-theme-light"
       : "dockview-theme-dark";
   return (
-    <>
+    <ErrorBoundary name={`workspace-dock:${workspaceId}`}>
       <DockviewReact
         className={`${themeClass} editor-dock`}
         components={dockComponents}
@@ -454,6 +455,6 @@ export function WorkspaceDock({
         leftHeaderActionsComponent={GroupAddMenu}
         watermarkComponent={EmptyWatermark}
       />
-    </>
+    </ErrorBoundary>
   );
 }

--- a/packages/extensions-core/src/editor/EditorPanel.tsx
+++ b/packages/extensions-core/src/editor/EditorPanel.tsx
@@ -5,6 +5,7 @@ import {
   store,
   resolveEditorForRecord,
 } from "@silo-code/extension-host/internal";
+import { ErrorBoundary } from "@silo-code/extension-host";
 import { EditorBreadcrumb } from "./EditorBreadcrumb";
 import { DiffPanelLazy } from "./DiffPanelLazy";
 import type { DockPanelApi, ExtensionContext } from "@silo-code/sdk";
@@ -49,17 +50,23 @@ export function EditorPanel(
           key={viewerKey}
           fallback={<div className="editor-panel placeholder">Loading…</div>}
         >
-          {isDiff ? (
-            <DiffPanelLazy editorId={editorId} ctx={ctx} dockApi={props.api} />
-          ) : (
-            <ViewerContent
-              filePath={currentPath}
-              title={currentTitle}
-              viewType={currentViewType}
-              editorId={editorId}
-              dockApi={props.api}
-            />
-          )}
+          <ErrorBoundary name={`editor:${editorId}`}>
+            {isDiff ? (
+              <DiffPanelLazy
+                editorId={editorId}
+                ctx={ctx}
+                dockApi={props.api}
+              />
+            ) : (
+              <ViewerContent
+                filePath={currentPath}
+                title={currentTitle}
+                viewType={currentViewType}
+                editorId={editorId}
+                dockApi={props.api}
+              />
+            )}
+          </ErrorBoundary>
         </Suspense>
       </div>
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,24 @@ importers:
         specifier: ^5.6.0
         version: 5.8.3
 
+  examples/extensions/error-boundary-demo:
+    devDependencies:
+      '@silo-code/sdk':
+        specifier: workspace:*
+        version: link:../../../packages/sdk
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.16
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      typescript:
+        specifier: ^5.6.0
+        version: 5.8.3
+
   examples/extensions/hello-extension:
     devDependencies:
       '@silo-code/sdk':


### PR DESCRIPTION
Closes #40

## Summary

- Adds a shared `ErrorBoundary` class component to `@silo-code/extension-host` with dev (error message + collapsible stack trace + Retry) and prod (friendly message + Retry) fallback modes
- Places boundaries at six containment layers — app root, per-column (left/right/center independently), per-workspace dock, per side-panel, per file editor/viewer, and per status bar item — so a crash is always scoped to the smallest possible surface
- Extends `pushToast` with an internal `dedupKey` field so multiple panels crashing with the same error produce exactly one notification instead of a flood
- Adds a standalone installable example extension (`examples/extensions/error-boundary-demo/`) for interactive testing — install it from the Extensions settings panel, click "Crash this panel", and observe the boundary catching it while everything else stays live

## Boundary placement

| Boundary | File | Fallback behavior |
|---|---|---|
| App root | `App.tsx` | Full-screen error UI |
| Left / center / right columns | `AppShell.tsx` | Column-level fallback, others unaffected |
| Workspace dock | `WorkspaceDock.tsx` | Editor area shows fallback |
| Per side panel | `PanelPane.tsx` | Failing tab shows fallback, sibling tabs unaffected |
| Per file viewer | `EditorPanel.tsx` | Inside existing `Suspense`, catches render errors separately from load errors |
| Per status item | `StatusBar.tsx` | `fallback={null}` — item silently disappears, bar stays intact |

## Test plan

- [ ] `pnpm test` — 305 tests pass (6 new `ErrorBoundary` tests, 3 new `pushToast` dedup tests)
- [ ] `pnpm lint` — clean
- [ ] `pnpm --filter silo exec tsc --noEmit` — clean
- [ ] Install `examples/extensions/error-boundary-demo` from Extensions settings, click "Crash this panel" — fallback renders, other panels unaffected, one error toast appears (not multiple), Retry resets
- [ ] Uninstall the demo extension — panel disappears cleanly with no ghost entries after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)