### PR TITLE
fix(git): truncate branch name in single-root mode

### DIFF
--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -74,7 +74,18 @@
   font-size: var(--silo-font-size-base);
   color: var(--silo-color-text);
 }
+.git-branch-name-wrap {
+  flex: 1;
+  min-width: 0;
+}
+.git-branch-name-wrap .silo-tooltip-host {
+  display: block;
+}
 .git-branch .branch-name {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 600;
   color: var(--silo-color-text-hi);
 }
@@ -84,9 +95,13 @@
   appearance: none;
   background: transparent;
   border: none;
-  display: inline-flex;
-  align-items: center;
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   height: 26px;
+  line-height: 26px;
   padding: 0 4px;
   /* Cancel the padding so the text still sits flush with the panel edge while
      the hover rect matches the sibling buttons' height + padding. */
@@ -111,9 +126,6 @@
 }
 .git-branch .branch-tracking {
   color: var(--silo-color-text-lo);
-}
-.git-branch .spacer {
-  flex: 1;
 }
 
 /* Multi-root: wrapper holding the sync/publish control next to the branch. */

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -635,20 +635,22 @@ export function GitView({
         </button>
       ) : (
         <div className="git-branch">
-          {status?.inRepo ? (
-            <Tooltip content="Manage branches">
-              <button
-                className="branch-name branch-name-button"
-                onClick={openBranchManager}
-              >
-                {status.branch ?? "(detached)"}
-              </button>
-            </Tooltip>
-          ) : (
-            <span className="branch-name">
-              {status ? (status.branch ?? "(detached)") : "Loading…"}
-            </span>
-          )}
+          <span className="git-branch-name-wrap">
+            {status?.inRepo ? (
+              <Tooltip content="Manage branches">
+                <button
+                  className="branch-name branch-name-button"
+                  onClick={openBranchManager}
+                >
+                  {status.branch ?? "(detached)"}
+                </button>
+              </Tooltip>
+            ) : (
+              <span className="branch-name">
+                {status ? (status.branch ?? "(detached)") : "Loading…"}
+              </span>
+            )}
+          </span>
           {/* Where the remote state lives: published → the ↑/↓ counts double as
               a Sync button; not yet published → a Publish-branch button. */}
           {status?.upstream ? (
@@ -673,7 +675,6 @@ export function GitView({
               </button>
             </Tooltip>
           ) : null}
-          <span className="spacer" />
           <Tooltip content="Refresh">
             <button
               className={`branch-action refresh-btn${busy ? " working" : ""}`}


### PR DESCRIPTION
## Summary

- Long branch names were wrapping instead of truncating in single-folder workspaces, pushing the action buttons off screen
- Wraps the branch `<Tooltip>` in a `git-branch-name-wrap` flex container (`flex: 1; min-width: 0`) so the branch gets a constrained width
- Forces `silo-tooltip-host` to `display: block` inside the wrapper — the Tooltip renders an inline span that was breaking the flex truncation chain
- Changes `branch-name-button` from `display: inline-flex` to `display: block` with `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`
- Removes the now-redundant `.spacer` flex item (the wrapper's `flex: 1` handles pushing buttons to the right)

## Test plan

- [ ] Open a workspace with a long branch name — branch should truncate with `…` before the sync/refresh/more buttons
- [ ] Click the truncated branch name — branch manager opens
- [ ] Sync, refresh, and more buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)