### PR TITLE
fix: use RUNNER_TEMP for cross-platform nightly config path

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -135,7 +135,7 @@ jobs:
             fs.writeFileSync(outPath, JSON.stringify(merged, null, 2));
             console.log('Nightly config:', merged.productName, merged.version, merged.identifier);
           "
-          # Save the merged config path for the next step
+          # Save the merged config path for the next step (use RUNNER_TEMP so it works on Windows too)
           echo "merged_config=${RUNNER_TEMP}/tauri-nightly-merged.json" >> $GITHUB_ENV
 
       - uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -131,13 +131,12 @@ jobs:
             const night = JSON.parse(fs.readFileSync('apps/desktop/src-tauri/tauri.nightly.conf.json', 'utf8'));
             night.version = '${{ needs.prepare.outputs.version }}';
             const merged = merge(base, night);
-            const outPath = path.join(require('os').tmpdir(), 'tauri-nightly-merged.json');
+            const outPath = path.join(process.env.RUNNER_TEMP || require('os').tmpdir(), 'tauri-nightly-merged.json');
             fs.writeFileSync(outPath, JSON.stringify(merged, null, 2));
             console.log('Nightly config:', merged.productName, merged.version, merged.identifier);
-            console.log(outPath);
           "
           # Save the merged config path for the next step
-          echo "merged_config=$(node -e \"console.log(path.join(require('os').tmpdir(), 'tauri-nightly-merged.json'))\")" >> $GITHUB_ENV
+          echo "merged_config=${RUNNER_TEMP}/tauri-nightly-merged.json" >> $GITHUB_ENV
 
       - uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
## Problem\n\nThe previous fix (#163) used a  to compute the temp path for , but  was undefined in that isolated node process, causing  to be empty. This made  fail with:\n\n\n\n## Fix\n\nUse GitHub Actions' built-in  env var directly — it's reliable and cross-platform (resolves to  on Linux/macOS,  on Windows). Also use it for the file write path.