### PR TITLE
fix(terminal): disable bell sound on copy/BEL sequences

### DIFF
--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -198,8 +198,10 @@ export function TerminalPanel(
       // glyphs from the font instead. Regular text is unaffected.
       customGlyphs: false,
       allowProposedApi: true,
-      bellStyle: "none",
     });
+    // xterm v6 removed the bellStyle option; subscribe to onBell with a no-op
+    // to suppress any audio the WebView would otherwise play on BEL (0x07).
+    term.onBell(() => {});
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.loadAddon(new WebLinksAddon());

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -198,6 +198,7 @@ export function TerminalPanel(
       // glyphs from the font instead. Regular text is unaffected.
       customGlyphs: false,
       allowProposedApi: true,
+      bellStyle: "none",
     });
     const fit = new FitAddon();
     term.loadAddon(fit);


### PR DESCRIPTION
## Summary

- Sets `bellStyle: "none"` on the xterm.js `Terminal` instance in `TerminalPanel.tsx`
- Silences the audible beep that fires when the terminal receives a BEL character (e.g. when copying text triggers a clipboard escape sequence)
- xterm.js defaults to `"sound"`; this changes it to `"none"`

## Test plan

- [ ] Copy text from the terminal — no beep
- [ ] Normal terminal output still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)