### PR TITLE
feat(markdown-preview): render frontmatter as a styled metadata block

### DIFF
--- a/packages/extensions-silo/package.json
+++ b/packages/extensions-silo/package.json
@@ -15,7 +15,8 @@
     "@silo-code/sdk": "workspace:*",
     "react": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/extensions-silo/src/markdown-preview/MarkdownPreview.css
+++ b/packages/extensions-silo/src/markdown-preview/MarkdownPreview.css
@@ -83,7 +83,9 @@
 }
 
 .markdown-preview__frontmatter tr:last-child .markdown-preview__frontmatter-key,
-.markdown-preview__frontmatter tr:last-child .markdown-preview__frontmatter-value {
+.markdown-preview__frontmatter
+  tr:last-child
+  .markdown-preview__frontmatter-value {
   border-bottom: none;
 }
 

--- a/packages/extensions-silo/src/markdown-preview/MarkdownPreview.css
+++ b/packages/extensions-silo/src/markdown-preview/MarkdownPreview.css
@@ -50,6 +50,43 @@
   margin-top: 0;
 }
 
+/* Frontmatter metadata block — rendered above the body when YAML frontmatter
+   is present. A compact two-column key/value table on a subtly tinted surface,
+   visually separated from the body. Design tokens only. */
+.markdown-preview__frontmatter {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5em;
+  font-size: 0.85em;
+  background: var(--silo-color-bg-hover);
+  border: 1px solid var(--silo-color-border-strong);
+  border-radius: var(--silo-radius-md);
+  overflow: hidden;
+}
+
+.markdown-preview__frontmatter-key {
+  font-family: var(--silo-font-mono);
+  color: var(--silo-color-text-lo);
+  white-space: nowrap;
+  padding: 4px 12px 4px 12px;
+  border-bottom: 1px solid var(--silo-color-border-strong);
+  vertical-align: top;
+  width: 1%;
+}
+
+.markdown-preview__frontmatter-value {
+  color: var(--silo-color-text-hi);
+  padding: 4px 12px;
+  border-bottom: 1px solid var(--silo-color-border-strong);
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.markdown-preview__frontmatter tr:last-child .markdown-preview__frontmatter-key,
+.markdown-preview__frontmatter tr:last-child .markdown-preview__frontmatter-value {
+  border-bottom: none;
+}
+
 .markdown-preview__body h1,
 .markdown-preview__body h2,
 .markdown-preview__body h3,

--- a/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
+++ b/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
@@ -8,11 +8,7 @@ import { classifyMarkdownLink } from "./links";
 import { parseFrontmatter, formatFrontmatterValue } from "./frontmatter";
 import "./MarkdownPreview.css";
 
-function FrontmatterBlock({
-  fields,
-}: {
-  fields: Record<string, unknown>;
-}) {
+function FrontmatterBlock({ fields }: { fields: Record<string, unknown> }) {
   const entries = Object.entries(fields);
   if (entries.length === 0) return null;
   return (
@@ -150,7 +146,9 @@ export function MarkdownPreview({
             return (
               <>
                 {parsed && <FrontmatterBlock fields={parsed.fields} />}
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {body}
+                </ReactMarkdown>
               </>
             );
           })()}

--- a/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
+++ b/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
@@ -5,7 +5,31 @@ import remarkGfm from "remark-gfm";
 import type { EditorProps, ExtensionContext } from "@silo-code/sdk";
 import { buildPreviewMenuItems } from "./menu";
 import { classifyMarkdownLink } from "./links";
+import { parseFrontmatter, formatFrontmatterValue } from "./frontmatter";
 import "./MarkdownPreview.css";
+
+function FrontmatterBlock({
+  fields,
+}: {
+  fields: Record<string, unknown>;
+}) {
+  const entries = Object.entries(fields);
+  if (entries.length === 0) return null;
+  return (
+    <table className="markdown-preview__frontmatter">
+      <tbody>
+        {entries.map(([key, value]) => (
+          <tr key={key}>
+            <td className="markdown-preview__frontmatter-key">{key}</td>
+            <td className="markdown-preview__frontmatter-value">
+              {formatFrontmatterValue(value)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
 
 /**
  * Read-only rendered-Markdown view of a `.md` file. Reads the file's text
@@ -120,7 +144,16 @@ export function MarkdownPreview({
         <div className="placeholder">Loading…</div>
       ) : (
         <article className="markdown-preview__body" ref={bodyRef}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          {(() => {
+            const parsed = parseFrontmatter(content);
+            const body = parsed ? parsed.body : content;
+            return (
+              <>
+                {parsed && <FrontmatterBlock fields={parsed.fields} />}
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
+              </>
+            );
+          })()}
         </article>
       )}
     </div>

--- a/packages/extensions-silo/src/markdown-preview/frontmatter.test.ts
+++ b/packages/extensions-silo/src/markdown-preview/frontmatter.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { parseFrontmatter, formatFrontmatterValue } from "./frontmatter";
+
+describe("parseFrontmatter", () => {
+  it("returns null for content without frontmatter", () => {
+    expect(parseFrontmatter("# Hello\n\nworld")).toBeNull();
+  });
+
+  it("returns null for content that starts with --- but has no closing ---", () => {
+    expect(parseFrontmatter("---\ntitle: Foo\n")).toBeNull();
+  });
+
+  it("parses a simple frontmatter block and strips it from the body", () => {
+    const content = "---\ntitle: My Doc\ndate: 2026-06-21\n---\n\n# Body";
+    const result = parseFrontmatter(content);
+    expect(result).not.toBeNull();
+    expect(result!.fields).toEqual({ title: "My Doc", date: "2026-06-21" });
+    expect(result!.body).toBe("\n# Body");
+  });
+
+  it("handles CRLF line endings", () => {
+    const content = "---\r\ntitle: CRLF\r\n---\r\n\r\n# Body";
+    const result = parseFrontmatter(content);
+    expect(result).not.toBeNull();
+    expect(result!.fields.title).toBe("CRLF");
+  });
+
+  it("returns null when YAML parses to a non-object (scalar)", () => {
+    expect(parseFrontmatter("---\njust a string\n---\n")).toBeNull();
+  });
+
+  it("returns null when YAML parses to an array", () => {
+    expect(parseFrontmatter("---\n- a\n- b\n---\n")).toBeNull();
+  });
+
+  it("returns null for invalid YAML", () => {
+    expect(parseFrontmatter("---\n: bad: yaml: :\n---\n")).toBeNull();
+  });
+
+  it("handles array values in frontmatter", () => {
+    const content = "---\ntags:\n  - foo\n  - bar\n---\nbody";
+    const result = parseFrontmatter(content);
+    expect(result).not.toBeNull();
+    expect(result!.fields.tags).toEqual(["foo", "bar"]);
+    expect(result!.body).toBe("body");
+  });
+
+  it("returns empty body when nothing follows the frontmatter", () => {
+    const result = parseFrontmatter("---\ntitle: Only\n---\n");
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe("");
+  });
+
+  it("does not match --- in the middle of content", () => {
+    const content = "# Heading\n\n---\ntitle: nope\n---\n";
+    expect(parseFrontmatter(content)).toBeNull();
+  });
+});
+
+describe("formatFrontmatterValue", () => {
+  it("converts a string as-is", () => {
+    expect(formatFrontmatterValue("hello")).toBe("hello");
+  });
+
+  it("converts a number", () => {
+    expect(formatFrontmatterValue(42)).toBe("42");
+  });
+
+  it("joins arrays with comma-space", () => {
+    expect(formatFrontmatterValue(["a", "b", "c"])).toBe("a, b, c");
+  });
+
+  it("stringifies objects as compact JSON", () => {
+    expect(formatFrontmatterValue({ x: 1 })).toBe('{"x":1}');
+  });
+
+  it("handles null", () => {
+    expect(formatFrontmatterValue(null)).toBe("");
+  });
+
+  it("handles undefined", () => {
+    expect(formatFrontmatterValue(undefined)).toBe("");
+  });
+
+  it("handles boolean values", () => {
+    expect(formatFrontmatterValue(true)).toBe("true");
+    expect(formatFrontmatterValue(false)).toBe("false");
+  });
+});

--- a/packages/extensions-silo/src/markdown-preview/frontmatter.ts
+++ b/packages/extensions-silo/src/markdown-preview/frontmatter.ts
@@ -29,11 +29,7 @@ export function parseFrontmatter(content: string): FrontmatterResult | null {
     return null;
   }
 
-  if (
-    !parsed ||
-    typeof parsed !== "object" ||
-    Array.isArray(parsed)
-  ) {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     return null;
   }
 

--- a/packages/extensions-silo/src/markdown-preview/frontmatter.ts
+++ b/packages/extensions-silo/src/markdown-preview/frontmatter.ts
@@ -1,0 +1,60 @@
+// Pure frontmatter parsing — kept out of the React component so the logic is
+// unit-testable. Same pattern as links.ts / match.ts.
+import { parse } from "yaml";
+
+export interface FrontmatterResult {
+  /** Parsed key/value pairs from the YAML block. */
+  fields: Record<string, unknown>;
+  /** The markdown body with the frontmatter block removed. */
+  body: string;
+}
+
+// Matches the opening `---`, a YAML block, and the closing `---` (with optional
+// trailing newline). The YAML content is capture group 1.
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+/**
+ * If `content` opens with a YAML frontmatter block (`---…---`), parse it and
+ * return the fields plus the remaining body. Returns `null` when there is no
+ * frontmatter or the YAML fails to parse as a plain object.
+ */
+export function parseFrontmatter(content: string): FrontmatterResult | null {
+  const match = FRONTMATTER_RE.exec(content);
+  if (!match) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = parse(match[1]);
+  } catch {
+    return null;
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed)
+  ) {
+    return null;
+  }
+
+  return {
+    fields: parsed as Record<string, unknown>,
+    body: content.slice(match[0].length),
+  };
+}
+
+/**
+ * Format a single frontmatter value for display:
+ * - Arrays → comma-separated string of their string representations
+ * - Objects → compact JSON
+ * - Everything else → String()
+ */
+export function formatFrontmatterValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((v) => String(v)).join(", ");
+  }
+  if (value !== null && typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value ?? "");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1


### PR DESCRIPTION
## Summary

- YAML frontmatter (`---…---`) is now stripped from the rendered body and displayed as a compact key/value table above the article
- Array values are joined as comma-separated strings; nested objects render as compact JSON; files without frontmatter are unaffected
- Parsing logic extracted to `frontmatter.ts` (pure helper, no React) with 17 unit tests covering happy path, CRLF, edge cases, and format helpers
- `yaml` added as a direct dep (already a transitive dep in the store — no new download)
- All styling uses `--silo-color-*` / `--silo-radius-*` / `--silo-font-*` design tokens — no hard-coded values

Closes #56

## Test plan

- [ ] Open a `.md` file with `---` frontmatter — metadata table renders above the body, raw `---`/YAML lines are gone from the body
- [ ] Open a `.md` file without frontmatter — renders identically to before
- [ ] Table looks correct in both dark and light themes (uses design tokens)
- [ ] `pnpm test` passes (17 new unit tests in `frontmatter.test.ts`)
- [ ] `pnpm lint` passes
- [ ] `pnpm --filter silo exec tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)