### PR TITLE
fix(markdown-preview): table and divider borders invisible in dark theme

### DIFF
--- a/packages/extensions-silo/src/markdown-preview/MarkdownPreview.css
+++ b/packages/extensions-silo/src/markdown-preview/MarkdownPreview.css
@@ -65,7 +65,7 @@
 .markdown-preview__body h1,
 .markdown-preview__body h2 {
   padding-bottom: 0.3em;
-  border-bottom: 1px solid var(--silo-color-border);
+  border-bottom: 1px solid var(--silo-color-border-strong);
 }
 
 .markdown-preview__body a {
@@ -104,13 +104,13 @@
   margin: 1em 0;
   padding: 0 1em;
   color: var(--silo-color-text-lo);
-  border-left: 3px solid var(--silo-color-border);
+  border-left: 3px solid var(--silo-color-border-strong);
 }
 
 .markdown-preview__body hr {
   height: 1px;
   border: none;
-  background: var(--silo-color-border);
+  background: var(--silo-color-border-strong);
   margin: 1.5em 0;
 }
 
@@ -121,7 +121,7 @@
 
 .markdown-preview__body th,
 .markdown-preview__body td {
-  border: 1px solid var(--silo-color-border);
+  border: 1px solid var(--silo-color-border-strong);
   padding: 6px 12px;
 }
 


### PR DESCRIPTION
## Summary

- `--silo-color-border` is `transparent` in dark mode (intentional for panel resize lines), which caused all markdown preview dividers to be invisible
- Switch table borders, h1/h2 underlines, blockquote left bars, and `<hr>` from `--silo-color-border` → `--silo-color-border-strong` (`#2b3148` dark / `#c8c8c8` light)
- Light theme is unaffected in practice (both tokens are visible there), and the fix uses only public design tokens per the theming contract

Closes #59

## Test plan

- [ ] Open a markdown file with a table, headings, blockquotes, and `---` in dark theme — borders/dividers should now be visible
- [ ] Verify light theme renders the same as before
- [ ] `pnpm lint` passes (CSS uses only `--silo-color-border-strong`, a public design token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)