### PR TITLE
chore: silo-extensions repo doc + Windows process no-console fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@ Orientation docs (read when relevant):
 - `docs/decisions/` — ADRs: the architecture decisions of record (the durable "why").
 - `docs/proposals/` — RFCs: forward-looking designs not yet decided.
 - `docs/ui-terminology.md` — high-level UI component naming.
+- `docs/silo-extensions-repo.md` — the **external** `silo-code/silo-extensions`
+  repo (cloned at `../silo-extensions`): how its third-party extensions relate to
+  this repo — published-SDK lag, npm (not pnpm) build commands, runtime trust /
+  `silo.permissions`, and how to install a branch without merging.
 
 ## Self-documentation — keep docs in sync AS YOU BUILD
 

--- a/apps/desktop/src-tauri/src/commands/process.rs
+++ b/apps/desktop/src-tauri/src/commands/process.rs
@@ -7,6 +7,9 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 #[cfg(unix)]
 use libc;
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
 /// Tauri-managed state for process resource stats (ctx.processes.enableStats).
 /// Holds a sysinfo::System that is refreshed in-place on each `process_get_stats`
 /// call so CPU% is computed as a delta between consecutive samples.
@@ -56,6 +59,15 @@ pub async fn process_exec(
     tauri::async_runtime::spawn_blocking(move || {
         let mut cmd = Command::new(&command);
         cmd.args(&args);
+        // On Windows a GUI (windows-subsystem) app spawning a console program
+        // like `powershell` allocates a fresh console window. Extensions that
+        // poll via ctx.process.exec would flash a window on every call, so
+        // suppress it. No effect on captured stdout/stderr.
+        #[cfg(windows)]
+        {
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
         if let Some(dir) = cwd.as_ref() {
             cmd.current_dir(dir);
         }

--- a/docs/silo-extensions-repo.md
+++ b/docs/silo-extensions-repo.md
@@ -1,0 +1,83 @@
+# The external `silo-extensions` repo
+
+Some official extensions live **outside this monorepo**, in the separate GitHub
+repo [`silo-code/silo-extensions`](https://github.com/silo-code/silo-extensions).
+Locally it's cloned as a sibling of this repo — from the Silo repo root that's
+`../silo-extensions` (i.e. `projects/silo-extensions`). This note captures how
+that repo relates to this one, so working across the boundary doesn't require
+rediscovering it each time.
+
+## What lives there
+
+Independently-installable extensions, one per top-level folder
+(`docs-panel`, `local-web-viewer`, `system-monitor`). Each is its own npm
+package. These are the model for **third-party** extensions — unlike the bundled
+`core.*` / `silo.*` extensions in `packages/extensions-*`, they consume Silo only
+through the public SDK and are installed at runtime, not compiled into the app.
+
+## It is NOT part of this pnpm workspace
+
+It's plain per-package **npm**, not pnpm. Build/test/typecheck commands run
+**inside each extension's folder**, not from the monorepo root:
+
+| Task      | Command (run in `silo-extensions/<ext>/`)   |
+| --------- | ------------------------------------------- |
+| Install   | `npm install`                               |
+| Build     | `npm run build` (esbuild → `dist/index.js`) |
+| Test      | `npx vitest run`                            |
+| Typecheck | `npx tsc --noEmit`                          |
+
+There's a shared `tsconfig.base.json` at the repo root and a `build:all` loop in
+the root `package.json`. `dist/` and `*.tgz` are gitignored — a build is required
+after cloning; the compiled output is never committed.
+
+## They depend on the _published_ SDK, not this workspace
+
+Each extension's `devDependency` is the **npm-published** `@silo-code/sdk`, not
+the `packages/sdk` in this repo. Consequence: **they lag the monorepo.** A new
+`ctx` member is usable inside this repo the moment it's added, but only reaches
+these extensions after the SDK is published to npm and the extension bumps its
+dependency. (Example: `ctx.system` shipped in SDK `0.17.0`; `system-monitor` had
+to move to `@silo-code/sdk@^0.18.0` to use it.)
+
+In their esbuild config, `react`, `react/jsx-runtime`, and `@silo-code/sdk` are
+marked **external** — the host injects its own singletons at load, so the
+extension shares one React and one SDK instance. CSS is loaded as a text string
+and injected at activate time.
+
+## Trust and permissions (the part that bites)
+
+At runtime these are **third-party / untrusted** extensions, _even the ones using
+the `silo.` id namespace_. Trust comes from being in the app's composition root
+(`apps/desktop/src/builtins.ts`), **not** from the id. Untrusted means their
+`ctx.files` / `ctx.process` access is **path-scoped to the workspace** (see
+`packages/extension-host/.../security/resolve-path.ts`).
+
+To reach beyond that scope they must declare capabilities in `package.json` under
+`silo.permissions` — an array drawn from the host's `KNOWN_PERMISSIONS`
+(`extension-manager.ts`): `"fs:read"`, `"fs:write"`, `"process"`, `"network"`.
+
+- Reading a path outside the workspace (e.g. `/proc/stat`) needs **`fs:read`**.
+- `ctx.process.exec` defaults its cwd to the workspace root, so it works
+  permission-free _only when a workspace is open_; an explicit out-of-workspace
+  cwd — or robustness when no folder is open — needs **`process`**.
+- `silo.engine` is currently **informational** — the host does not enforce it.
+  Set it to the real minimum SDK/host version the extension needs, as
+  documentation rather than a gate.
+
+## Installing one without merging to `main`
+
+The host `ExtensionManager` offers three install paths:
+
+- **Install from folder** (`previewInstall`) — point at a built extension dir.
+  Easiest for a branch: clone, `npm install && npm run build`, install the folder.
+- **Install from URL** (`installFromUrl`) — downloads a `.tgz` from any URL
+  (GitHub release asset or direct). The tarball must be **`npm pack` output**:
+  npm-standard `package/` layout, a `package.json` with the `silo.*` manifest,
+  and the built `dist/` (pulled in via the `files` field). A raw git-branch
+  codeload tarball does **not** qualify — no built `dist/`, wrong layout.
+- **Install from npm** (`installFromNpm`) — by package name from the registry.
+
+So to test a branch on another machine: either clone + build + install-folder, or
+`npm pack` the built extension and attach the `.tgz` to a GitHub **pre-release**
+(tag-based, independent of `main`), then install-from-URL with the asset link.


### PR DESCRIPTION
## Summary

Two independent changes bundled together:

**1. Orientation doc for the external `silo-extensions` repo** (`docs/silo-extensions-repo.md`)

Captures what bites when working across the monorepo ↔ silo-extensions boundary so it doesn't have to be rediscovered:
- It's plain **npm**, not pnpm — build commands run per-extension, not from the monorepo root
- Extensions depend on the **published** `@silo-code/sdk`, so they lag the monorepo (e.g. `ctx.system` was usable here immediately but only reached `system-monitor` after SDK 0.18.0 was published)
- Runtime trust comes from `apps/desktop/src/builtins.ts`, not the `silo.` id prefix — extensions in `silo-extensions` are untrusted and path-scoped
- `silo.permissions` requirements for each capability (`fs:read`, `fs:write`, `process`, `network`)
- Three install paths (folder / URL / npm) and how to use them for testing a branch

Referenced from `CLAUDE.md` under orientation docs.

**2. Suppress console window flash on Windows** (`apps/desktop/src-tauri/src/commands/process.rs`)

On Windows a GUI (windows-subsystem) Tauri app allocates a fresh visible console window each time it spawns a console subprocess (e.g. `powershell`, `cmd`). Extensions that poll via `ctx.process.exec` would flash a window on every call. Adding `CREATE_NO_WINDOW` to the `CommandExt::creation_flags` suppresses it. No effect on captured stdout/stderr or any other platform (`#[cfg(windows)]` gated).

## Test plan

- [ ] `pnpm test` passes (no Rust tests; the flag is Windows-only and compile-time gated)
- [ ] `pnpm lint` passes
- [ ] On Windows: an extension calling `ctx.process.exec` no longer flashes a console window

🤖 Generated with [Claude Code](https://claude.com/claude-code)