### PR TITLE
refactor(ui): replace native title= tooltips with SDK Tooltip across panels

### DIFF
--- a/packages/extensions-core/src/themes/ThemeEditorPanel.tsx
+++ b/packages/extensions-core/src/themes/ThemeEditorPanel.tsx
@@ -6,6 +6,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { HexColorPicker } from "react-colorful";
+import { Tooltip } from "@silo-code/sdk";
 import type {
   CustomTheme,
   ThemeVars,
@@ -158,12 +159,13 @@ function ColorVarRow({
     <div className="theme-var-row">
       <label className="theme-var-name">{varKey.replace(/^--/, "")}</label>
       <div className="theme-color-wrap" ref={popRef}>
-        <button
-          className="theme-color-swatch"
-          style={{ background: hex }}
-          onClick={() => setOpen((o) => !o)}
-          title="Open color picker"
-        />
+        <Tooltip content="Open color picker">
+          <button
+            className="theme-color-swatch"
+            style={{ background: hex }}
+            onClick={() => setOpen((o) => !o)}
+          />
+        </Tooltip>
         {open && (
           <div className="theme-color-popover">
             <HexColorPicker color={hex} onChange={(c) => onChange(varKey, c)} />
@@ -177,21 +179,22 @@ function ColorVarRow({
         spellCheck={false}
       />
       {hasEyeDropper && (
-        <button
-          className="theme-eyedropper-btn"
-          title="Pick color from screen"
-          onClick={async () => {
-            try {
-              const dropper = new EyeDropper();
-              const result = await dropper.open();
-              onChange(varKey, result.sRGBHex);
-            } catch {
-              /* cancelled */
-            }
-          }}
-        >
-          ⌖
-        </button>
+        <Tooltip content="Pick color from screen">
+          <button
+            className="theme-eyedropper-btn"
+            onClick={async () => {
+              try {
+                const dropper = new EyeDropper();
+                const result = await dropper.open();
+                onChange(varKey, result.sRGBHex);
+              } catch {
+                /* cancelled */
+              }
+            }}
+          >
+            ⌖
+          </button>
+        </Tooltip>
       )}
     </div>
   );
@@ -507,13 +510,14 @@ export function ThemeEditorPanel({
       <div className="theme-panel-header">
         <span className="theme-panel-title">Themes</span>
         <div className="theme-panel-header-actions">
-          <button
-            className="silo-button silo-button-sm"
-            onClick={handleImport}
-            title="Import theme JSON"
-          >
-            Import
-          </button>
+          <Tooltip content="Import theme JSON">
+            <button
+              className="silo-button silo-button-sm"
+              onClick={handleImport}
+            >
+              Import
+            </button>
+          </Tooltip>
           <button
             className="silo-button-primary silo-button-sm"
             onClick={handleNewTheme}

--- a/packages/extensions-core/src/workspaces/WorkspaceModals.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspaceModals.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { FolderPlus } from "@phosphor-icons/react";
 import { ModalActions } from "@silo-code/extension-host/internal";
+import { Tooltip } from "@silo-code/sdk";
 import {
   fullPath,
   type Workspace,
@@ -97,20 +98,23 @@ export function WorkspacePropertiesContent({
         <div className="ws-folders-list">
           {allFolders.map((folder, i) => (
             <div key={folder} className="ws-folder-list-item">
-              <span className="ws-folder-list-path" dir="ltr" title={folder}>
-                {fullPath(folder, home)}
-              </span>
+              <Tooltip content={folder}>
+                <span className="ws-folder-list-path" dir="ltr">
+                  {fullPath(folder, home)}
+                </span>
+              </Tooltip>
               {i === 0 ? (
                 <span className="ws-folder-primary-badge">primary</span>
               ) : (
-                <button
-                  type="button"
-                  className="ws-folder-list-remove"
-                  title="Remove folder"
-                  onClick={() => removeFolder(folder)}
-                >
-                  ×
-                </button>
+                <Tooltip content="Remove folder">
+                  <button
+                    type="button"
+                    className="ws-folder-list-remove"
+                    onClick={() => removeFolder(folder)}
+                  >
+                    ×
+                  </button>
+                </Tooltip>
               )}
             </div>
           ))}

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -274,6 +274,12 @@
   border-radius: var(--silo-radius-sm);
 }
 
+/* The Tooltip host wraps ws-folder-list-path and must inherit flex growth. */
+.ws-folder-list-item > .silo-tooltip-host {
+  flex: 1;
+  min-width: 0;
+}
+
 .ws-folder-list-path {
   flex: 1;
   min-width: 0;

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -130,6 +130,13 @@
   gap: 4px;
 }
 
+/* The Tooltip host wraps ws-folder-path and must inherit flex growth so the
+   inner span's ResizeObserver still measures the correct constrained width. */
+.ws-item .ws-folder > .silo-tooltip-host {
+  flex: 1;
+  min-width: 0;
+}
+
 .ws-item .ws-folder-path {
   flex: 1;
   min-width: 0;

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Plus, SquaresFour } from "@phosphor-icons/react";
 import {
+  Tooltip,
   useFocusGroup,
   useServiceState,
   type ExtensionContext,
@@ -226,7 +227,6 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
                     e.stopPropagation();
                     void openWorkspaceProperties(ctx, home, ws);
                   }}
-                  title="Right-click for menu · Double-click for properties"
                 >
                   <WorkspaceIcon
                     className="ws-icon"
@@ -234,12 +234,14 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
                     weight="duotone"
                   />
                   <div className="ws-name-row">
-                    <span className="ws-name">{ws.name}</span>
+                    <Tooltip content="Right-click for menu · Double-click for properties">
+                      <span className="ws-name">{ws.name}</span>
+                    </Tooltip>
                     <span className="ws-uptime">
                       {formatElapsed(ws.createdAt)}
                     </span>
                   </div>
-                  <div className="ws-folder" title={ws.folder}>
+                  <div className="ws-folder">
                     <FrontTruncatedPath
                       className="ws-folder-path"
                       text={fullPath(ws.folder, home)}
@@ -251,17 +253,18 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
                     )}
                   </div>
                   <WorkspaceStatusRows rows={service.getDecorations(ws.id)} />
-                  <button
-                    className="ws-close"
-                    title="Close workspace"
-                    tabIndex={-1}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      service.close(ws.id);
-                    }}
-                  >
-                    ×
-                  </button>
+                  <Tooltip content="Close workspace">
+                    <button
+                      className="ws-close"
+                      tabIndex={-1}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        service.close(ws.id);
+                      }}
+                    >
+                      ×
+                    </button>
+                  </Tooltip>
                 </li>
               );
             })}
@@ -269,15 +272,16 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
         )}
         {snap.hydrated && (
           <div className="ws-add-wrap" ref={addWrapRef}>
-            <button
-              className="ws-add-btn"
-              type="button"
-              onClick={openClosedMenu}
-              title="Add workspace"
-              aria-label="Add workspace"
-            >
-              <Plus weight="bold" size={14} />
-            </button>
+            <Tooltip content="Add workspace">
+              <button
+                className="ws-add-btn"
+                type="button"
+                onClick={openClosedMenu}
+                aria-label="Add workspace"
+              >
+                <Plus weight="bold" size={14} />
+              </button>
+            </Tooltip>
           </div>
         )}
       </div>

--- a/packages/extensions-core/src/workspaces/workspace-helpers.tsx
+++ b/packages/extensions-core/src/workspaces/workspace-helpers.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Tooltip } from "@silo-code/sdk";
 import type {
   FileService,
   WorkspaceService,
@@ -115,9 +116,11 @@ export function FrontTruncatedPath({
   }, [text]);
 
   return (
-    <span ref={ref} className={className} title={text}>
-      {display}
-    </span>
+    <Tooltip content={text}>
+      <span ref={ref} className={className}>
+        {display}
+      </span>
+    </Tooltip>
   );
 }
 

--- a/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
+++ b/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
@@ -127,7 +127,6 @@ export function DirNode({
         onContextMenu={(e) => onContextMenu(e, path, true)}
         draggable={!isRoot && !isRenaming}
         onDragStart={onDragStart}
-        title={path}
       >
         <span className="chev">{isExpanded ? CHEV_DOWN : CHEV_RIGHT}</span>
         {!isRoot && (isExpanded ? ICON_FOLDER_OPEN : ICON_FOLDER_CLOSED)}
@@ -157,7 +156,9 @@ export function DirNode({
             onClick={(e) => e.stopPropagation()}
           />
         ) : (
-          <span className="name">{isRoot ? name.toUpperCase() : name}</span>
+          <Tooltip content={path}>
+            <span className="name">{isRoot ? name.toUpperCase() : name}</span>
+          </Tooltip>
         )}
         {isRoot && rootActions && (
           <span
@@ -352,7 +353,6 @@ export function FileLeaf({
       onContextMenu={(e) => onContextMenu(e, path, false)}
       draggable={!isRenaming}
       onDragStart={onDragStart}
-      title={path}
     >
       <span className="chev" />
       {ICON_FILE}
@@ -382,7 +382,9 @@ export function FileLeaf({
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
-        <span className="name">{name}</span>
+        <Tooltip content={path}>
+          <span className="name">{name}</span>
+        </Tooltip>
       )}
     </div>
   );

--- a/packages/extensions-silo/src/git-explorer/BranchManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/BranchManager.tsx
@@ -9,6 +9,7 @@ import {
   Trash,
 } from "@phosphor-icons/react";
 import {
+  Tooltip,
   useFocusGroup,
   type ExtensionContext,
   type MenuEntry,
@@ -382,7 +383,6 @@ export function BranchManager({
               key={(b.remote ? "r:" : "l:") + b.name}
               className={`git-branch-row${b.current ? " current" : ""}`}
               role="button"
-              title={b.current ? "Current branch" : `Switch to ${b.name}`}
               onClick={() => void switchTo(b)}
               onContextMenu={(e) => {
                 e.preventDefault();
@@ -399,51 +399,60 @@ export function BranchManager({
               <span className="git-branch-glyph">
                 {b.remote ? <Cloud size={15} /> : <GitBranchIcon size={15} />}
               </span>
-              <span className="git-branch-name">{b.name}</span>
+              <Tooltip
+                content={b.current ? "Current branch" : `Switch to ${b.name}`}
+              >
+                <span className="git-branch-name">{b.name}</span>
+              </Tooltip>
               {b.current && <span className="git-branch-badge">current</span>}
               {!b.remote && (
                 <span
                   className="git-branch-actions"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <button
-                    type="button"
-                    className={`git-branch-action${pushing === b.name ? " working" : ""}`}
-                    title={
+                  <Tooltip
+                    content={
                       isPublished(b, remoteNames)
                         ? `Push ${b.name}`
                         : `Publish ${b.name}`
                     }
-                    tabIndex={-1}
-                    disabled={pushing === b.name}
-                    onClick={() => void pushBranch(b)}
                   >
-                    {isPublished(b, remoteNames) ? (
-                      ICON_PUSH
-                    ) : (
-                      <CloudArrowUp size={16} />
-                    )}
-                  </button>
+                    <button
+                      type="button"
+                      className={`git-branch-action${pushing === b.name ? " working" : ""}`}
+                      tabIndex={-1}
+                      disabled={pushing === b.name}
+                      onClick={() => void pushBranch(b)}
+                    >
+                      {isPublished(b, remoteNames) ? (
+                        ICON_PUSH
+                      ) : (
+                        <CloudArrowUp size={16} />
+                      )}
+                    </button>
+                  </Tooltip>
                   {!b.current && (
                     <>
-                      <button
-                        type="button"
-                        className="git-branch-action"
-                        title="Rename branch"
-                        tabIndex={-1}
-                        onClick={() => void rename(b)}
-                      >
-                        <PencilSimple size={14} />
-                      </button>
-                      <button
-                        type="button"
-                        className="git-branch-action danger"
-                        title="Delete branch"
-                        tabIndex={-1}
-                        onClick={() => void del(b)}
-                      >
-                        <Trash size={14} />
-                      </button>
+                      <Tooltip content="Rename branch">
+                        <button
+                          type="button"
+                          className="git-branch-action"
+                          tabIndex={-1}
+                          onClick={() => void rename(b)}
+                        >
+                          <PencilSimple size={14} />
+                        </button>
+                      </Tooltip>
+                      <Tooltip content="Delete branch">
+                        <button
+                          type="button"
+                          className="git-branch-action danger"
+                          tabIndex={-1}
+                          onClick={() => void del(b)}
+                        >
+                          <Trash size={14} />
+                        </button>
+                      </Tooltip>
                     </>
                   )}
                 </span>

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -7,6 +7,7 @@ import {
   DotsThreeVertical,
 } from "@phosphor-icons/react";
 import {
+  Tooltip,
   useFocusGroup,
   type ExtensionContext,
   type FocusGroupItemProps,
@@ -555,90 +556,94 @@ export function GitView({
             )}
           </span>
           <span className="git-root-name">{rootLabel.toUpperCase()}</span>
-          <span
-            className={`git-root-branch${status?.inRepo ? " clickable" : ""}`}
-            role={status?.inRepo ? "button" : undefined}
-            tabIndex={status?.inRepo ? 0 : undefined}
-            title={status?.inRepo ? "Manage branches" : undefined}
-            onClick={
-              status?.inRepo
-                ? (e) => {
+          {status?.inRepo ? (
+            <Tooltip content="Manage branches">
+              <span
+                className="git-root-branch clickable"
+                role="button"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openBranchManager();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
                     e.stopPropagation();
                     openBranchManager();
                   }
-                : undefined
-            }
-            onKeyDown={
-              status?.inRepo
-                ? (e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      openBranchManager();
-                    }
-                  }
-                : undefined
-            }
-          >
-            {status ? (status.branch ?? "(detached)") : ""}
-          </span>
+                }}
+              >
+                {status ? (status.branch ?? "(detached)") : ""}
+              </span>
+            </Tooltip>
+          ) : (
+            <span className="git-root-branch">
+              {status ? (status.branch ?? "(detached)") : ""}
+            </span>
+          )}
           <span
             className="git-root-remote"
             onClick={(e) => e.stopPropagation()}
           >
             {status?.upstream ? (
-              <button
-                className={`branch-tracking branch-sync${syncing ? " working" : ""}`}
-                title="Sync (pull, then push)"
-                onClick={syncing ? undefined : sync}
-              >
-                {syncing && (
-                  <ArrowsClockwise className="git-branch-spin" size={12} />
-                )}
-                ↑{status.ahead} ↓{status.behind}
-              </button>
+              <Tooltip content="Sync (pull, then push)">
+                <button
+                  className={`branch-tracking branch-sync${syncing ? " working" : ""}`}
+                  onClick={syncing ? undefined : sync}
+                >
+                  {syncing && (
+                    <ArrowsClockwise className="git-branch-spin" size={12} />
+                  )}
+                  ↑{status.ahead} ↓{status.behind}
+                </button>
+              </Tooltip>
             ) : status?.inRepo && status.branch ? (
-              <button
-                className={`branch-action branch-publish push-btn${pushing ? " working" : ""}`}
-                title="Publish branch"
-                onClick={pushing ? undefined : push}
-              >
-                <CloudArrowUp size={16} />
-              </button>
+              <Tooltip content="Publish branch">
+                <button
+                  className={`branch-action branch-publish push-btn${pushing ? " working" : ""}`}
+                  onClick={pushing ? undefined : push}
+                >
+                  <CloudArrowUp size={16} />
+                </button>
+              </Tooltip>
             ) : null}
           </span>
           <span
             className="git-root-actions"
             onClick={(e) => e.stopPropagation()}
           >
-            <button
-              className={`branch-action refresh-btn${busy ? " working" : ""}`}
-              title="Refresh"
-              onClick={busy ? undefined : refresh}
-            >
-              <ArrowsClockwise size={14} />
-            </button>
-            {status?.inRepo && (
+            <Tooltip content="Refresh">
               <button
-                className="branch-action git-menu-btn"
-                title="More actions"
-                onClick={(e) => openGitMenu(e.currentTarget)}
+                className={`branch-action refresh-btn${busy ? " working" : ""}`}
+                onClick={busy ? undefined : refresh}
               >
-                <DotsThreeVertical size={18} weight="bold" />
+                <ArrowsClockwise size={14} />
               </button>
+            </Tooltip>
+            {status?.inRepo && (
+              <Tooltip content="More actions">
+                <button
+                  className="branch-action git-menu-btn"
+                  onClick={(e) => openGitMenu(e.currentTarget)}
+                >
+                  <DotsThreeVertical size={18} weight="bold" />
+                </button>
+              </Tooltip>
             )}
           </span>
         </button>
       ) : (
         <div className="git-branch">
           {status?.inRepo ? (
-            <button
-              className="branch-name branch-name-button"
-              title="Manage branches"
-              onClick={openBranchManager}
-            >
-              {status.branch ?? "(detached)"}
-            </button>
+            <Tooltip content="Manage branches">
+              <button
+                className="branch-name branch-name-button"
+                onClick={openBranchManager}
+              >
+                {status.branch ?? "(detached)"}
+              </button>
+            </Tooltip>
           ) : (
             <span className="branch-name">
               {status ? (status.branch ?? "(detached)") : "Loading…"}
@@ -647,41 +652,45 @@ export function GitView({
           {/* Where the remote state lives: published → the ↑/↓ counts double as
               a Sync button; not yet published → a Publish-branch button. */}
           {status?.upstream ? (
-            <button
-              className={`branch-tracking branch-sync${syncing ? " working" : ""}`}
-              title="Sync (pull, then push)"
-              onClick={syncing ? undefined : sync}
-            >
-              {syncing && (
-                <ArrowsClockwise className="git-branch-spin" size={12} />
-              )}
-              ↑{status.ahead} ↓{status.behind}
-            </button>
+            <Tooltip content="Sync (pull, then push)">
+              <button
+                className={`branch-tracking branch-sync${syncing ? " working" : ""}`}
+                onClick={syncing ? undefined : sync}
+              >
+                {syncing && (
+                  <ArrowsClockwise className="git-branch-spin" size={12} />
+                )}
+                ↑{status.ahead} ↓{status.behind}
+              </button>
+            </Tooltip>
           ) : status?.inRepo && status.branch ? (
-            <button
-              className={`branch-action branch-publish push-btn${pushing ? " working" : ""}`}
-              title="Publish branch"
-              onClick={pushing ? undefined : push}
-            >
-              <CloudArrowUp size={16} />
-            </button>
+            <Tooltip content="Publish branch">
+              <button
+                className={`branch-action branch-publish push-btn${pushing ? " working" : ""}`}
+                onClick={pushing ? undefined : push}
+              >
+                <CloudArrowUp size={16} />
+              </button>
+            </Tooltip>
           ) : null}
           <span className="spacer" />
-          <button
-            className={`branch-action refresh-btn${busy ? " working" : ""}`}
-            title="Refresh"
-            onClick={busy ? undefined : refresh}
-          >
-            <ArrowsClockwise size={16} />
-          </button>
-          {status?.inRepo && (
+          <Tooltip content="Refresh">
             <button
-              className="branch-action git-menu-btn"
-              title="More actions"
-              onClick={(e) => openGitMenu(e.currentTarget)}
+              className={`branch-action refresh-btn${busy ? " working" : ""}`}
+              onClick={busy ? undefined : refresh}
             >
-              <DotsThreeVertical size={18} weight="bold" />
+              <ArrowsClockwise size={16} />
             </button>
+          </Tooltip>
+          {status?.inRepo && (
+            <Tooltip content="More actions">
+              <button
+                className="branch-action git-menu-btn"
+                onClick={(e) => openGitMenu(e.currentTarget)}
+              >
+                <DotsThreeVertical size={18} weight="bold" />
+              </button>
+            </Tooltip>
           )}
         </div>
       )}

--- a/packages/extensions-silo/src/git-explorer/git-rows.tsx
+++ b/packages/extensions-silo/src/git-explorer/git-rows.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { File as FileIcon } from "@phosphor-icons/react";
-import type { FocusGroupItemProps } from "@silo-code/sdk";
+import { Tooltip, type FocusGroupItemProps } from "@silo-code/sdk";
 import type { GitFileStatus } from "../git/git-api";
 import {
   ICON_CHEV_DOWN,
@@ -61,18 +61,18 @@ export function Section({
             onClick={(e) => e.stopPropagation()}
           >
             {actions.map((a) => (
-              <button
-                key={a.title}
-                className="section-add"
-                title={a.title}
-                tabIndex={-1}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  a.onClick();
-                }}
-              >
-                {a.icon}
-              </button>
+              <Tooltip key={a.title} content={a.title}>
+                <button
+                  className="section-add"
+                  tabIndex={-1}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    a.onClick();
+                  }}
+                >
+                  {a.icon}
+                </button>
+              </Tooltip>
             ))}
           </span>
         )}
@@ -137,55 +137,40 @@ export function FileRow({
   const { name, dir } = splitNameAndDir(file.path);
   const glyph = statusGlyph(file);
   return (
-    <div
-      className="git-file-row"
-      onClick={onRowClick}
-      title={file.path}
-      {...focusProps}
-    >
+    <div className="git-file-row" onClick={onRowClick} {...focusProps}>
       <span className="ico file">
         <FileIcon size="1.3em" weight="regular" aria-hidden="true" />
       </span>
-      <span className="file-name">{name}</span>
+      <Tooltip content={file.path}>
+        <span className="file-name">{name}</span>
+      </Tooltip>
       {dir && <span className="file-dir">{dir}</span>}
       <span className="row-actions" onClick={(e) => e.stopPropagation()}>
-        <button
-          className="row-action"
-          title="Open file"
-          tabIndex={-1}
-          onClick={onOpen}
-        >
-          {ICON_OPEN}
-        </button>
-        {kind === "changes" && onRevert && (
-          <button
-            className="row-action"
-            title="Discard changes"
-            tabIndex={-1}
-            onClick={onRevert}
-          >
-            {ICON_UNDO}
+        <Tooltip content="Open file">
+          <button className="row-action" tabIndex={-1} onClick={onOpen}>
+            {ICON_OPEN}
           </button>
+        </Tooltip>
+        {kind === "changes" && onRevert && (
+          <Tooltip content="Discard changes">
+            <button className="row-action" tabIndex={-1} onClick={onRevert}>
+              {ICON_UNDO}
+            </button>
+          </Tooltip>
         )}
         {kind === "changes" && onStage && (
-          <button
-            className="row-action"
-            title="Stage changes"
-            tabIndex={-1}
-            onClick={onStage}
-          >
-            {ICON_PLUS}
-          </button>
+          <Tooltip content="Stage changes">
+            <button className="row-action" tabIndex={-1} onClick={onStage}>
+              {ICON_PLUS}
+            </button>
+          </Tooltip>
         )}
         {kind === "staged" && onUnstage && (
-          <button
-            className="row-action"
-            title="Unstage changes"
-            tabIndex={-1}
-            onClick={onUnstage}
-          >
-            {ICON_MINUS}
-          </button>
+          <Tooltip content="Unstage changes">
+            <button className="row-action" tabIndex={-1} onClick={onUnstage}>
+              {ICON_MINUS}
+            </button>
+          </Tooltip>
         )}
       </span>
       <span className={`status-glyph status-${glyph}`}>{glyph}</span>


### PR DESCRIPTION
## Summary

- Converts all native `title=` HTML attributes to `<Tooltip>` from `@silo-code/sdk` across the file explorer, git explorer, branch manager, workspaces panel, and theme editor
- Consistent 600ms hover delay, styled popups via portal, and design-token theming across every panel
- Adds a CSS fix in `WorkspacesPanel.css` so the tooltip host span inherits `flex: 1` in the folder list (prevents the path span from losing its grow behaviour under the `inline-flex` wrapper)

## Panels changed

| Panel | File(s) |
|---|---|
| File Explorer | `TreeNodes.tsx` — dir + file name spans |
| Git Explorer | `git-rows.tsx` — file name, Open/Discard/Stage/Unstage buttons, section header actions |
| Git Explorer | `GitView.tsx` — branch name, Sync, Publish, Refresh, More actions (both rootLabel and standalone layouts) |
| Branch Manager | `BranchManager.tsx` — branch name, Push/Publish, Rename, Delete buttons |
| Workspaces | `WorkspacesPanel.tsx` — workspace name (instruction hint), Close workspace, Add workspace |
| Workspaces | `WorkspaceModals.tsx` — folder path span, Remove folder button |
| Theme Editor | `ThemeEditorPanel.tsx` — color swatch, eyedropper, Import buttons |

## Test plan

- [ ] Hover file/folder names in file explorer — SDK tooltip shows full path after 600ms
- [ ] Hover git file rows — full path tooltip on name; action button tooltips on Open/Discard/Stage/Unstage
- [ ] Hover branch name in git panel — "Manage branches" tooltip; sync/publish/refresh/more show tooltips
- [ ] Open branch manager — hover branch names and action icons
- [ ] Hover workspace rows — instruction hint on workspace name; "Close workspace" on ×
- [ ] Hover "+" add workspace button
- [ ] Open workspace properties — hover folder path and × remove button
- [ ] Open theme editor — hover color swatch, eyedropper, Import button

🤖 Generated with [Claude Code](https://claude.com/claude-code)