### PR TITLE
feat(output): add Output panel with ctx.log API and grouped channel selector

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "silo"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "core-graphics",

--- a/apps/desktop/src/builtins.ts
+++ b/apps/desktop/src/builtins.ts
@@ -3,6 +3,7 @@ import type { Extension } from "@silo-code/sdk";
 import {
   menu as coreMenu,
   terminal,
+  output,
   editor,
   workspaces,
   themes,
@@ -36,6 +37,7 @@ const builtins: Extension[] = [
   // kinds runs (CenterDock's first render). core.editor registers both the
   // editor and diff kinds (text + diff + settings are its modules).
   terminal,
+  output,
   // The text editor registers before markdown-preview so that, with both at
   // priority 0, a plain .md open ties to Text (the default view); Preview is
   // opt-in via "Open With" / the breadcrumb switcher.

--- a/packages/extension-host/src/components/StatusBar.tsx
+++ b/packages/extension-host/src/components/StatusBar.tsx
@@ -17,6 +17,10 @@ function byPriority(a: StatusItem, b: StatusItem): number {
   return (a.priority ?? 0) - (b.priority ?? 0);
 }
 
+function byPriorityDesc(a: StatusItem, b: StatusItem): number {
+  return (b.priority ?? 0) - (a.priority ?? 0);
+}
+
 /**
  * Status-bar focus behavior. The bar isn't a roving focus group (Tab moves
  * between its items naturally), but its keyboard ring uses the **same** mechanism
@@ -116,7 +120,9 @@ export function StatusBar() {
   const ref = useRef<HTMLDivElement>(null);
   useStatusBarFocus(ref);
   const left = items.filter((i) => i.alignment === "left").sort(byPriority);
-  const right = items.filter((i) => i.alignment === "right").sort(byPriority);
+  const right = items
+    .filter((i) => i.alignment === "right")
+    .sort(byPriorityDesc);
 
   return (
     <div className="status-bar" ref={ref}>

--- a/packages/extension-host/src/extension-host/builtins-registry.ts
+++ b/packages/extension-host/src/extension-host/builtins-registry.ts
@@ -24,6 +24,7 @@ import {
   deactivateExtensionRecord,
 } from "./extension-registry";
 import { dockPanelKindRegistry } from "./dock-panel-kinds";
+import { extHostLog } from "./extension-host-logger";
 import type { Extension, ExtensionContext } from "@silo-code/sdk";
 
 /** Brand shown for every built-in row (built-ins are first-party Silo). */
@@ -63,41 +64,55 @@ const entries = new Map<string, BuiltinEntry>();
 
 /** Create + retain a context, activate, record the API, and detect dock kinds. */
 function activate(entry: BuiltinEntry): void {
+  const id = entry.ext.id;
+  extHostLog.info(`Activating ${id}`);
   const dockBefore = new Set(dockPanelKindRegistry.list().map((k) => k.id));
   // Builtins are first-party — trusted, so `files`/`process` are unscoped.
-  const ctx = createContext(entry.ext.id, { trusted: true });
+  const ctx = createContext(id, {
+    trusted: true,
+    displayName: entry.ext.manifest?.name,
+  });
   const api = entry.ext.activate(ctx);
-  activateExtensionRecord(entry.ext.id, api);
+  activateExtensionRecord(id, api);
   entry.ctx = ctx;
   entry.enabled = true;
   const dockAfter = dockPanelKindRegistry.list().map((k) => k.id);
-  if (dockAfter.some((id) => !dockBefore.has(id))) entry.reloadRequired = true;
+  if (dockAfter.some((k) => !dockBefore.has(k))) {
+    entry.reloadRequired = true;
+    extHostLog.warn(
+      `${id} registered a dock panel kind; disabling may require a window reload`,
+    );
+  }
+  extHostLog.info(`Activated ${id}`);
 }
 
 /** Dispose the retained context's contributions, deactivate, mark inactive. */
 function teardown(entry: BuiltinEntry): void {
+  const id = entry.ext.id;
+  extHostLog.info(`Deactivating ${id}`);
   if (entry.ctx) {
     // Reverse registration order; each registry dispose fires onChange, so
     // status items / side panels / settings pages / commands leave reactively.
-    for (const d of [...entry.ctx.subscriptions].reverse()) safeDispose(d);
+    for (const d of [...entry.ctx.subscriptions].reverse()) safeDispose(id, d);
   }
   try {
     entry.ext.deactivate?.();
   } catch (err) {
-    console.error(`[extensions] deactivate failed: ${entry.ext.id}`, err);
+    extHostLog.error(`Deactivate hook failed: ${id}`, err);
   }
   // Keep the record (builtins are never cleared) but mark it inactive so
   // getExtension(id) resolves an inactive handle rather than undefined.
-  deactivateExtensionRecord(entry.ext.id);
+  deactivateExtensionRecord(id);
   entry.ctx = undefined;
   entry.enabled = false;
+  extHostLog.info(`Deactivated ${id}`);
 }
 
-function safeDispose(d: { dispose: () => void }): void {
+function safeDispose(extensionId: string, d: { dispose: () => void }): void {
   try {
     d.dispose();
   } catch (err) {
-    console.error("[extensions] dispose failed", err);
+    extHostLog.error(`Dispose failed: ${extensionId}`, err);
   }
 }
 
@@ -115,12 +130,15 @@ export function registerBuiltins(
     entries.set(ext.id, { ext, enabled: false, reloadRequired: false });
     recordExtension(ext.id);
   }
+  extHostLog.info(
+    `Registering ${list.length} built-in extensions (${disabled.size} disabled)`,
+  );
   for (const entry of entries.values()) {
     if (disabled.has(entry.ext.id)) continue;
     try {
       activate(entry);
     } catch (err) {
-      console.error(`[extensions] activate failed: ${entry.ext.id}`, err);
+      extHostLog.error(`Activation failed: ${entry.ext.id}`, err);
     }
   }
 }
@@ -130,6 +148,7 @@ export function enableBuiltin(id: string): void {
   const entry = entries.get(id);
   if (!entry || entry.enabled) return;
   activate(entry);
+  extHostLog.info(`Enabled ${id}`);
   void syncMenu();
 }
 
@@ -138,6 +157,7 @@ export function disableBuiltin(id: string): void {
   const entry = entries.get(id);
   if (!entry || !entry.enabled) return;
   teardown(entry);
+  extHostLog.info(`Disabled ${id}`);
   void syncMenu();
 }
 

--- a/packages/extension-host/src/extension-host/context.ts
+++ b/packages/extension-host/src/extension-host/context.ts
@@ -46,6 +46,12 @@ import {
 } from "./extension-storage";
 import { getActiveWorkspace } from "../state/store";
 import type { PathScope } from "./security/resolve-path";
+import {
+  registerChannel,
+  unregisterChannel,
+  pushEntry,
+  clearChannel,
+} from "./output-store";
 
 /**
  * Options for {@link createContext}. Trust and capabilities are supplied by the
@@ -58,6 +64,8 @@ import type { PathScope } from "./security/resolve-path";
 export interface ContextOptions {
   /** First-party (bundled) extension — unscoped `files`/`process`. */
   trusted?: boolean;
+  /** Human-readable display name for this extension's Output channel. Falls back to extensionId. */
+  displayName?: string;
   /** Capabilities granted at install (third-party only). */
   permissions?: readonly Permission[];
 }
@@ -74,6 +82,20 @@ export function createContext(
 
   // The filesystem/process scope for this extension. `roots` is a live getter so
   // it always reflects the active workspace (which switches under the extension).
+  // core.* extensions share a single "Application" channel (idempotent register);
+  // third-party extensions get their own per-extension channel, removed on teardown.
+  const isCoreExtension = extensionId.startsWith("core.");
+  const channelKey = isCoreExtension
+    ? "silo:application"
+    : `ext:${extensionId}`;
+  const channelDisplayName = isCoreExtension
+    ? "Application"
+    : (options.displayName ?? extensionId);
+  registerChannel(channelKey, channelDisplayName, options.trusted);
+  if (!isCoreExtension) {
+    subscriptions.push({ dispose: () => unregisterChannel(channelKey) });
+  }
+
   const permissions = new Set<Permission>(options.permissions ?? []);
   const scope: PathScope = {
     get roots(): readonly string[] {
@@ -142,6 +164,15 @@ export function createContext(
     ui: getUiService(),
     net: getNetworkService(),
     system: getSystemService(),
+    log: {
+      debug: (msg, data) => pushEntry(channelKey, "debug", msg, data),
+      info: (msg, data) => pushEntry(channelKey, "info", msg, data),
+      warn: (msg, data) => pushEntry(channelKey, "warn", msg, data),
+      error: (msg, data) => pushEntry(channelKey, "error", msg, data),
+      show: () =>
+        getLayoutService().openSingletonPanel("output", { title: "Output" }),
+      clear: () => clearChannel(channelKey),
+    },
     getExtension(id) {
       return getExtensionHandle(id);
     },

--- a/packages/extension-host/src/extension-host/extension-host-logger.test.ts
+++ b/packages/extension-host/src/extension-host/extension-host-logger.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { outputStore, clearChannel } from "./output-store";
+
+describe("extension-host-logger", () => {
+  beforeEach(() => {
+    clearChannel("silo:extension-host");
+  });
+
+  it("registers the Extension Host channel on import", async () => {
+    await import("./extension-host-logger");
+    expect(outputStore.channels["silo:extension-host"]).toBeDefined();
+    expect(outputStore.channels["silo:extension-host"].displayName).toBe(
+      "Extension Host",
+    );
+    expect(outputStore.order).toContain("silo:extension-host");
+  });
+
+  it("writes info entries to the channel", async () => {
+    const { extHostLog } = await import("./extension-host-logger");
+    extHostLog.info("test info message");
+    const entries = outputStore.channels["silo:extension-host"].entries;
+    const last = entries[entries.length - 1];
+    expect(last.level).toBe("info");
+    expect(last.message).toBe("test info message");
+    expect(last.data).toBeUndefined();
+  });
+
+  it("writes error entries with structured data", async () => {
+    const { extHostLog } = await import("./extension-host-logger");
+    const err = new Error("boom");
+    extHostLog.error("activation failed", err);
+    const entries = outputStore.channels["silo:extension-host"].entries;
+    const last = entries[entries.length - 1];
+    expect(last.level).toBe("error");
+    expect(last.message).toBe("activation failed");
+    expect(last.data).toBe(err);
+  });
+
+  it("writes warn entries", async () => {
+    const { extHostLog } = await import("./extension-host-logger");
+    extHostLog.warn("dock kind registered");
+    const entries = outputStore.channels["silo:extension-host"].entries;
+    const last = entries[entries.length - 1];
+    expect(last.level).toBe("warn");
+    expect(last.message).toBe("dock kind registered");
+  });
+
+  it("writes debug entries", async () => {
+    const { extHostLog } = await import("./extension-host-logger");
+    extHostLog.debug("verbose detail", { x: 1 });
+    const entries = outputStore.channels["silo:extension-host"].entries;
+    const last = entries[entries.length - 1];
+    expect(last.level).toBe("debug");
+    expect(last.data).toEqual({ x: 1 });
+  });
+
+  it("clear() empties the channel", async () => {
+    const { extHostLog } = await import("./extension-host-logger");
+    extHostLog.info("one");
+    extHostLog.info("two");
+    extHostLog.clear();
+    expect(outputStore.channels["silo:extension-host"].entries).toHaveLength(0);
+  });
+});

--- a/packages/extension-host/src/extension-host/extension-host-logger.ts
+++ b/packages/extension-host/src/extension-host/extension-host-logger.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared logger for the `silo:extension-host` Output channel.
+ *
+ * Imported (and thus created) before any extension activates so the channel
+ * appears first in the Output panel dropdown — ahead of `silo:application`
+ * and any `ext:*` channels.
+ * @internal
+ */
+import { createHostChannel } from "./output-store";
+
+export const extHostLog = createHostChannel(
+  "silo:extension-host",
+  "Extension Host",
+);

--- a/packages/extension-host/src/extension-host/extension-loader.ts
+++ b/packages/extension-host/src/extension-host/extension-loader.ts
@@ -23,6 +23,7 @@ import {
 import { dockPanelKindRegistry } from "./dock-panel-kinds";
 import { installExtensionDeps, SHARED_DEPS } from "./extension-deps";
 import { fsReadText } from "../services/tauri-fs";
+import { extHostLog } from "./extension-host-logger";
 import type { Extension, ExtensionContext, Permission } from "@silo-code/sdk";
 
 /** What the loader needs to load one extension. */
@@ -134,6 +135,8 @@ export async function loadExtension(spec: LoadSpec): Promise<void> {
 
   const shims = ensureDepShims();
   const bundlePath = `${spec.dir.replace(/\/+$/, "")}/${spec.main}`;
+  extHostLog.info(`Loading ${spec.id} from ${bundlePath}`);
+
   const source = await fsReadText(bundlePath);
   const rewritten = rewriteSpecifiers(source, shims);
 
@@ -164,6 +167,7 @@ export async function loadExtension(spec: LoadSpec): Promise<void> {
     ctx = createContext(ext.id, {
       trusted: false,
       permissions: spec.permissions,
+      displayName: ext.manifest?.name,
     });
     const api = ext.activate(ctx);
     activateExtensionRecord(ext.id, api);
@@ -175,16 +179,19 @@ export async function loadExtension(spec: LoadSpec): Promise<void> {
       // limitation"); the example uses a side panel instead. Recorded so the
       // Extensions page can show a "reload to finish disabling" hint.
       reloadRequiredIds.add(ext.id);
-      console.warn(
-        `[extensions] ${ext.id} registered a dock panel kind; disabling it may require a window reload`,
+      extHostLog.warn(
+        `${ext.id} registered a dock panel kind; disabling may require a window reload`,
       );
     }
 
     loaded.set(spec.id, { ctx, extension: ext, blobUrl });
+    extHostLog.info(`Loaded ${spec.id}`);
     void syncMenu();
   } catch (err) {
+    extHostLog.error(`Load failed: ${spec.id}`, err);
     // Roll back a partial activation so a failed load leaves nothing behind.
-    if (ctx) for (const d of [...ctx.subscriptions].reverse()) safeDispose(d);
+    if (ctx)
+      for (const d of [...ctx.subscriptions].reverse()) safeDispose(spec.id, d);
     clearExtensionRecord(spec.id);
     URL.revokeObjectURL(blobUrl);
     throw err;
@@ -195,18 +202,20 @@ export async function loadExtension(spec: LoadSpec): Promise<void> {
 export function unloadExtension(id: string): void {
   const entry = loaded.get(id);
   if (!entry) return;
+  extHostLog.info(`Unloading ${id}`);
   // Dispose in reverse registration order; each registry dispose removes the
   // contribution and fires onChange, so status items / settings pages / side
   // panels / commands / keybindings / menu items leave the UI reactively.
-  for (const d of [...entry.ctx.subscriptions].reverse()) safeDispose(d);
+  for (const d of [...entry.ctx.subscriptions].reverse()) safeDispose(id, d);
   try {
     entry.extension.deactivate?.();
   } catch (err) {
-    console.error(`[extensions] deactivate failed: ${id}`, err);
+    extHostLog.error(`Deactivate hook failed: ${id}`, err);
   }
   clearExtensionRecord(id);
   URL.revokeObjectURL(entry.blobUrl);
   loaded.delete(id);
+  extHostLog.info(`Unloaded ${id}`);
   // Drop any contributed native menu items.
   void syncMenu();
 }
@@ -215,10 +224,10 @@ export function isLoaded(id: string): boolean {
   return loaded.has(id);
 }
 
-function safeDispose(d: { dispose: () => void }): void {
+function safeDispose(extensionId: string, d: { dispose: () => void }): void {
   try {
     d.dispose();
   } catch (err) {
-    console.error("[extensions] dispose failed", err);
+    extHostLog.error(`Dispose failed: ${extensionId}`, err);
   }
 }

--- a/packages/extension-host/src/extension-host/layout-service.ts
+++ b/packages/extension-host/src/extension-host/layout-service.ts
@@ -56,6 +56,24 @@ export function getLayoutService(): LayoutService {
       const panel = api.addPanel({ id, component: kindId, title, params });
       panel.api.setActive();
     },
+    openSingletonPanel(kindId, params) {
+      const api = getActiveDockApi();
+      if (!api) return;
+      // Use kindId as the panel id so at most one instance can exist.
+      const existing = api.getPanel(kindId);
+      if (existing) {
+        existing.api.setActive();
+        return;
+      }
+      const title = (params?.title as string | undefined) ?? kindId;
+      const panel = api.addPanel({
+        id: kindId,
+        component: kindId,
+        title,
+        params,
+      });
+      panel.api.setActive();
+    },
     revealSidePanel(id) {
       const panel = sidePanelRegistry.get(id);
       if (!panel) return;

--- a/packages/extension-host/src/extension-host/output-store.ts
+++ b/packages/extension-host/src/extension-host/output-store.ts
@@ -1,0 +1,121 @@
+/**
+ * Per-channel output log store — the valtio proxy that backs the Output panel
+ * (`core.output`). Each channel maintains an independent ring buffer so a
+ * noisy source cannot crowd out entries from other channels.
+ *
+ * The write path is via `ctx.log` (public SDK) and `createHostChannel`
+ * (host-internal, for built-in channels like `silo:notifications`). The read
+ * path is `outputStore`, exported to `core.*` via `sdk-internal.ts`.
+ *
+ * Channel key scheme:
+ *   `silo:application` — shared channel for all `core.*` built-in extensions
+ *   `silo:<name>` — other host channels (notifications, future lint/build)
+ *   `ext:<extensionId>` — one auto-managed channel per third-party extension
+ */
+
+import { proxy } from "valtio";
+import type { LogLevel } from "@silo-code/sdk";
+
+/** Maximum entries per channel before the oldest are silently dropped. */
+export const MAX_CHANNEL_ENTRIES = 5_000;
+
+/**
+ * A single log entry in an output channel.
+ * @internal
+ */
+export interface OutputEntry {
+  /** Monotonic, unique per entry across all channels. */
+  id: number;
+  level: LogLevel;
+  message: string;
+  /** Optional structured payload — rendered as JSON in the panel. */
+  data?: unknown;
+  /** Unix epoch milliseconds from Date.now(). */
+  timestamp: number;
+}
+
+/**
+ * The state for one named output channel.
+ * @internal
+ */
+export interface OutputChannelState {
+  key: string;
+  displayName: string;
+  entries: OutputEntry[];
+  /** True for first-party bundled extensions (trusted); false/absent for third-party. */
+  builtin?: boolean;
+}
+
+/**
+ * Reactive output store. The `order` array preserves insertion order so the
+ * channel dropdown is stable across re-renders.
+ * @internal
+ */
+export const outputStore = proxy<{
+  channels: Record<string, OutputChannelState>;
+  order: string[];
+}>({ channels: {}, order: [] });
+
+let nextId = 0;
+
+/** Register a channel; idempotent if the key already exists. @internal */
+export function registerChannel(
+  key: string,
+  displayName: string,
+  builtin?: boolean,
+): void {
+  if (outputStore.channels[key]) return;
+  outputStore.channels[key] = { key, displayName, entries: [], builtin };
+  outputStore.order.push(key);
+}
+
+/** Remove a channel and its entries. @internal */
+export function unregisterChannel(key: string): void {
+  delete outputStore.channels[key];
+  outputStore.order = outputStore.order.filter((k) => k !== key);
+}
+
+/** Append an entry to a channel, trimming oldest if over the cap. @internal */
+export function pushEntry(
+  key: string,
+  level: LogLevel,
+  message: string,
+  data?: unknown,
+): void {
+  const ch = outputStore.channels[key];
+  if (!ch) return;
+  if (ch.entries.length >= MAX_CHANNEL_ENTRIES) {
+    ch.entries.splice(0, ch.entries.length - MAX_CHANNEL_ENTRIES + 1);
+  }
+  const entry: OutputEntry = {
+    id: nextId++,
+    level,
+    message,
+    timestamp: Date.now(),
+  };
+  if (data !== undefined) entry.data = data;
+  ch.entries.push(entry);
+}
+
+/** Remove all entries from a channel. @internal */
+export function clearChannel(key: string): void {
+  const ch = outputStore.channels[key];
+  if (ch) ch.entries.splice(0, ch.entries.length);
+}
+
+/**
+ * Create a host-owned output channel (e.g. `silo:notifications`).
+ * Exported via `sdk-internal.ts` for use by host services that need to write
+ * to the Output panel without going through `ctx.log`.
+ * @internal
+ */
+export function createHostChannel(key: string, displayName: string) {
+  registerChannel(key, displayName);
+  return {
+    debug: (msg: string, data?: unknown) => pushEntry(key, "debug", msg, data),
+    info: (msg: string, data?: unknown) => pushEntry(key, "info", msg, data),
+    warn: (msg: string, data?: unknown) => pushEntry(key, "warn", msg, data),
+    error: (msg: string, data?: unknown) => pushEntry(key, "error", msg, data),
+    clear: () => clearChannel(key),
+  };
+}

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -194,6 +194,14 @@ export {
 } from "../docked/dock-api-registry";
 export { cycleRegionFocus } from "./focus-regions";
 
+// Output panel store — per-channel valtio state read by the core.output dock
+// panel. The write path is public (`ctx.log`, auto-channel per extension, plus
+// `ctx.ui.notify` → the silo:notifications channel). Only core.output needs to
+// read back entries; `createHostChannel` lets other host services (e.g.
+// future build/lint) add channels without going through `ctx`.
+export { outputStore, createHostChannel, clearChannel } from "./output-store";
+export type { OutputChannelState, OutputEntry } from "./output-store";
+
 // Dev-shell window actions (Reload / Inspect Element) the base menu (core.menu)
 // surfaces under the Window menu in dev builds, replacing what the now-suppressed
 // native context menu used to offer. Host/platform-bound, core-only.

--- a/packages/extension-host/src/extension-host/ui-service.ts
+++ b/packages/extension-host/src/extension-host/ui-service.ts
@@ -12,6 +12,14 @@ import {
 } from "./modal-service";
 import { getActiveSelectionText } from "./active-selection";
 import type { NotifyAction, NotifyOptions, UiService } from "@silo-code/sdk";
+import { createHostChannel } from "./output-store";
+
+// All notifications are also mirrored into the Output panel's "Notifications"
+// channel so users can review them after the toast has dismissed.
+const notificationsChannel = createHostChannel(
+  "silo:notifications",
+  "Notifications",
+);
 
 // `ctx.ui` — the user-interaction domain. The host renders the chrome;
 // extensions ask. This is the single sanctioned way an extension talks to the
@@ -178,6 +186,7 @@ export function getUiService(): UiService {
     },
     notify(level, message, options) {
       pushToast(level, message, options);
+      notificationsChannel[level](message);
     },
     showMenu(opts) {
       return openMenu(opts);

--- a/packages/extensions-core/src/index.ts
+++ b/packages/extensions-core/src/index.ts
@@ -22,3 +22,4 @@ export { extension as extensions } from "./extensions";
 export { extension as panelToggles } from "./statusbar/panel-toggles";
 export { extension as settingsButton } from "./statusbar/settings-button";
 export { extension as updates } from "./statusbar/updates";
+export { extension as output } from "./output";

--- a/packages/extensions-core/src/menu/index.ts
+++ b/packages/extensions-core/src/menu/index.ts
@@ -200,7 +200,7 @@ export const extension: Extension = {
       command: "core.newFile",
       accelerator: "CmdOrCtrl+N",
       group: "1_new",
-      order: 1,
+      order: -20,
     });
     ctx.registerMenuItem({
       id: "core.menu.openFile",
@@ -208,7 +208,7 @@ export const extension: Extension = {
       command: "core.openFile",
       accelerator: "CmdOrCtrl+O",
       group: "1_new",
-      order: 2,
+      order: -10,
     });
     ctx.registerMenuItem({
       id: "core.menu.save",
@@ -216,7 +216,7 @@ export const extension: Extension = {
       command: "core.save",
       accelerator: "CmdOrCtrl+S",
       group: "2_save",
-      order: 1,
+      order: -20,
     });
     ctx.registerMenuItem({
       id: "core.menu.saveAs",
@@ -224,7 +224,7 @@ export const extension: Extension = {
       command: "core.saveAs",
       accelerator: "CmdOrCtrl+Shift+S",
       group: "2_save",
-      order: 2,
+      order: -10,
     });
     ctx.registerMenuItem({
       id: "core.menu.closeTab",
@@ -232,7 +232,7 @@ export const extension: Extension = {
       command: "core.closeTab",
       accelerator: "CmdOrCtrl+W",
       group: "3_close",
-      order: 1,
+      order: -10,
     });
 
     // View menu
@@ -242,7 +242,7 @@ export const extension: Extension = {
       command: "settings.open",
       accelerator: "CmdOrCtrl+,",
       group: "0_settings",
-      order: 1,
+      order: -10,
     });
     ctx.registerMenuItem({
       id: "view.toggleLeftPanel.menu",
@@ -250,7 +250,7 @@ export const extension: Extension = {
       command: "view.toggleLeftPanel",
       accelerator: "CmdOrCtrl+Alt+[",
       group: "1_layout",
-      order: 1,
+      order: -20,
     });
     ctx.registerMenuItem({
       id: "view.toggleRightPanel.menu",
@@ -258,7 +258,7 @@ export const extension: Extension = {
       command: "view.toggleRightPanel",
       accelerator: "CmdOrCtrl+Alt+]",
       group: "1_layout",
-      order: 2,
+      order: -10,
     });
     ctx.registerMenuItem({
       id: "core.menu.zoomIn",
@@ -266,7 +266,7 @@ export const extension: Extension = {
       command: "core.zoomIn",
       accelerator: "CmdOrCtrl+=",
       group: "1_zoom",
-      order: 1,
+      order: -30,
     });
     ctx.registerMenuItem({
       id: "core.menu.zoomOut",
@@ -274,7 +274,7 @@ export const extension: Extension = {
       command: "core.zoomOut",
       accelerator: "CmdOrCtrl+-",
       group: "1_zoom",
-      order: 2,
+      order: -20,
     });
     ctx.registerMenuItem({
       id: "core.menu.zoomReset",
@@ -282,7 +282,7 @@ export const extension: Extension = {
       command: "core.zoomReset",
       accelerator: "CmdOrCtrl+0",
       group: "1_zoom",
-      order: 3,
+      order: -10,
     });
 
     // Window menu
@@ -292,7 +292,7 @@ export const extension: Extension = {
       command: "core.newTerminal",
       accelerator: "CmdOrCtrl+T",
       group: "1_term",
-      order: 1,
+      order: -10,
     });
 
     // Help menu — link items present on all platforms. About + Check for
@@ -325,21 +325,21 @@ export const extension: Extension = {
       menu: "help",
       command: "core.openDocumentation",
       group: "1_links",
-      order: 1,
+      order: -30,
     });
     ctx.registerMenuItem({
       id: "core.help.extensions",
       menu: "help",
       command: "core.openExtensions",
       group: "1_links",
-      order: 2,
+      order: -20,
     });
     ctx.registerMenuItem({
       id: "core.help.github",
       menu: "help",
       command: "core.openGitHub",
       group: "1_links",
-      order: 3,
+      order: -10,
     });
 
     // Dev-only Window items. Silo suppresses the webview's native context menu
@@ -362,7 +362,7 @@ export const extension: Extension = {
         command: "core.reloadWindow",
         accelerator: "CmdOrCtrl+R",
         group: "9_dev",
-        order: 1,
+        order: -20,
       });
       ctx.registerMenuItem({
         id: "core.menu.toggleDevtools",
@@ -370,7 +370,7 @@ export const extension: Extension = {
         command: "core.toggleDevtools",
         accelerator: "CmdOrCtrl+Alt+I",
         group: "9_dev",
-        order: 2,
+        order: -10,
       });
     }
   },

--- a/packages/extensions-core/src/output/OutputPanel.css
+++ b/packages/extensions-core/src/output/OutputPanel.css
@@ -1,0 +1,175 @@
+.output-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  color-scheme: inherit;
+}
+
+/* ── toolbar ── matches the web-viewer toolbar pattern ───────────────────── */
+
+.output-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  background: var(--silo-color-toolbar-bg);
+  border-bottom: 1px solid var(--silo-color-border);
+  flex-shrink: 0;
+}
+
+/* Selects and inputs: 26px height, invisible border (matches bg) until focus */
+.output-toolbar select,
+.output-toolbar input[type="search"] {
+  height: 26px;
+  padding: 0 8px;
+  font-size: var(--silo-font-size-sm);
+  font-family: var(--silo-font-ui);
+  background-color: var(--silo-color-toolbar-input-bg);
+  color: var(--silo-color-toolbar-text);
+  border: 1px solid var(--silo-color-toolbar-input-bg);
+  border-radius: var(--silo-radius-sm);
+  outline: none;
+}
+
+/* Strip native macOS chrome (single border) and add custom chevron arrow */
+.output-toolbar select {
+  -webkit-appearance: none;
+  appearance: none;
+  padding-right: 22px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpolyline points='1,1 5,5 9,1' fill='none' stroke='%23c0c0c0' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  background-size: 8px 5px;
+}
+
+[data-theme="light"] .output-toolbar select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpolyline points='1,1 5,5 9,1' fill='none' stroke='%234a4a4a' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+/* Suppress the global theme outline (theme.css sets outline: 1.5px on focus-visible);
+   border-color change below is the sole focus indicator, matching the settings dialog pattern. */
+.output-toolbar :is(select, input):focus-visible {
+  outline: none;
+}
+
+.output-toolbar select:focus,
+.output-toolbar input[type="search"]:focus {
+  border-color: var(--silo-color-accent);
+}
+
+.output-channel-select {
+  min-width: 120px;
+  max-width: 180px;
+}
+
+.output-search {
+  flex: 1;
+  min-width: 60px;
+}
+
+.output-level-select {
+  width: 88px;
+}
+
+/* Icon-only toolbar buttons — matches the lwv-btn pattern */
+.output-icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+  border-radius: var(--silo-radius-sm);
+  background: transparent;
+  color: var(--silo-color-toolbar-text);
+  cursor: pointer;
+}
+
+.output-icon-btn:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+.output-icon-btn.on {
+  color: var(--silo-color-accent);
+  border-color: var(--silo-color-accent);
+  background: color-mix(in srgb, var(--silo-color-accent) 16%, transparent);
+}
+
+/* ── log list ── content-bg matches editor + web viewer ─────────────────── */
+
+.output-list {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--silo-color-content-bg);
+  color: var(--silo-color-content-text);
+  font-family: var(--silo-font-mono);
+  font-size: calc(var(--silo-font-size-base) + 1px);
+  line-height: 1.6;
+}
+
+.output-empty {
+  padding: 12px 10px;
+  color: var(--silo-color-text-lo);
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+}
+
+.output-entry {
+  display: flex;
+  flex-direction: column;
+  padding: 0 10px;
+}
+
+.output-entry-line {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.output-entry:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+.output-ts {
+  color: var(--silo-color-text-lo);
+  min-width: 56px;
+  flex-shrink: 0;
+}
+
+.output-level {
+  min-width: 38px;
+  flex-shrink: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.8em;
+  color: var(--silo-color-text-lo);
+}
+
+.output-msg {
+  flex: 1;
+  word-break: break-word;
+}
+
+.output-data {
+  padding-left: 110px;
+  color: var(--silo-color-text-lo);
+  font-size: 0.85em;
+  word-break: break-all;
+}
+
+/* Level color overrides */
+.output-entry[data-level="debug"] {
+  color: var(--silo-color-text-lo);
+}
+
+.output-entry[data-level="warn"] .output-level {
+  color: var(--silo-color-warn);
+}
+
+.output-entry[data-level="error"] .output-level,
+.output-entry[data-level="error"] .output-msg {
+  color: var(--silo-color-err);
+}

--- a/packages/extensions-core/src/output/OutputPanel.tsx
+++ b/packages/extensions-core/src/output/OutputPanel.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef, useState } from "react";
+import { useSnapshot } from "valtio";
+import type { IDockviewPanelProps } from "dockview";
+import { Tooltip } from "@silo-code/sdk";
+import { X, ArrowLineDown } from "@phosphor-icons/react";
+import {
+  outputStore,
+  clearChannel,
+  type OutputEntry,
+} from "@silo-code/extension-host/internal";
+import {
+  filterEntries,
+  formatTimestamp,
+  channelOptions,
+  type OutputFilter,
+} from "./output-model";
+import "./OutputPanel.css";
+
+export function OutputPanel(_props: IDockviewPanelProps) {
+  const snap = useSnapshot(outputStore);
+  const { host, builtinExtensions, extensions } = channelOptions(
+    snap.channels as typeof outputStore.channels,
+    snap.order as string[],
+  );
+
+  const [selectedKey, setSelectedKey] = useState<string>("silo:notifications");
+  const [filter, setFilter] = useState<OutputFilter>({
+    level: "all",
+    search: "",
+  });
+  const [autoScroll, setAutoScroll] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Fall back to the first available channel if the selected one was disposed
+  const activeKey = snap.channels[selectedKey]
+    ? selectedKey
+    : (host[0]?.key ?? builtinExtensions[0]?.key ?? extensions[0]?.key ?? "");
+
+  const rawEntries = (snap.channels[activeKey]?.entries ??
+    []) as readonly OutputEntry[];
+  const filtered = filterEntries(rawEntries, filter);
+
+  useEffect(() => {
+    if (autoScroll && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [filtered.length, autoScroll]);
+
+  return (
+    <div className="output-panel">
+      <div className="output-toolbar">
+        <select
+          className="output-channel-select"
+          value={activeKey}
+          onChange={(e) => setSelectedKey(e.target.value)}
+          aria-label="Channel"
+        >
+          {host.map(({ key, displayName }) => (
+            <option key={key} value={key}>
+              {displayName}
+            </option>
+          ))}
+          {builtinExtensions.length > 0 && (
+            <optgroup label="Built-in Extensions">
+              {builtinExtensions.map(({ key, displayName }) => (
+                <option key={key} value={key}>
+                  {displayName}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {extensions.length > 0 && (
+            <optgroup label="Extensions">
+              {extensions.map(({ key, displayName }) => (
+                <option key={key} value={key}>
+                  {displayName}
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </select>
+        <input
+          className="output-search"
+          type="search"
+          placeholder="Filter..."
+          value={filter.search}
+          onChange={(e) => setFilter((f) => ({ ...f, search: e.target.value }))}
+          aria-label="Filter entries"
+          autoCapitalize="off"
+          autoCorrect="off"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <select
+          className="output-level-select"
+          value={filter.level}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              level: e.target.value as OutputFilter["level"],
+            }))
+          }
+          aria-label="Log level"
+        >
+          <option value="all">All Levels</option>
+          <option value="debug">Debug</option>
+          <option value="info">Info</option>
+          <option value="warn">Warn</option>
+          <option value="error">Error</option>
+        </select>
+        <Tooltip content="Clear">
+          <button
+            className="output-icon-btn"
+            onClick={() => activeKey && clearChannel(activeKey)}
+            aria-label="Clear"
+          >
+            <X size={14} />
+          </button>
+        </Tooltip>
+        <Tooltip content={autoScroll ? "Auto-scroll on" : "Auto-scroll off"}>
+          <button
+            className={`output-icon-btn${autoScroll ? " on" : ""}`}
+            onClick={() => setAutoScroll((v) => !v)}
+            aria-pressed={autoScroll}
+            aria-label="Toggle auto-scroll"
+          >
+            <ArrowLineDown size={14} />
+          </button>
+        </Tooltip>
+      </div>
+      <div className="output-list" ref={scrollRef}>
+        {filtered.length === 0 ? (
+          <div className="output-empty">No entries.</div>
+        ) : (
+          filtered.map((entry) => (
+            <div
+              key={entry.id}
+              className="output-entry"
+              data-level={entry.level}
+            >
+              <div className="output-entry-line">
+                <span className="output-ts">
+                  {formatTimestamp(entry.timestamp)}
+                </span>
+                <span className="output-level">{entry.level}</span>
+                <span className="output-msg">{entry.message}</span>
+              </div>
+              {entry.data !== undefined && (
+                <div className="output-data">
+                  {typeof entry.data === "string"
+                    ? entry.data
+                    : JSON.stringify(entry.data)}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-core/src/output/index.tsx
+++ b/packages/extensions-core/src/output/index.tsx
@@ -1,0 +1,63 @@
+import type { Extension } from "@silo-code/sdk";
+import type { IDockviewPanelProps } from "dockview";
+import { Code } from "@phosphor-icons/react";
+import { OutputPanel } from "./OutputPanel";
+
+export const extension: Extension = {
+  id: "core.output",
+  manifest: {
+    name: "Output",
+    description:
+      "Aggregated log output from extensions and built-in subsystems.",
+  },
+  activate(ctx) {
+    ctx.registerDockPanelKind({
+      id: "output",
+      component: ((props: IDockviewPanelProps) => (
+        <OutputPanel {...props} />
+      )) as React.ComponentType<IDockviewPanelProps>,
+      addMenuItem: {
+        label: "Output",
+        params: { title: "Output" },
+      },
+    });
+
+    ctx.registerCommand({
+      id: "core.openOutput",
+      label: "Output",
+      run: () => ctx.layout.openSingletonPanel("output", { title: "Output" }),
+    });
+
+    ctx.registerMenuItem({
+      id: "core.menu.openOutput",
+      menu: "view",
+      command: "core.openOutput",
+      group: "2_panels",
+      order: -10,
+    });
+
+    function OutputButton() {
+      return (
+        <button
+          className="settings-button"
+          aria-label="Output"
+          onClick={() =>
+            ctx.layout.openSingletonPanel("output", { title: "Output" })
+          }
+        >
+          <Code size="1.3em" weight="bold" />
+        </button>
+      );
+    }
+
+    ctx.registerStatusItem({
+      id: "core.output.button",
+      alignment: "right",
+      // Right of settings (-10), left of panel-toggles (-20). Right items sort
+      // descending so lower priority = closer to the right edge.
+      priority: -12,
+      tooltip: "Open Output panel",
+      component: OutputButton,
+    });
+  },
+};

--- a/packages/extensions-core/src/output/output-model.test.ts
+++ b/packages/extensions-core/src/output/output-model.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterEntries,
+  formatTimestamp,
+  channelOptions,
+  type OutputFilter,
+} from "./output-model";
+import type { OutputEntry } from "@silo-code/extension-host/internal";
+
+function entry(
+  id: number,
+  level: OutputEntry["level"],
+  message: string,
+): OutputEntry {
+  return { id, level, message, timestamp: 0 };
+}
+
+describe("filterEntries", () => {
+  const entries: OutputEntry[] = [
+    entry(0, "debug", "connecting"),
+    entry(1, "info", "connected"),
+    entry(2, "warn", "slow response"),
+    entry(3, "error", "connection failed"),
+    entry(4, "info", "retrying connection"),
+  ];
+
+  it("returns same array reference when filter is all+empty", () => {
+    const filter: OutputFilter = { level: "all", search: "" };
+    expect(filterEntries(entries, filter)).toBe(entries);
+  });
+
+  it("filters by level", () => {
+    const result = filterEntries(entries, { level: "info", search: "" });
+    expect(result.map((e) => e.id)).toEqual([1, 4]);
+  });
+
+  it("excludes all entries when level matches nothing", () => {
+    const result = filterEntries([entry(0, "debug", "x")], {
+      level: "error",
+      search: "",
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("filters by case-insensitive substring search", () => {
+    const result = filterEntries(entries, { level: "all", search: "CONN" });
+    expect(result.map((e) => e.id)).toEqual([0, 1, 3, 4]);
+  });
+
+  it("partial match passes", () => {
+    const result = filterEntries(entries, { level: "all", search: "slow" });
+    expect(result.map((e) => e.id)).toEqual([2]);
+  });
+
+  it("both dims active — entry must satisfy both", () => {
+    const result = filterEntries(entries, { level: "info", search: "retry" });
+    expect(result.map((e) => e.id)).toEqual([4]);
+  });
+
+  it("entry that fails level is excluded even if search matches", () => {
+    const result = filterEntries(entries, {
+      level: "warn",
+      search: "connection",
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array for empty entries", () => {
+    expect(filterEntries([], { level: "all", search: "" })).toHaveLength(0);
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("formats midnight as 00:00:00", () => {
+    const midnight = new Date("2024-01-01T00:00:00").getTime();
+    expect(formatTimestamp(midnight)).toBe("00:00:00");
+  });
+
+  it("formats noon as 12:00:00", () => {
+    const noon = new Date("2024-01-01T12:00:00").getTime();
+    expect(formatTimestamp(noon)).toBe("12:00:00");
+  });
+
+  it("formats end-of-day as 23:59:59", () => {
+    const eod = new Date("2024-01-01T23:59:59").getTime();
+    expect(formatTimestamp(eod)).toBe("23:59:59");
+  });
+
+  it("zero-pads single-digit hours, minutes, and seconds", () => {
+    const ts = new Date("2024-01-01T03:07:09").getTime();
+    expect(formatTimestamp(ts)).toBe("03:07:09");
+  });
+
+  it("produces a HH:MM:SS shaped string", () => {
+    const ts = Date.now();
+    expect(formatTimestamp(ts)).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe("channelOptions", () => {
+  it("splits by silo: prefix and builtin flag", () => {
+    const channels = {
+      "silo:notifications": {
+        key: "silo:notifications",
+        displayName: "Notifications",
+        entries: [],
+      },
+      "ext:silo.git": {
+        key: "ext:silo.git",
+        displayName: "Git",
+        entries: [],
+        builtin: true,
+      },
+      "ext:acme.foo": {
+        key: "ext:acme.foo",
+        displayName: "Foo",
+        entries: [],
+        builtin: false,
+      },
+    };
+    const order = ["silo:notifications", "ext:silo.git", "ext:acme.foo"];
+    const result = channelOptions(channels, order);
+    expect(result.host).toEqual([
+      { key: "silo:notifications", displayName: "Notifications" },
+    ]);
+    expect(result.builtinExtensions).toEqual([
+      { key: "ext:silo.git", displayName: "Git" },
+    ]);
+    expect(result.extensions).toEqual([
+      { key: "ext:acme.foo", displayName: "Foo" },
+    ]);
+  });
+
+  it("a silo.* ext without builtin flag goes into extensions, not builtinExtensions", () => {
+    const channels = {
+      "ext:silo.docs-panel": {
+        key: "ext:silo.docs-panel",
+        displayName: "silo.docs-panel",
+        entries: [],
+      },
+    };
+    const result = channelOptions(channels, ["ext:silo.docs-panel"]);
+    expect(result.builtinExtensions).toHaveLength(0);
+    expect(result.extensions).toHaveLength(1);
+  });
+
+  it("skips keys missing from channels", () => {
+    const channels = {
+      "ext:acme.bar": { key: "ext:acme.bar", displayName: "Bar", entries: [] },
+    };
+    const order = ["silo:notifications", "ext:silo.git", "ext:acme.bar"];
+    const result = channelOptions(channels, order);
+    expect(result.host).toHaveLength(0);
+    expect(result.builtinExtensions).toHaveLength(0);
+    expect(result.extensions).toHaveLength(1);
+    expect(result.extensions[0].key).toBe("ext:acme.bar");
+  });
+
+  it("returns empty groups for empty inputs", () => {
+    expect(channelOptions({}, [])).toEqual({
+      host: [],
+      builtinExtensions: [],
+      extensions: [],
+    });
+  });
+
+  it("preserves insertion order within each group", () => {
+    const channels = {
+      "silo:b": { key: "silo:b", displayName: "B", entries: [] },
+      "silo:a": { key: "silo:a", displayName: "A", entries: [] },
+      "ext:silo.y": {
+        key: "ext:silo.y",
+        displayName: "Y",
+        entries: [],
+        builtin: true,
+      },
+      "ext:silo.z": {
+        key: "ext:silo.z",
+        displayName: "Z",
+        entries: [],
+        builtin: true,
+      },
+      "ext:vendor.p": { key: "ext:vendor.p", displayName: "P", entries: [] },
+      "ext:vendor.q": { key: "ext:vendor.q", displayName: "Q", entries: [] },
+    };
+    const order = [
+      "silo:a",
+      "silo:b",
+      "ext:silo.y",
+      "ext:silo.z",
+      "ext:vendor.p",
+      "ext:vendor.q",
+    ];
+    const result = channelOptions(channels, order);
+    expect(result.host.map((c) => c.key)).toEqual(["silo:a", "silo:b"]);
+    expect(result.builtinExtensions.map((c) => c.key)).toEqual([
+      "ext:silo.y",
+      "ext:silo.z",
+    ]);
+    expect(result.extensions.map((c) => c.key)).toEqual([
+      "ext:vendor.p",
+      "ext:vendor.q",
+    ]);
+  });
+
+  it("handles only host channels", () => {
+    const channels = {
+      "silo:app": { key: "silo:app", displayName: "Application", entries: [] },
+    };
+    const result = channelOptions(channels, ["silo:app"]);
+    expect(result.host).toHaveLength(1);
+    expect(result.builtinExtensions).toHaveLength(0);
+    expect(result.extensions).toHaveLength(0);
+  });
+
+  it("handles only third-party extensions", () => {
+    const channels = {
+      "ext:acme.main": {
+        key: "ext:acme.main",
+        displayName: "Acme",
+        entries: [],
+        builtin: false,
+      },
+    };
+    const result = channelOptions(channels, ["ext:acme.main"]);
+    expect(result.host).toHaveLength(0);
+    expect(result.builtinExtensions).toHaveLength(0);
+    expect(result.extensions).toHaveLength(1);
+  });
+});

--- a/packages/extensions-core/src/output/output-model.ts
+++ b/packages/extensions-core/src/output/output-model.ts
@@ -1,0 +1,82 @@
+import type { LogLevel } from "@silo-code/sdk";
+import type {
+  OutputChannelState,
+  OutputEntry,
+} from "@silo-code/extension-host/internal";
+
+export interface OutputFilter {
+  level: LogLevel | "all";
+  search: string;
+}
+
+/**
+ * Filter entries by level and/or substring search on the message.
+ * Returns the original array reference unchanged when both dimensions are
+ * at their defaults (stable identity for React memo/useEffect deps).
+ */
+export function filterEntries(
+  entries: readonly OutputEntry[],
+  filter: OutputFilter,
+): readonly OutputEntry[] {
+  if (filter.level === "all" && filter.search === "") return entries;
+  const lq = filter.search.toLowerCase();
+  return entries.filter((e) => {
+    if (filter.level !== "all" && e.level !== filter.level) return false;
+    if (lq && !e.message.toLowerCase().includes(lq)) return false;
+    return true;
+  });
+}
+
+/** Format a Unix epoch millisecond timestamp as HH:MM:SS (24-hour, zero-padded). */
+export function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+export interface ChannelOption {
+  key: string;
+  displayName: string;
+}
+
+export interface GroupedChannelOptions {
+  /** `silo:*` host channels — rendered flat with no group header. */
+  host: ChannelOption[];
+  /** `ext:silo.*` first-party bundled extensions — "Built-in Extensions" group. */
+  builtinExtensions: ChannelOption[];
+  /** All other `ext:*` channels — "Extensions" group. */
+  extensions: ChannelOption[];
+}
+
+/**
+ * Build the ordered channel list for the dropdown selector, split into three
+ * groups:
+ *   - `silo:*`             → host channels, rendered flat with no group header
+ *   - `ext:*` + builtin    → first-party bundled extensions ("Built-in Extensions")
+ *   - `ext:*` + !builtin   → third-party installed extensions ("Extensions")
+ *
+ * Keys present in `order` but absent from `channels` are skipped safely.
+ */
+export function channelOptions(
+  channels: Record<string, OutputChannelState>,
+  order: string[],
+): GroupedChannelOptions {
+  const host: ChannelOption[] = [];
+  const builtinExtensions: ChannelOption[] = [];
+  const extensions: ChannelOption[] = [];
+  for (const key of order) {
+    const ch = channels[key];
+    if (!ch) continue;
+    const item = { key, displayName: ch.displayName };
+    if (key.startsWith("silo:")) {
+      host.push(item);
+    } else if (ch.builtin) {
+      builtinExtensions.push(item);
+    } else {
+      extensions.push(item);
+    }
+  }
+  return { host, builtinExtensions, extensions };
+}

--- a/packages/extensions-core/src/statusbar/panel-toggles/index.tsx
+++ b/packages/extensions-core/src/statusbar/panel-toggles/index.tsx
@@ -98,7 +98,9 @@ export const extension: Extension = {
     ctx.registerStatusItem({
       id: "panel-toggles",
       alignment: "right",
-      priority: 0,
+      // Rightmost built-in item (at the right edge). Right items sort
+      // descending so the most negative priority lands at the far right.
+      priority: -20,
       component: PanelToggles,
     });
   },

--- a/packages/extensions-core/src/statusbar/settings-button/index.tsx
+++ b/packages/extensions-core/src/statusbar/settings-button/index.tsx
@@ -27,8 +27,9 @@ export const extension: Extension = {
     ctx.registerStatusItem({
       id: "settings-button",
       alignment: "right",
-      // Between the theme picker (-10) and the panel toggles (0).
-      priority: -5,
+      // Between theme (-5) and panel-toggles (-20). Right items sort descending
+      // so lower priority = closer to the right edge.
+      priority: -10,
       tooltip: "Settings",
       component: SettingsButton,
     });

--- a/packages/extensions-core/src/statusbar/updates/index.tsx
+++ b/packages/extensions-core/src/statusbar/updates/index.tsx
@@ -86,9 +86,8 @@ export const extension: Extension = {
     ctx.registerStatusItem({
       id: "updates",
       alignment: "right",
-      // Leftmost of the right cluster (theme picker is -10) so the rare link
-      // reads as prominent.
-      priority: -20,
+      // Leftmost of the right built-in cluster (closest to extension items).
+      priority: -2,
       component: UpdateLink,
     });
 

--- a/packages/extensions-core/src/themes/index.tsx
+++ b/packages/extensions-core/src/themes/index.tsx
@@ -9,6 +9,18 @@ export const extension: Extension = {
     // the app only through ctx (never state/store, layout/presets, …).
     const theme = ctx.theme;
 
+    // Log theme changes to the Application output channel.
+    let prevThemeId = theme.getState().activeId;
+    ctx.subscriptions.push(
+      theme.subscribe((state) => {
+        if (state.activeId !== prevThemeId) {
+          const preset = state.presets.find((p) => p.id === state.activeId);
+          ctx.log.info(`Theme changed: ${preset?.name ?? state.activeId}`);
+          prevThemeId = state.activeId;
+        }
+      }),
+    );
+
     ctx.registerSidePanel({
       id: "themes",
       location: "right",
@@ -27,12 +39,13 @@ export const extension: Extension = {
       lazyMount: true,
     });
 
-    // The theme picker in the status bar. Negative priority places it left of
-    // the panel-toggle buttons (priority 0).
+    // The theme picker in the status bar. Right items sort descending so lower
+    // priority = closer to right edge. -5 places it right of updates (-2) and
+    // left of settings (-10) and panel-toggles (-20).
     ctx.registerStatusItem({
       id: "theme-selector",
       alignment: "right",
-      priority: -10,
+      priority: -5,
       tooltip: "Change theme",
       component: () => <ThemeStatusItem theme={theme} ui={ctx.ui} />,
     });

--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -6,6 +6,33 @@ import { registerWorkspaceCycle } from "./workspace-cycle";
 export const extension: Extension = {
   id: "core.workspaces",
   activate(ctx) {
+    // Log workspace lifecycle events to the Application output channel.
+    let prev = ctx.workspaces.getState();
+    ctx.subscriptions.push(
+      ctx.workspaces.subscribe((state) => {
+        if (state.activeId !== prev.activeId && state.activeId) {
+          const ws = state.all.find((w) => w.id === state.activeId);
+          ctx.log.info(`Workspace activated: ${ws?.name ?? state.activeId}`);
+        }
+        for (const ws of state.all) {
+          if (!prev.all.find((p) => p.id === ws.id)) {
+            ctx.log.info(`Workspace created: ${ws.name}`);
+          }
+        }
+        for (const ws of state.closed) {
+          if (prev.open.find((p) => p.id === ws.id)) {
+            ctx.log.info(`Workspace closed: ${ws.name}`);
+          }
+        }
+        for (const ws of state.open) {
+          if (prev.closed.find((p) => p.id === ws.id)) {
+            ctx.log.info(`Workspace reopened: ${ws.name}`);
+          }
+        }
+        prev = state;
+      }),
+    );
+
     ctx.registerSidePanel({
       id: "workspaces",
       location: "left",
@@ -21,7 +48,7 @@ export const extension: Extension = {
     ctx.registerStatusItem({
       id: "workspace.active",
       alignment: "left",
-      priority: 0,
+      priority: -10,
       component: () => <WorkspaceStatusItem ctx={ctx} />,
     });
 

--- a/packages/extensions-silo/src/git/index.ts
+++ b/packages/extensions-silo/src/git/index.ts
@@ -24,9 +24,29 @@ export const extension: Extension<GitAPI> = {
     description: "Source control provider — status, diffs, and history.",
   },
   activate(ctx): GitAPI {
-    const api = createGitService((command, args, options) =>
-      ctx.process.exec(command, args, options),
-    );
+    const READ_ONLY = new Set([
+      "status",
+      "log",
+      "diff",
+      "show",
+      "for-each-ref",
+    ]);
+    const api = createGitService((command, args, options) => {
+      // Strip --no-optional-locks from the display — it's an internal safeguard.
+      const displayArgs = args.filter((a) => a !== "--no-optional-locks");
+      const subcommand = displayArgs[0] ?? "";
+      const isReadOnly = READ_ONLY.has(subcommand);
+      ctx.log[isReadOnly ? "debug" : "info"](
+        `> ${[command, ...displayArgs].join(" ")}`,
+        options?.cwd ? { cwd: options.cwd } : undefined,
+      );
+      return ctx.process.exec(command, args, options).then((result) => {
+        if (result.code !== 0 && result.stderr.trim()) {
+          ctx.log.error(result.stderr.trim());
+        }
+        return result;
+      });
+    });
     // Own the git-diff composition: core.editor's diff is generic and asks a
     // registered provider for the two sides. Lives here (the provider) so diffs
     // work even when the git-explorer panel is disabled. Tracked on

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -166,6 +166,11 @@ export type {
 // Static host-platform metadata: OS, CPU arch, and Silo version.
 export type { SystemService, SystemInfo } from "./system-service";
 
+// Structured output logging — the write-only channel extensions receive as
+// `ctx.log`. LogLevel is also used by the Output panel's built-in channels
+// (e.g. `silo:notifications`).
+export type { LogService, LogLevel } from "./output-service";
+
 // Context keys referenced by `when` predicates on menu items / keybindings.
 export type { ContextKeys } from "./context-keys";
 

--- a/packages/sdk/src/layout-service.ts
+++ b/packages/sdk/src/layout-service.ts
@@ -65,4 +65,16 @@ export interface LayoutService {
    *   survives workspace close/reopen.
    */
   openPanel(kindId: string, params?: Record<string, unknown>): void;
+  /**
+   * Open a **singleton** dock panel — a panel that should only ever have one
+   * instance at a time. If a panel with `kindId` already exists, focuses it;
+   * otherwise creates it. The panel's id equals `kindId` (not UUID-based, so
+   * at most one can exist). Use for utility panels like Output that don't
+   * benefit from multiple instances.
+   *
+   * @param kindId - The {@link DockPanelKind.id} to open or focus.
+   * @param params - Forwarded to the panel when creating; ignored when
+   *   focusing an existing instance.
+   */
+  openSingletonPanel(kindId: string, params?: Record<string, unknown>): void;
 }

--- a/packages/sdk/src/output-service.ts
+++ b/packages/sdk/src/output-service.ts
@@ -1,0 +1,43 @@
+/**
+ * Output channel logging — the write-only structured logger extensions receive
+ * as {@link ExtensionContext.log}. Each extension gets one channel
+ * auto-created at activation and auto-removed at deactivation; no setup is
+ * required from the extension author.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Log severity levels, ordered debug < info < warn < error.
+ *
+ * @category Consumer Services
+ * @public
+ */
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+/**
+ * Write-only structured logger automatically scoped to the calling extension.
+ * A channel is created for the extension at activation time and removed when
+ * the extension deactivates — no setup needed; just call `ctx.log.info("...")`.
+ *
+ * All entries appear in the **Output** panel (`core.openOutput`) under the
+ * extension's display name. Use {@link LogService.show} to focus the panel and
+ * select this extension's channel.
+ *
+ * @category Consumer Services
+ * @public
+ */
+export interface LogService {
+  /** Append a debug-level entry. Use for verbose diagnostic output. */
+  debug(message: string, data?: unknown): void;
+  /** Append an info-level entry. The default level for routine progress. */
+  info(message: string, data?: unknown): void;
+  /** Append a warn-level entry. Something unexpected but recoverable. */
+  warn(message: string, data?: unknown): void;
+  /** Append an error-level entry. A failure the user should know about. */
+  error(message: string, data?: unknown): void;
+  /** Open (or focus) the Output panel and select this extension's channel. */
+  show(): void;
+  /** Clear this extension's output channel entries. */
+  clear(): void;
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -33,6 +33,7 @@ import type { DndService } from "./dnd-service";
 import type { UiService } from "./ui-service";
 import type { NetworkService } from "./network-service";
 import type { SystemService } from "./system-service";
+import type { LogService } from "./output-service";
 import type {
   ExtensionStorage,
   ExtensionStorageScopes,
@@ -233,7 +234,13 @@ export interface MenuItemContribution {
    * Defaults to "9_default" so unspecified items land at the bottom.
    */
   group?: string;
-  /** Sort order within a group. Defaults to 0. */
+  /**
+   * Sort order within a group. Defaults to 0.
+   *
+   * **Convention:** built-in (core) items use negative values; extensions
+   * should use `0` or greater so they appear after built-in items within
+   * the same group by default.
+   */
   order?: number;
   /**
    * Optional predicate against current context keys. Items whose `when`
@@ -364,7 +371,19 @@ export interface StatusItem {
   id: string;
   /** Which end of the status bar this item sits at. */
   alignment: "left" | "right";
-  /** Sort order within its alignment group. Lower sorts first. Defaults to 0. */
+  /**
+   * Sort order within its alignment group. Defaults to 0.
+   *
+   * The sort direction mirrors the alignment so that **negative values always
+   * anchor an item toward the nearest edge**:
+   * - **Left items** sort ascending — lower priority = closer to the left edge.
+   * - **Right items** sort descending — lower priority = closer to the right edge.
+   *
+   * **Convention:** built-in (core) items use negative values so they are
+   * anchored to their respective edges. Extensions should use `0` or greater,
+   * which places them between the two built-in zones by default. An extension
+   * may still choose a negative value intentionally to interleave with built-ins.
+   */
   priority?: number;
   /**
    * Tooltip shown on hover over the entire status item. The host renders a
@@ -549,6 +568,19 @@ export interface ExtensionContext {
    * See {@link SystemService} for the full API.
    */
   readonly system: SystemService;
+  /**
+   * Write-only structured logger scoped to this extension. Entries appear in
+   * the **Output** panel under the extension's display name. A channel is
+   * created automatically at activation and removed at deactivation — no setup
+   * required.
+   *
+   * ```ts
+   * ctx.log.info("Extension activated");
+   * ctx.log.warn("Unexpected state", { detail: 42 });
+   * ctx.log.show(); // open the Output panel, select this extension's channel
+   * ```
+   */
+  readonly log: LogService;
   /**
    * Resolve a handle to another extension in order to consume the API it
    * published (the value its {@link Extension.activate} returned). This is how


### PR DESCRIPTION
## Summary

- **Output panel** (`core.output`) — new dock panel with channel selector (grouped into host channels, Built-in Extensions, and Extensions), level filter, text search, clear, and auto-scroll
- **`ctx.log` / `LogService`** — structured per-extension logging API wired into every extension context; `core.*` share the `silo:application` channel, others get their own `ext:<id>` channel that is auto-created and auto-removed with the extension lifecycle
- **Grouped channel dropdown** — uses a `builtin` flag threaded from `registerChannel` through `OutputChannelState`; key prefix alone is insufficient because runtime-loaded `silo.*` extensions from the external repo share the same prefix as bundled ones
- **Application channel lifecycle events** — `core.workspaces` logs workspace activated/created/closed/reopened; `core.themes` logs theme changes
- **Notifications mirrored to Output** — `ctx.ui.notify` now also writes to `silo:notifications` so dismissed toasts are reviewable
- **Git command logging** (`silo.git`) — read-only commands at `debug`, write commands at `info`, non-zero stderr at `error`
- **Extension host logging** — all `console.*` calls in `builtins-registry` and `extension-loader` replaced with `extHostLog.*` (the `silo:extension-host` Output channel)
- **`openSingletonPanel` layout API** — focuses an existing panel instead of opening a duplicate; used by `ctx.log.show()`
- **Status bar ordering fix** — right-side items now sort descending so lower priority anchors to the right edge; corrected priorities for updates/theme/settings/panel-toggles and documented the convention in SDK types

## Test plan

- [ ] Open Output panel via menu or `ctx.log.show()`; confirm channel dropdown shows host channels at top (no header), then Built-in Extensions group, then Extensions group
- [ ] Switch workspaces — "Workspace activated: \<name\>" appears in Application channel
- [ ] Create / close / reopen a workspace — corresponding events appear
- [ ] Switch themes — "Theme changed: \<name\>" appears in Application channel
- [ ] Trigger a notification — entry appears in Notifications channel
- [ ] Open a git diff or status — git commands appear in the Git channel (read-only at debug, write at info)
- [ ] Install a runtime extension — its channel appears under Extensions, not Built-in Extensions
- [ ] Status bar right cluster reads: Updates → Theme → Settings → Panel Toggles (left to right)
- [ ] `pnpm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)