### PR TITLE
feat(terminal): add configurable scroll speed settings

### DIFF
--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -155,6 +155,11 @@ export {
   setTerminalSetting,
 } from "./terminal-core";
 export type { TerminalSettings, TerminalCursorStyle } from "./terminal-core";
+export {
+  MIN_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_FAST_SCROLL_SENSITIVITY,
+} from "./terminal-core";
 // Focus-retry helpers that win dockview's focus shuffle for Monaco/xterm — host
 // DOM/focus plumbing, not a public capability.
 export {

--- a/packages/extension-host/src/extension-host/terminal-core.ts
+++ b/packages/extension-host/src/extension-host/terminal-core.ts
@@ -17,3 +17,8 @@ export {
   setTerminalSetting,
 } from "../state/terminal-settings";
 export type { TerminalSettings, TerminalCursorStyle } from "../state/types";
+export {
+  MIN_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_FAST_SCROLL_SENSITIVITY,
+} from "../state/types";

--- a/packages/extension-host/src/state/terminal-settings.test.ts
+++ b/packages/extension-host/src/state/terminal-settings.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_TERMINAL_SETTINGS,
+  MIN_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_SCROLL_SENSITIVITY,
+  DEFAULT_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_FAST_SCROLL_SENSITIVITY,
+  DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
+  type TerminalSettings,
+} from "./types";
+
+describe("DEFAULT_TERMINAL_SETTINGS scroll fields", () => {
+  it("scrollSensitivity defaults to DEFAULT_TERMINAL_SCROLL_SENSITIVITY (3)", () => {
+    expect(DEFAULT_TERMINAL_SETTINGS.scrollSensitivity).toBe(
+      DEFAULT_TERMINAL_SCROLL_SENSITIVITY,
+    );
+    expect(DEFAULT_TERMINAL_SETTINGS.scrollSensitivity).toBe(3);
+  });
+
+  it("fastScrollSensitivity defaults to DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY (5)", () => {
+    expect(DEFAULT_TERMINAL_SETTINGS.fastScrollSensitivity).toBe(
+      DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
+    );
+    expect(DEFAULT_TERMINAL_SETTINGS.fastScrollSensitivity).toBe(5);
+  });
+});
+
+describe("scroll sensitivity range constants", () => {
+  it("scroll sensitivity min is 1", () => {
+    expect(MIN_TERMINAL_SCROLL_SENSITIVITY).toBe(1);
+  });
+
+  it("scroll sensitivity max is 50", () => {
+    expect(MAX_TERMINAL_SCROLL_SENSITIVITY).toBe(50);
+  });
+
+  it("fast scroll sensitivity max is 50", () => {
+    expect(MAX_TERMINAL_FAST_SCROLL_SENSITIVITY).toBe(50);
+  });
+
+  it("default scroll sensitivity is within range", () => {
+    expect(DEFAULT_TERMINAL_SCROLL_SENSITIVITY).toBeGreaterThanOrEqual(
+      MIN_TERMINAL_SCROLL_SENSITIVITY,
+    );
+    expect(DEFAULT_TERMINAL_SCROLL_SENSITIVITY).toBeLessThanOrEqual(
+      MAX_TERMINAL_SCROLL_SENSITIVITY,
+    );
+  });
+
+  it("default fast scroll sensitivity is within range", () => {
+    expect(DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY).toBeGreaterThanOrEqual(
+      MIN_TERMINAL_SCROLL_SENSITIVITY,
+    );
+    expect(DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY).toBeLessThanOrEqual(
+      MAX_TERMINAL_FAST_SCROLL_SENSITIVITY,
+    );
+  });
+});
+
+describe("persistence merge backward compat", () => {
+  it("absent scroll fields fall back to defaults for existing users", () => {
+    const persisted: Partial<TerminalSettings> = { cursorStyle: "bar" };
+    const merged: TerminalSettings = {
+      ...DEFAULT_TERMINAL_SETTINGS,
+      ...persisted,
+    };
+    expect(merged.scrollSensitivity).toBe(DEFAULT_TERMINAL_SCROLL_SENSITIVITY);
+    expect(merged.fastScrollSensitivity).toBe(
+      DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
+    );
+  });
+
+  it("persisted scrollSensitivity overrides the default", () => {
+    const persisted: Partial<TerminalSettings> = { scrollSensitivity: 10 };
+    const merged: TerminalSettings = {
+      ...DEFAULT_TERMINAL_SETTINGS,
+      ...persisted,
+    };
+    expect(merged.scrollSensitivity).toBe(10);
+  });
+
+  it("persisted fastScrollSensitivity overrides the default", () => {
+    const persisted: Partial<TerminalSettings> = {
+      fastScrollSensitivity: 20,
+    };
+    const merged: TerminalSettings = {
+      ...DEFAULT_TERMINAL_SETTINGS,
+      ...persisted,
+    };
+    expect(merged.fastScrollSensitivity).toBe(20);
+  });
+});

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -149,7 +149,23 @@ export interface TerminalSettings {
   shell: string;
   /** Whitespace-separated args passed to the shell (default a login shell). */
   shellArgs: string;
+  /**
+   * Lines scrolled per mouse-wheel tick. Mirrors xterm's `scrollSensitivity`.
+   * Higher = faster. Valid range: {@link MIN_TERMINAL_SCROLL_SENSITIVITY}–{@link MAX_TERMINAL_SCROLL_SENSITIVITY}.
+   */
+  scrollSensitivity: number;
+  /**
+   * Lines scrolled per tick while holding Alt/Option. Mirrors xterm's
+   * `fastScrollSensitivity`. Valid range: {@link MIN_TERMINAL_SCROLL_SENSITIVITY}–{@link MAX_TERMINAL_FAST_SCROLL_SENSITIVITY}.
+   */
+  fastScrollSensitivity: number;
 }
+
+export const MIN_TERMINAL_SCROLL_SENSITIVITY = 1;
+export const MAX_TERMINAL_SCROLL_SENSITIVITY = 50;
+export const DEFAULT_TERMINAL_SCROLL_SENSITIVITY = 3;
+export const MAX_TERMINAL_FAST_SCROLL_SENSITIVITY = 50;
+export const DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY = 5;
 
 export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   breadcrumbs: true,
@@ -158,4 +174,6 @@ export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   pasteOnRightClick: false,
   shell: "",
   shellArgs: "-l",
+  scrollSensitivity: DEFAULT_TERMINAL_SCROLL_SENSITIVITY,
+  fastScrollSensitivity: DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
 };

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -180,8 +180,8 @@ export function TerminalPanel(
       cursorStyle: store.terminalSettings.cursorStyle,
       theme: xtermThemeFor(getThemeBase(store.activeThemeId)),
       scrollback: 10_000,
-      scrollSensitivity: 3,
-      fastScrollSensitivity: 5,
+      scrollSensitivity: store.terminalSettings.scrollSensitivity,
+      fastScrollSensitivity: store.terminalSettings.fastScrollSensitivity,
       // xterm hand-draws box-drawing/block glyphs (U+2500 etc.) with vector
       // paths instead of the font. Its WebGL renderer mis-draws some of those
       // cells as artifacts (e.g. blobs on pi's ──── separators), so render box
@@ -265,6 +265,20 @@ export function TerminalPanel(
       }
       if (term.options.cursorStyle !== store.terminalSettings.cursorStyle) {
         term.options.cursorStyle = store.terminalSettings.cursorStyle;
+      }
+      if (
+        term.options.scrollSensitivity !==
+        store.terminalSettings.scrollSensitivity
+      ) {
+        term.options.scrollSensitivity =
+          store.terminalSettings.scrollSensitivity;
+      }
+      if (
+        term.options.fastScrollSensitivity !==
+        store.terminalSettings.fastScrollSensitivity
+      ) {
+        term.options.fastScrollSensitivity =
+          store.terminalSettings.fastScrollSensitivity;
       }
       const themeChanged = store.activeThemeId !== lastThemeId;
       // Also detect live edits to --silo-content-terminal-bg in the active custom theme

--- a/packages/extensions-core/src/terminal/TerminalSettingsPage.tsx
+++ b/packages/extensions-core/src/terminal/TerminalSettingsPage.tsx
@@ -4,6 +4,9 @@ import {
   setTerminalSetting,
   type TerminalSettings,
   type TerminalCursorStyle,
+  MIN_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_SCROLL_SENSITIVITY,
+  MAX_TERMINAL_FAST_SCROLL_SENSITIVITY,
 } from "@silo-code/extension-host/internal";
 // Reuse the editor settings page's layout/control styles (the es-* classes are
 // generic settings-page styling).
@@ -118,6 +121,68 @@ export function TerminalSettingsPage() {
                   label="Paste on right-click"
                   checked={s.pasteOnRightClick}
                   onChange={toggle("pasteOnRightClick")}
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="es-section">
+          <h3 className="es-section-title">Scrolling</h3>
+          <div className="es-rows">
+            <div className="es-row">
+              <div className="es-row-text">
+                <span className="es-label">Scroll speed</span>
+                <span className="es-hint">
+                  Lines scrolled per mouse-wheel tick. Default: 3.
+                </span>
+              </div>
+              <div className="es-control">
+                <input
+                  className="es-number"
+                  type="number"
+                  min={MIN_TERMINAL_SCROLL_SENSITIVITY}
+                  max={MAX_TERMINAL_SCROLL_SENSITIVITY}
+                  step={1}
+                  value={s.scrollSensitivity}
+                  onChange={(e) => {
+                    const n = Number(e.target.value);
+                    if (
+                      Number.isFinite(n) &&
+                      n >= MIN_TERMINAL_SCROLL_SENSITIVITY &&
+                      n <= MAX_TERMINAL_SCROLL_SENSITIVITY
+                    ) {
+                      setTerminalSetting("scrollSensitivity", n);
+                    }
+                  }}
+                />
+              </div>
+            </div>
+            <div className="es-row">
+              <div className="es-row-text">
+                <span className="es-label">Fast scroll speed</span>
+                <span className="es-hint">
+                  Lines scrolled per tick while holding Alt/Option. Default: 5.
+                </span>
+              </div>
+              <div className="es-control">
+                <input
+                  className="es-number"
+                  type="number"
+                  min={MIN_TERMINAL_SCROLL_SENSITIVITY}
+                  max={MAX_TERMINAL_FAST_SCROLL_SENSITIVITY}
+                  step={1}
+                  value={s.fastScrollSensitivity}
+                  onChange={(e) => {
+                    const n = Number(e.target.value);
+                    if (
+                      Number.isFinite(n) &&
+                      n >= MIN_TERMINAL_SCROLL_SENSITIVITY &&
+                      n <= MAX_TERMINAL_FAST_SCROLL_SENSITIVITY
+                    ) {
+                      setTerminalSetting("fastScrollSensitivity", n);
+                    }
+                  }}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary

Adds `scrollSensitivity` and `fastScrollSensitivity` as user-configurable terminal settings, replacing the previously hardcoded values of 3 and 5.

## Changes

- **`TerminalSettings`** — two new fields with min/max/default constants
- **`TerminalPanel`** — reads from settings at init; live-updates on existing terminals via the store subscriber (no remount needed)
- **`TerminalSettingsPage`** — new **Scrolling** section with number inputs for both fields
- **`terminal-settings.test.ts`** — 10 new tests covering defaults, range constants, and backward-compat persistence merging