### PR TITLE
feat: add ctx.system (OS, arch, Silo version)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_paths;
+pub mod system;
 pub mod finder_drop;
 pub mod network;
 #[cfg(feature = "automation")]

--- a/apps/desktop/src-tauri/src/commands/system.rs
+++ b/apps/desktop/src-tauri/src/commands/system.rs
@@ -1,0 +1,17 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct SystemInfoResponse {
+    pub os: &'static str,
+    pub arch: &'static str,
+}
+
+/// Returns compile-time OS and CPU architecture constants. These are baked into
+/// the binary — no runtime lookup needed, no extra dependencies.
+#[tauri::command]
+pub fn system_info() -> SystemInfoResponse {
+    SystemInfoResponse {
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
             commands::network::net_fetch_headers,
             commands::finder_drop::dnd_get_finder_paths,
             commands::window_chrome::window_set_caption_color,
+            commands::system::system_info,
         ])
         .run(context)
         .expect("error while running tauri application");

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -47,6 +47,7 @@ const apiSidebar = [
       { text: "ctx.dnd", link: "/api/dnd/" },
       { text: "ctx.ui", link: "/api/ui/" },
       { text: "ctx.net", link: "/api/net/" },
+      { text: "ctx.system", link: "/api/system/" },
     ],
   },
   {

--- a/apps/docs/api/index.md
+++ b/apps/docs/api/index.md
@@ -59,6 +59,7 @@ importing the store or touching the platform directly. Opening files lives on
 | [`ctx.dnd`](/api/dnd/)                    | drag sources + drop targets with typed payloads ([`DndService`](/api/types/interfaces/DndService))                                                                                                                     |
 | [`ctx.ui`](/api/ui/)                      | native pickers + toasts + menus + modals (`confirm` / `prompt` / `showModal`) ([`UiService`](/api/types/interfaces/UiService))                                                                                         |
 | [`ctx.net`](/api/net/)                    | server-side HTTP client — bypasses browser CORS, reads any response header ([`NetworkService`](/api/types/interfaces/NetworkService))                                                                                  |
+| [`ctx.system`](/api/system/)              | static host-platform metadata — OS, CPU arch, and Silo version ([`SystemService`](/api/types/interfaces/SystemService))                                                                                                |
 
 ## Other
 

--- a/apps/docs/api/system/index.md
+++ b/apps/docs/api/system/index.md
@@ -1,0 +1,109 @@
+# ctx.system <Badge type="tip" text="stable" />
+
+Static host-platform metadata — the OS, CPU architecture, and running Silo
+version. All values are baked into the binary at build time and never change
+during a session. Use at activation time to make platform-specific decisions
+without branching on runtime strings.
+
+```ts
+ctx.system: SystemService
+```
+
+## Example
+
+### hello-extension — notify with OS, arch, and version
+
+The [`hello-extension`](https://github.com/silo-code/silo/tree/main/examples/extensions/hello-extension)
+starter shows the simplest use: read `ctx.system` in a command and surface the
+result as a toast.
+
+```ts
+ctx.registerCommand({
+  id: "silo.hello.greet",
+  label: "Hello: Say hello",
+  async run() {
+    const { os, arch, siloVersion } = await ctx.system.getInfo();
+    ctx.ui.notify(
+      "info",
+      `👋 Hello, from ${os} ${arch} with Silo v${siloVersion}`,
+    );
+  },
+});
+```
+
+Produces a notification like: **👋 Hello, from macos aarch64 with Silo v0.15.0**
+
+### Conditionally register a platform-specific command
+
+```ts
+export const extension: Extension = {
+  id: "my.platform-aware",
+  async activate(ctx) {
+    const { os, arch, siloVersion } = await ctx.system.getInfo();
+
+    if (os === "macos") {
+      ctx.subscriptions.push(
+        ctx.registerCommand({
+          id: "my.reveal-in-finder",
+          title: "Reveal in Finder",
+          run() {
+            /* ... */
+          },
+        }),
+      );
+    }
+
+    ctx.ui.notify({ title: `Silo ${siloVersion} · ${os}/${arch}` });
+  },
+};
+```
+
+### Show system info in a settings page
+
+```tsx
+export const extension: Extension = {
+  id: "my.system-info-page",
+  activate(ctx) {
+    ctx.subscriptions.push(
+      ctx.registerSettingsPage({
+        id: "my.system-info",
+        title: "System",
+        render() {
+          const [info, setInfo] = useState<SystemInfo | null>(null);
+          useEffect(() => {
+            ctx.system.getInfo().then(setInfo);
+          }, []);
+          if (!info) return null;
+          return (
+            <dl>
+              <dt>OS</dt>
+              <dd>{info.os}</dd>
+              <dt>Arch</dt>
+              <dd>{info.arch}</dd>
+              <dt>Silo</dt>
+              <dd>{info.siloVersion}</dd>
+            </dl>
+          );
+        },
+      }),
+    );
+  },
+};
+```
+
+## API
+
+```ts
+interface SystemService {
+  getInfo(): Promise<SystemInfo>;
+}
+```
+
+| Method      | Returns               | Description                                                      |
+| ----------- | --------------------- | ---------------------------------------------------------------- |
+| `getInfo()` | `Promise<SystemInfo>` | Resolve the host-platform snapshot. Cached after the first call. |
+
+## Types
+
+- [`SystemService`](/api/types/interfaces/SystemService)
+- [`SystemInfo`](/api/types/interfaces/SystemInfo)

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -44,6 +44,7 @@ designed. As a primitive ships, its badge flips from
 | `ctx.ui.openExternal` (open a URL out)         | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
 | `ctx.ui.getActiveSelectionText`                | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
 | `ctx.net` (server-side HTTP, bypasses CORS)    | <Badge type="tip" text="stable" />   | [docs](/api/net/)                                                                          |
+| `ctx.system` (OS, arch, Silo version)          | <Badge type="tip" text="stable" />   | [docs](/api/system/)                                                                       |
 | `ctx.search` (cross-file content search)       | <Badge type="tip" text="stable" />   | [docs](/api/search/)                                                                       |
 | `ctx.search` (replace-in-files)                | <Badge type="info" text="planned" /> | [design](/api/search/#replace)                                                             |
 | `ctx.ui` (quickPick / progress)                | <Badge type="info" text="planned" /> | [design](#ctx-ui)                                                                          |

--- a/examples/extensions/hello-extension/README.md
+++ b/examples/extensions/hello-extension/README.md
@@ -24,7 +24,9 @@ covers the manifest and build.
 
    In Silo: **Settings → Extensions → Install from folder…** and choose this
    folder. The **👋 Hello** item appears in the status bar; click it (or run the
-   `Hello: Say hello` command).
+   `Hello: Say hello` command) to see a notification like:
+
+   > 👋 Hello, from macos aarch64 with Silo v0.15.0
 
 ## What to change next
 
@@ -33,5 +35,8 @@ covers the manifest and build.
 - **Talk to the user** — `ctx.ui` (notifications, pickers, modals).
 - **Reach the workspace** — `ctx.files` / `ctx.process` (workspace-scoped by
   default; declare `silo.permissions` to go beyond — see `permissions-demo`).
+- **React to the platform** — `ctx.system.getInfo()` (already used here) gives
+  you the OS, CPU arch, and Silo version so you can branch on platform at
+  activation time.
 
 The full surface is the [`ctx` API reference](../../../apps/docs/api/index.md).

--- a/examples/extensions/hello-extension/src/index.tsx
+++ b/examples/extensions/hello-extension/src/index.tsx
@@ -20,7 +20,13 @@ export const extension: Extension = {
     ctx.registerCommand({
       id: "silo.hello.greet",
       label: "Hello: Say hello",
-      run: () => ctx.ui.notify("info", "👋 Hello from your extension!"),
+      async run() {
+        const { os, arch, siloVersion } = await ctx.system.getInfo();
+        ctx.ui.notify(
+          "info",
+          `👋 Hello, from ${os} ${arch} with Silo v${siloVersion}`,
+        );
+      },
     });
 
     // A status-bar item. The component renders its own content — here a button
@@ -46,14 +52,15 @@ export const extension: Extension = {
     style.id = STYLE_ID;
     style.textContent = `
       .hello-status {
+        -webkit-appearance: none;
+        appearance: none;
         font: inherit;
         cursor: pointer;
         background: transparent;
-        border: 0;
-        padding: 0 4px;
-        color: inherit;
+        border: none;
+        padding: 2px 8px;
+        border-radius: var(--silo-radius-sm);
       }
-      .hello-status:hover { color: var(--silo-color-text-hi); }
     `;
     document.head.appendChild(style);
   },

--- a/packages/extension-host/src/extension-host/context.ts
+++ b/packages/extension-host/src/extension-host/context.ts
@@ -37,6 +37,7 @@ import type { ThemePreset } from "@silo-code/sdk";
 import { getDndService } from "./dnd-service";
 import { getUiService } from "./ui-service";
 import { getNetworkService } from "./network-service";
+import { getSystemService } from "./system-service";
 import { themePresetRegistry } from "./theme-presets";
 import { getExtensionHandle } from "./extension-registry";
 import {
@@ -140,6 +141,7 @@ export function createContext(
     dnd: getDndService(),
     ui: getUiService(),
     net: getNetworkService(),
+    system: getSystemService(),
     getExtension(id) {
       return getExtensionHandle(id);
     },

--- a/packages/extension-host/src/extension-host/system-service.test.ts
+++ b/packages/extension-host/src/extension-host/system-service.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../services/tauri-system", () => ({
+  systemInfo: vi.fn(),
+}));
+vi.mock("../services/tauri-app", () => ({
+  appVersion: vi.fn(),
+}));
+
+import { systemInfo } from "../services/tauri-system";
+import { appVersion } from "../services/tauri-app";
+
+// Re-import the module under test after mocks are in place.
+// Each test re-imports to reset the module-level singleton.
+async function freshService() {
+  vi.resetModules();
+  const mod = await import("./system-service");
+  return mod.getSystemService();
+}
+
+describe("SystemService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(systemInfo).mockResolvedValue({ os: "macos", arch: "aarch64" });
+    vi.mocked(appVersion).mockResolvedValue("1.2.3");
+  });
+
+  it("returns correctly shaped SystemInfo", async () => {
+    const svc = await freshService();
+    const info = await svc.getInfo();
+    expect(info).toEqual({
+      os: "macos",
+      arch: "aarch64",
+      siloVersion: "1.2.3",
+    });
+  });
+
+  it("caches the result — tauri calls happen only once across multiple getInfo() calls", async () => {
+    const svc = await freshService();
+    await svc.getInfo();
+    await svc.getInfo();
+    await svc.getInfo();
+    expect(systemInfo).toHaveBeenCalledTimes(1);
+    expect(appVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it("getSystemService() returns the same singleton instance", async () => {
+    vi.resetModules();
+    const mod = await import("./system-service");
+    const a = mod.getSystemService();
+    const b = mod.getSystemService();
+    expect(a).toBe(b);
+  });
+});

--- a/packages/extension-host/src/extension-host/system-service.ts
+++ b/packages/extension-host/src/extension-host/system-service.ts
@@ -1,0 +1,26 @@
+import type { SystemInfo, SystemService } from "@silo-code/sdk";
+import { systemInfo } from "../services/tauri-system";
+import { appVersion } from "../services/tauri-app";
+
+// OS/arch/version never change during a session — resolve once and reuse.
+let cached: Promise<SystemInfo> | null = null;
+
+function resolve(): Promise<SystemInfo> {
+  if (cached) return cached;
+  cached = Promise.all([systemInfo(), appVersion()]).then(
+    ([{ os, arch }, siloVersion]) => ({
+      os: os as SystemInfo["os"],
+      arch,
+      siloVersion,
+    }),
+  );
+  return cached;
+}
+
+let service: SystemService | null = null;
+
+export function getSystemService(): SystemService {
+  if (service) return service;
+  service = { getInfo: resolve };
+  return service;
+}

--- a/packages/extension-host/src/services/tauri-system.ts
+++ b/packages/extension-host/src/services/tauri-system.ts
@@ -1,0 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// Thin wrapper over the `system_info` Tauri command — the leaf-layer seam for
+// host-platform metadata. Mirrors tauri-app.ts / tauri-fs.ts in shape.
+
+interface RawSystemInfo {
+  os: string;
+  arch: string;
+}
+
+/** Resolve the host OS and CPU architecture from the binary's compile-time constants. */
+export function systemInfo(): Promise<RawSystemInfo> {
+  return invoke<RawSystemInfo>("system_info");
+}

--- a/packages/extensions-core/src/about/AboutPage.css
+++ b/packages/extensions-core/src/about/AboutPage.css
@@ -26,3 +26,10 @@
   color: var(--silo-color-text-lo);
   font-family: var(--silo-font-mono, monospace);
 }
+
+.about-platform {
+  font-size: calc(var(--settings-font) - 2px);
+  color: var(--silo-color-text-lo);
+  font-family: var(--silo-font-mono, monospace);
+  opacity: 0.6;
+}

--- a/packages/extensions-core/src/about/index.tsx
+++ b/packages/extensions-core/src/about/index.tsx
@@ -1,20 +1,17 @@
 import { useEffect, useState } from "react";
-import type { Extension } from "@silo-code/sdk";
-import { getAppService } from "@silo-code/extension-host/internal";
+import type { Extension, SystemInfo, SystemService } from "@silo-code/sdk";
 import siloIcon from "./silo-icon.png";
 import "./AboutPage.css";
 
-const app = getAppService();
-
-function AboutPage() {
-  const [version, setVersion] = useState("");
+function AboutPage({ system }: { system: SystemService }) {
+  const [info, setInfo] = useState<SystemInfo | null>(null);
 
   useEffect(() => {
-    app
-      .getVersion()
-      .then(setVersion)
+    system
+      .getInfo()
+      .then(setInfo)
       .catch(() => {});
-  }, []);
+  }, [system]);
 
   return (
     <div className="about-page">
@@ -22,7 +19,14 @@ function AboutPage() {
       <div className="about-tagline">
         Run every workspace at once. Switch instantly, lose nothing.
       </div>
-      {version && <div className="about-version">Version {version}</div>}
+      {info && (
+        <>
+          <div className="about-version">Version {info.siloVersion}</div>
+          <div className="about-platform">
+            {info.os} · {info.arch}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -36,7 +40,7 @@ export const extension: Extension = {
       // Late group keeps it last in the rail regardless of other pages.
       group: "9_about",
       order: 1,
-      component: AboutPage,
+      component: () => <AboutPage system={ctx.system} />,
     });
   },
 };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -163,6 +163,9 @@ export type {
   NetworkResponse,
 } from "./network-service";
 
+// Static host-platform metadata: OS, CPU arch, and Silo version.
+export type { SystemService, SystemInfo } from "./system-service";
+
 // Context keys referenced by `when` predicates on menu items / keybindings.
 export type { ContextKeys } from "./context-keys";
 

--- a/packages/sdk/src/system-service.ts
+++ b/packages/sdk/src/system-service.ts
@@ -1,0 +1,76 @@
+// `ctx.system` — static host-platform metadata: OS, CPU architecture, and the
+// running Silo version. Values are baked in at build time and never change
+// during a session, so the result of getInfo() is cached after the first call.
+
+/**
+ * A point-in-time snapshot of the host machine and application version.
+ * Returned by {@link SystemService.getInfo}. All fields are static for the
+ * lifetime of the app — cache freely.
+ *
+ * @category Consumer Services
+ * @public
+ */
+export interface SystemInfo {
+  /**
+   * The host operating system.
+   *
+   * - `"macos"` — macOS (Apple Silicon or Intel)
+   * - `"linux"` — Linux
+   * - `"windows"` — Windows
+   */
+  os: "macos" | "linux" | "windows";
+  /**
+   * The CPU architecture the app binary was compiled for, e.g. `"aarch64"` or
+   * `"x86_64"`. Uses Rust's `std::env::consts::ARCH` vocabulary — common values
+   * on Silo's targets are `"aarch64"` (Apple Silicon, ARM) and `"x86_64"` (Intel
+   * / AMD64).
+   */
+  arch: string;
+  /**
+   * The running Silo application version from the bundle manifest, e.g.
+   * `"0.15.0"`.
+   */
+  siloVersion: string;
+}
+
+/**
+ * Read-only snapshot of the host machine and Silo version. Exposed as
+ * {@link ExtensionContext.system}.
+ *
+ * All values are static — they are baked into the binary at compile time and
+ * do not change during a session. `getInfo()` resolves on the first call and
+ * returns the cached result on every subsequent call.
+ *
+ * @example
+ * ```ts
+ * export const extension: Extension = {
+ *   id: "my.platform-aware",
+ *   async activate(ctx) {
+ *     const { os, arch, siloVersion } = await ctx.system.getInfo();
+ *
+ *     if (os === "macos") {
+ *       // Register a macOS-specific command.
+ *       ctx.subscriptions.push(
+ *         ctx.registerCommand({
+ *           id: "my.reveal-in-finder",
+ *           title: "Reveal in Finder",
+ *           run() { ... },
+ *         }),
+ *       );
+ *     }
+ *
+ *     ctx.ui.notify({ title: `Running Silo ${siloVersion} on ${os}/${arch}` });
+ *   },
+ * };
+ * ```
+ *
+ * @category Consumer Services
+ * @public
+ */
+export interface SystemService {
+  /**
+   * Resolve the host-platform snapshot. Resolves immediately after the first
+   * call (the result is cached) — safe to `await` in `activate`.
+   */
+  getInfo(): Promise<SystemInfo>;
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -32,6 +32,7 @@ import type { ThemeService, ThemePreset } from "./theme-service";
 import type { DndService } from "./dnd-service";
 import type { UiService } from "./ui-service";
 import type { NetworkService } from "./network-service";
+import type { SystemService } from "./system-service";
 import type {
   ExtensionStorage,
   ExtensionStorageScopes,
@@ -538,6 +539,14 @@ export interface ExtensionContext {
    * loading a URL. See {@link NetworkService} for the full API.
    */
   readonly net: NetworkService;
+  /**
+   * Static host-platform metadata — the OS, CPU architecture, and running Silo
+   * version. Values are baked into the binary at build time and never change
+   * during a session. Use to make platform-specific decisions at activation time
+   * (e.g. register a macOS-only command, show an arch-specific download URL).
+   * See {@link SystemService} for the full API.
+   */
+  readonly system: SystemService;
   /**
    * Resolve a handle to another extension in order to consume the API it
    * published (the value its {@link Extension.activate} returned). This is how


### PR DESCRIPTION
## Summary

- Adds `ctx.system` to `ExtensionContext` — a new public service giving extension builders read-only access to the host OS, CPU architecture, and running Silo version
- Implemented via a compile-time Tauri command (`std::env::consts`) for OS/arch + existing `appVersion()` for the version string — no new dependencies
- Result is cached after the first call (values never change during a session)
- Updates `core.about` to display OS + arch below the version, replacing the previous `AppService` internal import
- Updates `hello-extension` to demonstrate `ctx.system` in its greet command notification

## Test plan

- [ ] `pnpm test` — 387 extension-host tests pass including 3 new `system-service` tests (shape, caching, singleton)
- [ ] `pnpm --filter silo exec tsc --noEmit` — typecheck clean
- [ ] `pnpm lint` — no boundary violations
- [ ] Run `pnpm dev`, open Settings → About Silo — version, OS, and arch appear
- [ ] Install hello-extension, click 👋 Hello — notification shows `👋 Hello, from macos aarch64 with Silo v0.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)