### PR TITLE
feat(windows): sync caption bar and title-bar theme with app colors

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
     "core:window:allow-set-focus",
+    "core:window:allow-set-theme",
     "fs:default",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -21,3 +21,4 @@ pub mod session_registry;
 pub mod terminal;
 pub mod terminal_buffer;
 pub mod terminal_io;
+pub mod window_chrome;

--- a/apps/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/apps/desktop/src-tauri/src/commands/window_chrome.rs
@@ -1,0 +1,47 @@
+//! Windows-only: sync the DWM caption (title-bar) background color.
+//!
+//! `DWMWA_CAPTION_COLOR` (attribute 35) lets the app paint the caption bar
+//! with a custom COLORREF on Windows 11 build 22000+. Older Windows versions
+//! ignore the attribute silently, so the call is always safe to make.
+
+#[cfg(windows)]
+#[link(name = "Dwmapi")]
+extern "system" {
+    fn DwmSetWindowAttribute(
+        hwnd: isize,
+        dw_attribute: u32,
+        pv_attribute: *const core::ffi::c_void,
+        cb_attribute: u32,
+    ) -> i32;
+}
+
+#[cfg(windows)]
+const DWMWA_CAPTION_COLOR: u32 = 35;
+
+/// Paint the caption bar to match the app background color.
+/// `r`, `g`, `b` are sRGB 0–255. No-ops on Windows 10 and earlier.
+#[tauri::command]
+#[allow(unused_variables)]
+pub fn window_set_caption_color(window: tauri::WebviewWindow, r: u8, g: u8, b: u8) {
+    #[cfg(windows)]
+    {
+        use tauri::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+        let Ok(handle) = window.window_handle() else {
+            return;
+        };
+        let RawWindowHandle::Win32(h) = handle.as_raw() else {
+            return;
+        };
+        // COLORREF format: 0x00BBGGRR
+        let colorref: u32 = ((b as u32) << 16) | ((g as u32) << 8) | (r as u32);
+        unsafe {
+            DwmSetWindowAttribute(
+                h.hwnd.get(),
+                DWMWA_CAPTION_COLOR,
+                &colorref as *const u32 as *const core::ffi::c_void,
+                core::mem::size_of::<u32>() as u32,
+            );
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -158,6 +158,7 @@ pub fn run() {
             commands::network::net_fetch,
             commands::network::net_fetch_headers,
             commands::finder_drop::dnd_get_finder_paths,
+            commands::window_chrome::window_set_caption_color,
         ])
         .run(context)
         .expect("error while running tauri application");

--- a/packages/extension-host/src/layout/ThemeInjector.tsx
+++ b/packages/extension-host/src/layout/ThemeInjector.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useSyncExternalStore } from "react";
 import { useSnapshot } from "valtio";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { invoke } from "@tauri-apps/api/core";
 import { store } from "../state/store";
 import type { CustomTheme, ThemeBase, ThemeVars } from "../state/types";
 import { CORE_PRESETS } from "./presets";
 import { themePresetRegistry } from "../extension-host/theme-presets";
 import { refreshMonacoThemes } from "../docked/monaco-setup";
+
+const isWindows =
+  typeof navigator !== "undefined" &&
+  navigator.platform.toUpperCase().startsWith("WIN");
 
 interface ResolvedTheme {
   base: "dark" | "light";
@@ -118,6 +124,24 @@ export function ThemeInjector() {
     // Defer Monaco refresh so the CSS var update lands first; readVar() in
     // monaco-setup reads computed styles synchronously.
     queueMicrotask(() => refreshMonacoThemes(resolved.base));
+
+    // Sync OS window chrome: dark/light title-bar scheme on all platforms;
+    // custom caption color on Windows 11 (older Windows ignores it silently).
+    // Both calls are fire-and-forget — failures don't affect the UI.
+    void getCurrentWebviewWindow().setTheme(resolved.base);
+    if (isWindows) {
+      const hex = getComputedStyle(document.documentElement)
+        .getPropertyValue("--silo-color-bg")
+        .trim();
+      const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+      if (m) {
+        void invoke("window_set_caption_color", {
+          r: parseInt(m[1], 16),
+          g: parseInt(m[2], 16),
+          b: parseInt(m[3], 16),
+        });
+      }
+    }
   }, [activeThemeId, customThemes, presetList]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Windows 11**: paints the native caption (title) bar to match `--silo-color-bg` using `DwmSetWindowAttribute(DWMWA_CAPTION_COLOR)` — a raw FFI call to `Dwmapi.dll` with no new crate dependency. Older Windows versions ignore the attribute silently.
- **All platforms (Windows + Linux)**: syncs the OS window chrome to the active theme's dark/light mode via Tauri's `setTheme()` JS API, so the native title bar and native menu bar use the correct color scheme whenever the user switches themes.
- Custom themes that override `--silo-color-bg` are handled automatically — the caption color is read from `getComputedStyle` after CSS vars are applied, so it tracks any theme.

## Implementation

**Rust** (`apps/desktop/src-tauri/src/commands/window_chrome.rs`): new `window_set_caption_color(r, g, b)` command. Windows-specific DWM code is `#[cfg(windows)]`-gated; the function compiles as a no-op on other platforms so the invoke handler registration is unconditional.

**ThemeInjector.tsx**: at the end of the existing theme `useEffect`, fires two fire-and-forget calls:
1. `getCurrentWebviewWindow().setTheme(resolved.base)` — dark/light chrome on all platforms
2. `invoke('window_set_caption_color', { r, g, b })` on Windows only, reading the computed `--silo-color-bg` after CSS vars are applied

**Capability**: added `core:window:allow-set-theme` to `capabilities/default.json`.

## Test plan

- [ ] Switch between Dark and Light themes on Windows 11 — caption bar should match the panel background
- [ ] Switch themes on Linux — title bar should update to dark/light mode
- [ ] Apply a custom theme that overrides `--silo-color-bg` — caption bar should match
- [ ] Verify no visual change on macOS (where the webview overlays the traffic lights)
- [ ] Run on Windows 10 — no crash, caption stays default OS color

🤖 Generated with [Claude Code](https://claude.com/claude-code)