### PR TITLE
feat(extensions): dev-only reload button for installed extensions

### DIFF
--- a/packages/extensions-core/src/extensions/ExtensionsPage.css
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.css
@@ -181,3 +181,8 @@
   border-color: var(--silo-color-err);
   color: var(--silo-button-danger-text, #fff);
 }
+.ext-btn-icon {
+  padding: 5px 7px;
+  display: flex;
+  align-items: center;
+}

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { ArrowsClockwise } from "@phosphor-icons/react";
 import type { ExtensionContext } from "@silo-code/sdk";
 import { useServiceState } from "@silo-code/sdk";
 import {
@@ -105,6 +106,13 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       void run(ext.id, () =>
         ext.enabled ? mgr.disable(ext.id) : mgr.enable(ext.id),
       );
+    }
+
+    function reload(ext: InstalledExtension) {
+      void run(ext.id, async () => {
+        await mgr.disable(ext.id);
+        await mgr.enable(ext.id);
+      });
     }
 
     async function uninstall(ext: InstalledExtension) {
@@ -215,6 +223,16 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                   >
                     {ext.enabled ? "Disable" : "Enable"}
                   </button>
+                  {import.meta.env.DEV && !ext.builtin && ext.enabled && (
+                    <button
+                      className="ext-btn ext-btn-icon"
+                      onClick={() => reload(ext)}
+                      disabled={busy === ext.id}
+                      title="Reload extension"
+                    >
+                      <ArrowsClockwise size={14} />
+                    </button>
+                  )}
                   {!ext.builtin && (
                     <button
                       className="ext-btn ext-btn-danger"


### PR DESCRIPTION
## Summary

- Adds a refresh icon button to each enabled, non-builtin extension row in the Extensions settings page
- Only rendered in dev builds (`import.meta.env.DEV`) — zero impact on production
- Clicking it calls `disable` → `enable` on the extension, unloading and reloading it from its installed folder without touching the install record or copying any files

## Test plan

- [ ] Run `pnpm dev`, open Settings → Extensions, install a test extension from a local folder
- [ ] Confirm the reload button (refresh icon) appears between the Disable and Uninstall buttons
- [ ] Edit the extension source, click Reload, confirm the updated extension loads
- [ ] Confirm the button is absent for built-in extensions even in dev mode
- [ ] Confirm the button is absent when an extension is disabled (Enable button is the path there)
- [ ] Confirm no button appears in a production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)