### PR TITLE
fix(focus): restore correct panel focus and cursor position on workspace switch

### DIFF
--- a/packages/extension-host/src/extension-host/editor-core.ts
+++ b/packages/extension-host/src/extension-host/editor-core.ts
@@ -5,6 +5,8 @@ import {
   setEditorFilePath,
   setEditorScrollPosition,
   getEditorScrollPosition,
+  setEditorViewState,
+  getEditorViewState,
 } from "../state/workspaces";
 import {
   setEditorBackup,
@@ -57,6 +59,8 @@ export {
   setEditorFilePath,
   setEditorScrollPosition,
   getEditorScrollPosition,
+  setEditorViewState,
+  getEditorViewState,
   // Hot-exit backups: the text editor stashes/restores/clears unsaved buffers.
   setEditorBackup,
   clearEditorBackup,

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -106,6 +106,8 @@ export {
   setEditorFilePath,
   setEditorScrollPosition,
   getEditorScrollPosition,
+  setEditorViewState,
+  getEditorViewState,
   setEditorBackup,
   clearEditorBackup,
   readEditorBackup,

--- a/packages/extension-host/src/panels/WorkspaceDock.tsx
+++ b/packages/extension-host/src/panels/WorkspaceDock.tsx
@@ -214,15 +214,36 @@ export function WorkspaceDock({
       targetPanel.api.setActive();
     }
 
-    // Retry until a textarea inside this dock holds DOM focus. Both Monaco and
-    // xterm park their keyboard input on a <textarea>, so this is the reliable
-    // signal that content (not just the group chrome) actually got it.
-    retryFocus(
-      () => (targetPanel ?? api.activePanel)?.focus(),
-      () => isTextareaFocusedWithin(root),
-    );
+    // Delay the focus retry until after relayoutAndRefit (2 RAFs away) to
+    // prevent a one-frame editor flash. layout(force=true) can briefly hand
+    // active status to Monaco; firing retryFocus immediately would land in
+    // the editor, get disrupted on RAF 2, and produce a visible focus flicker.
+    // useFocusOnActive inside each panel component drives focus from
+    // relayoutAndRefit's setActive() call; this retryFocus is a fallback for
+    // the case where the active panel didn't change (no onDidActiveChange
+    // fires, so useFocusOnActive never triggers).
+    let cancelled = false;
+    let rafId = 0;
+    let frame = 0;
+    const step = () => {
+      frame++;
+      if (frame < 3) {
+        if (!cancelled) rafId = requestAnimationFrame(step);
+        return;
+      }
+      if (cancelled) return;
+      const panel = (savedId ? api.getPanel(savedId) : null) ?? api.activePanel;
+      retryFocus(
+        () => (panel ?? api.activePanel)?.focus(),
+        () => isTextareaFocusedWithin(root),
+        () => !cancelled,
+      );
+    };
+    rafId = requestAnimationFrame(step);
 
     return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
       // Save which panel was active so we can restore it on the next visit.
       lastActivePanelRef.current = api.activePanel?.id ?? null;
       // Dispatch synthetic blur/focusout to reset Monaco's _hasFocus tracker.
@@ -286,20 +307,21 @@ export function WorkspaceDock({
       const host = root?.parentElement;
       const width = host?.clientWidth ?? 0;
       const height = host?.clientHeight ?? 0;
+      // Snapshot active panel before layout — layout(force=true) fires
+      // onDidActiveChange and can hand active status to the wrong panel.
+      const savedPanel = liveApi.activePanel;
       if (width > 0 && height > 0) {
         try {
-          // layout(force=true) fires onDidActiveChange and can hand active
-          // status to the wrong panel (typically Monaco's group) by re-asserting
-          // dockview's stale internal "last active group". Save the panel we
-          // actually want active and restore it immediately after so the force
-          // layout can't permanently steal the active slot.
-          const savedPanel = liveApi.activePanel;
           liveApi.layout(width, height, true);
-          savedPanel?.api.setActive();
         } catch {
           /* no-op */
         }
       }
+      // Restore the correct active panel unconditionally — both to counter any
+      // active-slot change layout() made, and to trigger useFocusOnActive inside
+      // the panel so its retryFocus loop starts. This runs even when the layout
+      // call was skipped (zero dims) so focus is always driven on activation.
+      savedPanel?.api.setActive();
       window.dispatchEvent(new CustomEvent("app:refit-terminals"));
     }
     let raf2 = 0;

--- a/packages/extension-host/src/panels/WorkspaceDock.tsx
+++ b/packages/extension-host/src/panels/WorkspaceDock.tsx
@@ -34,7 +34,11 @@ import { getDndService, resolveDndMode } from "../extension-host/dnd-service";
 import { DND_MIME } from "@silo-code/sdk";
 import { setContextKey } from "../extension-host/context-keys";
 import { resolveEditorForRecord } from "../extension-host/editor-registry";
-import { retryFocus } from "../extension-host/use-focus-retry";
+import {
+  retryFocus,
+  isTextareaFocusedWithin,
+  blurTextareaWithin,
+} from "../extension-host/use-focus-retry";
 import { confirm } from "../extension-host/modal-service";
 import { getThemeBase } from "../layout/presets";
 import { DockTab } from "./DockTab";
@@ -68,6 +72,10 @@ export function WorkspaceDock({
   const layoutRestoredRef = useRef(false);
   const layoutSaveTimer = useRef<number | null>(null);
   const apiRef = useRef<DockviewApi | null>(null);
+  // Tracks the dockview panel that was active when this workspace last went
+  // inactive, so we can restore the correct panel on return rather than
+  // whatever dockview happens to remember after a force-layout pass.
+  const lastActivePanelRef = useRef<string | null>(null);
 
   function onReady(event: DockviewReadyEvent) {
     setApi(event.api);
@@ -194,24 +202,36 @@ export function WorkspaceDock({
   useEffect(() => {
     if (!active || !api) return;
     setActiveDockApi(api);
-    // When the dock becomes active (e.g. switching workspaces), focus the
-    // active panel's content. The panel itself doesn't fire onDidActiveChange
-    // here (it was already active within this dock; only the dock's visibility
-    // changed), so this is the only trigger — retry against dockview's focus
-    // shuffle just like the viewers do. Both Monaco and xterm park focus on a
-    // <textarea>, so a focused textarea inside this dock confirms the content
-    // (not merely the group wrapper) actually got it.
     const root = (api as unknown as { element?: HTMLElement }).element ?? null;
+
+    // Restore the panel that was active when this workspace was last visited.
+    // If this is the first activation there is no saved state, so we fall back
+    // to whatever dockview considers active right now.
+    const savedId = lastActivePanelRef.current;
+    const targetPanel =
+      (savedId ? api.getPanel(savedId) : null) ?? api.activePanel;
+    if (targetPanel && targetPanel !== api.activePanel) {
+      targetPanel.api.setActive();
+    }
+
+    // Retry until a textarea inside this dock holds DOM focus. Both Monaco and
+    // xterm park their keyboard input on a <textarea>, so this is the reliable
+    // signal that content (not just the group chrome) actually got it.
     retryFocus(
-      () => api.activePanel?.focus(),
-      () => {
-        const el = document.activeElement;
-        return (
-          root != null && el instanceof HTMLTextAreaElement && root.contains(el)
-        );
-      },
+      () => (targetPanel ?? api.activePanel)?.focus(),
+      () => isTextareaFocusedWithin(root),
     );
-    return () => setActiveDockApi(null);
+
+    return () => {
+      // Save which panel was active so we can restore it on the next visit.
+      lastActivePanelRef.current = api.activePanel?.id ?? null;
+      // Dispatch synthetic blur/focusout to reset Monaco's _hasFocus tracker.
+      // While the dock is invisible the real blur is often dropped, leaving
+      // Monaco believing it still owns focus; without this it re-steals via
+      // _setAndWriteTextAreaState the next time the workspace becomes visible.
+      blurTextareaWithin(root);
+      setActiveDockApi(null);
+    };
   }, [active, api]);
 
   // Push the active editor + viewer ids into the extension context-keys so
@@ -268,7 +288,14 @@ export function WorkspaceDock({
       const height = host?.clientHeight ?? 0;
       if (width > 0 && height > 0) {
         try {
+          // layout(force=true) fires onDidActiveChange and can hand active
+          // status to the wrong panel (typically Monaco's group) by re-asserting
+          // dockview's stale internal "last active group". Save the panel we
+          // actually want active and restore it immediately after so the force
+          // layout can't permanently steal the active slot.
+          const savedPanel = liveApi.activePanel;
           liveApi.layout(width, height, true);
+          savedPanel?.api.setActive();
         } catch {
           /* no-op */
         }

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -151,6 +151,24 @@ export function getEditorScrollPosition(
   );
 }
 
+export function setEditorViewState(
+  workspaceId: string,
+  editorId: string,
+  state: unknown,
+): void {
+  const ws = store.workspaces[workspaceId];
+  if (!ws) return;
+  if (!ws.editorViewStates) ws.editorViewStates = {};
+  ws.editorViewStates[editorId] = state;
+}
+
+export function getEditorViewState(
+  workspaceId: string,
+  editorId: string,
+): unknown {
+  return store.workspaces[workspaceId]?.editorViewStates?.[editorId] ?? null;
+}
+
 export function reorderWorkspaces(
   fromId: string,
   toId: string,

--- a/packages/extensions-core/src/editor/TextViewer.tsx
+++ b/packages/extensions-core/src/editor/TextViewer.tsx
@@ -15,6 +15,8 @@ import {
   setEditorFilePath,
   setEditorScrollPosition,
   getEditorScrollPosition,
+  setEditorViewState,
+  getEditorViewState,
   setEditorBackup,
   clearEditorBackup,
   readEditorBackup,
@@ -323,7 +325,8 @@ export function TextViewer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorId]);
 
-  // Capture final scroll position on unmount so it survives a full reload.
+  // Capture final view state (cursor + scroll) on unmount so it survives a
+  // full reload. Also keeps scroll-only data in sync for backward compat.
   useEffect(() => {
     return () => {
       const ed = editorRef.current;
@@ -335,6 +338,7 @@ export function TextViewer({
           ed.getScrollTop(),
           ed.getScrollLeft(),
         );
+        setEditorViewState(ws, editorId, ed.saveViewState());
       }
       // Drop any lingering selection-source registration for this editor.
       selSourceRef.current?.dispose();
@@ -394,13 +398,23 @@ export function TextViewer({
     if (hasReveal) {
       maybeApplyReveal();
     } else if (wsId) {
-      const pos = getEditorScrollPosition(wsId, editorId);
-      if (pos) {
-        requestAnimationFrame(() => {
-          editor.setScrollTop(pos.top);
-          editor.setScrollLeft(pos.left);
-        });
-      }
+      // Restore the full view state (cursor + scroll + selections + folds)
+      // saved from a previous mount. Falls back to scroll-only data kept by
+      // older persisted workspaces that predate editorViewStates.
+      const viewState = getEditorViewState(wsId, editorId);
+      requestAnimationFrame(() => {
+        if (viewState) {
+          editor.restoreViewState(
+            viewState as MonacoEditor.ICodeEditorViewState,
+          );
+        } else {
+          const pos = getEditorScrollPosition(wsId, editorId);
+          if (pos) {
+            editor.setScrollTop(pos.top);
+            editor.setScrollLeft(pos.left);
+          }
+        }
+      });
     }
 
     // Publish this editor's selection to the active-selection registry while it
@@ -420,11 +434,12 @@ export function TextViewer({
       selSourceRef.current = null;
     });
 
-    // Persist scroll position on change (debounced)
-    let scrollTimer: number | null = null;
-    editor.onDidScrollChange(() => {
-      if (scrollTimer !== null) window.clearTimeout(scrollTimer);
-      scrollTimer = window.setTimeout(() => {
+    // Persist view state (cursor + scroll) on change, debounced. A single
+    // timer handles both scroll and cursor events so they don't race.
+    let saveTimer: number | null = null;
+    function scheduleStateSave() {
+      if (saveTimer !== null) window.clearTimeout(saveTimer);
+      saveTimer = window.setTimeout(() => {
         const ws = wsIdRef.current;
         if (!ws) return;
         setEditorScrollPosition(
@@ -433,8 +448,11 @@ export function TextViewer({
           editor.getScrollTop(),
           editor.getScrollLeft(),
         );
+        setEditorViewState(ws, editorId, editor.saveViewState());
       }, 300);
-    });
+    }
+    editor.onDidScrollChange(scheduleStateSave);
+    editor.onDidChangeCursorPosition(scheduleStateSave);
 
     // Intentionally NOT registering Monaco's own Cmd+S keybinding. When
     // Monaco's keybinding service claims Cmd+S and preventDefaults, AppKit's

--- a/packages/sdk/src/domain-types.ts
+++ b/packages/sdk/src/domain-types.ts
@@ -122,6 +122,14 @@ export interface Workspace {
   /** Scroll positions keyed by editor record ID: { top, left } in pixels. */
   editorScrollPositions?: Record<string, { top: number; left: number }>;
   /**
+   * Monaco view states keyed by editor record ID. Each value is the opaque
+   * JSON produced by `editor.saveViewState()` — captures cursor position,
+   * selection, scroll, and folded regions. Supersedes
+   * {@link Workspace.editorScrollPositions} for editors that support it;
+   * scroll-only data is kept as a fallback for older persisted workspaces.
+   */
+  editorViewStates?: Record<string, unknown>;
+  /**
    * ISO timestamp of when the workspace was soft-closed, or null/undefined
    * if the workspace is open. Closed workspaces are hidden from the main
    * list and surfaced in a "reopen" picker.


### PR DESCRIPTION
## Summary

- **Wrong panel focused on switch**: When returning to a workspace where a terminal was active, focus was landing in an editor instead. Root cause: `relayoutAndRefit`'s `layout(force=true)` call synchronously fires `onDidActiveChange` for the wrong panel (dockview's stale last-active slot), kicking off a competing `retryFocus` loop in Monaco. Fixed by snapshotting `activePanel` before the layout call and immediately calling `savedPanel.api.setActive()` after, which cancels the stale loop via `stillWanted()` and starts the correct panel's focus sequence.
- **Cursor/scroll position lost after restart**: Editor view state (cursor, selections, scroll, fold regions) was not persisted across app restarts or panel remounts. Fixed by saving Monaco's `saveViewState()` output (debounced, on cursor move and scroll) to `workspace.editorViewStates` and restoring via `restoreViewState()` on `onMount`.
- **One-frame editor flash**: On workspace activation, `retryFocus` fired in RAF 1 and briefly focused Monaco before `relayoutAndRefit` (RAF 2) corrected the active slot — visible as a split-second editor highlight before the terminal took over. Fixed by delaying the backstop `retryFocus` to RAF 3 so it always runs after `relayoutAndRefit` has completed.

## Changes

- `WorkspaceDock.tsx`: Added `lastActivePanelRef` to track which panel was last active per workspace; pre-sets the correct panel on activation; delays `retryFocus` to RAF 3; `relayoutAndRefit` now unconditionally restores the saved active panel after `layout(true)`.
- `workspaces.ts`: Added `setEditorViewState` / `getEditorViewState` helpers; `editorViewStates` field on `Workspace`.
- `domain-types.ts`: Added `editorViewStates?: Record<string, unknown>` to the `Workspace` interface.
- `TextViewer.tsx`: Replaced separate scroll-only save with unified `saveViewState()` (captures cursor + scroll + selections + folds); restores via `restoreViewState()` on mount; saves on unmount.
- `editor-core.ts` / `sdk-internal.ts`: Plumbed `setEditorViewState` / `getEditorViewState` through the internal barrel.

## Test plan

- [ ] Open two workspaces: one with a terminal active, one with an editor active
- [ ] Switch between them — verify focus always lands in the last-active panel with no flash
- [ ] Open a file, move cursor deep into the file, switch workspaces and back — cursor stays put (in-memory)
- [ ] Open a file, move cursor, restart the app — cursor and scroll position restored
- [ ] `pnpm test` green (409 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)