### PR TITLE
fix(windows): import raw-window-handle directly instead of via tauri re-export

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4560,6 +4560,7 @@ dependencies = [
  "parking_lot",
  "portable-pty",
  "pty-host",
+ "raw-window-handle",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -60,6 +60,9 @@ base64 = { version = "0.22", optional = true }
 [target.'cfg(unix)'.dependencies]
 pty-host = { path = "../../../crates/pty-host" }
 
+[target.'cfg(windows)'.dependencies]
+raw-window-handle = "0.6"
+
 # macOS-only: Shift-state monitor. AppKit's NSEvent local monitor goes
 # silent during an HTML5 drag (the webview's drag session captures the
 # event flow), so we poll CoreGraphics' HID-level modifier state on a

--- a/apps/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/apps/desktop/src-tauri/src/commands/window_chrome.rs
@@ -25,7 +25,7 @@ const DWMWA_CAPTION_COLOR: u32 = 35;
 pub fn window_set_caption_color(window: tauri::WebviewWindow, r: u8, g: u8, b: u8) {
     #[cfg(windows)]
     {
-        use tauri::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+        use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
         let Ok(handle) = window.window_handle() else {
             return;


### PR DESCRIPTION
## Summary

- `tauri::raw_window_handle` is not a valid module path in Tauri 2 — the `raw-window-handle` crate types must be imported directly
- Adds `raw-window-handle = "0.6"` as an explicit `[target.'cfg(windows)'.dependencies]` entry
- Changes the `use` import in `window_chrome.rs` from `tauri::raw_window_handle::...` to `raw_window_handle::...`

Fixes the Windows build failure in the v0.11.0 release run.

## Test plan

- [ ] Windows CI build passes (the E0432/E0599 compile errors are gone)
- [ ] macOS/Linux builds unaffected (dep is Windows-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)