### PR TITLE
fix(windows): normalize path separators to forward slashes throughout

### DIFF
--- a/apps/desktop/src-tauri/src/commands/cli.rs
+++ b/apps/desktop/src-tauri/src/commands/cli.rs
@@ -52,7 +52,7 @@ pub fn resolve_cli_request(argv: &[String], cwd: &str) -> Option<CliRequest> {
             let resolved = resolve_path(raw, cwd);
             Some(CliRequest {
                 action: "install".to_string(),
-                path: Some(resolved.to_string_lossy().into_owned()),
+                path: Some(super::fs::normalize_path(&resolved)),
                 kind: None,
                 id: None,
             })
@@ -75,7 +75,7 @@ pub fn resolve_cli_request(argv: &[String], cwd: &str) -> Option<CliRequest> {
             };
             Some(CliRequest {
                 action: "open".to_string(),
-                path: Some(resolved.to_string_lossy().into_owned()),
+                path: Some(super::fs::normalize_path(&resolved)),
                 kind: Some(kind.to_string()),
                 id: None,
             })

--- a/apps/desktop/src-tauri/src/commands/fs.rs
+++ b/apps/desktop/src-tauri/src/commands/fs.rs
@@ -4,6 +4,18 @@ use std::time::UNIX_EPOCH;
 use serde::Serialize;
 use tauri::ipc::Response;
 
+/// Normalize path separators to forward slashes for the JS frontend.
+/// On Unix/macOS this is a no-op; on Windows it converts `\` → `/` so the
+/// entire TypeScript layer can assume POSIX-style paths regardless of platform.
+pub(super) fn normalize_path(path: &Path) -> String {
+    let s = path.to_string_lossy();
+    if cfg!(windows) {
+        s.replace('\\', "/")
+    } else {
+        s.into_owned()
+    }
+}
+
 #[derive(Serialize)]
 pub struct FileMeta {
     pub name: String,
@@ -58,7 +70,7 @@ pub fn fs_read_dir(path: String) -> Result<Vec<FileMeta>, String> {
         let name = entry.file_name().to_string_lossy().to_string();
         out.push(FileMeta {
             name,
-            path: path_buf.to_string_lossy().to_string(),
+            path: normalize_path(&path_buf),
             is_dir: metadata.is_dir(),
             size: metadata.len(),
             modified_ms,

--- a/apps/desktop/src-tauri/src/commands/search.rs
+++ b/apps/desktop/src-tauri/src/commands/search.rs
@@ -203,14 +203,10 @@ fn run_search(
 
             if !matches.is_empty() {
                 total += matches.len();
+                let rel = entry.path().strip_prefix(root).unwrap_or(entry.path());
                 files.push(FileResult {
                     root: cwd.clone(),
-                    path: entry
-                        .path()
-                        .strip_prefix(root)
-                        .unwrap_or(entry.path())
-                        .to_string_lossy()
-                        .to_string(),
+                    path: super::fs::normalize_path(rel),
                     matches,
                 });
             }

--- a/apps/desktop/src-tauri/src/commands/watch.rs
+++ b/apps/desktop/src-tauri/src/commands/watch.rs
@@ -21,6 +21,8 @@ pub struct FileChangeEvent {
 fn should_skip(path: &str) -> bool {
     // Skip events from noisy / heavy directories. Keep this list short and
     // conservative — anything matched here will not surface to the frontend.
+    // Paths are already forward-slash–normalized at this point (see below), so
+    // the separators in these needles always match on every platform.
     const NEEDLES: &[&str] = &[
         "/node_modules/",
         "/.git/",
@@ -57,10 +59,13 @@ pub fn start_watch<R: Runtime>(
                 ) {
                     return;
                 }
+                // Normalize to forward slashes before filtering and emitting so
+                // `should_skip`'s NEEDLES and the TypeScript layer both see `/`
+                // on every platform (Windows uses `\` natively).
                 let paths: Vec<String> = event
                     .paths
                     .iter()
-                    .map(|p| p.to_string_lossy().to_string())
+                    .map(|p| super::fs::normalize_path(p))
                     .filter(|p| !should_skip(p))
                     .collect();
                 if paths.is_empty() {

--- a/apps/desktop/src/cli/open-handler.ts
+++ b/apps/desktop/src/cli/open-handler.ts
@@ -16,9 +16,15 @@ export interface CliOpenRequest {
   kind: "dir" | "file" | "missing";
 }
 
+/** Normalize path separators to forward slashes (Windows-safe). */
+function toForwardSlash(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
 /** Strip trailing separators so `/a/b` and `/a/b/` compare equal (keeps root). */
 export function normalizeFolder(p: string): string {
-  return p.length > 1 ? p.replace(/\/+$/, "") : p;
+  const fwd = toForwardSlash(p);
+  return fwd.length > 1 ? fwd.replace(/\/+$/, "") : fwd;
 }
 
 /** POSIX dirname of an absolute path (the host always hands us absolute paths). */

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -19,8 +19,13 @@ function uuid(): string {
 export async function pickFolderAndCreateWorkspace(): Promise<Workspace | null> {
   const picked = await open({ directory: true, multiple: false });
   if (!picked || typeof picked !== "string") return null;
-  const name = await basename(picked);
-  return createWorkspace({ folder: picked, name });
+  // Normalize to forward slashes so the whole TypeScript layer (path splits,
+  // breadcrumbs, file-tree, etc.) can assume POSIX-style separators on every
+  // platform.  Windows APIs accept forward slashes, so round-tripping the
+  // normalized path back to Tauri commands works without conversion.
+  const folder = picked.replace(/\\/g, "/");
+  const name = await basename(folder);
+  return createWorkspace({ folder, name });
 }
 
 export function createWorkspace(input: {


### PR DESCRIPTION
## Summary

- Adds `normalize_path()` helper in `fs.rs` that converts `\` → `/` on Windows (no-op on macOS/Linux)
- Applies it everywhere a path crosses the Rust→JS boundary: `fs_read_dir`, search results, file watcher events, and CLI open requests
- Normalizes the folder picker result in `workspaces.ts` and `normalizeFolder()` in `open-handler.ts` on the JS side

Without this, Windows-native backslash paths break assumptions throughout the TypeScript layer — path splits, breadcrumb rendering, file-tree matching, and workspace comparison all expect POSIX separators.

## Test plan

- [ ] All existing tests pass (verified locally — 514 tests across 6 packages)
- [ ] On Windows: open a folder via the folder picker and confirm the workspace path shows forward slashes
- [ ] On Windows: file watcher events arrive with forward-slash paths (check devtools console)
- [ ] On macOS/Linux: no behavior change (normalize_path is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)