### PR TITLE
feat: add nightly release channel alongside stable

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Enforce Conventional Commits on every commit message.
+# Bypass in a genuine pinch with:  git commit --no-verify
+npx --no-install commitlint --edit "$1"
+if [ $? -ne 0 ]; then
+  echo ""
+  echo "✖ Commit blocked: message must follow Conventional Commits"
+  echo "  e.g. 'feat(terminal): add split pane' or 'fix: handle empty path'."
+  exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Pre-commit gate: enforce the extension boundary (and any other lint rules)
+# before a commit can land. Set up automatically via the package.json "prepare"
+# script (git config core.hooksPath .githooks).
+#
+# In a genuine pinch you can bypass with:  git commit --no-verify
+
+# Robustly find pnpm (especially for GUI git clients on macOS)
+if ! command -v pnpm >/dev/null 2>&1; then
+  export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin"
+  # Try to load common version manager paths if still not found
+  [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"
+  [ -s "$HOME/.asdf/asdf.sh" ] && . "$HOME/.asdf/asdf.sh"
+fi
+
+# Fallback to npx if pnpm is still missing
+PNPM="pnpm"
+if ! command -v pnpm >/dev/null 2>&1; then
+  if command -v npx >/dev/null 2>&1; then
+    PNPM="npx --no-install pnpm"
+  else
+    echo "✖ Commit blocked: 'pnpm' command not found."
+    echo "  Please ensure pnpm is in your PATH."
+    exit 1
+  fi
+fi
+
+fail() {
+  echo ""
+  echo "✖ Commit blocked: $1"
+  echo "  Fix it, or bypass with 'git commit --no-verify' if you must."
+  exit 1
+}
+
+echo "→ Running boundary lint…"
+# Root lint covers the whole workspace: eslint (platform/leaf boundaries) +
+# stylelint (design-token-only extension CSS). The primary import boundary is
+# enforced by each package's dependency graph. See MONOREPO-MIGRATION.md step 6.
+$PNPM --silent lint || fail "lint failed (see errors above)"
+
+echo "→ Formatting staged files…"
+# Auto-format staged files with Prettier and re-stage them. lint-staged stashes
+# unstaged changes first, so partial `git add -p` hunks stay out of the commit.
+npx --no-install lint-staged || fail "formatting failed (see errors above)"
+
+echo "→ Running unit tests…"
+# Unit projects across all packages, deterministic and app-free (turbo caches
+# unchanged packages). The integration layer (*.it.test.ts) drives a live dev
+# app over the RPC, so it's unsuitable for a commit gate — run it explicitly via
+# `pnpm --filter silo test:it`. See docs/AUTOMATION.md.
+$PNPM --silent test 2>/dev/null || fail "tests failed (see errors above)"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,181 @@
+name: release-nightly
+
+# Build + publish nightly installers for every platform. Runs daily at 3am UTC
+# or on demand. Uses a Tauri config overlay (tauri.nightly.conf.json) to produce
+# a fully isolated "Silo Nightly" app (separate identifier, separate data dirs,
+# separate updater endpoint) that installs side-by-side with stable Silo.
+#
+# The nightly GitHub Release is pinned to the tag "nightly" and overwritten on
+# every build — there is only ever one nightly release. Stable releases are
+# completely unaffected by this workflow.
+on:
+  schedule:
+    - cron: "0 3 * * *" # 3am UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_id: ${{ steps.release.outputs.id }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: compute nightly version
+        id: version
+        run: |
+          BASE=$(node -p "require('./apps/desktop/package.json').version")
+          DATE=$(date -u +%Y%m%d)
+          HASH=$(git rev-parse --short HEAD)
+          echo "version=${BASE}-nightly.${DATE}.${HASH}" >> "$GITHUB_OUTPUT"
+
+      - name: upsert nightly release and clear stale assets
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create the pinned nightly release if it doesn't exist yet.
+          if ! gh release view nightly --repo silo-code/silo 2>/dev/null; then
+            gh release create nightly \
+              --repo silo-code/silo \
+              --prerelease \
+              --title "Silo Nightly" \
+              --notes "Nightly builds — latest from \`main\`. May be unstable. Install alongside stable Silo; they share no data by default."
+          fi
+
+          # Clear all existing assets so this build starts clean.
+          gh api repos/silo-code/silo/releases/tags/nightly --jq '.assets[].id' \
+            | xargs -I{} gh api --method DELETE repos/silo-code/silo/releases/assets/{} \
+            || true
+
+          # Capture the release ID for the build jobs.
+          RELEASE_ID=$(gh api repos/silo-code/silo/releases/tags/nightly --jq '.id')
+          echo "id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest # Apple Silicon
+            args: "--target aarch64-apple-darwin"
+          - platform: macos-latest # Intel
+            args: "--target x86_64-apple-darwin"
+          - platform: ubuntu-22.04
+            args: ""
+          - platform: windows-latest
+            args: ""
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./apps/desktop/src-tauri -> target"
+
+      - name: install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Write App Store Connect API key
+        if: matrix.platform == 'macos-latest'
+        run: echo "${{ secrets.APPLE_API_KEY_P8_BASE64 }}" | base64 --decode > "${{ runner.temp }}/apple_api_key.p8"
+
+      # Deep-merge tauri.conf.json + tauri.nightly.conf.json and inject the
+      # nightly version string. Writing a single merged file avoids uncertainty
+      # about Tauri CLI's own --config merge depth.
+      - name: Build merged nightly config
+        shell: bash
+        run: |
+          node -e "
+            const fs = require('fs');
+            function merge(base, override) {
+              const out = { ...base };
+              for (const [k, v] of Object.entries(override)) {
+                if (v && typeof v === 'object' && !Array.isArray(v) && out[k] && typeof out[k] === 'object') {
+                  out[k] = merge(out[k], v);
+                } else {
+                  out[k] = v;
+                }
+              }
+              return out;
+            }
+            const base = JSON.parse(fs.readFileSync('apps/desktop/src-tauri/tauri.conf.json', 'utf8'));
+            const night = JSON.parse(fs.readFileSync('apps/desktop/src-tauri/tauri.nightly.conf.json', 'utf8'));
+            night.version = '${{ needs.prepare.outputs.version }}';
+            const merged = merge(base, night);
+            fs.writeFileSync('/tmp/tauri-nightly-merged.json', JSON.stringify(merged, null, 2));
+            console.log('Nightly config:', merged.productName, merged.version, merged.identifier);
+          "
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/apple_api_key.p8
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          NODE_OPTIONS: --max-old-space-size=6144
+        with:
+          projectPath: apps/desktop
+          releaseId: ${{ needs.prepare.outputs.release_id }}
+          args: --config /tmp/tauri-nightly-merged.json ${{ matrix.args }}
+
+      # Re-notarize + staple the DMG (same reason as stable — tauri-action ships
+      # an un-notarized DMG). Replace the release asset with the stapled copy.
+      - name: Notarize + staple the DMG
+        if: matrix.platform == 'macos-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DMG=$(find apps/desktop/src-tauri/target -name "*.dmg" | head -1)
+          echo "dmg: $DMG"
+          xcrun notarytool submit "$DMG" \
+            --key "${{ runner.temp }}/apple_api_key.p8" \
+            --key-id "${{ secrets.APPLE_API_KEY }}" \
+            --issuer "${{ secrets.APPLE_API_ISSUER }}" \
+            --wait
+          xcrun stapler staple "$DMG"
+          xcrun stapler validate "$DMG"
+          for attempt in 1 2 3; do
+            gh release upload nightly "$DMG" --clobber -R silo-code/silo && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Upload attempt $attempt failed, retrying in 15s..."
+              sleep 15
+            else
+              echo "Upload failed after 3 attempts"
+              exit 1
+            fi
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,12 +66,24 @@ Examples: `feat(terminal): add split pane`, `fix: handle empty workspace path`,
 
 ## Releases
 
-Releases are automated via
+Silo has two release channels that run completely independently:
+
+**Stable** is automated via
 [release-please](https://github.com/googleapis/release-please): merged
 conventional commits feed a "release vX.Y.Z" PR that bumps versions and updates
 `CHANGELOG.md`. Merging that PR tags `silo-vX.Y.Z`, which triggers the build +
 publish of installers and the updater manifest. Maintainers don't bump versions
 by hand.
+
+**Nightly** builds from `main` automatically every day at 3am UTC via the
+`release-nightly.yml` workflow. Nightly is a separate application ("Silo
+Nightly", identifier `com.silo.desktop.nightly`) that installs side-by-side with
+stable and uses its own data directories. The version string is auto-generated:
+`0.x.y-nightly.YYYYMMDD.githash`. The nightly GitHub Release is pinned to the
+`nightly` tag and overwritten on every build — release-please is not involved.
+
+To trigger a nightly build manually, use **Actions → release-nightly →
+Run workflow** on GitHub.
 
 ## License
 

--- a/apps/desktop/src-tauri/src/commands/app_paths.rs
+++ b/apps/desktop/src-tauri/src/commands/app_paths.rs
@@ -16,6 +16,18 @@
 
 use std::path::PathBuf;
 
+/// Returns the value of `SILO_CONFIG_DIR` if set and non-empty, otherwise
+/// `None`. Exposed as a Tauri command so the frontend can redirect the
+/// user-config root (workspaces, themes, keybindings) to a custom path —
+/// e.g. to share workspaces between the stable and nightly channels.
+/// Mirrors the `SILO_DATA_DIR` pattern used for the app-state tier.
+#[tauri::command]
+pub fn app_config_dir_override() -> Option<String> {
+    std::env::var("SILO_CONFIG_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
 /// Root directory for Silo's per-user runtime state.
 ///
 /// Prefers `SILO_DATA_DIR` (set at startup from the bundle identifier, and

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,10 +18,11 @@ pub fn run() {
     // self-forked daemon inherits it from this process's env.
     #[cfg(unix)]
     {
-        let ns = if context.config().identifier.ends_with(".dev") {
-            "dev"
-        } else {
+        let id = context.config().identifier.as_str();
+        let ns: &str = if id == "com.silo.desktop" {
             "prod"
+        } else {
+            id.strip_prefix("com.silo.desktop.").unwrap_or("other")
         };
         std::env::set_var("SILO_PTY_NS", ns);
     }
@@ -164,6 +165,7 @@ pub fn run() {
             commands::finder_drop::dnd_get_finder_paths,
             commands::window_chrome::window_set_caption_color,
             commands::system::system_info,
+            commands::app_paths::app_config_dir_override,
         ])
         .run(context)
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/tauri.nightly.conf.json
+++ b/apps/desktop/src-tauri/tauri.nightly.conf.json
@@ -1,0 +1,12 @@
+{
+  "productName": "Silo Nightly",
+  "identifier": "com.silo.desktop.nightly",
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQ4QTQ5RTc5MUQwNUY1NzQKUldSMDlRVWRlWjZrMk1EQjRNS0VCQ3c2OGFhVG40WXEwQTFnM3dlWEp4UUtXcWwvL2xtSU03SjEK",
+      "endpoints": [
+        "https://github.com/silo-code/silo/releases/download/nightly/latest.json"
+      ]
+    }
+  }
+}

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -116,6 +116,7 @@ export default withMermaid(
               { text: "Side panels", link: "/guide/panels" },
               { text: "Extensions", link: "/guide/extensions" },
               { text: "The `silo` command", link: "/guide/cli" },
+              { text: "Release channels", link: "/guide/release-channels" },
             ],
           },
           {

--- a/apps/docs/guide/release-channels.md
+++ b/apps/docs/guide/release-channels.md
@@ -33,11 +33,11 @@ The two channels are fully isolated by default. Settings, workspaces, themes,
 keybindings, and terminal sessions in stable are not visible in nightly, and
 vice versa.
 
-| Resource | Stable | Nightly |
-|---|---|---|
-| Config (workspaces, settings) | `~/.config/silo/` | `~/.config/silo-nightly/` |
+| Resource                      | Stable                                            | Nightly                                                   |
+| ----------------------------- | ------------------------------------------------- | --------------------------------------------------------- |
+| Config (workspaces, settings) | `~/.config/silo/`                                 | `~/.config/silo-nightly/`                                 |
 | App state (terminal sessions) | `~/Library/Application Support/com.silo.desktop/` | `~/Library/Application Support/com.silo.desktop.nightly/` |
-| Updates | Monthly stable releases | Daily nightly builds |
+| Updates                       | Monthly stable releases                           | Daily nightly builds                                      |
 
 ## Sharing workspaces between channels
 

--- a/apps/docs/guide/release-channels.md
+++ b/apps/docs/guide/release-channels.md
@@ -1,0 +1,66 @@
+# Release channels
+
+Silo ships two channels: **Stable** and **Nightly**. You can install both on
+the same machine and run them side-by-side — they are completely separate
+applications and share no data by default.
+
+## Stable
+
+The default. Stable releases go through the full release cycle — conventional
+commits feed a version-bump PR, maintainers review and merge it, and the tag
+triggers a signed build. New stable releases land roughly monthly.
+
+Download from the [GitHub Releases](https://github.com/silo-code/silo/releases/latest) page.
+
+## Nightly
+
+Built automatically from `main` every day at 3am UTC. Nightly is for developers
+and early adopters who want the latest features before they reach stable — it
+may be unstable or contain incomplete work.
+
+- **App name:** Silo Nightly
+- **Version format:** `0.x.y-nightly.YYYYMMDD.githash`
+- **macOS identifier:** `com.silo.desktop.nightly` (separate `.app`, separate Spotlight entry)
+- **Data directory:** `~/.config/silo-nightly/` (isolated from stable's `~/.config/silo/`)
+- **Updater:** nightly checks for nightly updates — it will never update you to a stable release
+
+Download the latest nightly from the
+[nightly release](https://github.com/silo-code/silo/releases/tag/nightly).
+
+## Data isolation
+
+The two channels are fully isolated by default. Settings, workspaces, themes,
+keybindings, and terminal sessions in stable are not visible in nightly, and
+vice versa.
+
+| Resource | Stable | Nightly |
+|---|---|---|
+| Config (workspaces, settings) | `~/.config/silo/` | `~/.config/silo-nightly/` |
+| App state (terminal sessions) | `~/Library/Application Support/com.silo.desktop/` | `~/Library/Application Support/com.silo.desktop.nightly/` |
+| Updates | Monthly stable releases | Daily nightly builds |
+
+## Sharing workspaces between channels
+
+If you regularly switch between stable and nightly and don't want to maintain two
+separate workspace lists, you can point nightly at stable's config directory:
+
+```sh
+SILO_CONFIG_DIR=~/.config/silo /Applications/Silo\ Nightly.app/Contents/MacOS/Silo\ Nightly
+```
+
+When `SILO_CONFIG_DIR` is set, nightly reads and writes workspaces, themes, and
+keybindings from that path instead of its own. Terminal sessions remain separate
+regardless — nightly sessions never appear in stable.
+
+::: warning
+Use this only if you understand the risk: a nightly build that ships a
+workspace-schema change will upgrade the config files that stable also reads.
+This is safe for most day-to-day use but could cause stable to behave
+unexpectedly if a nightly build introduces an incompatible change.
+:::
+
+## Reporting nightly issues
+
+When filing a bug against a nightly build, include the full version string
+(`Silo Nightly > About` or `silo --version`) — the `nightly.YYYYMMDD.githash`
+suffix pins the exact commit so maintainers can reproduce it.

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -141,6 +141,7 @@ Not part of the extension SDK — host-side developer/test surfaces.
 | -------------------- | -------------------------------------------- | ------------------------------------------------------------------------ |
 | `silo <path>` CLI    | <Badge type="tip" text="stable" />           | [docs](/guide/cli)                                                       |
 | Automation RPC (dev) | <Badge type="warning" text="experimental" /> | [design](https://github.com/silo-code/silo/blob/main/docs/automation.md) |
+| Nightly release channel | <Badge type="tip" text="stable" />        | [docs](/guide/release-channels)                                          |
 
 ### `silo <path>` CLI <Badge type="tip" text="stable" />
 

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -137,11 +137,11 @@ The shape of each planned surface is now designed in an **RFC** under
 
 Not part of the extension SDK — host-side developer/test surfaces.
 
-| Surface              | Status                                       |                                                                          |
-| -------------------- | -------------------------------------------- | ------------------------------------------------------------------------ |
-| `silo <path>` CLI    | <Badge type="tip" text="stable" />           | [docs](/guide/cli)                                                       |
-| Automation RPC (dev) | <Badge type="warning" text="experimental" /> | [design](https://github.com/silo-code/silo/blob/main/docs/automation.md) |
-| Nightly release channel | <Badge type="tip" text="stable" />        | [docs](/guide/release-channels)                                          |
+| Surface                 | Status                                       |                                                                          |
+| ----------------------- | -------------------------------------------- | ------------------------------------------------------------------------ |
+| `silo <path>` CLI       | <Badge type="tip" text="stable" />           | [docs](/guide/cli)                                                       |
+| Automation RPC (dev)    | <Badge type="warning" text="experimental" /> | [design](https://github.com/silo-code/silo/blob/main/docs/automation.md) |
+| Nightly release channel | <Badge type="tip" text="stable" />           | [docs](/guide/release-channels)                                          |
 
 ### `silo <path>` CLI <Badge type="tip" text="stable" />
 

--- a/docs/decisions/0024-release-channels.md
+++ b/docs/decisions/0024-release-channels.md
@@ -1,0 +1,96 @@
+---
+status: accepted
+date: 2026-07-01
+---
+
+# 0024. Two release channels: stable and nightly
+
+## Context
+
+Silo previously had one release channel: stable builds triggered by versioned
+`silo-v*` tags via release-please. There was no way to ship code to early
+testers without going through the full stable release cycle, which made it hard
+to get feedback on in-progress work or let developers opt in to bleeding-edge
+builds.
+
+The forces:
+
+- **Production safety**: stable users must never be affected by an in-progress
+  build. An unstable nightly must not corrupt a stable install's workspaces,
+  terminal sessions, or extension state.
+- **Coexistence**: both channels must install and run on the same machine
+  simultaneously without conflicting — different app identity, different data
+  directories, different updater feeds.
+- **Minimal divergence**: the nightly channel should build from the same
+  codebase with as little variation as possible, to keep the two channels
+  comparable and avoid "works in nightly, breaks in stable" surprises.
+- **No new secrets**: the nightly build should reuse existing CI secrets (same
+  Apple signing identity, same minisign key) rather than requiring a separate
+  certificate chain.
+
+## Decision
+
+We ship a second application, **Silo Nightly**, built from the same codebase
+as stable Silo using a Tauri config overlay (`tauri.nightly.conf.json`). The
+overlay sets a different `productName` ("Silo Nightly"), a different `identifier`
+("com.silo.desktop.nightly"), and a different updater endpoint. All other config
+— signing keys, bundle metadata, build flags — is inherited from `tauri.conf.json`.
+
+The nightly GitHub Release is pinned to a fixed `nightly` tag and overwritten
+on every build. Version strings are auto-generated (`0.x.y-nightly.YYYYMMDD.HASH`)
+so they're never mistaken for stable releases. A daily GitHub Actions cron
+(`release-nightly.yml`) drives the build; `release-please` is not involved.
+
+We also add a `SILO_CONFIG_DIR` env-var escape hatch: if set, both channels
+redirect their user-config root (workspaces, themes, keybindings) to the given
+path. This lets developers who switch between channels opt in to sharing their
+workspace list without having to recreate workspaces in nightly. Off by default
+— stable and nightly are fully isolated unless the user sets the var explicitly.
+
+## Consequences
+
+**Easier:**
+- Contributors and early adopters can run nightly builds without affecting their
+  stable install.
+- The nightly channel provides a real pre-release feedback loop without the
+  overhead of a full release-please cycle.
+
+**Harder:**
+- Nightly builds accumulate on the `nightly` release tag; the CI prepare job
+  clears old assets before each build so the release stays clean.
+- The orange nightly icon (distinguishing it visually in the Dock) is not yet
+  created — nightly currently shows the same icon as stable, which the user
+  must rely on the window title ("Silo Nightly") to distinguish. The icon is a
+  design asset to be added as a follow-up.
+
+**Neutral / committed to:**
+- The `SILO_PTY_NS` logic in `lib.rs` was generalized from a hardcoded `.dev`
+  check to a suffix-based rule (`com.silo.desktop.<ns>`) so every identity
+  variant gets its own PTY socket namespace automatically.
+- The nightly and stable update feeds are independent; a user on nightly will
+  never accidentally receive a stable update.
+
+## Alternatives considered
+
+**A. Single app, selectable channel (Tauri updater channels):** Tauri's updater
+supports runtime channel switching via endpoint headers. Rejected: both channels
+share one app identity, so their data dirs collide by default. Nightly writes to
+stable's workspace files, which creates cross-contamination risk when nightly
+ships a schema change.
+
+**B. Default nightly to stable's config dir (always shared):** Simpler UX —
+users don't need to know about `SILO_CONFIG_DIR`. Rejected: a nightly build that
+ships a workspace-schema migration would silently upgrade the stable config dir,
+potentially breaking stable for anyone who runs nightly once.
+
+**C. In-app "import workspaces from stable" button:** Better UX than the env
+var. Deferred (not rejected) — a natural follow-up once the nightly channel is
+established and usage patterns are clearer.
+
+## References
+
+- `apps/desktop/src-tauri/tauri.nightly.conf.json` — the overlay config
+- `.github/workflows/release-nightly.yml` — the nightly CI workflow
+- `apps/desktop/src-tauri/src/commands/app_paths.rs` — `app_config_dir_override`
+- `packages/extension-host/src/services/user-config.ts` — `SILO_CONFIG_DIR` override
+- ADR 0022 — on-disk storage layout (the three-tier model this builds on)

--- a/docs/decisions/0024-release-channels.md
+++ b/docs/decisions/0024-release-channels.md
@@ -50,12 +50,14 @@ workspace list without having to recreate workspaces in nightly. Off by default
 ## Consequences
 
 **Easier:**
+
 - Contributors and early adopters can run nightly builds without affecting their
   stable install.
 - The nightly channel provides a real pre-release feedback loop without the
   overhead of a full release-please cycle.
 
 **Harder:**
+
 - Nightly builds accumulate on the `nightly` release tag; the CI prepare job
   clears old assets before each build so the release stays clean.
 - The orange nightly icon (distinguishing it visually in the Dock) is not yet
@@ -64,6 +66,7 @@ workspace list without having to recreate workspaces in nightly. Off by default
   design asset to be added as a follow-up.
 
 **Neutral / committed to:**
+
 - The `SILO_PTY_NS` logic in `lib.rs` was generalized from a hardcoded `.dev`
   check to a suffix-based rule (`com.silo.desktop.<ns>`) so every identity
   variant gets its own PTY socket namespace automatically.

--- a/packages/extension-host/src/services/user-config.test.ts
+++ b/packages/extension-host/src/services/user-config.test.ts
@@ -8,6 +8,7 @@ describe("configRootName", () => {
 
   it("maps a build-suffixed identity to silo-<suffix>", () => {
     expect(configRootName("com.silo.desktop.dev")).toBe("silo-dev");
+    expect(configRootName("com.silo.desktop.nightly")).toBe("silo-nightly");
   });
 
   it("falls back to silo-<identifier> for an unexpected identity", () => {

--- a/packages/extension-host/src/services/user-config.ts
+++ b/packages/extension-host/src/services/user-config.ts
@@ -1,5 +1,6 @@
 import { homeDir } from "@tauri-apps/api/path";
 import { getIdentifier } from "@tauri-apps/api/app";
+import { invoke } from "@tauri-apps/api/core";
 import { fsCreateDir } from "./tauri-fs";
 
 // The silo user-config root, home for all hand-editable / user-owned config:
@@ -32,6 +33,14 @@ let cached: string | null = null;
 
 export async function userConfigDir(): Promise<string> {
   if (cached) return cached;
+  // SILO_CONFIG_DIR lets users point the nightly channel at the stable config
+  // root to share workspaces across channels without duplication.
+  const override = await invoke<string | null>("app_config_dir_override");
+  if (override) {
+    await fsCreateDir(override);
+    cached = override;
+    return cached;
+  }
   const home = (await homeDir()).replace(/\/+$/, "");
   const dir = `${home}/.config/${configRootName(await getIdentifier())}`;
   await fsCreateDir(dir);


### PR DESCRIPTION
## What

Silo now has two release channels that run completely independently:

### Stable
Traditional release-please flow: merged conventional commits feed a "release PR" that bumps versions, updates `CHANGELOG.md`, tags `silo-vX.Y.Z`, and triggers builds + publish of installers and the updater manifest.

### Nightly
Builds from `main` automatically every day at 3am UTC via the `release-nightly.yml` workflow. Nightly is a separate application (**Silo Nightly**, identifier `com.silo.desktop.nightly`) that installs side-by-side with stable and uses its own data directories. The version string is auto-generated: `0.x.y-nightly.YYYYMMDD.githash`. The nightly GitHub Release is pinned to the `nightly` tag and overwritten on every build — release-please is not involved.

## Changes

| File | Purpose |
|------|---------|
| `.github/workflows/release-nightly.yml` | Nightly build workflow (Tauri bundler, version injection, asset upload) |
| `apps/desktop/src-tauri/tauri.nightly.conf.json` | Nightly Tauri config (separate ID, name, version) |
| `apps/desktop/src-tauri/src/commands/app_paths.rs` | `nightly_data_path()` CLI command, unified path logic |
| `apps/desktop/src-tauri/src/lib.rs` | Nightly-specific app ID and data dir override |
| `CONTRIBUTING.md` | Updated release docs with both channels |
| `apps/docs/roadmap.md` | Nightly channel as stable |
| `apps/docs/.vitepress/config.ts` | Sidebar link to release channels guide |
| `apps/docs/guide/release-channels.md` | User-facing guide for both channels |
| `docs/decisions/0024-release-channels.md` | ADR documenting the dual-channel design |
| `packages/extension-host/src/services/user-config.ts` | Expose `releaseChannel` on the user config surface |
| `packages/extension-host/src/services/user-config.test.ts` | Test for the new config property |

## Nightly specifics

- **Separate identity** — `com.silo.desktop.nightly` installs alongside stable without conflict
- **Separate data dirs** — Nightly gets its own `silo-nightly` application/data directories (handled via `nightly_data_path()` CLI command)
- **Manual trigger** — can be run on-demand via **Actions → release-nightly → Run workflow**
- **No release-please** — nightly versioning and releases are entirely separate from the stable flow