### PR TITLE
fix: remove .git from file watch skip list for git panel auto-refresh

### DIFF
--- a/apps/desktop/src-tauri/src/commands/watch.rs
+++ b/apps/desktop/src-tauri/src/commands/watch.rs
@@ -25,7 +25,6 @@ fn should_skip(path: &str) -> bool {
     // the separators in these needles always match on every platform.
     const NEEDLES: &[&str] = &[
         "/node_modules/",
-        "/.git/",
         "/target/",
         "/dist/",
         "/build/",


### PR DESCRIPTION
## Problem

The git side panel's file watcher never received events from `.git/` directory changes because the Rust watcher explicitly skips it (alongside `node_modules/`, `target/`, etc.). This meant:

- **Staging** files worked — workspace file changes (timestamps, index updates) fired normally
- **Committing** and **pushing** did not — those operations mutate `.git/` internals (refs, objects, index), which were silently dropped
- Users had to manually refresh the git panel after an agent committed or pushed

## Root cause

The skip list in `apps/desktop/src-tauri/src/commands/watch.rs`:

```rust
const NEEDLES: &[&str] = &[
    "/node_modules/",
    "/.git/",           <-- this was suppressing all git operations
    "/target/",
    ...
];
```

The intent was to reduce noise, but the trade-off was too high for the git panel which specifically needs to detect git mutations.

## Solution

Remove `/.git/` from the skip list. The existing **400ms debounce** in `GitView.tsx` already batches bursty `.git` writes (a commit can modify dozens of files in milliseconds), so the UX cost is negligible.

## Testing

- Unit tests: all pass (141/141 in extensions-silo)
- Lint: clean
- Manual: coding agent creates PR (stage → commit → push) — panel now updates automatically
- Integration test exists at `apps/desktop/src/automation/git-explorer-watch.it.test.ts` (workspace file changes; a separate test for `.git` operations could be added later)