### PR TITLE
feat: add Dark preset text/border contrast overrides

### DIFF
--- a/packages/extension-host/src/layout/presets.ts
+++ b/packages/extension-host/src/layout/presets.ts
@@ -12,7 +12,12 @@ export const CORE_PRESETS: ThemePreset[] = [
     name: "Dark",
     base: "dark",
     colorScheme: "dark",
-    vars: {},
+    vars: {
+      "--silo-color-text-hi": "#818181",
+      "--silo-color-bg-active": "#282d3a",
+      "--silo-color-text-lo": "#575757",
+      "--silo-color-border": "#222222",
+    },
   },
   {
     id: "light",


### PR DESCRIPTION
Port the "My Theme" Dark preset overrides into the base preset so they apply globally without requiring a custom theme:

- **text-hi**: #666 → #818181 (more visible hi-contrast text)
- **text-lo**: #3c3c3c → #575757 (more visible low-contrast text)
- **bg-active**: #1e222b → #282d3a (slightly brighter active background)
- **border**: transparent → #222222 (visible structural dividers)

All four are lighter/sharper — text and borders are more visible, and the active background is a bit brighter. The active-bg shift is subtle (~6% brighter in each RGB channel).