### PR TITLE
feat(search): multi-folder workspace search

### DIFF
--- a/apps/desktop/src-tauri/src/commands/search.rs
+++ b/apps/desktop/src-tauri/src/commands/search.rs
@@ -40,6 +40,33 @@ impl Default for SearchOptions {
     }
 }
 
+/// Thin newtype so the Tauri command can accept either one root (`cwd`) or many
+/// (`cwds`). The frontend always sends `cwds`; the single-`cwd` path is kept for
+/// backwards-compat with any caller that hasn't migrated yet.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchRoots {
+    /// Legacy single-root path. Ignored when `cwds` is non-empty.
+    #[serde(default)]
+    cwd: Option<String>,
+    /// Ordered list of absolute roots to search. When non-empty, `cwd` is unused.
+    #[serde(default)]
+    cwds: Vec<String>,
+}
+
+impl SearchRoots {
+    /// Resolve to the concrete list of roots to walk.
+    fn roots(self) -> Vec<String> {
+        if !self.cwds.is_empty() {
+            self.cwds
+        } else if let Some(c) = self.cwd {
+            vec![c]
+        } else {
+            vec![]
+        }
+    }
+}
+
 /// One matching line within a file.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,7 +84,9 @@ pub struct SearchMatch {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileResult {
-    /// Path relative to the search `cwd`.
+    /// Absolute path of the search root this file lives under.
+    root: String,
+    /// Path relative to `root`.
     path: String,
     matches: Vec<SearchMatch>,
 }
@@ -71,24 +100,28 @@ pub struct SearchResponse {
     truncated: bool,
 }
 
-/// Search file contents under `cwd` — the native backend for `ctx.search`.
-/// Uses ripgrep's matcher/searcher plus the `ignore` crate's `.gitignore`-aware
-/// walker, so results match what `rg` would find without depending on `rg` being
-/// installed. Runs on a `spawn_blocking` worker (mirrors `process_exec`) so a
-/// large tree never stutters the UI thread. `cwd` is pre-validated by the host
-/// scope guard, so it is trusted as an absolute directory here.
+/// Search file contents under one or more roots — the native backend for
+/// `ctx.search`. Uses ripgrep's matcher/searcher plus the `ignore` crate's
+/// `.gitignore`-aware walker, so results match what `rg` would find without
+/// depending on `rg` being installed. Runs on a `spawn_blocking` worker so a
+/// large tree never stutters the UI thread. Roots are pre-validated by the host
+/// scope guard, so they are trusted as absolute directories here.
 #[tauri::command]
 pub async fn search_files(
     query: String,
-    cwd: String,
+    roots: SearchRoots,
     options: SearchOptions,
 ) -> Result<SearchResponse, String> {
-    tauri::async_runtime::spawn_blocking(move || run_search(&query, &cwd, &options))
+    tauri::async_runtime::spawn_blocking(move || run_search(&query, &roots.roots(), &options))
         .await
         .map_err(|e| format!("search task panicked: {}", e))?
 }
 
-fn run_search(query: &str, cwd: &str, options: &SearchOptions) -> Result<SearchResponse, String> {
+fn run_search(
+    query: &str,
+    roots: &[String],
+    options: &SearchOptions,
+) -> Result<SearchResponse, String> {
     if query.is_empty() {
         return Ok(SearchResponse {
             files: Vec::new(),
@@ -108,77 +141,79 @@ fn run_search(query: &str, cwd: &str, options: &SearchOptions) -> Result<SearchR
         .build(&pattern)
         .map_err(|e| format!("invalid search pattern: {}", e))?;
 
-    let root = Path::new(cwd);
-    let mut overrides = OverrideBuilder::new(root);
-    for glob in &options.include_globs {
-        overrides
-            .add(glob)
-            .map_err(|e| format!("invalid include glob '{}': {}", glob, e))?;
-    }
-    for glob in &options.exclude_globs {
-        overrides
-            .add(&format!("!{}", glob))
-            .map_err(|e| format!("invalid exclude glob '{}': {}", glob, e))?;
-    }
-    let overrides = overrides
-        .build()
-        .map_err(|e| format!("failed to build globs: {}", e))?;
-
-    let mut walk = WalkBuilder::new(root);
-    walk.overrides(overrides);
-    if let Some(max) = options.max_file_size {
-        walk.max_filesize(Some(max));
-    }
-
     let max_results = if options.max_results == 0 {
         DEFAULT_MAX_RESULTS
     } else {
         options.max_results
     };
 
-    let mut searcher = SearcherBuilder::new()
-        .line_number(true)
-        .binary_detection(BinaryDetection::quit(0))
-        .build();
-
     let mut files: Vec<FileResult> = Vec::new();
     let mut total: usize = 0;
     let mut truncated = false;
 
-    for entry in walk.build() {
-        if total >= max_results {
-            truncated = true;
-            break;
+    'outer: for cwd in roots {
+        let root = Path::new(cwd);
+        let mut overrides = OverrideBuilder::new(root);
+        for glob in &options.include_globs {
+            overrides
+                .add(glob)
+                .map_err(|e| format!("invalid include glob '{}': {}", glob, e))?;
         }
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        if !entry.file_type().map_or(false, |ft| ft.is_file()) {
-            continue;
+        for glob in &options.exclude_globs {
+            overrides
+                .add(&format!("!{}", glob))
+                .map_err(|e| format!("invalid exclude glob '{}': {}", glob, e))?;
+        }
+        let overrides = overrides
+            .build()
+            .map_err(|e| format!("failed to build globs: {}", e))?;
+
+        let mut walk = WalkBuilder::new(root);
+        walk.overrides(overrides);
+        if let Some(max) = options.max_file_size {
+            walk.max_filesize(Some(max));
         }
 
-        let mut matches: Vec<SearchMatch> = Vec::new();
-        let mut sink = MatchSink {
-            matcher: &matcher,
-            matches: &mut matches,
-            limit: max_results - total,
-        };
-        // A read/UTF-8 error on a single file shouldn't abort the whole search.
-        let _ = searcher.search_path(&matcher, entry.path(), &mut sink);
+        let mut searcher = SearcherBuilder::new()
+            .line_number(true)
+            .binary_detection(BinaryDetection::quit(0))
+            .build();
 
-        if !matches.is_empty() {
-            total += matches.len();
-            let rel = entry
-                .path()
-                .strip_prefix(root)
-                .unwrap_or(entry.path())
-                .to_string_lossy()
-                .to_string();
-            files.push(FileResult {
-                path: rel,
-                matches,
-            });
+        for entry in walk.build() {
+            if total >= max_results {
+                truncated = true;
+                break 'outer;
+            }
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            if !entry.file_type().map_or(false, |ft| ft.is_file()) {
+                continue;
+            }
+
+            let mut matches: Vec<SearchMatch> = Vec::new();
+            let mut sink = MatchSink {
+                matcher: &matcher,
+                matches: &mut matches,
+                limit: max_results - total,
+            };
+            // A read/UTF-8 error on a single file shouldn't abort the whole search.
+            let _ = searcher.search_path(&matcher, entry.path(), &mut sink);
+
+            if !matches.is_empty() {
+                total += matches.len();
+                files.push(FileResult {
+                    root: cwd.clone(),
+                    path: entry
+                        .path()
+                        .strip_prefix(root)
+                        .unwrap_or(entry.path())
+                        .to_string_lossy()
+                        .to_string(),
+                    matches,
+                });
+            }
         }
     }
 

--- a/packages/extension-host/src/extension-host/search-service.ts
+++ b/packages/extension-host/src/extension-host/search-service.ts
@@ -23,13 +23,15 @@ export function getSearchService(): SearchService {
   if (service) return service;
   service = {
     search(query, options) {
+      const cwds = options?.cwds ?? [];
       const cwd = options?.cwd ?? activeWorkspaceFolder();
-      if (cwd === undefined) {
+      // Tauri command receives roots as a SearchRoots struct: cwds takes priority.
+      if (cwds.length === 0 && cwd === undefined) {
         return Promise.reject(new PathDeniedError("", "No workspace is open"));
       }
       return invoke<SearchResponse>("search_files", {
         query,
-        cwd,
+        roots: { cwds, cwd: cwds.length === 0 ? cwd : undefined },
         options: {
           regex: options?.regex ?? false,
           caseSensitive: options?.caseSensitive ?? false,
@@ -78,8 +80,21 @@ export function scopeSearchService(
 ): SearchService {
   if (scope.trusted) return base;
   return {
-    search: async (query, options) =>
-      base.search(query, { ...options, cwd: guardCwd(scope, options?.cwd) }),
+    search: async (query, options) => {
+      const cwds = options?.cwds ?? [];
+      if (cwds.length > 0) {
+        const guardedCwds = cwds.map((c) => guardCwd(scope, c));
+        return base.search(query, {
+          ...options,
+          cwds: guardedCwds,
+          cwd: undefined,
+        });
+      }
+      return base.search(query, {
+        ...options,
+        cwd: guardCwd(scope, options?.cwd),
+      });
+    },
   };
 }
 

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -146,13 +146,10 @@
   gap: 6px;
   padding: 6px 8px 4px;
   margin-top: 4px;
-  font-size: calc(1em - 1px);
+  font-size: 1em;
   font-weight: 600;
   color: var(--silo-color-text);
   border-bottom: 1px solid var(--silo-color-border);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .fsearch-folder-header::before {
@@ -162,6 +159,13 @@
   height: 1px;
   background: var(--silo-color-border);
   flex-shrink: 0;
+}
+
+.fsearch-folder-header > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .fsearch-file-head {

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -146,26 +146,26 @@
   z-index: 1;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
+  gap: 4px;
+  width: 100%;
+  padding: 7px 8px;
   font-size: calc(1em - 2px);
   font-weight: 700;
   letter-spacing: 0.04em;
   color: var(--silo-color-text-hi);
   background: var(--silo-color-bg-hover);
+  border: none;
   border-bottom: 1px solid var(--silo-color-border);
+  font-family: var(--silo-font-ui);
+  text-align: left;
+  cursor: pointer;
 }
 
-.fsearch-folder-header::before {
-  content: "";
-  display: inline-block;
-  width: 12px;
-  height: 1px;
-  background: var(--silo-color-border);
-  flex-shrink: 0;
+.fsearch-folder-header:hover {
+  background: var(--silo-color-bg-active);
 }
 
-.fsearch-folder-header > span {
+.fsearch-folder-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -215,3 +215,41 @@
   color: var(--silo-color-text-hi);
   border-radius: 2px;
 }
+
+/* Folder scope filter — only shown when a workspace has multiple root folders */
+.fsearch-folder-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--silo-color-border);
+}
+
+.fsearch-folder-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: var(--silo-radius-sm);
+  font-size: calc(1em - 1px);
+  color: var(--silo-color-text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.fsearch-folder-toggle:hover {
+  background: var(--silo-color-bg-hover);
+  color: var(--silo-color-text);
+}
+
+.fsearch-folder-toggle input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.fsearch-folder-toggle span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 120px;
+}

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -139,15 +139,17 @@
 }
 
 /* Folder name header — separates result groups by root in multi-folder
-   workspaces. Styled as a small, subdued label so it reads as metadata
-   rather than a clickable item. */
+   workspaces. */
 .fsearch-folder-header {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px 2px;
-  font-size: calc(1em - 2px);
-  color: var(--silo-color-text-lo);
+  padding: 6px 8px 4px;
+  margin-top: 4px;
+  font-size: calc(1em - 1px);
+  font-weight: 600;
+  color: var(--silo-color-text);
+  border-bottom: 1px solid var(--silo-color-border);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -156,10 +158,9 @@
 .fsearch-folder-header::before {
   content: "";
   display: inline-block;
-  width: 10px;
+  width: 12px;
   height: 1px;
-  background: currentColor;
-  opacity: 0.4;
+  background: var(--silo-color-border);
   flex-shrink: 0;
 }
 

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -297,9 +297,10 @@
 }
 
 .fsearch-folder-chevron {
-  font-size: 0.65em;
-  opacity: 0.6;
+  display: inline-flex;
+  align-items: center;
   flex-shrink: 0;
+  color: var(--silo-color-text-lo);
 }
 
 .fsearch-folder-menu {

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -132,6 +132,37 @@
   padding: 2px 6px 6px;
 }
 
+/* Wrapper rendered per-root when isMultiFolder; collapses to nothing in
+   single-folder workspaces where there are no headers. */
+.fsearch-group {
+  display: contents;
+}
+
+/* Folder name header — separates result groups by root in multi-folder
+   workspaces. Styled as a small, subdued label so it reads as metadata
+   rather than a clickable item. */
+.fsearch-folder-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 2px;
+  font-size: calc(1em - 2px);
+  color: var(--silo-color-text-lo);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fsearch-folder-header::before {
+  content: "";
+  display: inline-block;
+  width: 10px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+
 .fsearch-file-head {
   display: flex;
   align-items: center;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -141,14 +141,18 @@
 /* Folder name header — separates result groups by root in multi-folder
    workspaces. */
 .fsearch-folder-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 8px 4px;
-  margin-top: 4px;
-  font-size: 1em;
-  font-weight: 600;
-  color: var(--silo-color-text);
+  padding: 4px 8px;
+  font-size: calc(1em - 2px);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--silo-color-text-hi);
+  background: var(--silo-color-bg-hover);
   border-bottom: 1px solid var(--silo-color-border);
 }
 

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -129,7 +129,7 @@
      row's ring floats off the panel edges instead of being clipped by the
      scroll container (mirrors the file-explorer tree). */
   gap: 10px;
-  padding: 2px 6px 6px;
+  padding: 0 6px 6px;
 }
 
 /* Wrapper rendered per-root when isMultiFolder; collapses to nothing in
@@ -147,8 +147,12 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  width: 100%;
-  padding: 7px 8px;
+  /* Stretch beyond the container's 6px horizontal padding so the background
+     covers the full width of the scroll container — prevents rows from
+     bleeding through the side gutters when scrolling. */
+  width: calc(100% + 12px);
+  margin-left: -6px;
+  padding: 7px 14px;
   font-size: calc(1em - 2px);
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -151,7 +151,7 @@
   /* Left edge aligned with controls (6px padding + 2px = 8px from panel edge).
      width: 100% ends at the content area right edge, leaving a natural ~4px
      gap before the panel border — no need to extend into the right gutter. */
-  width: 100%;
+  width: calc(100% - 1px);
   margin-left: 2px;
   padding: 7px 8px;
   font-size: calc(1em - 2px);

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -43,13 +43,6 @@
   padding: 6px 8px;
   font-family: var(--silo-font-ui);
   font-size: inherit;
-  outline: none;
-}
-
-.fsearch-input:focus,
-.fsearch-input:focus-visible {
-  outline: none;
-  border-color: var(--silo-color-accent);
 }
 
 .fsearch-input::placeholder {

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -147,13 +147,11 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  /* Stretch beyond the container's right padding so the background covers
-     the full right edge — prevents rows bleeding through that gutter.
-     On the left we only cancel 2px (leaving a 4px visual gap from the edge)
-     to avoid the header looking flush against the panel border. */
-  width: calc(100% + 8px);
-  margin-left: -2px;
-  padding: 7px 14px 7px 10px;
+  /* Left edge aligned with the controls above (padding: 8px = 6px results
+     padding + 2px margin). Right side extends to cover the right gutter. */
+  width: calc(100% + 4px);
+  margin-left: 2px;
+  padding: 7px 14px 7px 8px;
   font-size: calc(1em - 2px);
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -216,40 +216,78 @@
   border-radius: 2px;
 }
 
-/* Folder scope filter — only shown when a workspace has multiple root folders */
-.fsearch-folder-filter {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--silo-color-border);
+/* Folder scope dropdown — always visible when workspace has multiple folders */
+.fsearch-folder-dropdown {
+  position: relative;
 }
 
-.fsearch-folder-toggle {
+.fsearch-folder-trigger {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 6px;
+  justify-content: space-between;
+  width: 100%;
+  padding: 3px 6px;
+  background: var(--silo-color-input-bg);
+  color: var(--silo-color-text);
+  border: 1px solid var(--silo-color-border);
   border-radius: var(--silo-radius-sm);
+  font-family: var(--silo-font-ui);
+  font-size: calc(1em - 1px);
+  cursor: pointer;
+  text-align: left;
+  gap: 4px;
+}
+
+.fsearch-folder-trigger:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+.fsearch-folder-trigger.filtered {
+  border-color: var(--silo-color-accent, var(--silo-color-border));
+}
+
+.fsearch-folder-chevron {
+  font-size: 0.65em;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.fsearch-folder-menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: var(--silo-color-input-bg);
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm);
+  padding: 4px 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.fsearch-folder-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
   font-size: calc(1em - 1px);
   color: var(--silo-color-text);
   cursor: pointer;
   user-select: none;
 }
 
-.fsearch-folder-toggle:hover {
+.fsearch-folder-item:hover {
   background: var(--silo-color-bg-hover);
-  color: var(--silo-color-text);
 }
 
-.fsearch-folder-toggle input[type="checkbox"] {
+.fsearch-folder-item input[type="checkbox"] {
   margin: 0;
   cursor: pointer;
+  flex-shrink: 0;
 }
 
-.fsearch-folder-toggle span {
+.fsearch-folder-item span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 120px;
 }

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -123,6 +123,7 @@
 .fsearch-results {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   /* Breathing room between file groups, and a horizontal inset so a focused

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -46,7 +46,9 @@
   outline: none;
 }
 
-.fsearch-input:focus {
+.fsearch-input:focus,
+.fsearch-input:focus-visible {
+  outline: none;
   border-color: var(--silo-color-accent);
 }
 
@@ -151,7 +153,7 @@
   /* Left edge aligned with controls (6px padding + 2px = 8px from panel edge).
      width: 100% ends at the content area right edge, leaving a natural ~4px
      gap before the panel border — no need to extend into the right gutter. */
-  width: calc(100% - 1px);
+  width: calc(100% - 5px);
   margin-left: 2px;
   padding: 7px 8px;
   font-size: calc(1em - 2px);

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -148,11 +148,12 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  /* Left edge aligned with the controls above (padding: 8px = 6px results
-     padding + 2px margin). Right side extends to cover the right gutter. */
-  width: calc(100% + 4px);
+  /* Left edge aligned with controls (6px padding + 2px = 8px from panel edge).
+     width: 100% ends at the content area right edge, leaving a natural ~4px
+     gap before the panel border — no need to extend into the right gutter. */
+  width: 100%;
   margin-left: 2px;
-  padding: 7px 14px 7px 8px;
+  padding: 7px 8px;
   font-size: calc(1em - 2px);
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -321,8 +321,13 @@
   align-items: center;
   gap: 6px;
   padding: 4px 8px;
+  width: 100%;
   font-size: calc(1em - 1px);
+  font-family: var(--silo-font-ui);
   color: var(--silo-color-text);
+  background: transparent;
+  border: none;
+  text-align: left;
   cursor: pointer;
   user-select: none;
 }
@@ -331,13 +336,17 @@
   background: var(--silo-color-bg-hover);
 }
 
-.fsearch-folder-item input[type="checkbox"] {
-  margin: 0;
-  cursor: pointer;
+.fsearch-folder-check {
   flex-shrink: 0;
+  display: inline-flex;
+  color: var(--silo-color-text-lo);
 }
 
-.fsearch-folder-item span {
+.fsearch-folder-item[aria-selected="true"] .fsearch-folder-check {
+  color: var(--silo-color-accent);
+}
+
+.fsearch-folder-item span:last-child {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -225,30 +225,36 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 4px;
   width: 100%;
-  padding: 3px 6px;
+  box-sizing: border-box;
   background: var(--silo-color-input-bg);
-  color: var(--silo-color-text);
+  color: var(--silo-color-input-text);
   border: 1px solid var(--silo-color-border);
   border-radius: var(--silo-radius-sm);
+  padding: 6px 8px;
   font-family: var(--silo-font-ui);
-  font-size: calc(1em - 1px);
+  font-size: inherit;
   cursor: pointer;
   text-align: left;
-  gap: 4px;
 }
 
-.fsearch-folder-trigger:hover {
-  background: var(--silo-color-bg-hover);
+.fsearch-folder-trigger:hover,
+.fsearch-folder-dropdown.open .fsearch-folder-trigger {
+  border-color: var(--silo-color-accent);
 }
 
-.fsearch-folder-trigger.filtered {
-  border-color: var(--silo-color-accent, var(--silo-color-border));
+.fsearch-folder-trigger-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .fsearch-folder-chevron {
   font-size: 0.65em;
-  opacity: 0.7;
+  opacity: 0.6;
   flex-shrink: 0;
 }
 

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -147,12 +147,13 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  /* Stretch beyond the container's 6px horizontal padding so the background
-     covers the full width of the scroll container — prevents rows from
-     bleeding through the side gutters when scrolling. */
-  width: calc(100% + 12px);
-  margin-left: -6px;
-  padding: 7px 14px;
+  /* Stretch beyond the container's right padding so the background covers
+     the full right edge — prevents rows bleeding through that gutter.
+     On the left we only cancel 2px (leaving a 4px visual gap from the edge)
+     to avoid the header looking flush against the panel border. */
+  width: calc(100% + 8px);
+  margin-left: -2px;
+  padding: 7px 14px 7px 10px;
   font-size: calc(1em - 2px);
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -261,6 +261,10 @@
   position: relative;
 }
 
+.fsearch-folder-dropdown > .silo-tooltip-host {
+  display: contents;
+}
+
 .fsearch-folder-trigger {
   display: flex;
   align-items: center;

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -261,7 +261,8 @@
   position: relative;
 }
 
-.fsearch-folder-dropdown > .silo-tooltip-host {
+.fsearch-folder-dropdown > .silo-tooltip-host,
+.fsearch-folder-menu > .silo-tooltip-host {
   display: contents;
 }
 
@@ -311,6 +312,8 @@
   width: max-content;
   max-width: calc(100vw - 16px);
   z-index: 100;
+  display: flex;
+  flex-direction: column;
   background: var(--silo-color-input-bg);
   border: 1px solid var(--silo-color-border);
   border-radius: var(--silo-radius-sm);

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -307,7 +307,9 @@
   position: absolute;
   top: calc(100% + 2px);
   left: 0;
-  right: 0;
+  min-width: 100%;
+  width: max-content;
+  max-width: calc(100vw - 16px);
   z-index: 100;
   background: var(--silo-color-input-bg);
   border: 1px solid var(--silo-color-border);

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -15,6 +15,7 @@ import {
   type WorkspaceViewCache,
 } from "./search-model";
 import { SearchResults } from "./SearchResults";
+import { ICON_CHEV_DOWN, ICON_CHEV_UP } from "./search-icons";
 import { onSearchRequest, takePendingSearch } from "./search-bus";
 
 const DEBOUNCE_MS = 250;
@@ -326,7 +327,7 @@ export function FileSearchView({
                   {folderTriggerText}
                 </span>
                 <span className="fsearch-folder-chevron" aria-hidden>
-                  {folderMenuOpen ? "▴" : "▾"}
+                  {folderMenuOpen ? ICON_CHEV_UP : ICON_CHEV_DOWN}
                 </span>
               </button>
               {folderMenuOpen && (

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -16,7 +16,12 @@ import {
   type WorkspaceViewCache,
 } from "./search-model";
 import { SearchResults } from "./SearchResults";
-import { ICON_CHEV_DOWN, ICON_CHEV_UP } from "./search-icons";
+import {
+  ICON_CHEV_DOWN,
+  ICON_CHEV_UP,
+  ICON_CHECKBOX_OFF,
+  ICON_CHECKBOX_ON,
+} from "./search-icons";
 import { onSearchRequest, takePendingSearch } from "./search-bus";
 
 const DEBOUNCE_MS = 250;
@@ -341,19 +346,18 @@ export function FileSearchView({
                       ui.enabledFolders.includes(f);
                     return (
                       <Tooltip key={f} content={f}>
-                        <label
-                          key={f}
+                        <button
+                          type="button"
                           className="fsearch-folder-item"
                           role="option"
                           aria-selected={enabled}
+                          onClick={() => toggleFolder(f)}
                         >
-                          <input
-                            type="checkbox"
-                            checked={enabled}
-                            onChange={() => toggleFolder(f)}
-                          />
+                          <span className="fsearch-folder-check">
+                            {enabled ? ICON_CHECKBOX_ON : ICON_CHECKBOX_OFF}
+                          </span>
                           <span>{name}</span>
-                        </label>
+                        </button>
                       </Tooltip>
                     );
                   })}

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -79,6 +79,8 @@ export function FileSearchView({
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const resultsRef = useRef<HTMLDivElement | null>(null);
+  const folderMenuRef = useRef<HTMLDivElement | null>(null);
+  const [folderMenuOpen, setFolderMenuOpen] = useState(false);
   // Monotonic token so a slow earlier search can't overwrite a newer result.
   const runIdRef = useRef(0);
   // Skip the very first search run when we're restoring saved results so the
@@ -124,6 +126,18 @@ export function FileSearchView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
+
+  // Close the folder dropdown when clicking outside it.
+  useEffect(() => {
+    if (!folderMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (!folderMenuRef.current?.contains(e.target as Node)) {
+        setFolderMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [folderMenuOpen]);
 
   // Restore scroll position after the saved results paint on mount.
   useEffect(() => {
@@ -233,6 +247,15 @@ export function FileSearchView({
 
   const files = response?.files ?? [];
 
+  const enabledCount =
+    ui.enabledFolders == null
+      ? allFolders.length
+      : ui.enabledFolders.filter((f) => allFolders.includes(f)).length;
+  const folderLabel =
+    enabledCount === allFolders.length
+      ? "All folders"
+      : `${enabledCount} of ${allFolders.length} folders`;
+
   return (
     <div className="fsearch-view">
       <div className="fsearch-controls">
@@ -285,6 +308,50 @@ export function FileSearchView({
           spellCheck={false}
           onChange={(e) => patch({ excludes: e.target.value })}
         />
+        {isMultiFolder && (
+          <div
+            ref={folderMenuRef}
+            className={`fsearch-folder-dropdown${folderMenuOpen ? " open" : ""}`}
+          >
+            <button
+              type="button"
+              className={`fsearch-folder-trigger${enabledCount < allFolders.length ? " filtered" : ""}`}
+              onClick={() => setFolderMenuOpen((o) => !o)}
+              aria-haspopup="listbox"
+              aria-expanded={folderMenuOpen}
+            >
+              <span>{folderLabel}</span>
+              <span className="fsearch-folder-chevron" aria-hidden>
+                {folderMenuOpen ? "▴" : "▾"}
+              </span>
+            </button>
+            {folderMenuOpen && (
+              <div className="fsearch-folder-menu" role="listbox">
+                {allFolders.map((f) => {
+                  const name = f.split("/").pop() ?? f;
+                  const enabled =
+                    ui.enabledFolders == null || ui.enabledFolders.includes(f);
+                  return (
+                    <label
+                      key={f}
+                      className="fsearch-folder-item"
+                      title={f}
+                      role="option"
+                      aria-selected={enabled}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={enabled}
+                        onChange={() => toggleFolder(f)}
+                      />
+                      <span>{name}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {error ? (
@@ -293,25 +360,6 @@ export function FileSearchView({
         <div className="fsearch-status">Searching…</div>
       ) : response ? (
         <>
-          {isMultiFolder && (
-            <div className="fsearch-folder-filter">
-              {allFolders.map((f) => {
-                const name = f.split("/").pop() ?? f;
-                const enabled =
-                  ui.enabledFolders === null || ui.enabledFolders.includes(f);
-                return (
-                  <label key={f} className="fsearch-folder-toggle" title={f}>
-                    <input
-                      type="checkbox"
-                      checked={enabled}
-                      onChange={() => toggleFolder(f)}
-                    />
-                    <span>{name}</span>
-                  </label>
-                );
-              })}
-            </div>
-          )}
           <div className="fsearch-status">
             {summarize(response.totalMatches, files.length, response.truncated)}
           </div>

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -247,14 +247,13 @@ export function FileSearchView({
 
   const files = response?.files ?? [];
 
-  const enabledCount =
+  const folderTriggerText =
     ui.enabledFolders == null
-      ? allFolders.length
-      : ui.enabledFolders.filter((f) => allFolders.includes(f)).length;
-  const folderLabel =
-    enabledCount === allFolders.length
       ? "All folders"
-      : `${enabledCount} of ${allFolders.length} folders`;
+      : ui.enabledFolders
+          .filter((f) => allFolders.includes(f))
+          .map((f) => f.split("/").pop() ?? f)
+          .join(", ") || "All folders";
 
   return (
     <div className="fsearch-view">
@@ -309,48 +308,55 @@ export function FileSearchView({
           onChange={(e) => patch({ excludes: e.target.value })}
         />
         {isMultiFolder && (
-          <div
-            ref={folderMenuRef}
-            className={`fsearch-folder-dropdown${folderMenuOpen ? " open" : ""}`}
-          >
-            <button
-              type="button"
-              className={`fsearch-folder-trigger${enabledCount < allFolders.length ? " filtered" : ""}`}
-              onClick={() => setFolderMenuOpen((o) => !o)}
-              aria-haspopup="listbox"
-              aria-expanded={folderMenuOpen}
+          <>
+            <label className="fsearch-field-label">folders to search</label>
+            <div
+              ref={folderMenuRef}
+              className={`fsearch-folder-dropdown${folderMenuOpen ? " open" : ""}`}
             >
-              <span>{folderLabel}</span>
-              <span className="fsearch-folder-chevron" aria-hidden>
-                {folderMenuOpen ? "▴" : "▾"}
-              </span>
-            </button>
-            {folderMenuOpen && (
-              <div className="fsearch-folder-menu" role="listbox">
-                {allFolders.map((f) => {
-                  const name = f.split("/").pop() ?? f;
-                  const enabled =
-                    ui.enabledFolders == null || ui.enabledFolders.includes(f);
-                  return (
-                    <label
-                      key={f}
-                      className="fsearch-folder-item"
-                      title={f}
-                      role="option"
-                      aria-selected={enabled}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={enabled}
-                        onChange={() => toggleFolder(f)}
-                      />
-                      <span>{name}</span>
-                    </label>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+              <button
+                type="button"
+                className={`fsearch-folder-trigger${ui.enabledFolders != null ? " filtered" : ""}`}
+                onClick={() => setFolderMenuOpen((o) => !o)}
+                aria-haspopup="listbox"
+                aria-expanded={folderMenuOpen}
+                title={folderTriggerText}
+              >
+                <span className="fsearch-folder-trigger-label">
+                  {folderTriggerText}
+                </span>
+                <span className="fsearch-folder-chevron" aria-hidden>
+                  {folderMenuOpen ? "▴" : "▾"}
+                </span>
+              </button>
+              {folderMenuOpen && (
+                <div className="fsearch-folder-menu" role="listbox">
+                  {allFolders.map((f) => {
+                    const name = f.split("/").pop() ?? f;
+                    const enabled =
+                      ui.enabledFolders == null ||
+                      ui.enabledFolders.includes(f);
+                    return (
+                      <label
+                        key={f}
+                        className="fsearch-folder-item"
+                        title={f}
+                        role="option"
+                        aria-selected={enabled}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={enabled}
+                          onChange={() => toggleFolder(f)}
+                        />
+                        <span>{name}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </>
         )}
       </div>
 

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -74,6 +74,9 @@ export function FileSearchView({
     () => savedState?.collapsed ?? new Set(),
   );
 
+  const allFolders = [workspace.folder, ...(workspace.extraFolders ?? [])];
+  const isMultiFolder = allFolders.length > 1;
+
   const inputRef = useRef<HTMLInputElement | null>(null);
   const resultsRef = useRef<HTMLDivElement | null>(null);
   // Monotonic token so a slow earlier search can't overwrite a newer result.
@@ -100,7 +103,14 @@ export function FileSearchView({
       return merged;
     });
 
-  const folder = workspace.folder;
+  function toggleFolder(folder: string) {
+    const current = ui.enabledFolders ?? allFolders;
+    const next = current.includes(folder)
+      ? current.filter((f) => f !== folder)
+      : [...current, folder];
+    // If all folders are enabled, normalize back to null (meaning "all").
+    patch({ enabledFolders: next.length === allFolders.length ? null : next });
+  }
 
   // Save state when unmounting (workspace switch) so it can be restored next time.
   useEffect(
@@ -142,7 +152,7 @@ export function FileSearchView({
     setSearching(true);
     const timer = setTimeout(() => {
       ctx.search
-        .search(query, buildSearchOptions(ui, folder))
+        .search(query, buildSearchOptions(ui, allFolders))
         .then((res) => {
           if (runId !== runIdRef.current) return;
           setResponse(res);
@@ -166,7 +176,9 @@ export function FileSearchView({
     ui.regex,
     ui.includes,
     ui.excludes,
-    folder,
+    ui.enabledFolders,
+    // Use join so the effect fires when folder list identity changes.
+    allFolders.join("\0"),
     paused,
   ]);
 
@@ -206,7 +218,8 @@ export function FileSearchView({
     const range = match.ranges[0];
     const column = range ? range[0] + 1 : 1;
     const endColumn = range ? range[1] + 1 : undefined;
-    ctx.editors.open(`${folder}/${file.path}`, {
+    const root = file.root ?? workspace.folder;
+    ctx.editors.open(`${root}/${file.path}`, {
       workspaceId: workspace.id,
       preview: true,
       selection: {
@@ -280,6 +293,25 @@ export function FileSearchView({
         <div className="fsearch-status">Searching…</div>
       ) : response ? (
         <>
+          {isMultiFolder && (
+            <div className="fsearch-folder-filter">
+              {allFolders.map((f) => {
+                const name = f.split("/").pop() ?? f;
+                const enabled =
+                  ui.enabledFolders === null || ui.enabledFolders.includes(f);
+                return (
+                  <label key={f} className="fsearch-folder-toggle" title={f}>
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={() => toggleFolder(f)}
+                    />
+                    <span>{name}</span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
           <div className="fsearch-status">
             {summarize(response.totalMatches, files.length, response.truncated)}
           </div>

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -372,6 +372,7 @@ export function FileSearchView({
           <div className="fsearch-results" ref={resultsRef}>
             <SearchResults
               files={files}
+              isMultiFolder={isMultiFolder}
               collapsed={collapsed}
               onToggleFile={toggleFile}
               onOpenMatch={openMatch}

--- a/packages/extensions-silo/src/file-search/FileSearchView.tsx
+++ b/packages/extensions-silo/src/file-search/FileSearchView.tsx
@@ -7,6 +7,7 @@ import type {
   SearchResponse,
   Workspace,
 } from "@silo-code/sdk";
+import { Tooltip } from "@silo-code/sdk";
 import {
   buildSearchOptions,
   summarize,
@@ -315,21 +316,22 @@ export function FileSearchView({
               ref={folderMenuRef}
               className={`fsearch-folder-dropdown${folderMenuOpen ? " open" : ""}`}
             >
-              <button
-                type="button"
-                className={`fsearch-folder-trigger${ui.enabledFolders != null ? " filtered" : ""}`}
-                onClick={() => setFolderMenuOpen((o) => !o)}
-                aria-haspopup="listbox"
-                aria-expanded={folderMenuOpen}
-                title={folderTriggerText}
-              >
-                <span className="fsearch-folder-trigger-label">
-                  {folderTriggerText}
-                </span>
-                <span className="fsearch-folder-chevron" aria-hidden>
-                  {folderMenuOpen ? ICON_CHEV_UP : ICON_CHEV_DOWN}
-                </span>
-              </button>
+              <Tooltip content={folderTriggerText}>
+                <button
+                  type="button"
+                  className={`fsearch-folder-trigger${ui.enabledFolders != null ? " filtered" : ""}`}
+                  onClick={() => setFolderMenuOpen((o) => !o)}
+                  aria-haspopup="listbox"
+                  aria-expanded={folderMenuOpen}
+                >
+                  <span className="fsearch-folder-trigger-label">
+                    {folderTriggerText}
+                  </span>
+                  <span className="fsearch-folder-chevron" aria-hidden>
+                    {folderMenuOpen ? ICON_CHEV_UP : ICON_CHEV_DOWN}
+                  </span>
+                </button>
+              </Tooltip>
               {folderMenuOpen && (
                 <div className="fsearch-folder-menu" role="listbox">
                   {allFolders.map((f) => {
@@ -338,20 +340,21 @@ export function FileSearchView({
                       ui.enabledFolders == null ||
                       ui.enabledFolders.includes(f);
                     return (
-                      <label
-                        key={f}
-                        className="fsearch-folder-item"
-                        title={f}
-                        role="option"
-                        aria-selected={enabled}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={enabled}
-                          onChange={() => toggleFolder(f)}
-                        />
-                        <span>{name}</span>
-                      </label>
+                      <Tooltip key={f} content={f}>
+                        <label
+                          key={f}
+                          className="fsearch-folder-item"
+                          role="option"
+                          aria-selected={enabled}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={enabled}
+                            onChange={() => toggleFolder(f)}
+                          />
+                          <span>{name}</span>
+                        </label>
+                      </Tooltip>
                     );
                   })}
                 </div>

--- a/packages/extensions-silo/src/file-search/SearchResults.tsx
+++ b/packages/extensions-silo/src/file-search/SearchResults.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { SearchFileResult, SearchMatch } from "@silo-code/sdk";
+import { Tooltip } from "@silo-code/sdk";
 import { clampPreviewStart, highlightSegments } from "./search-model";
 import { ICON_CHEV_DOWN, ICON_CHEV_RIGHT, ICON_FILE } from "./search-icons";
 
@@ -26,24 +27,25 @@ function MatchRow({
   const clamped = clampPreviewStart(match.preview, match.ranges);
   const segments = highlightSegments(clamped.preview, clamped.ranges);
   return (
-    <button
-      type="button"
-      className="fsearch-match"
-      title={match.preview}
-      onClick={() => onOpen(match)}
-    >
-      <span className="fsearch-match-text">
-        {segments.map((seg, i) =>
-          seg.match ? (
-            <mark key={i} className="fsearch-hit">
-              {seg.text}
-            </mark>
-          ) : (
-            <span key={i}>{seg.text}</span>
-          ),
-        )}
-      </span>
-    </button>
+    <Tooltip content={match.preview}>
+      <button
+        type="button"
+        className="fsearch-match"
+        onClick={() => onOpen(match)}
+      >
+        <span className="fsearch-match-text">
+          {segments.map((seg, i) =>
+            seg.match ? (
+              <mark key={i} className="fsearch-hit">
+                {seg.text}
+              </mark>
+            ) : (
+              <span key={i}>{seg.text}</span>
+            ),
+          )}
+        </span>
+      </button>
+    </Tooltip>
   );
 }
 
@@ -91,19 +93,20 @@ export function SearchResults({
         return (
           <div key={root ?? gi} className="fsearch-group">
             {isMultiFolder && root && (
-              <button
-                type="button"
-                className="fsearch-folder-header"
-                title={root}
-                onClick={() => toggleRoot(root)}
-              >
-                <span className="fsearch-chev">
-                  {rootCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
-                </span>
-                <span className="fsearch-folder-name">
-                  {(root.split("/").pop() ?? root).toUpperCase()}
-                </span>
-              </button>
+              <Tooltip content={root}>
+                <button
+                  type="button"
+                  className="fsearch-folder-header"
+                  onClick={() => toggleRoot(root)}
+                >
+                  <span className="fsearch-chev">
+                    {rootCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
+                  </span>
+                  <span className="fsearch-folder-name">
+                    {(root.split("/").pop() ?? root).toUpperCase()}
+                  </span>
+                </button>
+              </Tooltip>
             )}
             {!rootCollapsed &&
               groupFiles.map((file) => {
@@ -112,22 +115,23 @@ export function SearchResults({
                 const isCollapsed = collapsed.has(key);
                 return (
                   <div key={key} className="fsearch-file">
-                    <button
-                      type="button"
-                      className="fsearch-file-head"
-                      onClick={() => onToggleFile(key)}
-                      title={file.path}
-                    >
-                      <span className="fsearch-chev">
-                        {isCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
-                      </span>
-                      <span className="fsearch-file-icon">{ICON_FILE}</span>
-                      <span className="fsearch-file-name">{name}</span>
-                      {dir && <span className="fsearch-file-dir">{dir}</span>}
-                      <span className="fsearch-file-count">
-                        {file.matches.length}
-                      </span>
-                    </button>
+                    <Tooltip content={file.path}>
+                      <button
+                        type="button"
+                        className="fsearch-file-head"
+                        onClick={() => onToggleFile(key)}
+                      >
+                        <span className="fsearch-chev">
+                          {isCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
+                        </span>
+                        <span className="fsearch-file-icon">{ICON_FILE}</span>
+                        <span className="fsearch-file-name">{name}</span>
+                        {dir && <span className="fsearch-file-dir">{dir}</span>}
+                        <span className="fsearch-file-count">
+                          {file.matches.length}
+                        </span>
+                      </button>
+                    </Tooltip>
                     {!isCollapsed && (
                       <div className="fsearch-match-list">
                         {file.matches.map((match, i) => (

--- a/packages/extensions-silo/src/file-search/SearchResults.tsx
+++ b/packages/extensions-silo/src/file-search/SearchResults.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { SearchFileResult, SearchMatch } from "@silo-code/sdk";
 import { clampPreviewStart, highlightSegments } from "./search-model";
 import { ICON_CHEV_DOWN, ICON_CHEV_RIGHT, ICON_FILE } from "./search-icons";
@@ -59,6 +60,17 @@ export function SearchResults({
   onToggleFile: (key: string) => void;
   onOpenMatch: (file: SearchFileResult, match: SearchMatch) => void;
 }) {
+  const [collapsedRoots, setCollapsedRoots] = useState(() => new Set<string>());
+
+  function toggleRoot(root: string) {
+    setCollapsedRoots((prev) => {
+      const next = new Set(prev);
+      if (next.has(root)) next.delete(root);
+      else next.add(root);
+      return next;
+    });
+  }
+
   // Group consecutive files by root so we can render a folder header between
   // groups when the workspace has more than one root folder.
   const groups: Array<{ root: string | undefined; files: SearchFileResult[] }> =
@@ -74,51 +86,65 @@ export function SearchResults({
 
   return (
     <>
-      {groups.map(({ root, files: groupFiles }, gi) => (
-        <div key={root ?? gi} className="fsearch-group">
-          {isMultiFolder && root && (
-            <div className="fsearch-folder-header" title={root}>
-              <span>{(root.split("/").pop() ?? root).toUpperCase()}</span>
-            </div>
-          )}
-          {groupFiles.map((file) => {
-            const key = fileKey(file);
-            const { name, dir } = splitPath(file.path);
-            const isCollapsed = collapsed.has(key);
-            return (
-              <div key={key} className="fsearch-file">
-                <button
-                  type="button"
-                  className="fsearch-file-head"
-                  onClick={() => onToggleFile(key)}
-                  title={file.path}
-                >
-                  <span className="fsearch-chev">
-                    {isCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
-                  </span>
-                  <span className="fsearch-file-icon">{ICON_FILE}</span>
-                  <span className="fsearch-file-name">{name}</span>
-                  {dir && <span className="fsearch-file-dir">{dir}</span>}
-                  <span className="fsearch-file-count">
-                    {file.matches.length}
-                  </span>
-                </button>
-                {!isCollapsed && (
-                  <div className="fsearch-match-list">
-                    {file.matches.map((match, i) => (
-                      <MatchRow
-                        key={`${match.line}:${i}`}
-                        match={match}
-                        onOpen={(m) => onOpenMatch(file, m)}
-                      />
-                    ))}
+      {groups.map(({ root, files: groupFiles }, gi) => {
+        const rootCollapsed = !!root && collapsedRoots.has(root);
+        return (
+          <div key={root ?? gi} className="fsearch-group">
+            {isMultiFolder && root && (
+              <button
+                type="button"
+                className="fsearch-folder-header"
+                title={root}
+                onClick={() => toggleRoot(root)}
+              >
+                <span className="fsearch-chev">
+                  {rootCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
+                </span>
+                <span className="fsearch-folder-name">
+                  {(root.split("/").pop() ?? root).toUpperCase()}
+                </span>
+              </button>
+            )}
+            {!rootCollapsed &&
+              groupFiles.map((file) => {
+                const key = fileKey(file);
+                const { name, dir } = splitPath(file.path);
+                const isCollapsed = collapsed.has(key);
+                return (
+                  <div key={key} className="fsearch-file">
+                    <button
+                      type="button"
+                      className="fsearch-file-head"
+                      onClick={() => onToggleFile(key)}
+                      title={file.path}
+                    >
+                      <span className="fsearch-chev">
+                        {isCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
+                      </span>
+                      <span className="fsearch-file-icon">{ICON_FILE}</span>
+                      <span className="fsearch-file-name">{name}</span>
+                      {dir && <span className="fsearch-file-dir">{dir}</span>}
+                      <span className="fsearch-file-count">
+                        {file.matches.length}
+                      </span>
+                    </button>
+                    {!isCollapsed && (
+                      <div className="fsearch-match-list">
+                        {file.matches.map((match, i) => (
+                          <MatchRow
+                            key={`${match.line}:${i}`}
+                            match={match}
+                            onOpen={(m) => onOpenMatch(file, m)}
+                          />
+                        ))}
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      ))}
+                );
+              })}
+          </div>
+        );
+      })}
     </>
   );
 }

--- a/packages/extensions-silo/src/file-search/SearchResults.tsx
+++ b/packages/extensions-silo/src/file-search/SearchResults.tsx
@@ -9,6 +9,12 @@ function splitPath(path: string): { name: string; dir: string } {
   return { name, dir: parts.join("/") };
 }
 
+/** Stable key for a file result — includes root so same-relative-path files
+ *  from different roots don't collide in the collapsed set or React keys. */
+function fileKey(file: SearchFileResult): string {
+  return file.root ? `${file.root}:${file.path}` : file.path;
+}
+
 function MatchRow({
   match,
   onOpen,
@@ -42,50 +48,77 @@ function MatchRow({
 
 export function SearchResults({
   files,
+  isMultiFolder,
   collapsed,
   onToggleFile,
   onOpenMatch,
 }: {
   files: SearchFileResult[];
+  isMultiFolder: boolean;
   collapsed: ReadonlySet<string>;
-  onToggleFile: (path: string) => void;
+  onToggleFile: (key: string) => void;
   onOpenMatch: (file: SearchFileResult, match: SearchMatch) => void;
 }) {
+  // Group consecutive files by root so we can render a folder header between
+  // groups when the workspace has more than one root folder.
+  const groups: Array<{ root: string | undefined; files: SearchFileResult[] }> =
+    [];
+  for (const file of files) {
+    const last = groups[groups.length - 1];
+    if (last && last.root === file.root) {
+      last.files.push(file);
+    } else {
+      groups.push({ root: file.root, files: [file] });
+    }
+  }
+
   return (
     <>
-      {files.map((file) => {
-        const { name, dir } = splitPath(file.path);
-        const isCollapsed = collapsed.has(file.path);
-        return (
-          <div key={file.path} className="fsearch-file">
-            <button
-              type="button"
-              className="fsearch-file-head"
-              onClick={() => onToggleFile(file.path)}
-              title={file.path}
-            >
-              <span className="fsearch-chev">
-                {isCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
-              </span>
-              <span className="fsearch-file-icon">{ICON_FILE}</span>
-              <span className="fsearch-file-name">{name}</span>
-              {dir && <span className="fsearch-file-dir">{dir}</span>}
-              <span className="fsearch-file-count">{file.matches.length}</span>
-            </button>
-            {!isCollapsed && (
-              <div className="fsearch-match-list">
-                {file.matches.map((match, i) => (
-                  <MatchRow
-                    key={`${match.line}:${i}`}
-                    match={match}
-                    onOpen={(m) => onOpenMatch(file, m)}
-                  />
-                ))}
+      {groups.map(({ root, files: groupFiles }, gi) => (
+        <div key={root ?? gi} className="fsearch-group">
+          {isMultiFolder && root && (
+            <div className="fsearch-folder-header" title={root}>
+              {root.split("/").pop() ?? root}
+            </div>
+          )}
+          {groupFiles.map((file) => {
+            const key = fileKey(file);
+            const { name, dir } = splitPath(file.path);
+            const isCollapsed = collapsed.has(key);
+            return (
+              <div key={key} className="fsearch-file">
+                <button
+                  type="button"
+                  className="fsearch-file-head"
+                  onClick={() => onToggleFile(key)}
+                  title={file.path}
+                >
+                  <span className="fsearch-chev">
+                    {isCollapsed ? ICON_CHEV_RIGHT : ICON_CHEV_DOWN}
+                  </span>
+                  <span className="fsearch-file-icon">{ICON_FILE}</span>
+                  <span className="fsearch-file-name">{name}</span>
+                  {dir && <span className="fsearch-file-dir">{dir}</span>}
+                  <span className="fsearch-file-count">
+                    {file.matches.length}
+                  </span>
+                </button>
+                {!isCollapsed && (
+                  <div className="fsearch-match-list">
+                    {file.matches.map((match, i) => (
+                      <MatchRow
+                        key={`${match.line}:${i}`}
+                        match={match}
+                        onOpen={(m) => onOpenMatch(file, m)}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-        );
-      })}
+            );
+          })}
+        </div>
+      ))}
     </>
   );
 }

--- a/packages/extensions-silo/src/file-search/SearchResults.tsx
+++ b/packages/extensions-silo/src/file-search/SearchResults.tsx
@@ -78,7 +78,7 @@ export function SearchResults({
         <div key={root ?? gi} className="fsearch-group">
           {isMultiFolder && root && (
             <div className="fsearch-folder-header" title={root}>
-              <span>{root.split("/").pop() ?? root}</span>
+              <span>{(root.split("/").pop() ?? root).toUpperCase()}</span>
             </div>
           )}
           {groupFiles.map((file) => {

--- a/packages/extensions-silo/src/file-search/SearchResults.tsx
+++ b/packages/extensions-silo/src/file-search/SearchResults.tsx
@@ -78,7 +78,7 @@ export function SearchResults({
         <div key={root ?? gi} className="fsearch-group">
           {isMultiFolder && root && (
             <div className="fsearch-folder-header" title={root}>
-              {root.split("/").pop() ?? root}
+              <span>{root.split("/").pop() ?? root}</span>
             </div>
           )}
           {groupFiles.map((file) => {

--- a/packages/extensions-silo/src/file-search/search-icons.tsx
+++ b/packages/extensions-silo/src/file-search/search-icons.tsx
@@ -60,7 +60,7 @@ export const ICON_FILE: ReactNode = (
 );
 
 export const ICON_CHECKBOX_OFF: ReactNode = (
-  <svg viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true">
+  <svg viewBox="0 0 16 16" width="1.2em" height="1.2em" aria-hidden="true">
     <rect
       x="2.5"
       y="2.5"
@@ -75,7 +75,7 @@ export const ICON_CHECKBOX_OFF: ReactNode = (
 );
 
 export const ICON_CHECKBOX_ON: ReactNode = (
-  <svg viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true">
+  <svg viewBox="0 0 16 16" width="1.2em" height="1.2em" aria-hidden="true">
     <rect
       x="2.5"
       y="2.5"

--- a/packages/extensions-silo/src/file-search/search-icons.tsx
+++ b/packages/extensions-silo/src/file-search/search-icons.tsx
@@ -58,3 +58,41 @@ export const ICON_FILE: ReactNode = (
     />
   </svg>
 );
+
+export const ICON_CHECKBOX_OFF: ReactNode = (
+  <svg viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true">
+    <rect
+      x="2.5"
+      y="2.5"
+      width="11"
+      height="11"
+      rx="2"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+export const ICON_CHECKBOX_ON: ReactNode = (
+  <svg viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true">
+    <rect
+      x="2.5"
+      y="2.5"
+      width="11"
+      height="11"
+      rx="2"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M5 8.5l2.5 2.5 4-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/packages/extensions-silo/src/file-search/search-icons.tsx
+++ b/packages/extensions-silo/src/file-search/search-icons.tsx
@@ -14,6 +14,19 @@ export const ICON_CHEV_DOWN: ReactNode = (
   </svg>
 );
 
+export const ICON_CHEV_UP: ReactNode = (
+  <svg viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true">
+    <path
+      d="M3 10l5-5 5 5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export const ICON_CHEV_RIGHT: ReactNode = (
   <svg viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true">
     <path

--- a/packages/extensions-silo/src/file-search/search-model.test.ts
+++ b/packages/extensions-silo/src/file-search/search-model.test.ts
@@ -18,7 +18,7 @@ describe("parseGlobs", () => {
 });
 
 describe("buildSearchOptions", () => {
-  it("maps UI controls + globs into the SDK payload", () => {
+  it("maps UI controls + globs into the SDK payload for a single folder", () => {
     const opts = buildSearchOptions(
       {
         ...EMPTY_UI_STATE,
@@ -29,16 +29,41 @@ describe("buildSearchOptions", () => {
         includes: "*.ts",
         excludes: "dist/**, *.min.js",
       },
-      "/repo",
+      ["/repo"],
     );
     expect(opts).toEqual({
-      cwd: "/repo",
+      cwds: ["/repo"],
       regex: true,
       caseSensitive: true,
       wholeWord: true,
       includeGlobs: ["*.ts"],
       excludeGlobs: ["dist/**", "*.min.js"],
     });
+  });
+
+  it("passes all folders as cwds when enabledFolders is null", () => {
+    const opts = buildSearchOptions(
+      { ...EMPTY_UI_STATE, enabledFolders: null },
+      ["/repo/a", "/repo/b", "/repo/c"],
+    );
+    expect(opts.cwds).toEqual(["/repo/a", "/repo/b", "/repo/c"]);
+  });
+
+  it("filters cwds to only enabled folders", () => {
+    const opts = buildSearchOptions(
+      { ...EMPTY_UI_STATE, enabledFolders: ["/repo/a", "/repo/c"] },
+      ["/repo/a", "/repo/b", "/repo/c"],
+    );
+    expect(opts.cwds).toEqual(["/repo/a", "/repo/c"]);
+  });
+
+  it("falls back to all folders when enabledFolders filters to empty", () => {
+    // This guards against a user somehow ending up with no folders selected.
+    const opts = buildSearchOptions(
+      { ...EMPTY_UI_STATE, enabledFolders: ["/repo/x"] },
+      ["/repo/a", "/repo/b"],
+    );
+    expect(opts.cwds).toEqual(["/repo/a", "/repo/b"]);
   });
 });
 

--- a/packages/extensions-silo/src/file-search/search-model.test.ts
+++ b/packages/extensions-silo/src/file-search/search-model.test.ts
@@ -65,6 +65,15 @@ describe("buildSearchOptions", () => {
     );
     expect(opts.cwds).toEqual(["/repo/a", "/repo/b"]);
   });
+
+  it("treats undefined enabledFolders (migrating from pre-field stored state) as all folders", () => {
+    const opts = buildSearchOptions(
+      // Cast to simulate a stored state written before enabledFolders existed.
+      { ...EMPTY_UI_STATE, enabledFolders: undefined as unknown as null },
+      ["/repo/a", "/repo/b"],
+    );
+    expect(opts.cwds).toEqual(["/repo/a", "/repo/b"]);
+  });
 });
 
 describe("highlightSegments", () => {

--- a/packages/extensions-silo/src/file-search/search-model.ts
+++ b/packages/extensions-silo/src/file-search/search-model.ts
@@ -25,6 +25,11 @@ export interface SearchUiState {
   includes: string;
   /** Raw comma-separated "files to exclude" globs. */
   excludes: string;
+  /**
+   * Folders the user has toggled on for search. `null` means "all folders"
+   * (the default). Only meaningful when the workspace has more than one folder.
+   */
+  enabledFolders: string[] | null;
 }
 
 export const EMPTY_UI_STATE: SearchUiState = {
@@ -34,6 +39,7 @@ export const EMPTY_UI_STATE: SearchUiState = {
   regex: false,
   includes: "",
   excludes: "",
+  enabledFolders: null,
 };
 
 /** Split a comma-separated glob field into trimmed, non-empty patterns. */
@@ -47,10 +53,18 @@ export function parseGlobs(csv: string): string[] {
 /** Translate the UI controls into the SDK {@link SearchOptions} payload. */
 export function buildSearchOptions(
   ui: SearchUiState,
-  cwd?: string,
+  allFolders: string[],
 ): SearchOptions {
+  // Resolve which folders are active: null enabledFolders means all folders.
+  const activeFolders =
+    ui.enabledFolders === null
+      ? allFolders
+      : allFolders.filter((f) => ui.enabledFolders!.includes(f));
+
+  const cwds = activeFolders.length > 0 ? activeFolders : allFolders;
+
   return {
-    cwd,
+    cwds,
     regex: ui.regex,
     caseSensitive: ui.caseSensitive,
     wholeWord: ui.wholeWord,

--- a/packages/extensions-silo/src/file-search/search-model.ts
+++ b/packages/extensions-silo/src/file-search/search-model.ts
@@ -55,9 +55,12 @@ export function buildSearchOptions(
   ui: SearchUiState,
   allFolders: string[],
 ): SearchOptions {
-  // Resolve which folders are active: null enabledFolders means all folders.
+  // Resolve which folders are active: null/undefined enabledFolders means all
+  // folders (null is the canonical value; undefined can appear when loading a
+  // stored SearchUiState written before this field was added).
+  // eslint-disable-next-line eqeqeq
   const activeFolders =
-    ui.enabledFolders === null
+    ui.enabledFolders == null
       ? allFolders
       : allFolders.filter((f) => ui.enabledFolders!.includes(f));
 

--- a/packages/sdk/src/search-service.ts
+++ b/packages/sdk/src/search-service.ts
@@ -16,8 +16,15 @@ export interface SearchOptions {
    * Search root. Defaults to the open **workspace folder** when omitted. A `cwd`
    * outside the workspace throws {@link PathDeniedError} unless the extension
    * declared the `process` {@link Permission}; first-party extensions are unscoped.
+   * Ignored when {@link SearchOptions.cwds} is non-empty.
    */
   cwd?: string;
+  /**
+   * Multiple search roots. When provided, all listed folders are searched and
+   * results are merged. Each root is subject to the same scope guard as `cwd`.
+   * Takes precedence over `cwd` when non-empty.
+   */
+  cwds?: string[];
   /** Treat `query` as a regular expression instead of a literal string. */
   regex?: boolean;
   /** Match case exactly. When false (default), the search is case-insensitive. */
@@ -66,7 +73,13 @@ export interface SearchMatch {
  * @public
  */
 export interface SearchFileResult {
-  /** File path **relative to** the search `cwd` (the workspace folder by default). */
+  /**
+   * Absolute path of the search root this file lives under. Present when
+   * searching multiple roots (via {@link SearchOptions.cwds}); omitted for
+   * single-root searches where the caller already knows the root.
+   */
+  root?: string;
+  /** File path **relative to** `root` (or the search `cwd` for single-root searches). */
   path: string;
   /** The matching lines within this file, in file order. */
   matches: SearchMatch[];


### PR DESCRIPTION
Fixes #79

## Summary

Extends the file search panel to search all workspace folders, not just the primary one.

## Backend
- **Rust** (search.rs): New SearchRoots struct accepts multiple cwds; FileResult gains a root field identifying which folder each result came from
- **SDK** (search-service.ts): Added cwds to SearchOptions, root to SearchFileResult
- **Host service**: Forwards all roots to Tauri; scopeSearchService guards all cwds

## Search model
- Added enabledFolders to SearchUiState with loose null guard (handles undefined from migrated stored state)
- 21 unit tests covering multi-folder, folder filtering, and undefined migration

## UI
- **Folder scope dropdown**: Always visible when workspace has more than one folder; flat SVG checkbox icons (accent color when checked); each folder on its own row; SDK Tooltip on trigger and items
- **Result group headers**: Sticky, collapsible folder headers matching file-explorer root typography (uppercase, bold, letter-spacing); slight background; 5px right margin
- **Focus ring**: Inputs now inherit the global 1.5px accent outline from theme.css, matching the git panel
- **Tooltips**: All result rows use SDK Tooltip instead of native title attribute
- **No horizontal scrollbar**: overflow-x hidden on results container