### PR TITLE
feat: store left/right panel collapse state per workspace

### DIFF
--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -32,6 +32,8 @@ const PANEL: PanelState = {
   sidePanelScrollPositions: { explorer: 12 },
   sidePanelVisibility: { themes: false },
   extensionState: { "silo.explorer": { expanded: ["/a"] } },
+  leftPanelCollapsed: true,
+  rightPanelCollapsed: false,
 };
 
 describe("splitPersistedState", () => {
@@ -114,6 +116,8 @@ describe("withActivePanelState", () => {
     expect(merged.extensionState).toEqual({
       "silo.explorer": { expanded: ["/a"] },
     });
+    expect(merged.leftPanelCollapsed).toBe(true);
+    expect(merged.rightPanelCollapsed).toBe(false);
   });
 
   it("isolates the visibility bag from the source panel state", () => {
@@ -248,18 +252,5 @@ describe("buildIndex", () => {
     expect(index.editorSettings).toBeUndefined();
     expect(index.terminalSettings).toBeUndefined();
     expect(index.uiFontSize).toBeUndefined();
-    expect(index.leftPanelCollapsed).toBeUndefined();
-    expect(index.rightPanelCollapsed).toBeUndefined();
-  });
-
-  it("carries the global side-dock collapse flags through", () => {
-    const index = buildIndex({
-      workspaceOrder: [],
-      activeWorkspaceId: null,
-      leftPanelCollapsed: true,
-      rightPanelCollapsed: false,
-    });
-    expect(index.leftPanelCollapsed).toBe(true);
-    expect(index.rightPanelCollapsed).toBe(false);
   });
 });

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -24,11 +24,6 @@ export interface PersistedIndex {
   activeThemeId?: string;
   editorSettings?: Partial<EditorSettings>;
   terminalSettings?: Partial<TerminalSettings>;
-  // Side-dock visibility is global (shared across workspaces), so it lives in
-  // the index rather than per-workspace. Optional: absent in pre-this-change
-  // indexes, hydrated with a per-workspace fallback (see persistence.ts).
-  leftPanelCollapsed?: boolean;
-  rightPanelCollapsed?: boolean;
   // Per-extension global storage (`ctx.storage.global`), keyed by extension id.
   // Global (not per-workspace), so it lives in the index; absent in older
   // indexes, in which case extensions start from their defaults.
@@ -62,6 +57,8 @@ export interface PanelState {
   sidePanelScrollPositions: Record<string, number>;
   sidePanelVisibility: Record<string, boolean>;
   extensionState: Record<string, Record<string, unknown>>;
+  leftPanelCollapsed: boolean;
+  rightPanelCollapsed: boolean;
 }
 
 /** Deep-clone the two-level extension-state bag so a stored snapshot can't alias
@@ -133,8 +130,6 @@ export function buildIndex(snapshot: PersistedIndex): PersistedIndex {
     terminalSettings: snapshot.terminalSettings
       ? { ...snapshot.terminalSettings }
       : undefined,
-    leftPanelCollapsed: snapshot.leftPanelCollapsed,
-    rightPanelCollapsed: snapshot.rightPanelCollapsed,
     globalExtensionState: snapshot.globalExtensionState
       ? cloneExtensionState(snapshot.globalExtensionState)
       : undefined,
@@ -155,6 +150,8 @@ export function withActivePanelState(
     sidePanelScrollPositions: { ...panel.sidePanelScrollPositions },
     sidePanelVisibility: { ...panel.sidePanelVisibility },
     extensionState: cloneExtensionState(panel.extensionState),
+    leftPanelCollapsed: panel.leftPanelCollapsed,
+    rightPanelCollapsed: panel.rightPanelCollapsed,
   };
 }
 

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -28,6 +28,9 @@ export interface PersistedIndex {
   // Global (not per-workspace), so it lives in the index; absent in older
   // indexes, in which case extensions start from their defaults.
   globalExtensionState?: Record<string, Record<string, unknown>>;
+  // Legacy migration fields — stored globally in old installs, now per-workspace.
+  leftPanelCollapsed?: boolean;
+  rightPanelCollapsed?: boolean;
 }
 
 /** The legacy monolithic blob (one `"state"` key in the app-data store) we

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -188,18 +188,12 @@ export async function hydrate(configDir: string): Promise<void> {
     : null;
   if (activeWs) loadPanelStateFromWorkspace(activeWs);
 
-  // Side-dock visibility is global, so it comes from the index. Pre-this-change
-  // installs stored it per-workspace; the field is gone from the Workspace type,
-  // so read it off the raw active record as a one-time fallback — the user's
-  // current collapse state carries over instead of resetting on first launch.
-  const legacyWs = activeWs as {
-    leftPanelCollapsed?: boolean;
-    rightPanelCollapsed?: boolean;
-  } | null;
+  // Side-dock collapse state is per-workspace. Fall back to the index for a
+  // one-time migration carry-over from installs that stored it globally.
   store.leftPanelCollapsed =
-    index?.leftPanelCollapsed ?? legacyWs?.leftPanelCollapsed ?? false;
+    activeWs?.leftPanelCollapsed ?? index?.leftPanelCollapsed ?? false;
   store.rightPanelCollapsed =
-    index?.rightPanelCollapsed ?? legacyWs?.rightPanelCollapsed ?? false;
+    activeWs?.rightPanelCollapsed ?? index?.rightPanelCollapsed ?? false;
 
   // Side-panel visibility is per-workspace, restored from the active workspace
   // by loadPanelStateFromWorkspace above (defaults to all-visible when absent).
@@ -216,6 +210,8 @@ function snapshotPanelState(): PanelState {
     sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
     sidePanelVisibility: { ...store.sidePanelVisibility },
     extensionState: cloneExtensionState(store.extensionState),
+    leftPanelCollapsed: store.leftPanelCollapsed,
+    rightPanelCollapsed: store.rightPanelCollapsed,
   };
 }
 
@@ -270,8 +266,6 @@ async function doPersist(): Promise<void> {
       activeThemeId: store.activeThemeId,
       editorSettings: { ...store.editorSettings },
       terminalSettings: { ...store.terminalSettings },
-      leftPanelCollapsed: store.leftPanelCollapsed,
-      rightPanelCollapsed: store.rightPanelCollapsed,
       globalExtensionState: store.globalExtensionState,
     }),
   );

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -60,6 +60,8 @@ export function savePanelStateToWorkspace(wsId: string): void {
   ws.activeSidePanelTabs = { ...store.activeSidePanelTabs };
   ws.sidePanelScrollPositions = { ...store.sidePanelScrollPositions };
   ws.sidePanelVisibility = { ...store.sidePanelVisibility };
+  ws.leftPanelCollapsed = store.leftPanelCollapsed;
+  ws.rightPanelCollapsed = store.rightPanelCollapsed;
   const ext: Record<string, Record<string, unknown>> = {};
   for (const k of Object.keys(store.extensionState))
     ext[k] = { ...store.extensionState[k] };
@@ -73,6 +75,8 @@ export function loadPanelStateFromWorkspace(ws: Workspace): void {
   store.activeSidePanelTabs = { ...(ws.activeSidePanelTabs ?? {}) };
   store.sidePanelScrollPositions = { ...(ws.sidePanelScrollPositions ?? {}) };
   store.sidePanelVisibility = { ...(ws.sidePanelVisibility ?? {}) };
+  store.leftPanelCollapsed = ws.leftPanelCollapsed ?? false;
+  store.rightPanelCollapsed = ws.rightPanelCollapsed ?? false;
   const ext: Record<string, Record<string, unknown>> = {};
   for (const k of Object.keys(ws.extensionState ?? {}))
     ext[k] = { ...ws.extensionState![k] };

--- a/packages/sdk/src/domain-types.ts
+++ b/packages/sdk/src/domain-types.ts
@@ -136,6 +136,10 @@ export interface Workspace {
    * is stored, so an absent key means visible (the default). */
   sidePanelVisibility?: Record<string, boolean>;
   extensionState?: Record<string, Record<string, unknown>>;
+  /** Whether the left side column is collapsed. Per-workspace. */
+  leftPanelCollapsed?: boolean;
+  /** Whether the right side column is collapsed. Per-workspace. */
+  rightPanelCollapsed?: boolean;
   /** ID of the current preview (temporary) editor, if any. */
   previewEditorId?: string | null;
 }


### PR DESCRIPTION
## Summary

- `leftPanelCollapsed` and `rightPanelCollapsed` were previously global (shared across all workspaces via `app-state.json`). They now travel with each workspace and are saved/restored on workspace switch, exactly like the other panel state fields (`sidePanelLocations`, `sidePanelVisibility`, etc.)
- Adds both fields as optional to `Workspace` in the SDK type, routes them through `PanelState` / `withActivePanelState` / `savePanelStateToWorkspace` / `loadPanelStateFromWorkspace`, and removes them from `PersistedIndex` and `buildIndex`

## Migration

Seamless: on first launch after update, the active workspace reads from the index as a fallback, so the user's current collapse state carries over. Non-active workspaces default to both panels expanded until visited.

## Test plan

- [x] `pnpm test` — all 386 extension-host tests pass, full suite green
- [ ] Run the app, collapse the left panel in workspace A, switch to workspace B, switch back — workspace A should restore its collapsed state
- [ ] Restart the app — active workspace collapse state should survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)