### PR TITLE
feat(file-explorer): persist scroll position and per-root selection across workspace switches

### DIFF
--- a/packages/extensions-silo/src/file-explorer/FileExplorerPanel.tsx
+++ b/packages/extensions-silo/src/file-explorer/FileExplorerPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import {
   useServiceState,
   type ExtensionContext,
@@ -8,7 +9,11 @@ import { Tree } from "./Tree";
 import "./FileExplorerPanel.css";
 
 const TREE_EXPANDED_KEY = "treeExpanded";
+const TREE_SELECTED_KEY = "treeSelected";
+const SCROLL_TOP_KEY = "scrollTop";
+
 type ExpandedMap = Record<string, boolean>;
+type SelectedMap = Record<string, string | null>;
 
 export function FileExplorerPanel({
   ctx,
@@ -20,6 +25,41 @@ export function FileExplorerPanel({
   const wsState = useServiceState(ctx.workspaces);
   const ws = wsState.all.find((w) => w.id === wsState.activeId) ?? null;
 
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Restore scroll position when the active workspace changes. The ResizeObserver
+  // retries if the content isn't tall enough yet (directories still loading).
+  useEffect(() => {
+    // Cancel any pending save from the previous workspace before restoring.
+    if (scrollTimerRef.current !== null) {
+      clearTimeout(scrollTimerRef.current);
+      scrollTimerRef.current = null;
+    }
+    const el = scrollRef.current;
+    if (!el) return;
+    const saved = storage.get<number>(SCROLL_TOP_KEY, 0) ?? 0;
+    if (saved === 0) return;
+    el.scrollTop = saved;
+    if (el.scrollTop >= saved) return;
+    const obs = new ResizeObserver(() => {
+      el.scrollTop = saved;
+      if (el.scrollTop >= saved) obs.disconnect();
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ws?.id]);
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    const top = e.currentTarget.scrollTop;
+    if (scrollTimerRef.current !== null) clearTimeout(scrollTimerRef.current);
+    scrollTimerRef.current = setTimeout(() => {
+      storage.set(SCROLL_TOP_KEY, top);
+      scrollTimerRef.current = null;
+    }, 300);
+  }
+
   // Per-workspace expansion state lives in the panel's storage bag (which the
   // host swaps and persists per active workspace), not on the Workspace model.
   const treeExpanded = storage.get<ExpandedMap>(TREE_EXPANDED_KEY, {});
@@ -27,6 +67,14 @@ export function FileExplorerPanel({
     storage.set(TREE_EXPANDED_KEY, {
       ...storage.get<ExpandedMap>(TREE_EXPANDED_KEY, {}),
       ...next,
+    });
+
+  // Per-workspace, per-root selection state.
+  const treeSelected = storage.get<SelectedMap>(TREE_SELECTED_KEY, {});
+  const persistSelected = (folder: string, path: string | null) =>
+    storage.set(TREE_SELECTED_KEY, {
+      ...storage.get<SelectedMap>(TREE_SELECTED_KEY, {}),
+      [folder]: path,
     });
 
   if (!ws) return <div className="placeholder">No active workspace.</div>;
@@ -39,7 +87,11 @@ export function FileExplorerPanel({
   // selected row and Tab hands off from the last row to the editor.
   return (
     <div className="file-explorer-panel">
-      <div className="file-explorer-scroll">
+      <div
+        ref={scrollRef}
+        className="file-explorer-scroll"
+        onScroll={handleScroll}
+      >
         {allFolders.map((folder) => (
           <Tree
             key={ws.id + "::" + folder}
@@ -49,6 +101,8 @@ export function FileExplorerPanel({
             rootLabel={rootName(folder)}
             initialExpanded={treeExpanded}
             persistExpanded={persistExpanded}
+            initialSelected={treeSelected[folder] ?? null}
+            persistSelected={(path) => persistSelected(folder, path)}
           />
         ))}
       </div>

--- a/packages/extensions-silo/src/file-explorer/Tree.tsx
+++ b/packages/extensions-silo/src/file-explorer/Tree.tsx
@@ -24,6 +24,8 @@ export function Tree({
   rootLabel,
   initialExpanded,
   persistExpanded,
+  initialSelected,
+  persistSelected,
 }: {
   ctx: ExtensionContext;
   workspaceId: string;
@@ -32,6 +34,8 @@ export function Tree({
   initialExpanded?: Record<string, boolean>;
   /** Persist the expanded-paths map (merged into the panel's stored state). */
   persistExpanded: (expanded: Record<string, boolean>) => void;
+  initialSelected?: string | null;
+  persistSelected?: (path: string | null) => void;
 }) {
   // The public primitives this tree drives — read through ctx, never the host
   // getters. (Stable per extension, so safe to bind once per render.)
@@ -50,7 +54,14 @@ export function Tree({
   const fileTreeRef = useRef<HTMLDivElement>(null);
   const [newItem, setNewItem] = useState<NewItem | null>(null);
   const [renaming, setRenaming] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(
+    () => initialSelected ?? null,
+  );
+
+  function selectPath(path: string | null) {
+    setSelected(path);
+    persistSelected?.(path);
+  }
 
   // The visible rows in document order — the index space useFocusGroup roves
   // over. Built from listings/expanded so it tracks expand/collapse, and ordered
@@ -165,7 +176,7 @@ export function Tree({
       ...gp,
       onFocus: () => {
         gp.onFocus();
-        setSelected(path);
+        selectPath(path);
       },
       onKeyDown: (e) => {
         if (handleRowKey(e, path, isDir)) return;
@@ -261,7 +272,7 @@ export function Tree({
   }
 
   function toggle(path: string, isDir: boolean) {
-    setSelected(path);
+    selectPath(path);
     if (!isDir) {
       editors.open(path, { workspaceId, preview: true });
       return;
@@ -275,7 +286,7 @@ export function Tree({
   }
 
   function togglePermanent(path: string) {
-    setSelected(path);
+    selectPath(path);
     editors.open(path, { workspaceId });
   }
 
@@ -302,7 +313,7 @@ export function Tree({
     placement: { at?: { x: number; y: number }; anchor?: HTMLElement | null },
     rootArea = false,
   ) {
-    setSelected(path);
+    selectPath(path);
     void ctx.ui.showMenu({
       items: menuItemsFor(path, isDir, rootArea),
       toggle: false,


### PR DESCRIPTION
Two workspace-switch persistence improvements for the file explorer:

**Scroll position** — saves scroll position per workspace and restores it when switching back, using a ResizeObserver retry for directories still loading, with debounced saves (300ms).

**Per-root selection** — tracks the selected file/folder independently per root folder, persisting across workspace switches via the panel's per-workspace storage.

### Files changed
- `FileExplorerPanel.tsx` — scroll ref, scroll save/restore effect, `treeSelected` storage + `persistSelected` callback
- `Tree.tsx` — new `initialSelected` / `persistSelected` props, `selectPath()` helper wired into all selection call sites