### PR TITLE
feat(dnd): native Finder file drag-and-drop via WKWebView swizzle

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4556,6 +4556,7 @@ dependencies = [
  "grep",
  "ignore",
  "notify",
+ "objc2",
  "parking_lot",
  "portable-pty",
  "pty-host",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -64,8 +64,11 @@ pty-host = { path = "../../../crates/pty-host" }
 # silent during an HTML5 drag (the webview's drag session captures the
 # event flow), so we poll CoreGraphics' HID-level modifier state on a
 # background thread instead. CG queries don't depend on event delivery.
+# objc2: method-swizzle WKWebView to capture Finder drag-drop file paths
+# (NSDraggingInfo.draggingPasteboard) — only accessible via the delegate.
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.25"
+objc2 = "0.6"
 
 # Auto-updater + single-instance — desktop only (no mobile update channel; no
 # second-launch model on mobile). Single-instance powers the `silo <path>` CLI:

--- a/apps/desktop/src-tauri/src/commands/finder_drop.rs
+++ b/apps/desktop/src-tauri/src/commands/finder_drop.rs
@@ -55,6 +55,7 @@ mod macos {
     static ORIG_ENTERED: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
     static ORIG_EXITED: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
     static ORIG_CONCLUDE: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+    static ORIG_BEGIN_DRAG: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
 
     // Raw ObjC runtime — not all exposed cleanly through objc2::ffi in 0.6.
     extern "C" {
@@ -122,6 +123,135 @@ mod macos {
                 std::mem::transmute(orig);
             f(this, cmd, sender);
         }
+    }
+
+    // ── outgoing drag: inject NSFilenamesPboardType ──────────────────────────
+
+    // Swizzle beginDraggingSessionWithItems:event:source: so we can add
+    // NSFilenamesPboardType to the drag pasteboard after WebKit sets it up.
+    // Finder requires NSFilenamesPboardType to accept a file-drop; WebKit
+    // does not write it even when the DataTransfer carries text/uri-list.
+    unsafe extern "C" fn hooked_begin_dragging_session(
+        this: *mut AnyObject,
+        cmd: Sel,
+        items: *mut AnyObject,   // NSArray<NSDraggingItem *>
+        event: *mut AnyObject,   // NSEvent *
+        source: *mut AnyObject,  // id<NSDraggingSource>
+    ) -> *mut AnyObject /* NSDraggingSession * */ {
+        let orig = ORIG_BEGIN_DRAG.load(Ordering::Acquire);
+        let f: unsafe extern "C" fn(
+            *mut AnyObject, Sel,
+            *mut AnyObject, *mut AnyObject, *mut AnyObject,
+        ) -> *mut AnyObject = std::mem::transmute(orig);
+        let session = f(this, cmd, items, event, source);
+
+        if !session.is_null() {
+            autoreleasepool(|_| {
+                let pb: *mut AnyObject = msg_send![session, draggingPasteboard];
+                if !pb.is_null() {
+                    inject_filenames_if_needed(pb);
+                }
+            });
+        }
+        session
+    }
+
+    // Read the drag pasteboard and, if it contains file URLs in any
+    // WebKit-written type, also write NSFilenamesPboardType so Finder can
+    // accept the drop. Logs all types for diagnostics.
+    unsafe fn inject_filenames_if_needed(pb: *mut AnyObject) {
+        let types: *mut AnyObject = msg_send![pb, types];
+        if types.is_null() { return; }
+        let count: usize = msg_send![types, count];
+        eprintln!("[finder_drop] outgoing drag: {} pasteboard type(s)", count);
+
+        let mut file_paths: Vec<String> = Vec::new();
+
+        for i in 0..count {
+            let t: *mut AnyObject = msg_send![types, objectAtIndex: i];
+            if t.is_null() { continue; }
+            let utf8: *const c_char = msg_send![t, UTF8String];
+            if utf8.is_null() { continue; }
+            let type_name = CStr::from_ptr(utf8).to_str().unwrap_or("?");
+            eprintln!("[finder_drop]   type[{}]: {}", i, type_name);
+
+            // Collect file paths from likely URL types WebKit may write.
+            // (public.url, public.file-url, NSURLPboardType are all candidates)
+            let is_url_type = matches!(type_name,
+                "public.url" | "public.file-url" | "Apple URL pasteboard type"
+            );
+            if is_url_type {
+                let val: *mut AnyObject = msg_send![pb, stringForType: t];
+                if val.is_null() { continue; }
+                let vutf8: *const c_char = msg_send![val, UTF8String];
+                if vutf8.is_null() { continue; }
+                let url_str = CStr::from_ptr(vutf8).to_str().unwrap_or("");
+                eprintln!("[finder_drop]     value: {}", url_str);
+                // Grab each line (text/uri-list is CRLF-separated)
+                for line in url_str.split(['\r', '\n']) {
+                    let line = line.trim();
+                    if line.starts_with("file://") {
+                        let path = percent_decode_path(line.trim_start_matches("file://"));
+                        if !path.is_empty() && !file_paths.contains(&path) {
+                            file_paths.push(path);
+                        }
+                    }
+                }
+            }
+        }
+
+        if file_paths.is_empty() {
+            eprintln!("[finder_drop] outgoing drag: no file URLs found");
+            return;
+        }
+        eprintln!("[finder_drop] outgoing drag: injecting {} path(s): {:?}", file_paths.len(), file_paths);
+
+        // Build NSArray<NSString> of POSIX paths.
+        let path_ptrs: Vec<*mut AnyObject> = file_paths.iter().map(|p| {
+            let cs = CString::new(p.as_str()).unwrap_or_default();
+            let s: *mut AnyObject = msg_send![class!(NSString), stringWithUTF8String: cs.as_ptr()];
+            s
+        }).filter(|p| !p.is_null()).collect();
+
+        if path_ptrs.is_empty() { return; }
+
+        let arr: *mut AnyObject = msg_send![
+            class!(NSArray),
+            arrayWithObjects: path_ptrs.as_ptr(),
+            count: path_ptrs.len()
+        ];
+
+        let fnames_type: *mut AnyObject = msg_send![
+            class!(NSString),
+            stringWithUTF8String: b"NSFilenamesPboardType\0".as_ptr() as *const c_char
+        ];
+        let type_arr: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: fnames_type];
+
+        // Add the type to the drag pasteboard (owner:nil = we don't need callbacks).
+        let _: bool = msg_send![pb, addTypes: type_arr, owner: ptr::null::<AnyObject>()];
+        let _: bool = msg_send![pb, setPropertyList: arr, forType: fnames_type];
+        eprintln!("[finder_drop] outgoing drag: NSFilenamesPboardType written");
+    }
+
+    // Minimal percent-decode for file paths (%20 → space, etc.).
+    fn percent_decode_path(s: &str) -> String {
+        // Remove the leading extra slash if the URL is file:///path
+        let s = s.strip_prefix('/').unwrap_or(s);
+        let s = format!("/{}", s); // restore the leading /
+        let mut out = String::with_capacity(s.len());
+        let mut bytes = s.bytes();
+        while let Some(b) = bytes.next() {
+            if b == b'%' {
+                let h1 = bytes.next().and_then(|b| (b as char).to_digit(16));
+                let h2 = bytes.next().and_then(|b| (b as char).to_digit(16));
+                if let (Some(h1), Some(h2)) = (h1, h2) {
+                    out.push(((h1 * 16 + h2) as u8) as char);
+                }
+            } else {
+                out.push(b as char);
+            }
+        }
+        out
     }
 
     // ── read paths from NSDraggingInfo ───────────────────────────────────────
@@ -264,6 +394,12 @@ mod macos {
             sel!(concludeDragOperation:),
             hooked_conclude_drag as *const c_void,
             &ORIG_CONCLUDE,
+        );
+        swizzle_method(
+            target_cls,
+            sel!(beginDraggingSessionWithItems:event:source:),
+            hooked_begin_dragging_session as *const c_void,
+            &ORIG_BEGIN_DRAG,
         );
     }
 }

--- a/apps/desktop/src-tauri/src/commands/finder_drop.rs
+++ b/apps/desktop/src-tauri/src/commands/finder_drop.rs
@@ -1,0 +1,269 @@
+// Finder → Silo drag-and-drop file path interception.
+//
+// macOS problem: WKWebView with dragDropEnabled:false fires HTML5 drag events
+// for Finder file drags, but DataTransfer.getData("text/uri-list") is always
+// empty — WebKit only populates DataTransfer.files (no .path in WKWebView), and
+// named pasteboards (NSDragPboard) are a different object from the drag-session
+// pasteboard passed by the OS to the NSDraggingDestination delegate.
+//
+// Solution: swizzle WKWebView's draggingEntered: method so we receive the
+// NSDraggingInfo before WebKit does, read the file paths from
+// NSDraggingInfo.draggingPasteboard (the authoritative source), store them in a
+// static, and clear on draggingExited:/concludeDragOperation:. The Tauri command
+// `dnd_get_finder_paths` simply reads the static; JS calls it during the very
+// first dragover event (while the drag is still active) and caches the result.
+
+use std::sync::OnceLock;
+use std::sync::Mutex;
+
+static DRAG_PATHS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn drag_paths_store() -> &'static Mutex<Vec<String>> {
+    DRAG_PATHS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Return the file paths being dragged from Finder into the current window.
+/// Populated by the WKWebView swizzle installed at startup; empty on non-macOS.
+#[tauri::command]
+pub fn dnd_get_finder_paths() -> Vec<String> {
+    drag_paths_store()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+/// Install the WKWebView NSDraggingDestination swizzle.
+/// Must be called before the first WKWebView is created (i.e. before app.run()).
+pub fn install_drag_swizzle() {
+    #[cfg(target_os = "macos")]
+    macos::install();
+}
+
+// ─── macOS implementation ────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::drag_paths_store;
+    use std::ffi::{CStr, CString, c_char, c_void};
+    use std::ptr;
+    use std::sync::atomic::{AtomicPtr, Ordering};
+    use objc2::rc::autoreleasepool;
+    use objc2::runtime::{AnyObject, Sel};
+    use objc2::{class, msg_send, sel};
+
+    // Original IMPs saved at swizzle time so we can call through to WebKit.
+    static ORIG_ENTERED: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+    static ORIG_EXITED: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+    static ORIG_CONCLUDE: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+
+    // Raw ObjC runtime — not all exposed cleanly through objc2::ffi in 0.6.
+    extern "C" {
+        fn class_getInstanceMethod(cls: *const c_void, sel: Sel) -> *mut c_void;
+        fn method_setImplementation(method: *mut c_void, imp: *const c_void) -> *const c_void;
+    }
+
+    // NSDragOperation is NSUInteger (u64 on 64-bit).
+    type NSDragOperation = u64;
+
+    // ── hooked draggingEntered: ──────────────────────────────────────────────
+    unsafe extern "C" fn hooked_dragging_entered(
+        this: *mut AnyObject,
+        cmd: Sel,
+        sender: *mut AnyObject,
+    ) -> NSDragOperation {
+        // Capture paths before WebKit touches the drag info.
+        autoreleasepool(|_| {
+            let paths = paths_from_drag_info(sender);
+            eprintln!("[finder_drop] draggingEntered — captured {} path(s): {:?}", paths.len(), paths);
+            *drag_paths_store().lock().unwrap_or_else(|e| e.into_inner()) = paths;
+        });
+
+        let orig = ORIG_ENTERED.load(Ordering::Acquire);
+        let f: unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject) -> NSDragOperation =
+            std::mem::transmute(orig);
+        f(this, cmd, sender)
+    }
+
+    // ── hooked draggingExited: ───────────────────────────────────────────────
+    unsafe extern "C" fn hooked_dragging_exited(
+        this: *mut AnyObject,
+        cmd: Sel,
+        sender: *mut AnyObject,
+    ) {
+        eprintln!("[finder_drop] draggingExited — clearing cache");
+        drag_paths_store()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+
+        let orig = ORIG_EXITED.load(Ordering::Acquire);
+        if !orig.is_null() {
+            let f: unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject) =
+                std::mem::transmute(orig);
+            f(this, cmd, sender);
+        }
+    }
+
+    // ── hooked concludeDragOperation: ───────────────────────────────────────
+    unsafe extern "C" fn hooked_conclude_drag(
+        this: *mut AnyObject,
+        cmd: Sel,
+        sender: *mut AnyObject,
+    ) {
+        eprintln!("[finder_drop] concludeDragOperation — clearing cache");
+        drag_paths_store()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+
+        let orig = ORIG_CONCLUDE.load(Ordering::Acquire);
+        if !orig.is_null() {
+            let f: unsafe extern "C" fn(*mut AnyObject, Sel, *mut AnyObject) =
+                std::mem::transmute(orig);
+            f(this, cmd, sender);
+        }
+    }
+
+    // ── read paths from NSDraggingInfo ───────────────────────────────────────
+    unsafe fn paths_from_drag_info(info: *mut AnyObject) -> Vec<String> {
+        if info.is_null() {
+            return vec![];
+        }
+        let pb: *mut AnyObject = msg_send![info, draggingPasteboard];
+        if pb.is_null() {
+            eprintln!("[finder_drop] draggingPasteboard is nil");
+            return vec![];
+        }
+
+        // Primary: NSFilenamesPboardType → NSArray<NSString> of absolute paths.
+        let paths = try_filenames_type(pb);
+        if !paths.is_empty() {
+            return paths;
+        }
+
+        // Fallback: read NSURL objects (modern macOS approach).
+        try_file_urls(pb)
+    }
+
+    unsafe fn try_filenames_type(pb: *mut AnyObject) -> Vec<String> {
+        let str_cls = class!(NSString);
+        let type_str: *mut AnyObject = msg_send![
+            str_cls,
+            stringWithUTF8String: b"NSFilenamesPboardType\0".as_ptr() as *const c_char
+        ];
+        if type_str.is_null() {
+            return vec![];
+        }
+        let plist: *mut AnyObject = msg_send![pb, propertyListForType: type_str];
+        if plist.is_null() {
+            eprintln!("[finder_drop] NSFilenamesPboardType → nil");
+            return vec![];
+        }
+        let count: usize = msg_send![plist, count];
+        eprintln!("[finder_drop] NSFilenamesPboardType count={}", count);
+        let mut paths = Vec::with_capacity(count);
+        for i in 0..count {
+            let item: *mut AnyObject = msg_send![plist, objectAtIndex: i];
+            if item.is_null() {
+                continue;
+            }
+            let utf8: *const c_char = msg_send![item, UTF8String];
+            if utf8.is_null() {
+                continue;
+            }
+            if let Ok(s) = CStr::from_ptr(utf8).to_str() {
+                paths.push(s.to_owned());
+            }
+        }
+        paths
+    }
+
+    unsafe fn try_file_urls(pb: *mut AnyObject) -> Vec<String> {
+        // [pb readObjectsForClasses:@[[NSURL class]] options:nil]
+        let url_cls = class!(NSURL);
+        let arr_cls = class!(NSArray);
+        let url_cls_obj: *mut AnyObject = url_cls as *const _ as *mut AnyObject;
+        let classes: *mut AnyObject =
+            msg_send![arr_cls, arrayWithObject: url_cls_obj];
+        let objects: *mut AnyObject =
+            msg_send![pb, readObjectsForClasses: classes, options: ptr::null::<AnyObject>()];
+        if objects.is_null() {
+            eprintln!("[finder_drop] readObjectsForClasses → nil");
+            return vec![];
+        }
+        let count: usize = msg_send![objects, count];
+        eprintln!("[finder_drop] readObjectsForClasses NSURL count={}", count);
+        let mut paths = Vec::with_capacity(count);
+        for i in 0..count {
+            let url: *mut AnyObject = msg_send![objects, objectAtIndex: i];
+            if url.is_null() {
+                continue;
+            }
+            let is_file: bool = msg_send![url, isFileURL];
+            if !is_file {
+                continue;
+            }
+            let path_obj: *mut AnyObject = msg_send![url, path];
+            if path_obj.is_null() {
+                continue;
+            }
+            let utf8: *const c_char = msg_send![path_obj, UTF8String];
+            if utf8.is_null() {
+                continue;
+            }
+            if let Ok(s) = CStr::from_ptr(utf8).to_str() {
+                paths.push(s.to_owned());
+            }
+        }
+        paths
+    }
+
+    // ── swizzle installation ─────────────────────────────────────────────────
+    fn swizzle_method(cls_ptr: *const c_void, sel: Sel, imp: *const c_void, store: &AtomicPtr<c_void>) {
+        unsafe {
+            let method = class_getInstanceMethod(cls_ptr, sel);
+            if method.is_null() {
+                eprintln!("[finder_drop] class_getInstanceMethod returned null for {:?}", sel);
+                return;
+            }
+            let orig = method_setImplementation(method, imp);
+            store.store(orig as *mut c_void, Ordering::Release);
+            eprintln!("[finder_drop] swizzled {:?}", sel);
+        }
+    }
+
+    pub fn install() {
+        eprintln!("[finder_drop] installing WKWebView drag swizzle");
+        // Try WryWebView first (WRY's WKWebView subclass); fall back to WKWebView.
+        // WRY may or may not define its own drag methods depending on dragDropEnabled.
+        let target_cls = {
+            use objc2::runtime::AnyClass;
+            let name = CString::new("WryWebView").unwrap();
+            AnyClass::get(name.as_c_str())
+                .map(|c| c as *const AnyClass as *const c_void)
+                .unwrap_or_else(|| {
+                    eprintln!("[finder_drop] WryWebView not found, using WKWebView");
+                    unsafe { class!(WKWebView) as *const _ as *const c_void }
+                })
+        };
+
+        swizzle_method(
+            target_cls,
+            sel!(draggingEntered:),
+            hooked_dragging_entered as *const c_void,
+            &ORIG_ENTERED,
+        );
+        swizzle_method(
+            target_cls,
+            sel!(draggingExited:),
+            hooked_dragging_exited as *const c_void,
+            &ORIG_EXITED,
+        );
+        swizzle_method(
+            target_cls,
+            sel!(concludeDragOperation:),
+            hooked_conclude_drag as *const c_void,
+            &ORIG_CONCLUDE,
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_paths;
+pub mod finder_drop;
 pub mod network;
 #[cfg(feature = "automation")]
 pub mod automation;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -105,6 +105,14 @@ pub fn run() {
                 });
             }
 
+            // macOS: swizzle WKWebView dragging methods so that Finder
+            // file-drop paths are captured via NSDraggingInfo (the
+            // authoritative pasteboard) before WebKit processes the drag.
+            // Called here — after windows are created — so WryWebView is
+            // already registered as an ObjC class and can be targeted.
+            #[cfg(target_os = "macos")]
+            commands::finder_drop::install_drag_swizzle();
+
             // Cleanup stale terminal buffers on startup
             std::thread::spawn(|| {
                 let _ = commands::terminal_buffer::cleanup_stale_buffers();
@@ -145,6 +153,7 @@ pub fn run() {
             commands::terminal::terminal_save_buffer,
             commands::network::net_fetch,
             commands::network::net_fetch_headers,
+            commands::finder_drop::dnd_get_finder_paths,
         ])
         .run(context)
         .expect("error while running tauri application");

--- a/packages/extension-host/src/extension-host/dnd-service.test.ts
+++ b/packages/extension-host/src/extension-host/dnd-service.test.ts
@@ -1,14 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // The affordance + modifier tracker touch the real DOM / Tauri; mock them so we
 // can unit-test the pure dispatch logic (MIME round-trip + mode resolution).
 vi.mock("./file-drag-ghost", () => ({ startFileDragGhost: vi.fn() }));
 vi.mock("./alt-tracker", () => ({ isPasteModifierActive: vi.fn(() => false) }));
+// Dynamic import used by prefetchFinderPaths().
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue([]),
+}));
 
 import { getDndService } from "./dnd-service";
 import { DND_MIME, type DropContext } from "@silo-code/sdk";
 import { startFileDragGhost } from "./file-drag-ghost";
 import { isPasteModifierActive } from "./alt-tracker";
+import { invoke } from "@tauri-apps/api/core";
 
 function fakeDataTransfer(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial));
@@ -107,5 +112,205 @@ describe("dnd-service", () => {
       dropEvent(fakeDataTransfer({ [DND_MIME.filePath]: "/p" })),
     );
     expect(onDrop).not.toHaveBeenCalled();
+  });
+});
+
+// ── native Finder drop tests ─────────────────────────────────────────────────
+
+// Flush the microtask + macrotask queues — needed to let the dynamic import
+// chain inside prefetchFinderPaths() resolve fully.
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+/** Build a DataTransfer-like object whose .types mimics an OS file drag. */
+function finderDt(extraTypes: Record<string, string> = {}) {
+  return fakeDataTransfer({ Files: "", ...extraTypes });
+}
+
+function fireWindowEvent(
+  type: "dragover" | "dragleave" | "drop",
+  dt: ReturnType<typeof fakeDataTransfer>,
+  opts: { x?: number; y?: number; relatedTarget?: Element | null } = {},
+): Event {
+  const evt = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(evt, "dataTransfer", { value: dt });
+  Object.defineProperty(evt, "clientX", { value: opts.x ?? 10 });
+  Object.defineProperty(evt, "clientY", { value: opts.y ?? 10 });
+  if (type === "dragleave") {
+    Object.defineProperty(evt, "relatedTarget", {
+      value:
+        opts.relatedTarget !== undefined
+          ? opts.relatedTarget
+          : document.createElement("div"),
+    });
+  }
+  window.dispatchEvent(evt);
+  return evt;
+}
+
+describe("native Finder file drop (swizzle path)", () => {
+  const mockInvoke = vi.mocked(invoke);
+
+  // jsdom doesn't implement elementFromPoint; define it directly.
+  function stubEFP(el: Element | null) {
+    Object.defineProperty(document, "elementFromPoint", {
+      value: () => el,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockInvoke.mockResolvedValue([]);
+    // Ensure elementFromPoint exists (returns null by default between tests).
+    stubEFP(null);
+    // Reset native drag state: simulating a window-exit dragleave calls
+    // clearFinderDragCache() which nulls the cache and increments the session.
+    fireWindowEvent("dragleave", finderDt(), { relatedTarget: null });
+    await flushPromises();
+  });
+
+  it("registerDropTarget adds to registry; dispose removes it", async () => {
+    const el = document.createElement("div");
+    const onDrop = vi.fn(() => undefined);
+    const reg = getDndService().registerDropTarget(el, {
+      accepts: [DND_MIME.filePath],
+      onDrop,
+    });
+    mockInvoke.mockResolvedValue(["/x.txt"]);
+    stubEFP(el);
+
+    fireWindowEvent("dragover", finderDt());
+    await flushPromises();
+    fireWindowEvent("drop", finderDt());
+    expect(onDrop).toHaveBeenCalledTimes(1);
+
+    reg.dispose();
+    // Fire another drag — element is gone from registry, onDrop must not fire.
+    fireWindowEvent("dragleave", finderDt(), { relatedTarget: null }); // clear cache
+    await flushPromises();
+    mockInvoke.mockResolvedValue(["/x.txt"]);
+    stubEFP(el);
+    fireWindowEvent("dragover", finderDt());
+    await flushPromises();
+    fireWindowEvent("drop", finderDt());
+    expect(onDrop).toHaveBeenCalledTimes(1); // still 1 — dispose worked
+  });
+
+  it("prefetch is triggered once on first dragover and not repeated", async () => {
+    const el = document.createElement("div");
+    const reg = getDndService().registerDropTarget(el, {
+      accepts: [DND_MIME.filePath],
+      onDrop: vi.fn(() => undefined),
+    });
+    stubEFP(el);
+
+    fireWindowEvent("dragover", finderDt());
+    fireWindowEvent("dragover", finderDt()); // second over — no new fetch
+    await flushPromises();
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).toHaveBeenCalledWith("dnd_get_finder_paths");
+    reg.dispose();
+  });
+
+  it("drop delivers prefetched paths as DND items with mode='paste'", async () => {
+    mockInvoke.mockResolvedValue(["/a/b.txt", "/c/d.png"]);
+
+    const el = document.createElement("div");
+    const onDrop = vi.fn(() => undefined);
+    const reg = getDndService().registerDropTarget(el, {
+      accepts: [DND_MIME.filePath],
+      onDrop,
+    });
+    stubEFP(el);
+
+    fireWindowEvent("dragover", finderDt());
+    await flushPromises(); // finderDragPaths = ["/a/b.txt", "/c/d.png"]
+    fireWindowEvent("drop", finderDt()); // no uri-list → uses cache
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    const ctx = onDrop.mock.calls[0][0] as DropContext;
+    expect(ctx.items).toEqual([
+      { mime: DND_MIME.filePath, value: "/a/b.txt" },
+      { mime: DND_MIME.filePath, value: "/c/d.png" },
+    ]);
+    expect(ctx.mode).toBe("paste");
+    reg.dispose();
+  });
+
+  it("window-exit dragleave clears the cache; subsequent drop fires nothing", async () => {
+    mockInvoke.mockResolvedValue(["/a/b.txt"]);
+
+    const el = document.createElement("div");
+    const onDrop = vi.fn(() => undefined);
+    const reg = getDndService().registerDropTarget(el, {
+      accepts: [DND_MIME.filePath],
+      onDrop,
+    });
+    stubEFP(el);
+
+    fireWindowEvent("dragover", finderDt());
+    await flushPromises();
+    fireWindowEvent("dragleave", finderDt(), { relatedTarget: null }); // leaves window
+    fireWindowEvent("drop", finderDt()); // cache gone → no paths → nothing fired
+
+    expect(onDrop).not.toHaveBeenCalled();
+    reg.dispose();
+  });
+
+  it("intra-DOM dragleave (relatedTarget != null) does NOT clear the cache", async () => {
+    mockInvoke.mockResolvedValue(["/a/b.txt"]);
+
+    const el = document.createElement("div");
+    const onDrop = vi.fn(() => undefined);
+    const reg = getDndService().registerDropTarget(el, {
+      accepts: [DND_MIME.filePath],
+      onDrop,
+    });
+    stubEFP(el);
+
+    fireWindowEvent("dragover", finderDt());
+    await flushPromises();
+    // Cursor moved to a sibling element — relatedTarget is a DOM node, not null.
+    fireWindowEvent("dragleave", finderDt(), {
+      relatedTarget: document.createElement("span"),
+    });
+    fireWindowEvent("drop", finderDt()); // cache intact → paths delivered
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    reg.dispose();
+  });
+
+  it("drop on unregistered element does not crash", () => {
+    const el = document.createElement("div"); // NOT registered
+    stubEFP(el);
+
+    expect(() => {
+      fireWindowEvent("dragover", finderDt());
+      fireWindowEvent("drop", finderDt());
+    }).not.toThrow();
+  });
+
+  it("internal Silo drag (carries DND_MIME.filePath) is not treated as a Finder drag", async () => {
+    const el = document.createElement("div");
+    const onDrop = vi.fn(() => true);
+    const reg = getDndService().registerDropTarget(el, {
+      accepts: [DND_MIME.filePath],
+      onDrop,
+    });
+    stubEFP(el);
+
+    // Has "Files" but also our internal MIME → isExternalFileDrag returns false.
+    const internalDt = fakeDataTransfer({
+      Files: "",
+      [DND_MIME.filePath]: "/x.txt",
+    });
+    fireWindowEvent("dragover", internalDt);
+    await flushPromises();
+
+    // invoke must NOT have been called (no prefetch for internal drag)
+    expect(mockInvoke).not.toHaveBeenCalled();
+    reg.dispose();
   });
 });

--- a/packages/extension-host/src/extension-host/dnd-service.test.ts
+++ b/packages/extension-host/src/extension-host/dnd-service.test.ts
@@ -55,6 +55,33 @@ describe("dnd-service", () => {
     expect(startFileDragGhost).toHaveBeenCalledWith("b.txt", expect.anything());
   });
 
+  it("beginDrag sets text/uri-list for Finder interop (spaces encoded)", () => {
+    const dt = fakeDataTransfer();
+    getDndService().beginDrag({ dataTransfer: dt } as unknown as DragEvent, {
+      items: [{ mime: DND_MIME.filePath, value: "/a/my file.txt" }],
+      label: "my file.txt",
+    });
+    expect(dt.setData).toHaveBeenCalledWith(
+      "text/uri-list",
+      "file:///a/my%20file.txt",
+    );
+  });
+
+  it("beginDrag joins multiple file paths with CRLF in text/uri-list", () => {
+    const dt = fakeDataTransfer();
+    getDndService().beginDrag({ dataTransfer: dt } as unknown as DragEvent, {
+      items: [
+        { mime: DND_MIME.filePath, value: "/a/b.txt" },
+        { mime: DND_MIME.filePath, value: "/c/d.png" },
+      ],
+      label: "2 files",
+    });
+    expect(dt.setData).toHaveBeenCalledWith(
+      "text/uri-list",
+      "file:///a/b.txt\r\nfile:///c/d.png",
+    );
+  });
+
   it("registerDropTarget reads items, resolves copy mode, and handles", () => {
     const el = document.createElement("div");
     const onDrop = vi.fn((_ctx: DropContext) => true);

--- a/packages/extension-host/src/extension-host/dnd-service.ts
+++ b/packages/extension-host/src/extension-host/dnd-service.ts
@@ -1,12 +1,37 @@
 import { startFileDragGhost } from "./file-drag-ghost";
 import { isPasteModifierActive } from "./alt-tracker";
-import type { DndService, DndItem, DndMode, DropContext } from "@silo-code/sdk";
+import type {
+  DndService,
+  DndItem,
+  DndMode,
+  DropContext,
+  DropTargetHandlers,
+} from "@silo-code/sdk";
+import { DND_MIME } from "@silo-code/sdk";
 
 // `ctx.dnd` — the public contract (incl. the DND_MIME vocabulary) lives in
 // @silo-code/sdk (dnd-service.ts); this is the host implementation that owns the
-// floating drag chip + paste-mode overlay and the modifier-mode resolution.
+// floating drag chip + paste-mode overlay, modifier-mode resolution, and the
+// window-level listener that routes Finder file drags to registered targets.
+
+// Registry: every active registerDropTarget call adds its element here so the
+// window-level native-drop handler can find the right target via hit-test + DOM walk.
+const registry = new Map<HTMLElement, DropTargetHandlers>();
 
 let service: DndService | null = null;
+
+// ── native Finder drop state ─────────────────────────────────────────────────
+
+let nativeHoveredHandlers: DropTargetHandlers | null = null;
+// Paths captured during draggingEntered: by the Rust swizzle, fetched async
+// via prefetchFinderPaths() on the first dragover, used synchronously on drop.
+let finderDragPaths: string[] | null = null;
+let finderDragFetching = false;
+// Incremented on every clearFinderDragCache() call; each async prefetch chain
+// checks the counter before writing so stale results don't overwrite a newer drag.
+let finderDragSession = 0;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
 
 function accepted(dt: DataTransfer | null, accepts: string[]): boolean {
   if (!dt) return false;
@@ -24,6 +49,162 @@ function readItems(dt: DataTransfer | null, accepts: string[]): DndItem[] {
   return items;
 }
 
+/** True only for Finder/OS file drags (not internal Silo drags). */
+function isExternalFileDrag(dt: DataTransfer | null): boolean {
+  if (!dt) return false;
+  return dt.types.includes("Files") && !dt.types.includes(DND_MIME.filePath);
+}
+
+/**
+ * Walk up the DOM from `el` until we find a registered ancestor that
+ * accepts at least one of `mimes`.
+ */
+function findDropTarget(
+  el: Element | null,
+  mimes: string[],
+): DropTargetHandlers | null {
+  let node: Element | null = el;
+  while (node) {
+    const handlers = registry.get(node as HTMLElement);
+    if (handlers && mimes.some((m) => handlers.accepts.includes(m))) {
+      return handlers;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+function parseUriList(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith("#"))
+    .map((uri) => {
+      try {
+        const u = new URL(uri);
+        return u.protocol === "file:" ? decodeURIComponent(u.pathname) : "";
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Kick off a background fetch of the file paths captured by the Rust swizzle
+ * during the current drag session. Called on the FIRST dragover so the result
+ * is ready (or nearly ready) by the time the user drops.
+ *
+ * Note: text/uri-list is always empty in WKWebView when dragDropEnabled:false,
+ * so we must retrieve paths through the swizzle-backed Tauri command.
+ */
+function prefetchFinderPaths(): void {
+  if (finderDragPaths !== null || finderDragFetching) return;
+  finderDragFetching = true;
+  const session = finderDragSession;
+  void import("@tauri-apps/api/core")
+    .then(({ invoke }) => invoke<string[]>("dnd_get_finder_paths"))
+    .then((paths) => {
+      if (finderDragSession === session) finderDragPaths = paths;
+    })
+    .catch(() => {
+      if (finderDragSession === session) finderDragPaths = [];
+    })
+    .finally(() => {
+      if (finderDragSession === session) finderDragFetching = false;
+    });
+}
+
+function clearFinderDragCache(): void {
+  finderDragPaths = null;
+  finderDragFetching = false;
+  finderDragSession++;
+}
+
+// ── window-level Finder drop routing ─────────────────────────────────────────
+
+/**
+ * Attach window-level capture listeners that intercept external (Finder) file
+ * drags. Internal Silo drags carry DND_MIME.filePath and are handled at the
+ * element level by registerDropTarget; external drags carry "Files" and need
+ * special routing because dt.getData("text/uri-list") is always empty in
+ * WKWebView with dragDropEnabled:false.
+ */
+function subscribeToNativeFileDrop(): void {
+  window.addEventListener(
+    "dragover",
+    (e: DragEvent) => {
+      if (!isExternalFileDrag(e.dataTransfer)) return;
+      // Start the async path fetch on the very first dragover so it's ready
+      // (or close to ready) when the user lifts the mouse.
+      prefetchFinderPaths();
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      const handlers = findDropTarget(el, [DND_MIME.filePath]);
+      nativeHoveredHandlers = handlers;
+      if (!handlers) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const effect = handlers.onDragOver?.({
+        items: [],
+        mode: "paste",
+        clientX: e.clientX,
+        clientY: e.clientY,
+        nativeEvent: e,
+      });
+      if (effect && e.dataTransfer) e.dataTransfer.dropEffect = effect;
+    },
+    true,
+  );
+
+  window.addEventListener(
+    "dragleave",
+    (e: DragEvent) => {
+      if (!isExternalFileDrag(e.dataTransfer)) return;
+      // Only clear when the drag has fully left the browser window.
+      // Intra-DOM dragleaves (e.relatedTarget !== null) are noise.
+      if (e.relatedTarget !== null) return;
+      nativeHoveredHandlers?.onDragLeave?.(e);
+      nativeHoveredHandlers = null;
+      clearFinderDragCache();
+    },
+    true,
+  );
+
+  window.addEventListener(
+    "drop",
+    (e: DragEvent) => {
+      if (!isExternalFileDrag(e.dataTransfer)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      nativeHoveredHandlers = null;
+      const clientX = e.clientX;
+      const clientY = e.clientY;
+      const el = document.elementFromPoint(clientX, clientY);
+      const handlers = findDropTarget(el, [DND_MIME.filePath]);
+      if (!handlers) {
+        clearFinderDragCache();
+        return;
+      }
+      // text/uri-list is always empty in WKWebView with dragDropEnabled:false.
+      // Fall back to the swizzle-prefetched paths.
+      let paths = parseUriList(e.dataTransfer?.getData("text/uri-list") ?? "");
+      if (!paths.length) paths = finderDragPaths ?? [];
+      clearFinderDragCache();
+      if (!paths.length) return;
+      handlers.onDrop({
+        items: paths.map((p) => ({ mime: DND_MIME.filePath, value: p })),
+        mode: "paste",
+        clientX,
+        clientY,
+        nativeEvent: e,
+      });
+    },
+    true,
+  );
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
 /**
  * Resolve the drag {@link DndMode} from an event's held modifiers (Shift ⇒
  * `"paste"`), robust to WebKit suppressing key events mid-drag. Used internally
@@ -40,6 +221,7 @@ export function resolveDndMode(event: { shiftKey: boolean }): DndMode {
 /** @internal — host factory; extensions receive this as `ctx.dnd`. */
 export function getDndService(): DndService {
   if (service) return service;
+  subscribeToNativeFileDrop();
   service = {
     beginDrag(event, init) {
       const dt = event.dataTransfer;
@@ -51,6 +233,7 @@ export function getDndService(): DndService {
       startFileDragGhost(init.label, event);
     },
     registerDropTarget(el, handlers) {
+      registry.set(el, handlers);
       const capture = handlers.capture ?? false;
       const ctxFor = (e: DragEvent): DropContext => ({
         items: readItems(e.dataTransfer, handlers.accepts),
@@ -83,6 +266,7 @@ export function getDndService(): DndService {
         el.addEventListener("dragleave", onDragLeave, capture);
       return {
         dispose() {
+          registry.delete(el);
           el.removeEventListener("dragover", onDragOver, capture);
           el.removeEventListener("drop", onDrop, capture);
           el.removeEventListener("dragleave", onDragLeave, capture);

--- a/packages/extension-host/src/extension-host/dnd-service.ts
+++ b/packages/extension-host/src/extension-host/dnd-service.ts
@@ -227,6 +227,14 @@ export function getDndService(): DndService {
       const dt = event.dataTransfer;
       if (!dt) return;
       for (const { mime, value } of init.items) dt.setData(mime, value);
+      // Expose file paths as text/uri-list so native apps (Finder, shell
+      // windows, etc.) can receive the drag. WKWebView converts file:// URIs
+      // in text/uri-list into native NSURL pasteboard items when the drag
+      // session starts, which is what Finder reads.
+      const filePaths = init.items
+        .filter((i) => i.mime === DND_MIME.filePath)
+        .map((i) => encodeURI("file://" + i.value));
+      if (filePaths.length) dt.setData("text/uri-list", filePaths.join("\r\n"));
       dt.effectAllowed = init.effect ?? "copyMove";
       // The ghost hides the native preview (setDragImage) and renders the chip
       // + paste overlay; it polls the modifier so the overlay flips live.

--- a/packages/extensions-core/src/terminal/terminal-path-paste.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-path-paste.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildTerminalPaste } from "./terminal-path-paste";
+
+describe("buildTerminalPaste", () => {
+  it("wraps a simple path in single quotes", () => {
+    expect(buildTerminalPaste(["/path/to/file.txt"])).toBe(
+      "'/path/to/file.txt'",
+    );
+  });
+
+  it("escapes embedded single quotes with POSIX sequence", () => {
+    expect(buildTerminalPaste(["/path/it's here/file"])).toBe(
+      "'/path/it'\\''s here/file'",
+    );
+  });
+
+  it("joins multiple paths with a space", () => {
+    expect(buildTerminalPaste(["/a/b", "/c/d"])).toBe("'/a/b' '/c/d'");
+  });
+
+  it("handles multiple paths that each contain single quotes", () => {
+    expect(buildTerminalPaste(["/a's/b", "/c/d's"])).toBe(
+      "'/a'\\''s/b' '/c/d'\\''s'",
+    );
+  });
+
+  it("returns an empty string for an empty array", () => {
+    expect(buildTerminalPaste([])).toBe("");
+  });
+});

--- a/packages/extensions-core/src/terminal/terminal-path-paste.ts
+++ b/packages/extensions-core/src/terminal/terminal-path-paste.ts
@@ -1,0 +1,8 @@
+/**
+ * Build the text to paste into the terminal for one or more file paths.
+ * Each path is wrapped in POSIX single-quotes; embedded single-quotes are
+ * escaped with the '\'' sequence. Multiple paths are space-separated.
+ */
+export function buildTerminalPaste(paths: string[]): string {
+  return paths.map((p) => `'${p.replace(/'/g, "'\\''")}'`).join(" ");
+}


### PR DESCRIPTION
## Summary

- Adds a Rust/ObjC swizzle on `WKWebView`'s `NSDraggingDestination` methods (`draggingEntered:`, `draggingExited:`, `concludeDragOperation:`) to capture Finder file paths before WebKit strips them from `DataTransfer`
- Exposes a `dnd_get_finder_paths` Tauri command that JS can call during `dragover` to prefetch the captured paths
- Swizzles `beginDraggingSessionWithItems:` to inject `NSFilenamesPboardType` so drops from Silo → Finder work correctly
- Extends `dnd-service.ts` to wire up a window-level `dragover`/`drop` listener that routes native file drags to registered `DropTarget` elements via DOM hit-test walk
- Adds `text/uri-list` propagation on outbound drags for cross-app compatibility
- Ships full test coverage for the new `dnd-service` logic (234 lines of new tests) and terminal path-paste integration (30 lines)

## Background

macOS `WKWebView` exposes `DataTransfer.files` for Finder drags but never populates `DataTransfer.getData("text/uri-list")` or `DataTransfer.getData("text/plain")`. The named pasteboard (`NSDragPboard`) is also a different object from the drag-session pasteboard, so the authoritative path list is only available via `NSDraggingInfo.draggingPasteboard` during the drag callbacks — hence the swizzle approach.

## Test plan

- [ ] Drag a file from Finder onto a terminal drop zone — paths pasted correctly
- [ ] Drag multiple files — all paths captured
- [ ] Start a drag, move off the window (`draggingExited:`) — cache cleared, no stale drop
- [ ] Drag a file from Silo to Finder — Finder accepts it
- [ ] `pnpm test` green
- [ ] `pnpm --filter silo exec tsc --noEmit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)