### PR TITLE
feat: make side-panel visibility per-workspace

### DIFF
--- a/apps/docs/api/types/interfaces/CustomTheme.md
+++ b/apps/docs/api/types/interfaces/CustomTheme.md
@@ -1,6 +1,6 @@
 # Interface: CustomTheme
 
-Defined in: [packages/sdk/src/domain-types.ts:233](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L233)
+Defined in: [packages/sdk/src/domain-types.ts:236](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L236)
 
 A persisted custom theme.
 
@@ -12,7 +12,7 @@ A persisted custom theme.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:234](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L234)
+Defined in: [packages/sdk/src/domain-types.ts:237](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L237)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [packages/sdk/src/domain-types.ts:234](https://github.com/silo-code/
 version: 2;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:239](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L239)
+Defined in: [packages/sdk/src/domain-types.ts:242](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L242)
 
 `2` since the `--silo-*` token rename (theming-contract.md › Migration).
 v1 themes used the legacy bare names (`--bg`, `--text-hi`, …).
@@ -35,7 +35,7 @@ v1 themes used the legacy bare names (`--bg`, `--text-hi`, …).
 name: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:240](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L240)
+Defined in: [packages/sdk/src/domain-types.ts:243](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L243)
 
 ***
 
@@ -45,7 +45,7 @@ Defined in: [packages/sdk/src/domain-types.ts:240](https://github.com/silo-code/
 base: ThemeBase;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:241](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L241)
+Defined in: [packages/sdk/src/domain-types.ts:244](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L244)
 
 ***
 
@@ -55,7 +55,7 @@ Defined in: [packages/sdk/src/domain-types.ts:241](https://github.com/silo-code/
 colorScheme: "dark" | "light";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:242](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L242)
+Defined in: [packages/sdk/src/domain-types.ts:245](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L245)
 
 ***
 
@@ -65,4 +65,4 @@ Defined in: [packages/sdk/src/domain-types.ts:242](https://github.com/silo-code/
 vars: Partial<ThemeVars>;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:243](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L243)
+Defined in: [packages/sdk/src/domain-types.ts:246](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L246)

--- a/apps/docs/api/types/interfaces/ThemeVars.md
+++ b/apps/docs/api/types/interfaces/ThemeVars.md
@@ -1,6 +1,6 @@
 # Interface: ThemeVars
 
-Defined in: [packages/sdk/src/domain-types.ts:160](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L160)
+Defined in: [packages/sdk/src/domain-types.ts:163](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L163)
 
 The full theme-override surface, in type form: every `--silo-*` token a theme
 preset's `vars` may recolor. Per the theming contract it spans **the design
@@ -21,7 +21,7 @@ docs/architecture-audit/theming-contract.md
 --silo-color-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:162](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L162)
+Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L165)
 
 ***
 
@@ -31,7 +31,7 @@ Defined in: [packages/sdk/src/domain-types.ts:162](https://github.com/silo-code/
 --silo-color-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:163](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L163)
+Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L166)
 
 ***
 
@@ -41,7 +41,7 @@ Defined in: [packages/sdk/src/domain-types.ts:163](https://github.com/silo-code/
 --silo-color-bg-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:164](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L164)
+Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L167)
 
 ***
 
@@ -51,7 +51,7 @@ Defined in: [packages/sdk/src/domain-types.ts:164](https://github.com/silo-code/
 --silo-color-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L165)
+Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L168)
 
 ***
 
@@ -61,7 +61,7 @@ Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/
 --silo-color-text-hi: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L166)
+Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L169)
 
 ***
 
@@ -71,7 +71,7 @@ Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/
 --silo-color-text-lo: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L167)
+Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L170)
 
 ***
 
@@ -81,7 +81,7 @@ Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/
 --silo-color-accent: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L168)
+Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L171)
 
 ***
 
@@ -91,7 +91,7 @@ Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/
 --silo-color-accent-2: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L169)
+Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L172)
 
 ***
 
@@ -101,7 +101,7 @@ Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/
 --silo-color-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L170)
+Defined in: [packages/sdk/src/domain-types.ts:173](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L173)
 
 ***
 
@@ -111,7 +111,7 @@ Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/
 --silo-color-border-strong: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L171)
+Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L174)
 
 ***
 
@@ -121,7 +121,7 @@ Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/
 --silo-color-ok: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L172)
+Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L175)
 
 ***
 
@@ -131,7 +131,7 @@ Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/
 --silo-color-warn: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:173](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L173)
+Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L176)
 
 ***
 
@@ -141,7 +141,7 @@ Defined in: [packages/sdk/src/domain-types.ts:173](https://github.com/silo-code/
 --silo-color-err: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L174)
+Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L177)
 
 ***
 
@@ -151,7 +151,7 @@ Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/
 --silo-color-input-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L175)
+Defined in: [packages/sdk/src/domain-types.ts:178](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L178)
 
 ***
 
@@ -161,7 +161,7 @@ Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/
 --silo-color-input-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L176)
+Defined in: [packages/sdk/src/domain-types.ts:179](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L179)
 
 ***
 
@@ -171,7 +171,7 @@ Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/
 --silo-color-button-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L177)
+Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L180)
 
 ***
 
@@ -181,7 +181,7 @@ Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/
 --silo-color-button-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:178](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L178)
+Defined in: [packages/sdk/src/domain-types.ts:181](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L181)
 
 ***
 
@@ -191,7 +191,7 @@ Defined in: [packages/sdk/src/domain-types.ts:178](https://github.com/silo-code/
 --silo-color-toolbar-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L180)
+Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L183)
 
 ***
 
@@ -201,7 +201,7 @@ Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/
 --silo-color-toolbar-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:181](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L181)
+Defined in: [packages/sdk/src/domain-types.ts:184](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L184)
 
 ***
 
@@ -211,7 +211,7 @@ Defined in: [packages/sdk/src/domain-types.ts:181](https://github.com/silo-code/
 --silo-color-toolbar-text-disabled: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:182](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L182)
+Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L185)
 
 ***
 
@@ -221,7 +221,7 @@ Defined in: [packages/sdk/src/domain-types.ts:182](https://github.com/silo-code/
 --silo-color-toolbar-input-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L183)
+Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L186)
 
 ***
 
@@ -231,7 +231,7 @@ Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/
 --silo-color-content-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L185)
+Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L188)
 
 ***
 
@@ -241,7 +241,7 @@ Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/
 --silo-color-content-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L186)
+Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L189)
 
 ***
 
@@ -251,7 +251,7 @@ Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/
 optional --silo-font-ui?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L188)
+Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L191)
 
 ***
 
@@ -261,7 +261,7 @@ Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/
 optional --silo-font-mono?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L189)
+Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L192)
 
 ***
 
@@ -271,7 +271,7 @@ Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/
 --silo-content-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L191)
+Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L194)
 
 ***
 
@@ -281,7 +281,7 @@ Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/
 --silo-content-terminal-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L192)
+Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L195)
 
 ***
 
@@ -291,7 +291,7 @@ Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/
 --silo-content-editor-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:193](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L193)
+Defined in: [packages/sdk/src/domain-types.ts:196](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L196)
 
 ***
 
@@ -301,7 +301,7 @@ Defined in: [packages/sdk/src/domain-types.ts:193](https://github.com/silo-code/
 --silo-content-editor-selection: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L194)
+Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L197)
 
 ***
 
@@ -311,7 +311,7 @@ Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/
 --silo-content-editor-selection-inactive: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L195)
+Defined in: [packages/sdk/src/domain-types.ts:198](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L198)
 
 ***
 
@@ -321,7 +321,7 @@ Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/
 --silo-content-editor-text-dim: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:196](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L196)
+Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L199)
 
 ***
 
@@ -331,7 +331,7 @@ Defined in: [packages/sdk/src/domain-types.ts:196](https://github.com/silo-code/
 --silo-content-editor-text-faint: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L197)
+Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L200)
 
 ***
 
@@ -341,7 +341,7 @@ Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/
 --silo-content-tab-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:198](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L198)
+Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L201)
 
 ***
 
@@ -351,7 +351,7 @@ Defined in: [packages/sdk/src/domain-types.ts:198](https://github.com/silo-code/
 --silo-content-tab-tray-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L199)
+Defined in: [packages/sdk/src/domain-types.ts:202](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L202)
 
 ***
 
@@ -361,7 +361,7 @@ Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/
 --silo-content-tab-tray-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L200)
+Defined in: [packages/sdk/src/domain-types.ts:203](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L203)
 
 ***
 
@@ -371,7 +371,7 @@ Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/
 --silo-content-tab-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L201)
+Defined in: [packages/sdk/src/domain-types.ts:204](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L204)
 
 ***
 
@@ -381,7 +381,7 @@ Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/
 --silo-content-tab-text-inactive: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:202](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L202)
+Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L205)
 
 ***
 
@@ -391,7 +391,7 @@ Defined in: [packages/sdk/src/domain-types.ts:202](https://github.com/silo-code/
 --silo-content-tab-text-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:203](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L203)
+Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L206)
 
 ***
 
@@ -401,7 +401,7 @@ Defined in: [packages/sdk/src/domain-types.ts:203](https://github.com/silo-code/
 --silo-statusbar-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L205)
+Defined in: [packages/sdk/src/domain-types.ts:208](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L208)
 
 ***
 
@@ -411,7 +411,7 @@ Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/
 --silo-statusbar-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L206)
+Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L209)
 
 ***
 
@@ -421,7 +421,7 @@ Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/
 --silo-statusbar-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:207](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L207)
+Defined in: [packages/sdk/src/domain-types.ts:210](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L210)
 
 ***
 
@@ -431,7 +431,7 @@ Defined in: [packages/sdk/src/domain-types.ts:207](https://github.com/silo-code/
 --silo-tab-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L209)
+Defined in: [packages/sdk/src/domain-types.ts:212](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L212)
 
 ***
 
@@ -441,7 +441,7 @@ Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/
 --silo-tab-text-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:210](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L210)
+Defined in: [packages/sdk/src/domain-types.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L213)
 
 ***
 
@@ -451,7 +451,7 @@ Defined in: [packages/sdk/src/domain-types.ts:210](https://github.com/silo-code/
 --silo-tab-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L211)
+Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L214)
 
 ***
 
@@ -461,7 +461,7 @@ Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/
 --silo-tab-border-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:212](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L212)
+Defined in: [packages/sdk/src/domain-types.ts:215](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L215)
 
 ***
 
@@ -471,7 +471,7 @@ Defined in: [packages/sdk/src/domain-types.ts:212](https://github.com/silo-code/
 --silo-menu-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L214)
+Defined in: [packages/sdk/src/domain-types.ts:217](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L217)
 
 ***
 
@@ -481,7 +481,7 @@ Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/
 --silo-menu-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:215](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L215)
+Defined in: [packages/sdk/src/domain-types.ts:218](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L218)
 
 ***
 
@@ -491,7 +491,7 @@ Defined in: [packages/sdk/src/domain-types.ts:215](https://github.com/silo-code/
 --silo-menu-item-hover-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L216)
+Defined in: [packages/sdk/src/domain-types.ts:219](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L219)
 
 ***
 
@@ -501,7 +501,7 @@ Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/
 --silo-menu-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:217](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L217)
+Defined in: [packages/sdk/src/domain-types.ts:220](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L220)
 
 ***
 
@@ -511,7 +511,7 @@ Defined in: [packages/sdk/src/domain-types.ts:217](https://github.com/silo-code/
 --silo-modal-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:219](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L219)
+Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L222)
 
 ***
 
@@ -521,7 +521,7 @@ Defined in: [packages/sdk/src/domain-types.ts:219](https://github.com/silo-code/
 --silo-modal-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:220](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L220)
+Defined in: [packages/sdk/src/domain-types.ts:223](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L223)
 
 ***
 
@@ -531,7 +531,7 @@ Defined in: [packages/sdk/src/domain-types.ts:220](https://github.com/silo-code/
 --silo-notify-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L222)
+Defined in: [packages/sdk/src/domain-types.ts:225](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L225)
 
 ***
 
@@ -541,7 +541,7 @@ Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/
 --silo-notify-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:223](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L223)
+Defined in: [packages/sdk/src/domain-types.ts:226](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L226)
 
 ***
 
@@ -551,4 +551,4 @@ Defined in: [packages/sdk/src/domain-types.ts:223](https://github.com/silo-code/
 --silo-notify-text-hi: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:224](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L224)
+Defined in: [packages/sdk/src/domain-types.ts:227](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L227)

--- a/apps/docs/api/types/interfaces/Workspace.md
+++ b/apps/docs/api/types/interfaces/Workspace.md
@@ -172,13 +172,26 @@ Defined in: [packages/sdk/src/domain-types.ts:134](https://github.com/silo-code/
 
 ***
 
+### sidePanelVisibility?
+
+```ts
+optional sidePanelVisibility?: Record<string, boolean>;
+```
+
+Defined in: [packages/sdk/src/domain-types.ts:137](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L137)
+
+Hidden side panels, keyed by panel id; only an explicit `false` (hidden)
+is stored, so an absent key means visible (the default).
+
+***
+
 ### extensionState?
 
 ```ts
 optional extensionState?: Record<string, Record<string, unknown>>;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L135)
+Defined in: [packages/sdk/src/domain-types.ts:138](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L138)
 
 ***
 
@@ -188,6 +201,6 @@ Defined in: [packages/sdk/src/domain-types.ts:135](https://github.com/silo-code/
 optional previewEditorId?: string | null;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:137](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L137)
+Defined in: [packages/sdk/src/domain-types.ts:140](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L140)
 
 ID of the current preview (temporary) editor, if any.

--- a/apps/docs/api/types/type-aliases/ThemeBase.md
+++ b/apps/docs/api/types/type-aliases/ThemeBase.md
@@ -4,6 +4,6 @@
 type ThemeBase = "dark" | "light";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:146](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L146)
+Defined in: [packages/sdk/src/domain-types.ts:149](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L149)
 
 Light or dark theme base.

--- a/apps/docs/api/types/type-aliases/ThemeExport.md
+++ b/apps/docs/api/types/type-aliases/ThemeExport.md
@@ -4,7 +4,7 @@
 type ThemeExport = Omit<CustomTheme, "id">;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:253](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L253)
+Defined in: [packages/sdk/src/domain-types.ts:256](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L256)
 
 A [CustomTheme](../interfaces/CustomTheme.md) without its `id` — the shape exported/imported as a
 shareable theme file.

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -47,7 +47,7 @@ designed. As a primitive ships, its badge flips from
 | `ctx.search` (replace-in-files)                | <Badge type="info" text="planned" /> | [design](/api/search/#replace)                                                             |
 | `ctx.ui` (quickPick / progress)                | <Badge type="info" text="planned" /> | [design](#ctx-ui)                                                                          |
 | `ctx` events (typed `Event<T>`)                | <Badge type="info" text="planned" /> | [design](#ctx-events)                                                                      |
-| `ctx.settings` / configuration                 | <Badge type="info" text="planned" /> | —                                                                                          |
+| per-extension settings (page + persistence)    | <Badge type="tip" text="stable" />   | [docs](/api/registration/register-settings-page)                                           |
 | `ctx.storage` (global / workspace)             | <Badge type="tip" text="stable" />   | [docs](/api/storage/)                                                                      |
 | `ctx.secrets` (host-mediated credentials)      | <Badge type="info" text="planned" /> | [RFC 0004](https://github.com/silo-code/silo/blob/main/docs/proposals/0004-ctx-storage.md) |
 | `ctx.webview` (iframe navigation events)       | <Badge type="info" text="planned" /> | [design](#ctx-webview)                                                                     |
@@ -120,7 +120,6 @@ The shape of each planned surface is now designed in an **RFC** under
 | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | <a id="ctx-ui"></a>`ctx.ui` slice 2 — `quickPick` / `inputBox` / `progress`         | [RFC 0001](https://github.com/silo-code/silo/blob/main/docs/proposals/0001-ctx-ui-slice-2.md)                          |
 | <a id="ctx-events"></a>Typed `ctx` events (`Event<T>`, domain-owned, no global bus) | [RFC 0002](https://github.com/silo-code/silo/blob/main/docs/proposals/0002-ctx-events.md)                              |
-| `ctx.settings` — per-extension configuration                                        | [RFC 0003](https://github.com/silo-code/silo/blob/main/docs/proposals/0003-ctx-settings.md)                            |
 | `ctx.secrets` — host-mediated credentials (storage `global` / `workspace` shipped)  | [RFC 0004](https://github.com/silo-code/silo/blob/main/docs/proposals/0004-ctx-storage.md)                             |
 | Declarative `contributes` + activation events                                       | [RFC 0005](https://github.com/silo-code/silo/blob/main/docs/proposals/0005-declarative-contributes-activation.md)      |
 | Extension permissions + sandbox                                                     | [RFC 0006](https://github.com/silo-code/silo/blob/main/docs/proposals/0006-extension-permissions-sandbox.md)           |

--- a/docs/proposals/0003-ctx-settings.md
+++ b/docs/proposals/0003-ctx-settings.md
@@ -1,9 +1,20 @@
 ---
-status: draft
+status: superseded
 created: 2026-06-04
+superseded-by: ctx.registerSettingsPage + ctx.storage
 ---
 
 # 0003. `ctx.settings` — per-extension configuration
+
+> **Superseded.** The need this RFC named — a consistent place for an extension
+> to expose user-facing settings and persist them — is met by two primitives
+> that shipped separately: [`ctx.registerSettingsPage`](/api/registration/register-settings-page)
+> (a host-placed, host-themed slot in the Settings dialog) and
+> [`ctx.storage`](./0004-ctx-storage.md) (`global` / `workspace` persistence).
+> The system-monitor reference extension uses exactly this combination
+> (`ctx.storage.global` + `registerSettingsPage`). The declarative-schema
+> primitive proposed below was **not** built, and on reflection is the wrong
+> bet — see "Why superseded." Kept for the record.
 
 ## Summary
 
@@ -26,16 +37,41 @@ imperative `ctx.settings.define(schema)`); `ctx.settings.get(key)` /
 `update(key, value)` / `onDidChange`; the host renders a generated settings page.
 Persistence pairs with [`ctx.storage`](./0004-ctx-storage.md).
 
+## Why superseded
+
+The codebase took the **composable, component-based** path instead of the
+declarative-schema path proposed here:
+
+- **Placement / theming / persistence are already solved.**
+  `ctx.registerSettingsPage` gives an extension a themed slot (non-core pages are
+  grouped under **Extensions**), and `ctx.storage.global` persists its values
+  across surfaces — the two halves this RFC wanted to fuse into one primitive
+  now exist independently and compose.
+- **The reference extension is richer than a flat schema could express.**
+  system-monitor's settings are two drag-to-reorder ordered lists shared across
+  the side panel, status bar, and settings page. A `contributes.configuration`
+  vocabulary (checkboxes / dropdowns / text) couldn't render that without growing
+  a generated-UI language indefinitely. Owning the React component is simpler and
+  strictly more capable.
+- **The "kill boilerplate" promise wasn't the real win.** The uniform look comes
+  from the design-token CSS contract, not from host-generated widgets — so an
+  extension writing its own thin settings component still gets a consistent UX.
+
+The one thing not delivered is **zero-code declarative settings** (a checkbox
+without writing React) and **machine-readable settings** (for a future
+settings-search / export / sync). If demand appears, that should be a _new,
+narrow_ RFC for an optional sugar layer **on top of** `registerSettingsPage` +
+`ctx.storage` — not a standalone primitive that owns rendering and persistence.
+
 ## Alternatives considered
 
-- **Extensions hand-roll settings UI + persistence** (status quo) — fragmented,
-  inconsistent, and not themed/validated by the host.
-
-## Decision
-
-Draft. Demand-driven — lands when a non-core extension wants user-facing config.
+- **Extensions hand-roll settings UI + persistence** (status quo at time of
+  writing) — judged fragmented and inconsistent. In practice, `registerSettingsPage`
+  (host placement + theming) plus `ctx.storage` (host-managed persistence) closed
+  that gap without a schema, which is why this RFC is superseded rather than built.
 
 ## References
 
-- [RFC 0004](./0004-ctx-storage.md) (storage),
+- [`ctx.registerSettingsPage`](/api/registration/register-settings-page) (the
+  shipped settings slot), [RFC 0004](./0004-ctx-storage.md) (storage — accepted),
   [RFC 0007](./0007-extension-authoring-toolchain.md) (authoring DX).

--- a/docs/proposals/0004-ctx-storage.md
+++ b/docs/proposals/0004-ctx-storage.md
@@ -70,4 +70,5 @@ uninstall-time cleanup remain demand-driven follow-ups.
 ## References
 
 - [ADR 0019](../decisions/0019-runtime-extension-loading.md) (loading / uninstall),
-  [RFC 0003](./0003-ctx-settings.md) (settings).
+  [RFC 0003](./0003-ctx-settings.md) (settings — superseded; storage is the
+  persistence half of how extension settings actually work).

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -45,8 +45,8 @@ never deleted** — "we considered X and rejected it" stops the debate recurring
 | --------------------------------------------------------- | ----------------------------------------------------------------- | ---------- | ----------- |
 | [0001](./0001-ctx-ui-slice-2.md)                          | `ctx.ui` slice 2 — quickPick / inputBox / progress                | 2026-06-04 | draft       |
 | [0002](./0002-ctx-events.md)                              | Typed `ctx` events (`Event<T>`)                                   | 2026-06-04 | draft       |
-| [0003](./0003-ctx-settings.md)                            | `ctx.settings` — per-extension configuration                      | 2026-06-04 | draft       |
-| [0004](./0004-ctx-storage.md)                             | `ctx.storage` — global / workspace / secret                       | 2026-06-04 | draft       |
+| [0003](./0003-ctx-settings.md)                            | `ctx.settings` — per-extension configuration                      | 2026-06-04 | superseded  |
+| [0004](./0004-ctx-storage.md)                             | `ctx.storage` — global / workspace / secret                       | 2026-06-04 | accepted    |
 | [0005](./0005-declarative-contributes-activation.md)      | Declarative `contributes` + activation events                     | 2026-06-04 | draft       |
 | [0006](./0006-extension-permissions-sandbox.md)           | Extension permissions + sandbox model                             | 2026-06-04 | draft       |
 | [0007](./0007-extension-authoring-toolchain.md)           | Extension authoring toolchain (build/dev, scaffolder, CSS, store) | 2026-06-04 | draft       |

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -30,6 +30,7 @@ const PANEL: PanelState = {
   sidePanelOrder: { explorer: 0 },
   activeSidePanelTabs: { left: "explorer" },
   sidePanelScrollPositions: { explorer: 12 },
+  sidePanelVisibility: { themes: false },
   extensionState: { "silo.explorer": { expanded: ["/a"] } },
 };
 
@@ -109,9 +110,16 @@ describe("withActivePanelState", () => {
     const merged = withActivePanelState(makeWorkspace("a"), PANEL);
     expect(merged.sidePanelLocations).toEqual({ explorer: "left" });
     expect(merged.sidePanelScrollPositions).toEqual({ explorer: 12 });
+    expect(merged.sidePanelVisibility).toEqual({ themes: false });
     expect(merged.extensionState).toEqual({
       "silo.explorer": { expanded: ["/a"] },
     });
+  });
+
+  it("isolates the visibility bag from the source panel state", () => {
+    const merged = withActivePanelState(makeWorkspace("a"), PANEL);
+    merged.sidePanelVisibility!.explorer = false;
+    expect(PANEL.sidePanelVisibility.explorer).toBeUndefined();
   });
 
   it("does not mutate the source workspace and isolates the extension-state bag", () => {
@@ -229,18 +237,10 @@ describe("buildIndex", () => {
       activeWorkspaceId: "a",
       editorSettings,
     });
-    const sidePanelVisibility = { explorer: false };
-    const index2 = buildIndex({
-      workspaceOrder: [],
-      activeWorkspaceId: null,
-      sidePanelVisibility,
-    });
     order.push("c");
     editorSettings.tabSize = 8;
-    sidePanelVisibility.explorer = true;
     expect(index.workspaceOrder).toEqual(["a", "b"]);
     expect(index.editorSettings).toEqual({ tabSize: 2 });
-    expect(index2.sidePanelVisibility).toEqual({ explorer: false });
   });
 
   it("preserves undefined optional fields", () => {
@@ -250,19 +250,16 @@ describe("buildIndex", () => {
     expect(index.uiFontSize).toBeUndefined();
     expect(index.leftPanelCollapsed).toBeUndefined();
     expect(index.rightPanelCollapsed).toBeUndefined();
-    expect(index.sidePanelVisibility).toBeUndefined();
   });
 
-  it("carries the global side-dock visibility flags through", () => {
+  it("carries the global side-dock collapse flags through", () => {
     const index = buildIndex({
       workspaceOrder: [],
       activeWorkspaceId: null,
       leftPanelCollapsed: true,
       rightPanelCollapsed: false,
-      sidePanelVisibility: { themes: false },
     });
     expect(index.leftPanelCollapsed).toBe(true);
     expect(index.rightPanelCollapsed).toBe(false);
-    expect(index.sidePanelVisibility).toEqual({ themes: false });
   });
 });

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -29,9 +29,6 @@ export interface PersistedIndex {
   // indexes, hydrated with a per-workspace fallback (see persistence.ts).
   leftPanelCollapsed?: boolean;
   rightPanelCollapsed?: boolean;
-  // Side-panel visibility is global too; absent in pre-this-change indexes, in
-  // which case every panel hydrates as visible (the default).
-  sidePanelVisibility?: Record<string, boolean>;
   // Per-extension global storage (`ctx.storage.global`), keyed by extension id.
   // Global (not per-workspace), so it lives in the index; absent in older
   // indexes, in which case extensions start from their defaults.
@@ -63,6 +60,7 @@ export interface PanelState {
   sidePanelOrder: Record<string, number>;
   activeSidePanelTabs: Record<string, string>;
   sidePanelScrollPositions: Record<string, number>;
+  sidePanelVisibility: Record<string, boolean>;
   extensionState: Record<string, Record<string, unknown>>;
 }
 
@@ -137,9 +135,6 @@ export function buildIndex(snapshot: PersistedIndex): PersistedIndex {
       : undefined,
     leftPanelCollapsed: snapshot.leftPanelCollapsed,
     rightPanelCollapsed: snapshot.rightPanelCollapsed,
-    sidePanelVisibility: snapshot.sidePanelVisibility
-      ? { ...snapshot.sidePanelVisibility }
-      : undefined,
     globalExtensionState: snapshot.globalExtensionState
       ? cloneExtensionState(snapshot.globalExtensionState)
       : undefined,
@@ -158,6 +153,7 @@ export function withActivePanelState(
     sidePanelOrder: { ...panel.sidePanelOrder },
     activeSidePanelTabs: { ...panel.activeSidePanelTabs },
     sidePanelScrollPositions: { ...panel.sidePanelScrollPositions },
+    sidePanelVisibility: { ...panel.sidePanelVisibility },
     extensionState: cloneExtensionState(panel.extensionState),
   };
 }

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -201,8 +201,8 @@ export async function hydrate(configDir: string): Promise<void> {
   store.rightPanelCollapsed =
     index?.rightPanelCollapsed ?? legacyWs?.rightPanelCollapsed ?? false;
 
-  // Side-panel visibility is global; absent in older indexes → all visible.
-  store.sidePanelVisibility = index?.sidePanelVisibility ?? {};
+  // Side-panel visibility is per-workspace, restored from the active workspace
+  // by loadPanelStateFromWorkspace above (defaults to all-visible when absent).
 
   store.hydrated = true;
   subscribe(store, schedulePersist);
@@ -214,6 +214,7 @@ function snapshotPanelState(): PanelState {
     sidePanelOrder: { ...store.sidePanelOrder },
     activeSidePanelTabs: { ...store.activeSidePanelTabs },
     sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
+    sidePanelVisibility: { ...store.sidePanelVisibility },
     extensionState: cloneExtensionState(store.extensionState),
   };
 }
@@ -271,7 +272,6 @@ async function doPersist(): Promise<void> {
       terminalSettings: { ...store.terminalSettings },
       leftPanelCollapsed: store.leftPanelCollapsed,
       rightPanelCollapsed: store.rightPanelCollapsed,
-      sidePanelVisibility: { ...store.sidePanelVisibility },
       globalExtensionState: store.globalExtensionState,
     }),
   );

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -69,8 +69,10 @@ export interface AppState {
   leftPanelCollapsed: boolean;
   rightPanelCollapsed: boolean;
   /**
-   * Global side-panel visibility, keyed by panel id. Shared across workspaces.
-   * Absent = visible (default); only an explicit `false` (hidden) is stored.
+   * Side-panel visibility, keyed by panel id. Per-workspace: snapshotted into
+   * the active workspace and swapped when the active workspace changes (like
+   * the other panel-state fields). Absent = visible (default); only an explicit
+   * `false` (hidden) is stored.
    */
   sidePanelVisibility: Record<string, boolean>;
   /**

--- a/packages/extension-host/src/state/workspaces.test.ts
+++ b/packages/extension-host/src/state/workspaces.test.ts
@@ -8,7 +8,13 @@ vi.mock("./editor-backups", () => ({
 }));
 
 import { store } from "./store";
-import { openEditor, removeEditor } from "./workspaces";
+import {
+  openEditor,
+  removeEditor,
+  savePanelStateToWorkspace,
+  loadPanelStateFromWorkspace,
+  activateWorkspace,
+} from "./workspaces";
 import { clearEditorBackup } from "./editor-backups";
 
 function makeWorkspace(id: string): Workspace {
@@ -42,5 +48,52 @@ describe("removeEditor", () => {
   it("does nothing for an unknown editor id", () => {
     expect(removeEditor("w", "nope")).toBeNull();
     expect(clearEditorBackup).not.toHaveBeenCalled();
+  });
+});
+
+describe("side-panel visibility is per-workspace", () => {
+  beforeEach(() => {
+    store.sidePanelVisibility = {};
+  });
+
+  it("snapshots live visibility onto the workspace record", () => {
+    store.sidePanelVisibility = { themes: false };
+    savePanelStateToWorkspace("w");
+    expect(store.workspaces.w.sidePanelVisibility).toEqual({ themes: false });
+    // The snapshot is a copy — later live edits don't bleed into the record.
+    store.sidePanelVisibility.git = false;
+    expect(store.workspaces.w.sidePanelVisibility).toEqual({ themes: false });
+  });
+
+  it("restores visibility from the workspace record, defaulting to all-visible", () => {
+    store.workspaces.w.sidePanelVisibility = { explorer: false };
+    loadPanelStateFromWorkspace(store.workspaces.w);
+    expect(store.sidePanelVisibility).toEqual({ explorer: false });
+
+    // A workspace with no stored visibility hydrates as empty (all visible).
+    const fresh = makeWorkspace("fresh");
+    loadPanelStateFromWorkspace(fresh);
+    expect(store.sidePanelVisibility).toEqual({});
+  });
+
+  it("isolates hidden panels between workspaces on switch", () => {
+    store.workspaces = { w: makeWorkspace("w"), w2: makeWorkspace("w2") };
+    store.workspaceOrder = ["w", "w2"];
+    store.activeWorkspaceId = "w";
+
+    // Hide a panel in w, then switch to w2 → w2 starts all-visible.
+    store.sidePanelVisibility = { themes: false };
+    activateWorkspace("w2");
+    expect(store.sidePanelVisibility).toEqual({});
+
+    // Hide a different panel in w2, switch back → w's hidden set returns and
+    // w2's choice didn't leak into it.
+    store.sidePanelVisibility = { git: false };
+    activateWorkspace("w");
+    expect(store.sidePanelVisibility).toEqual({ themes: false });
+
+    // And w2 kept its own.
+    activateWorkspace("w2");
+    expect(store.sidePanelVisibility).toEqual({ git: false });
   });
 });

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -59,6 +59,7 @@ export function savePanelStateToWorkspace(wsId: string): void {
   ws.sidePanelOrder = { ...store.sidePanelOrder };
   ws.activeSidePanelTabs = { ...store.activeSidePanelTabs };
   ws.sidePanelScrollPositions = { ...store.sidePanelScrollPositions };
+  ws.sidePanelVisibility = { ...store.sidePanelVisibility };
   const ext: Record<string, Record<string, unknown>> = {};
   for (const k of Object.keys(store.extensionState))
     ext[k] = { ...store.extensionState[k] };
@@ -71,6 +72,7 @@ export function loadPanelStateFromWorkspace(ws: Workspace): void {
   store.sidePanelOrder = { ...(ws.sidePanelOrder ?? {}) };
   store.activeSidePanelTabs = { ...(ws.activeSidePanelTabs ?? {}) };
   store.sidePanelScrollPositions = { ...(ws.sidePanelScrollPositions ?? {}) };
+  store.sidePanelVisibility = { ...(ws.sidePanelVisibility ?? {}) };
   const ext: Record<string, Record<string, unknown>> = {};
   for (const k of Object.keys(ws.extensionState ?? {}))
     ext[k] = { ...ws.extensionState![k] };

--- a/packages/sdk/src/domain-types.ts
+++ b/packages/sdk/src/domain-types.ts
@@ -132,6 +132,9 @@ export interface Workspace {
   sidePanelOrder?: Record<string, number>;
   activeSidePanelTabs?: Record<string, string>;
   sidePanelScrollPositions?: Record<string, number>;
+  /** Hidden side panels, keyed by panel id; only an explicit `false` (hidden)
+   * is stored, so an absent key means visible (the default). */
+  sidePanelVisibility?: Record<string, boolean>;
   extensionState?: Record<string, Record<string, unknown>>;
   /** ID of the current preview (temporary) editor, if any. */
   previewEditorId?: string | null;


### PR DESCRIPTION
## What

Side-panel **visibility** (which panels are hidden) was the one piece of side-panel state still persisted globally in the `app-state.json` index, while dock position, ordering, and active tab were already per-workspace. This moves visibility into the per-workspace panel-state snapshot so hiding a panel follows the workspace instead of applying everywhere.

## Why

It's workbench chrome that should differ per project, consistent with how `sidePanelLocations` / `sidePanelOrder` / `activeSidePanelTabs` already behave. This is host/core state end-to-end — no `ctx`/extension surface changes (nothing to flip on the roadmap).

## Changes

- **sdk** (`domain-types.ts`) — add `sidePanelVisibility?` to the `Workspace` type (documented).
- **persistence-model** — move it from `PersistedIndex` to `PanelState`: dropped from `buildIndex`, carried in `withActivePanelState`.
- **persistence** — `snapshotPanelState` captures it; `hydrate` restores it from the active workspace instead of the global index; `doPersist` no longer writes it to the index.
- **workspaces** — `savePanelStateToWorkspace` / `loadPanelStateFromWorkspace` carry it through the workspace-switch swap.
- **types** — `AppState` doc comment updated from global → per-workspace.
- **docs** — regenerated API reference (`Workspace` leaf gains the field; the other doc diffs are `Defined in:` line-ref shifts).

`leftPanelCollapsed` / `rightPanelCollapsed` (dock collapse) deliberately stay global; only per-panel visibility moved.

## Migration

**None** (intentional). Any existing global `sidePanelVisibility` is ignored and dropped on the next save — every workspace starts all-visible, then diverges as you hide panels per workspace.

## Tests

- `persistence-model.test.ts` — `PanelState` fixture includes visibility; `withActivePanelState` asserts it merges + a copy-isolation test; `buildIndex` tests no longer reference the removed index field.
- `workspaces.test.ts` — new `describe("side-panel visibility is per-workspace")`: snapshot-onto-record (with copy isolation), restore-with-all-visible default, and **isolation between workspaces across `activateWorkspace` switches**.

Full host suite (369) green, `pnpm lint` clean, app typecheck clean. The pre-commit hook reran all package tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)