### PR TITLE
fix(git): left-align branch name in single-root panel

### DIFF
--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -141,6 +141,7 @@
   border-radius: var(--silo-radius-sm);
   font: inherit;
   font-weight: 600;
+  text-align: left;
   cursor: pointer;
 }
 .git-branch .branch-name-button:hover {


### PR DESCRIPTION
## Summary

- `<button>` elements have a browser default of `text-align: center`; the branch name button in the single-root git panel was rendering centered instead of flush-left
- Added `text-align: left` to `.git-branch .branch-name-button` — truncation behavior is unchanged

## Test plan

- [ ] Open the GIT panel with a single-root workspace and confirm the branch name is left-aligned
- [ ] Confirm long branch names still truncate with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)