### PR TITLE
feat(dnd): handle multi-file drops in terminal, editor, and file tree

### DIFF
--- a/packages/extensions-core/src/editor/TextViewer.tsx
+++ b/packages/extensions-core/src/editor/TextViewer.tsx
@@ -476,14 +476,16 @@ export function TextViewer({
       capture: true,
       onDrop({ mode, items }) {
         if (mode !== "paste") return; // copy mode → let dockview open a pane
-        const path = items.find((i) => i.mime === DND_MIME.filePath)?.value;
-        if (!path) return;
+        const paths = items
+          .filter((i) => i.mime === DND_MIME.filePath)
+          .map((i) => i.value);
+        if (!paths.length) return;
         const ed = editorRef.current;
         if (!ed) return;
         const selection = ed.getSelection();
         if (!selection) return;
         ed.executeEdits("paste-path", [
-          { range: selection, text: path, forceMoveMarkers: true },
+          { range: selection, text: paths.join(" "), forceMoveMarkers: true },
         ]);
         ed.focus();
         return true; // handled — host preventDefault + stopPropagation

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -29,6 +29,7 @@ import {
   registerSelectionSource,
 } from "@silo-code/extension-host/internal";
 import { xtermThemeFor } from "./xterm-theme";
+import { buildTerminalPaste } from "./terminal-path-paste";
 import { findFileLinks, getHomeDir } from "./terminal-links";
 import { TerminalSearch } from "./TerminalSearch";
 import { Breadcrumb } from "../editor/Breadcrumb";
@@ -711,9 +712,9 @@ export function TerminalPanel(
     };
   }, [props.api, forceRefit]);
 
-  // Shift-held file drops paste the path into the shell. Plain (copy-mode)
-  // drops fall through to dockview, which opens the file as a new pane next
-  // to the terminal — same as dragging a tab. Capture phase intercepts before
+  // File drops paste the path(s) into the shell. Shift-held (paste mode) or
+  // native Finder drops always paste; plain copy-mode internal drops fall
+  // through to dockview (opens a new pane). Capture phase intercepts before
   // dockview's bubble-phase drop handler.
   useEffect(() => {
     const host = containerRef.current;
@@ -723,14 +724,13 @@ export function TerminalPanel(
       capture: true,
       onDrop({ mode, items }) {
         if (mode !== "paste") return; // copy mode → let dockview open a pane
-        const path = items.find((i) => i.mime === DND_MIME.filePath)?.value;
-        if (!path) return;
+        const paths = items
+          .filter((i) => i.mime === DND_MIME.filePath)
+          .map((i) => i.value);
+        if (!paths.length) return;
         const live = liveRef.current;
         if (!live) return;
-        // POSIX-safe single-quote wrapping: inner ' → '\'' so embedded quotes
-        // close, escape, and reopen the quoted run.
-        const escaped = path.replace(/'/g, "'\\''");
-        live.term.paste(`'${escaped}'`);
+        live.term.paste(buildTerminalPaste(paths));
         live.term.focus();
         return true; // handled — host preventDefault + stopPropagation
       },

--- a/packages/extensions-silo/src/file-explorer/Tree.tsx
+++ b/packages/extensions-silo/src/file-explorer/Tree.tsx
@@ -496,8 +496,9 @@ export function Tree({
       accepts: [DND_MIME.filePath],
       onDragOver: () => "move",
       onDrop: ({ items }) => {
-        const dragged = items.find((i) => i.mime === DND_MIME.filePath)?.value;
-        if (dragged) handleDropRef.current(dragged, root);
+        for (const item of items.filter((i) => i.mime === DND_MIME.filePath)) {
+          handleDropRef.current(item.value, root);
+        }
         return true;
       },
     });

--- a/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
+++ b/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
@@ -103,8 +103,9 @@ export function DirNode({
       },
       onDrop: ({ items }) => {
         setIsDragOver(false);
-        const dragged = items.find((i) => i.mime === DND_MIME.filePath)?.value;
-        if (dragged) onDropRef.current(dragged, path);
+        for (const item of items.filter((i) => i.mime === DND_MIME.filePath)) {
+          onDropRef.current(item.value, path);
+        }
         return true; // handled — don't fall through to the tree container
       },
     });
@@ -327,10 +328,9 @@ export function FileLeaf({
       accepts: [DND_MIME.filePath],
       onDragOver: () => "move",
       onDrop: ({ items }) => {
-        const dragged = items.find((i) => i.mime === DND_MIME.filePath)?.value;
-        if (dragged) {
-          const parentDir = path.substring(0, path.lastIndexOf("/"));
-          onDropRef.current(dragged, parentDir);
+        const parentDir = path.substring(0, path.lastIndexOf("/"));
+        for (const item of items.filter((i) => i.mime === DND_MIME.filePath)) {
+          onDropRef.current(item.value, parentDir);
         }
         return true;
       },


### PR DESCRIPTION
## What

Drop targets previously acted on only the **first** dropped file path
(`items.find(...)`). This extends the terminal, text editor, and file-explorer
tree to handle **every** dropped path when you drag multiple files in.

- **Terminal** — wires up the `buildTerminalPaste` helper (added in #76 but left
  unused) to paste all paths, space-separated and individually POSIX-quoted.
- **Text editor** — inserts all dropped paths at the cursor, space-separated.
- **File tree** (`Tree` / `TreeNodes`) — routes each dropped path to the drop
  handler, so dragging N files moves all N instead of just the first.

## Why

#76 shipped the Finder drag-drop feature and added the `buildTerminalPaste`
helper for multi-path quoting, but never connected it — the terminal still
pasted a single path. This finishes that wiring and brings the same multi-path
behavior to the editor and file tree for consistency.

## Testing

- Multi-path quoting logic is already covered by `terminal-path-paste.test.ts`.
- Full unit suite green; TS typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)