### PR TITLE
feat: warn on engine version mismatch at install and in extensions list

### DIFF
--- a/packages/extension-host/src/extension-host/engine-compat.test.ts
+++ b/packages/extension-host/src/extension-host/engine-compat.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseEngineFloor,
+  compareVersions,
+  isEngineCompatible,
+} from "./engine-compat";
+
+describe("parseEngineFloor", () => {
+  it.each([
+    ["^0.17.0", [0, 17, 0]],
+    ["~0.17.0", [0, 17, 0]],
+    [">=0.17.0", [0, 17, 0]],
+    ["0.17.0", [0, 17, 0]],
+    ["<=0.17.0", [0, 17, 0]],
+    [">0.17.0", [0, 17, 0]],
+    ["<0.17.0", [0, 17, 0]],
+    ["=0.17.0", [0, 17, 0]],
+  ])("parses %s as floor %j", (input, expected) => {
+    expect(parseEngineFloor(input)).toEqual(expected);
+  });
+
+  it("defaults missing minor/patch to 0", () => {
+    expect(parseEngineFloor("^1")).toEqual([1, 0, 0]);
+    expect(parseEngineFloor("^1.2")).toEqual([1, 2, 0]);
+  });
+
+  it("returns null for absent, empty, or garbage input", () => {
+    expect(parseEngineFloor(undefined)).toBeNull();
+    expect(parseEngineFloor("")).toBeNull();
+    expect(parseEngineFloor("not-a-version")).toBeNull();
+    expect(parseEngineFloor("^")).toBeNull();
+  });
+
+  it("strips pre-release suffix from engine string", () => {
+    expect(parseEngineFloor("0.17.0-beta.1")).toEqual([0, 17, 0]);
+  });
+});
+
+describe("compareVersions", () => {
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions([1, 2, 3], [1, 2, 3])).toBe(0);
+  });
+
+  it("major beats minor and patch", () => {
+    expect(compareVersions([1, 0, 0], [0, 99, 99])).toBeGreaterThan(0);
+    expect(compareVersions([0, 99, 99], [1, 0, 0])).toBeLessThan(0);
+  });
+
+  it("minor beats patch", () => {
+    expect(compareVersions([0, 2, 0], [0, 1, 99])).toBeGreaterThan(0);
+    expect(compareVersions([0, 1, 99], [0, 2, 0])).toBeLessThan(0);
+  });
+
+  it("patch tie-break", () => {
+    expect(compareVersions([0, 0, 2], [0, 0, 1])).toBeGreaterThan(0);
+    expect(compareVersions([0, 0, 1], [0, 0, 2])).toBeLessThan(0);
+  });
+});
+
+describe("isEngineCompatible", () => {
+  it("is compatible when engine is absent or empty", () => {
+    expect(isEngineCompatible(undefined, "0.1.0")).toBe(true);
+    expect(isEngineCompatible("", "0.1.0")).toBe(true);
+  });
+
+  it("is compatible when engine is garbage (no constraint)", () => {
+    expect(isEngineCompatible("not-a-version", "0.1.0")).toBe(true);
+  });
+
+  it("host below floor → incompatible", () => {
+    expect(isEngineCompatible("^0.17.0", "0.16.5")).toBe(false);
+    expect(isEngineCompatible("^0.17.0", "0.16.99")).toBe(false);
+  });
+
+  it("host equal to floor → compatible (>=)", () => {
+    expect(isEngineCompatible("^0.17.0", "0.17.0")).toBe(true);
+  });
+
+  it("host above floor → compatible", () => {
+    expect(isEngineCompatible("^0.17.0", "0.18.0")).toBe(true);
+    expect(isEngineCompatible("^0.17.0", "1.0.0")).toBe(true);
+  });
+
+  it("host with pre-release suffix is compared on numeric core only", () => {
+    expect(isEngineCompatible("^0.17.0", "0.18.0-beta.1")).toBe(true);
+    expect(isEngineCompatible("^0.17.0", "0.16.0-rc.1")).toBe(false);
+  });
+
+  it("is compatible when host version is unreadable", () => {
+    expect(isEngineCompatible("^0.17.0", "")).toBe(true);
+    expect(isEngineCompatible("^0.17.0", "not-a-version")).toBe(true);
+  });
+
+  it("existing ^0.15.0 extensions stay compatible on 0.17+ hosts", () => {
+    expect(isEngineCompatible("^0.15.0", "0.17.0")).toBe(true);
+    expect(isEngineCompatible("^0.15.0", "0.15.0")).toBe(true);
+  });
+});

--- a/packages/extension-host/src/extension-host/engine-compat.ts
+++ b/packages/extension-host/src/extension-host/engine-compat.ts
@@ -1,0 +1,56 @@
+/**
+ * Minimum-version compatibility for `silo.engine`. The engine string declares a
+ * floor (the lowest host version the extension supports); the host must be at or
+ * above it. Upper bounds are intentionally ignored — the SDK is additive, so a
+ * newer host always satisfies an older floor. @internal
+ */
+
+/**
+ * Extract the first `x.y.z` numeric triple from an engine string like
+ * `"^0.17.0"`, `"~0.17.0"`, `">=0.17.0"`, or bare `"0.17.0"`. Range operators
+ * and pre-release suffixes are stripped; missing patch/minor segments default to
+ * 0. Returns `null` when the input is absent, empty, or contains no digits.
+ */
+export function parseEngineFloor(
+  engine: string | undefined,
+): [number, number, number] | null {
+  if (!engine) return null;
+  // Strip leading range operators: ^, ~, >=, <=, >, <, =
+  const stripped = engine.replace(/^[^0-9]*/, "");
+  // Match the first x.y.z (or x.y or x) in what remains
+  const m = stripped.match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  if (!m) return null;
+  const major = parseInt(m[1], 10);
+  const minor = m[2] !== undefined ? parseInt(m[2], 10) : 0;
+  const patch = m[3] !== undefined ? parseInt(m[3], 10) : 0;
+  return [major, minor, patch];
+}
+
+/**
+ * Compare two version triples. Returns negative when `a < b`, 0 when equal,
+ * positive when `a > b`.
+ */
+export function compareVersions(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  if (a[0] !== b[0]) return a[0] - b[0];
+  if (a[1] !== b[1]) return a[1] - b[1];
+  return a[2] - b[2];
+}
+
+/**
+ * Returns `true` when `hostVersion` satisfies the `engine` floor, or when
+ * there is no constraint. Pre-release suffixes on the host version (e.g.
+ * `"0.18.0-beta.1"`) are ignored — only the numeric core is compared.
+ */
+export function isEngineCompatible(
+  engine: string | undefined,
+  hostVersion: string,
+): boolean {
+  const floor = parseEngineFloor(engine);
+  if (!floor) return true; // no/garbage engine → no constraint
+  const host = parseEngineFloor(hostVersion);
+  if (!host) return true; // can't parse host version → don't warn
+  return compareVersions(host, floor) >= 0;
+}

--- a/packages/extension-host/src/extension-host/extension-manager.test.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.test.ts
@@ -61,6 +61,10 @@ vi.mock("@tauri-apps/api/path", () => ({
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: invokeMock,
 }));
+vi.mock("../services/tauri-app", () => ({
+  appVersion: async () => "0.15.0",
+  appName: async () => "Silo",
+}));
 
 import {
   getExtensionManager,
@@ -133,6 +137,9 @@ describe("previewInstall", () => {
       id: "acme.x",
       name: "Acme",
       permissions: ["fs:read", "network"],
+      engine: undefined,
+      hostVersion: "0.15.0",
+      engineCompatible: true,
     });
     expect(fsMap.has(INSTALLED)).toBe(false);
   });

--- a/packages/extension-host/src/extension-host/extension-manager.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.ts
@@ -33,6 +33,8 @@ import {
   disableBuiltin,
   builtinRows,
 } from "./builtins-registry";
+import { appVersion } from "../services/tauri-app";
+import { isEngineCompatible } from "./engine-compat";
 import type { Disposable, Permission } from "@silo-code/sdk";
 import type { ReactiveService } from "@silo-code/sdk";
 
@@ -106,6 +108,16 @@ export interface InstalledExtension {
   reloadRequired?: boolean;
   /** Capabilities the user granted at install (from the manifest). */
   permissions: readonly Permission[];
+  /** The `silo.engine` floor declared by the extension (e.g. `"^0.17.0"`). */
+  engine?: string;
+  /** The running Silo version at the time this row was built. */
+  hostVersion: string;
+  /**
+   * `false` when the host version is below the extension's declared `engine`
+   * floor. The extension is still installed and may partially work — this is a
+   * warning, not a hard block.
+   */
+  engineCompatible: boolean;
 }
 
 export interface ExtensionManagerState {
@@ -169,6 +181,12 @@ export interface ManifestPreview {
   id: string;
   name: string;
   permissions: readonly Permission[];
+  /** The `silo.engine` floor declared by the manifest (e.g. `"^0.17.0"`). */
+  engine?: string;
+  /** The running Silo version, for messaging in the consent dialog. */
+  hostVersion: string;
+  /** `false` when the host is below the declared engine floor. */
+  engineCompatible: boolean;
 }
 
 /** The on-disk manifest fields the host reads (a subset of package.json). */
@@ -181,6 +199,8 @@ interface ExtensionManifest {
   publisher?: string;
   main: string;
   permissions: Permission[];
+  /** Minimum host version floor declared by the extension (`silo.engine`). */
+  engine?: string;
 }
 
 /**
@@ -266,7 +286,18 @@ function parseManifest(
     silo.permissions,
     sourceLabel,
   );
-  return { id, name, version, description, publisher, main, permissions };
+  const engine =
+    typeof silo.engine === "string" && silo.engine ? silo.engine : undefined;
+  return {
+    id,
+    name,
+    version,
+    description,
+    publisher,
+    main,
+    permissions,
+    engine,
+  };
 }
 
 async function readManifest(dir: string): Promise<ExtensionManifest> {
@@ -312,6 +343,7 @@ function emit(): void {
 async function refresh(): Promise<void> {
   const file = await readInstalledFile();
   const root = await extensionsRoot();
+  const hostVersion = await appVersion().catch(() => "");
   const rows: InstalledExtension[] = [];
   for (const rec of file.extensions) {
     const dir = `${root}/${rec.dir}`;
@@ -328,6 +360,9 @@ async function refresh(): Promise<void> {
         builtin: false,
         reloadRequired: needsReload(rec.id) || undefined,
         permissions: rec.permissions ?? [],
+        engine: m.engine,
+        hostVersion,
+        engineCompatible: isEngineCompatible(m.engine, hostVersion),
       });
     } catch {
       rows.push({
@@ -341,6 +376,8 @@ async function refresh(): Promise<void> {
         builtin: false,
         reloadRequired: needsReload(rec.id) || undefined,
         permissions: rec.permissions ?? [],
+        hostVersion,
+        engineCompatible: true, // can't read manifest → no constraint to check
       });
     }
   }
@@ -359,6 +396,8 @@ async function refresh(): Promise<void> {
       builtin: true,
       reloadRequired: b.reloadRequired || undefined,
       permissions: [],
+      hostVersion,
+      engineCompatible: true, // built-ins ship with the host, always compatible
     });
   }
   rows.sort((a, b) => a.name.localeCompare(b.name));
@@ -599,10 +638,14 @@ export function getExtensionManager(): ExtensionManager {
 
     async previewInstall(srcDir) {
       const manifest = await readManifest(srcDir.replace(/\/+$/, ""));
+      const hostVersion = await appVersion().catch(() => "");
       return {
         id: manifest.id,
         name: manifest.name,
         permissions: manifest.permissions,
+        engine: manifest.engine,
+        hostVersion,
+        engineCompatible: isEngineCompatible(manifest.engine, hostVersion),
       };
     },
 

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -49,13 +49,17 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
     }
 
     async function requestConsent(preview: ManifestPreview): Promise<boolean> {
-      if (preview.permissions.length === 0) return true;
+      if (preview.permissions.length === 0 && preview.engineCompatible)
+        return true;
       return (
         (await ctx.ui.showModal<boolean>(
           (close) => (
             <PermissionConsent
               name={preview.name}
               permissions={preview.permissions}
+              engine={preview.engine}
+              hostVersion={preview.hostVersion}
+              engineCompatible={preview.engineCompatible}
               onCancel={() => close(false)}
               onGrant={() => close(true)}
             />
@@ -212,6 +216,12 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                   {showsReloadHint(ext) && (
                     <span className="ext-hint ext-hint-warn">
                       Reload the window to finish disabling this extension.
+                    </span>
+                  )}
+                  {!ext.engineCompatible && (
+                    <span className="ext-hint ext-hint-warn">
+                      Needs Silo {ext.engine} — you&rsquo;re on{" "}
+                      {ext.hostVersion}. Update Silo to use this extension.
                     </span>
                   )}
                 </div>

--- a/packages/extensions-core/src/extensions/PermissionConsent.css
+++ b/packages/extensions-core/src/extensions/PermissionConsent.css
@@ -45,6 +45,26 @@
   color: var(--silo-color-text-lo);
 }
 
+/* Engine-incompatibility warning banner. */
+.perm-consent-warn {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: var(--silo-radius-md);
+  background: color-mix(in srgb, var(--silo-color-warn) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--silo-color-warn) 35%, transparent);
+  color: var(--silo-color-warn);
+  font-size: 1em;
+  line-height: 1.4;
+}
+.perm-consent-warn svg {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+}
+
 /* The capability list — one card per requested permission. */
 .perm-consent-list {
   list-style: none;

--- a/packages/extensions-core/src/extensions/PermissionConsent.tsx
+++ b/packages/extensions-core/src/extensions/PermissionConsent.tsx
@@ -32,22 +32,30 @@ const PERMISSION_META: Record<
 
 /**
  * The install-time consent dialog for an extension that requests capabilities
- * beyond the workspace. Rendered as the content of `ctx.ui.showModal` (the host
- * owns the card chrome); `onCancel` / `onGrant` settle it. A dedicated layout —
- * not `ctx.ui.confirm` — because a permission grant is a higher-stakes decision
- * than a yes/no prompt and reads better as an itemized list with an icon.
+ * beyond the workspace, or that declares an engine version above the running
+ * host. Rendered as the content of `ctx.ui.showModal`; `onCancel` / `onGrant`
+ * settle it.
  */
 export function PermissionConsent({
   name,
   permissions,
+  engine,
+  hostVersion,
+  engineCompatible,
   onCancel,
   onGrant,
 }: {
   name: string;
   permissions: readonly Permission[];
+  engine?: string;
+  hostVersion?: string;
+  engineCompatible?: boolean;
   onCancel: () => void;
   onGrant: () => void;
 }) {
+  const hasPerms = permissions.length > 0;
+  const incompatible = engineCompatible === false;
+
   return (
     <div className="perm-consent">
       <div className="perm-consent-head">
@@ -56,36 +64,58 @@ export function PermissionConsent({
         </span>
         <div className="perm-consent-titles">
           <span className="perm-consent-title">{name}</span>
-          <span className="perm-consent-sub">
-            wants access beyond your workspace
-          </span>
+          {hasPerms && (
+            <span className="perm-consent-sub">
+              wants access beyond your workspace
+            </span>
+          )}
         </div>
       </div>
 
-      <ul className="perm-consent-list">
-        {permissions.map((p) => {
-          const meta = PERMISSION_META[p];
-          return (
-            <li key={p} className="perm-consent-item">
-              <span className="perm-consent-item-icon">{meta.icon}</span>
-              <span className="perm-consent-item-text">
-                <span className="perm-consent-item-label">{meta.label}</span>
-                <span className="perm-consent-item-detail">{meta.detail}</span>
-              </span>
-            </li>
-          );
-        })}
-      </ul>
+      {incompatible && (
+        <div className="perm-consent-warn">
+          <WarnIcon />
+          <span>
+            Requires Silo {engine} — you&rsquo;re on {hostVersion}. It may not
+            work until you update Silo.
+          </span>
+        </div>
+      )}
 
-      <p className="perm-consent-note">
-        Only install extensions you trust — granted capabilities run with the
-        app&rsquo;s privileges.
-      </p>
+      {hasPerms && (
+        <ul className="perm-consent-list">
+          {permissions.map((p) => {
+            const meta = PERMISSION_META[p];
+            return (
+              <li key={p} className="perm-consent-item">
+                <span className="perm-consent-item-icon">{meta.icon}</span>
+                <span className="perm-consent-item-text">
+                  <span className="perm-consent-item-label">{meta.label}</span>
+                  <span className="perm-consent-item-detail">
+                    {meta.detail}
+                  </span>
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {hasPerms && (
+        <p className="perm-consent-note">
+          Only install extensions you trust — granted capabilities run with the
+          app&rsquo;s privileges.
+        </p>
+      )}
 
       <div className="perm-consent-actions">
         <button onClick={onCancel}>Cancel</button>
         <button className="silo-button-primary" onClick={onGrant}>
-          Install &amp; grant
+          {incompatible
+            ? "Install anyway"
+            : hasPerms
+              ? "Install & grant"
+              : "Install"}
         </button>
       </div>
     </div>
@@ -93,6 +123,24 @@ export function PermissionConsent({
 }
 
 /* ── Icons (inline SVG, currentColor so they theme with the surrounding text) ── */
+
+function WarnIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
 
 function ShieldIcon() {
   return (


### PR DESCRIPTION
## Summary

- Adds a pure `engine-compat` helper (`parseEngineFloor` / `isEngineCompatible`) with minimum-version semantics: `^0.17.0` means `>= 0.17.0`, upper bounds ignored (SDK is additive). Pre-release suffixes stripped before comparison.
- `ExtensionManager` now stamps each installed extension and install preview with `engineCompatible` + `hostVersion` (fetched once via `appVersion()` with a fail-open fallback).
- The install consent dialog shows a yellow warning banner when the extension needs a newer host — the user can still install anyway.
- The extensions list shows an inline hint ("Needs Silo ^x.y — you're on z.w. Update Silo to use this extension.") on incompatible rows.
- 23 unit tests for the version-parsing logic; `extension-manager.test.ts` updated to cover the new fields.

## Warn-don't-block rationale

Blocking install would be too aggressive: an extension may work fine on an older host even if it declares a floor (e.g. just being cautious). The user sees the warning, decides, and can always uninstall if it breaks.

## Test plan

- [ ] `pnpm test` — all 410 tests pass
- [ ] `pnpm lint` — no boundary violations
- [ ] Dev: install an extension with `"silo": { "engine": "^99.0.0" }` — consent dialog shows the warning banner; "Install anyway" works
- [ ] After install, the extension row shows the incompatibility hint
- [ ] Install an extension with no `engine` field — no warning shown, dialog skipped for zero-perm extensions as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)