### PR TITLE
fix: improve workspace group text contrast on light themes

### DIFF
--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -578,6 +578,10 @@
 [data-theme="light"] .ws-group--colored {
   --ws-group-mix: 35%;
   --ws-group-mix-hover: 45%;
+  /* Darken the group color for readable text on the tinted header. On dark
+     themes this isn't set, so `var(--ws-group-text-color)` falls through to
+     `var(--ws-group-color)`, which already contrasts well against dark bg. */
+  --ws-group-text-color: color-mix(in srgb, var(--ws-group-color) 80%, black);
 }
 
 /* Header fills the top of the card with a subtle tint */
@@ -602,7 +606,7 @@
 
 .ws-group--colored .ws-group-name,
 .ws-group--colored .ws-group-caret {
-  color: var(--ws-group-color);
+  color: var(--ws-group-text-color, var(--ws-group-color));
   opacity: 1;
 }
 


### PR DESCRIPTION
On light themes, darken the group name and caret text color to ensure readable contrast against the tinted group header background.

## The problem
Colored group headers set `color: var(--ws-group-color)` on the group name and caret icon. On light themes with a 35% color mix on the header background, some group colors (especially lighter/tinted ones) do not contrast enough with the header surface.

## The fix
- **Light themes**: `--ws-group-text-color` is set to `color-mix(in srgb, var(--ws-group-color) 80%, black)` — darkening the group color by 20% while preserving its hue. The text now reads clearly against the tinted header.
- **Dark themes**: The variable is not defined, so the fallback `var(--ws-group-color)` applies. On dark backgrounds the original color already has sufficient contrast, so no change.

This is a fully automated, per-group-color fix — no hard-coded adjustments needed for any particular swatch.