### PR TITLE
feat(examples): agent-monitor — at-a-glance agent status in the Workspaces panel

### DIFF
--- a/examples/extensions/agent-monitor/build.mjs
+++ b/examples/extensions/agent-monitor/build.mjs
@@ -1,0 +1,27 @@
+import { build } from "esbuild";
+import { copyFileSync, existsSync } from "fs";
+import { homedir } from "os";
+
+await build({
+  entryPoints: ["src/index.tsx"],
+  outfile: "dist/index.js",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2020",
+  jsx: "automatic",
+  minify: false,
+  external: ["react", "react/jsx-runtime", "@silo-code/sdk"],
+  loader: { ".css": "text" },
+  logLevel: "info",
+});
+
+// Sync to the dev-build's installed extension directory so "Reload" in the
+// Extensions page picks up the new bundle without a full reinstall.
+const installed = `${homedir()}/.config/silo-dev/extensions/silo.agent-monitor/dist/index.js`;
+if (existsSync(installed)) {
+  copyFileSync("dist/index.js", installed);
+  console.log(
+    "  synced → ~/.config/silo-dev/extensions/silo.agent-monitor/dist/index.js",
+  );
+}

--- a/examples/extensions/agent-monitor/package.json
+++ b/examples/extensions/agent-monitor/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "agent-monitor",
+  "displayName": "Agent Monitor",
+  "version": "0.1.0",
+  "description": "At-a-glance agent status in the Workspaces panel: rows for coding agents that are working or finished and need attention, cleared when you view the terminal.",
+  "private": true,
+  "type": "module",
+  "silo": {
+    "id": "silo.agent-monitor",
+    "engine": "^0.9",
+    "main": "dist/index.js",
+    "permissions": []
+  },
+  "scripts": {
+    "build": "node build.mjs",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@silo-code/sdk": "workspace:*",
+    "@types/react": "^19.0.0",
+    "esbuild": "^0.24.0",
+    "react": "^19.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.7"
+  }
+}

--- a/examples/extensions/agent-monitor/src/agent-status.test.ts
+++ b/examples/extensions/agent-monitor/src/agent-status.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from "vitest";
+import {
+  initialState,
+  reduce,
+  deriveStatusRow,
+  deriveTabBadge,
+  type AgentEvent,
+  type TerminalAgentState,
+} from "./agent-status";
+
+const T0 = "2026-07-03T10:00:00.000Z";
+const T1 = "2026-07-03T10:05:00.000Z";
+
+function detected(
+  status: Extract<AgentEvent, { type: "detected" }>["status"],
+  source: Extract<AgentEvent, { type: "detected" }>["source"],
+  opts: { active?: boolean; now?: string } = {},
+): AgentEvent {
+  return {
+    type: "detected",
+    status,
+    source,
+    isActiveTerminal: opts.active ?? false,
+    now: opts.now ?? T0,
+  };
+}
+
+/** Fold a sequence of events over an initial state. */
+function run(start: TerminalAgentState, ...events: AgentEvent[]) {
+  return events.reduce(reduce, start);
+}
+
+describe("initialState", () => {
+  it("marks claude/pi terminals as agents from birth", () => {
+    expect(initialState("claude").isAgent).toBe(true);
+    expect(initialState("pi").isAgent).toBe(true);
+  });
+
+  it("marks shell terminals as non-agents", () => {
+    expect(initialState("shell").isAgent).toBe(false);
+  });
+});
+
+describe("promotion and demotion", () => {
+  it("promotes a shell terminal when an agent detector fires", () => {
+    const s = run(initialState("shell"), detected("working", "agent"));
+    expect(s.isAgent).toBe(true);
+  });
+
+  it("never promotes on plain shell-integration events", () => {
+    const s = run(initialState("shell"), detected("working", "shell"));
+    expect(s.isAgent).toBe(false);
+  });
+
+  it("never promotes on timer events", () => {
+    const s = run(initialState("shell"), detected("waiting", "timer"));
+    expect(s.isAgent).toBe(false);
+  });
+
+  it("demotes a promoted shell terminal once shell traffic resumes", () => {
+    // claude runs in a zsh tab (promoted), finishes, the user views it, then
+    // the user runs a plain shell command → back to non-agent.
+    const s = run(
+      initialState("shell"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+      { type: "activated" },
+      detected("working", "shell"),
+    );
+    expect(s.isAgent).toBe(false);
+  });
+
+  it("defers demotion while attention is pending", () => {
+    // The agent exits straight back to the shell prompt: the 133 event both
+    // ends the working phase (setting attention) and is shell traffic. The
+    // unseen "agent finished" must survive.
+    const s = run(
+      initialState("shell"),
+      detected("working", "agent"),
+      detected("waiting", "shell"),
+    );
+    expect(s.isAgent).toBe(true);
+    expect(s.needsAttention).toBe(true);
+  });
+
+  it("never demotes kind-claude/pi terminals on shell traffic", () => {
+    // pi is driven by OSC 133 (source "shell") — its kind keeps it an agent.
+    const s = run(
+      initialState("pi"),
+      detected("working", "shell"),
+      detected("waiting", "shell"),
+      { type: "activated" },
+      detected("working", "shell"),
+    );
+    expect(s.isAgent).toBe(true);
+  });
+});
+
+describe("working state", () => {
+  it("stamps workingSince on entering working", () => {
+    const s = run(initialState("claude"), detected("working", "agent"));
+    expect(s.activity).toBe("working");
+    expect(s.workingSince).toBe(T0);
+  });
+
+  it("returns prev by identity for repeated working events", () => {
+    // Claude Code's braille spinner fires one OSC 0 per animation frame; the
+    // identity check is what prevents an invalidate storm.
+    const s1 = run(initialState("claude"), detected("working", "agent"));
+    const s2 = reduce(s1, detected("working", "agent", { now: T1 }));
+    expect(s2).toBe(s1);
+    expect(s2.workingSince).toBe(T0);
+  });
+
+  it("re-entering working restamps workingSince and clears attention", () => {
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+      detected("working", "agent", { now: T1 }),
+    );
+    expect(s.needsAttention).toBe(false);
+    expect(s.workingSince).toBe(T1);
+  });
+});
+
+describe("needs attention", () => {
+  it("is set when working stops while the terminal is not active", () => {
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+    );
+    expect(s.needsAttention).toBe(true);
+    expect(s.workingSince).toBeNull();
+  });
+
+  it("is set on working → done as well", () => {
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("done", "agent"),
+    );
+    expect(s.needsAttention).toBe(true);
+  });
+
+  it("is suppressed when the terminal is the active tab", () => {
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent", { active: true }),
+    );
+    expect(s.needsAttention).toBe(false);
+  });
+
+  it("is not set without a preceding working phase", () => {
+    // A freshly opened agent sitting at its prompt emits "waiting" signals.
+    const s = run(initialState("claude"), detected("waiting", "agent"));
+    expect(s.needsAttention).toBe(false);
+  });
+
+  it("is sticky across further waiting events", () => {
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+      detected("waiting", "timer"),
+      detected("waiting", "agent"),
+    );
+    expect(s.needsAttention).toBe(true);
+  });
+
+  it("is cleared by activation", () => {
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+      { type: "activated" },
+    );
+    expect(s.needsAttention).toBe(false);
+  });
+
+  it("activation is a no-op (by identity) when nothing is pending", () => {
+    const s1 = run(initialState("claude"), detected("waiting", "agent"));
+    expect(reduce(s1, { type: "activated" })).toBe(s1);
+  });
+
+  it("is set by the idle-timer fallback ending a working phase", () => {
+    // pi never emits an explicit done signal; the debounce timer does it.
+    const s = run(
+      initialState("pi"),
+      detected("working", "shell"),
+      detected("waiting", "timer"),
+    );
+    expect(s.needsAttention).toBe(true);
+  });
+});
+
+describe("deriveStatusRow", () => {
+  it("returns a busy row with startedAt while an agent works", () => {
+    const s = run(initialState("claude"), detected("working", "agent"));
+    expect(deriveStatusRow(s)).toEqual({ status: "busy", startedAt: T0 });
+  });
+
+  it("returns a warn row while attention is pending", () => {
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+    );
+    expect(deriveStatusRow(s)).toEqual({ status: "warn" });
+  });
+
+  it("returns null for idle agents", () => {
+    expect(deriveStatusRow(initialState("claude"))).toBeNull();
+    const viewed = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+      { type: "activated" },
+    );
+    expect(deriveStatusRow(viewed)).toBeNull();
+  });
+
+  it("returns null for shells, even busy ones", () => {
+    const s = run(initialState("shell"), detected("working", "shell"));
+    expect(deriveStatusRow(s)).toBeNull();
+  });
+});
+
+describe("deriveTabBadge", () => {
+  it("maps agent states to badges", () => {
+    const working = run(initialState("claude"), detected("working", "agent"));
+    expect(deriveTabBadge(working)).toBe("working");
+
+    const attention = run(working, detected("waiting", "agent"));
+    expect(deriveTabBadge(attention)).toBe("attention");
+
+    const viewed = reduce(attention, { type: "activated" });
+    expect(deriveTabBadge(viewed)).toBe("waiting");
+
+    expect(deriveTabBadge(initialState("claude"))).toBeNull();
+  });
+
+  it("returns null for shells, whatever their activity", () => {
+    const s = run(initialState("shell"), detected("working", "shell"));
+    expect(deriveTabBadge(s)).toBeNull();
+  });
+});

--- a/examples/extensions/agent-monitor/src/agent-status.test.ts
+++ b/examples/extensions/agent-monitor/src/agent-status.test.ts
@@ -122,6 +122,39 @@ describe("working state", () => {
     expect(s.needsAttention).toBe(false);
     expect(s.workingSince).toBe(T1);
   });
+
+  it("shell events cannot pull a born-agent out of working (flicker fix)", () => {
+    // Claude Code subprocess tool calls emit OSC 133;A/D from the inner shell.
+    // Those arrive as source:"shell" status:"waiting" — they must not override
+    // the agent-driven "working" state, which only agent events or the timer
+    // should end.
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "shell"), // subprocess shell-integration noise
+      detected("waiting", "shell"), // another one
+    );
+    expect(s.activity).toBe("working");
+    expect(s.workingSince).toBe(T0);
+    expect(s.needsAttention).toBe(false);
+  });
+
+  it("pi can be driven into working by shell events", () => {
+    // pi uses OSC 133;C (source:"shell", status:"working"); the timer ends it.
+    const s = run(initialState("pi"), detected("working", "shell"));
+    expect(s.activity).toBe("working");
+    expect(s.isAgent).toBe(true);
+  });
+
+  it("born-agent working state ends on agent-source waiting", () => {
+    // The actual idle signal from Claude Code (✳) should still end working.
+    const s = run(
+      initialState("claude"),
+      detected("working", "agent"),
+      detected("waiting", "agent"),
+    );
+    expect(s.activity).toBe("waiting");
+  });
 });
 
 describe("needs attention", () => {

--- a/examples/extensions/agent-monitor/src/agent-status.ts
+++ b/examples/extensions/agent-monitor/src/agent-status.ts
@@ -85,21 +85,30 @@ export function reduce(
 
   let { activity, needsAttention, workingSince } = prev;
   if (ev.status !== activity) {
-    if (ev.status === "working") {
-      workingSince = ev.now;
-      needsAttention = false;
-    } else {
-      if (
-        activity === "working" &&
-        (ev.status === "waiting" || ev.status === "done")
-      ) {
-        // Work just stopped: flag for attention unless the user is already
-        // looking at this terminal.
-        needsAttention = isAgent && !ev.isActiveTerminal;
+    // Born-agent terminals (kind !== "shell") use agent-source or timer events
+    // as the authoritative signal. Shell events can promote them to "working"
+    // (needed for pi's OSC 133;C steps), but cannot pull them back out of
+    // "working" — that prevents subprocess shell-integration OSC 133;A/D
+    // (emitted inside Claude Code's bash tool calls) from causing flicker.
+    const blockShellDemotion =
+      ev.source === "shell" && prev.kind !== "shell" && ev.status !== "working";
+    if (!blockShellDemotion) {
+      if (ev.status === "working") {
+        workingSince = ev.now;
+        needsAttention = false;
+      } else {
+        if (
+          activity === "working" &&
+          (ev.status === "waiting" || ev.status === "done")
+        ) {
+          // Work just stopped: flag for attention unless the user is already
+          // looking at this terminal.
+          needsAttention = isAgent && !ev.isActiveTerminal;
+        }
+        workingSince = null;
       }
-      workingSince = null;
+      activity = ev.status;
     }
-    activity = ev.status;
   }
 
   // Demotion last: plain shell-integration traffic on a kind-"shell" terminal

--- a/examples/extensions/agent-monitor/src/agent-status.ts
+++ b/examples/extensions/agent-monitor/src/agent-status.ts
@@ -1,0 +1,157 @@
+/**
+ * The per-terminal agent-status state machine — the pure, unit-tested core of
+ * the extension. `index.tsx` feeds it events (OSC detections, terminal
+ * activations) and renders the derived row/badge; all the rules live here.
+ *
+ * The model it implements:
+ *
+ * - A terminal is an **agent** if it was created as one (kind `"claude"`/`"pi"`)
+ *   or an agent-specific OSC detector fires in it (covers typing `claude` into
+ *   a plain shell). Plain shell-integration traffic (OSC 133) on a kind-`"shell"`
+ *   terminal demotes it again once the agent process is gone.
+ * - While an agent is **working** it shows a busy row (with a start timestamp
+ *   so the host renders elapsed time).
+ * - When work stops (working → waiting/done) the terminal **needs attention**
+ *   — sticky until the user views it — unless it was already the active tab.
+ * - **Activation** (the user views the terminal) clears needs-attention.
+ *
+ * Non-agent terminals derive no row and no badge, whatever their activity.
+ */
+
+import type { TerminalKind } from "@silo-code/sdk";
+
+/** Detected activity for a terminal. `"none"` = nothing observed yet. */
+export type Activity = "none" | "working" | "waiting" | "done" | "error";
+
+/** Which class of source produced a detection — see `osc-detectors.ts`. */
+export type EventSource = "agent" | "shell" | "timer";
+
+export interface TerminalAgentState {
+  /** The terminal record's kind at registration time. */
+  kind: TerminalKind;
+  /** Whether this terminal currently hosts an agent (see module doc). */
+  isAgent: boolean;
+  /** Last observed activity. */
+  activity: Activity;
+  /** Sticky "finished, go look" flag — cleared by the `activated` event. */
+  needsAttention: boolean;
+  /** ISO timestamp of when the current work started; null when not working. */
+  workingSince: string | null;
+}
+
+export type AgentEvent =
+  | {
+      type: "detected";
+      status: Activity;
+      /**
+       * `"agent"`/`"shell"` from the matching detector; `"timer"` for the
+       * idle-debounce fallback (neutral: never promotes or demotes).
+       */
+      source: EventSource;
+      /** Whether this terminal was the active tab when the event arrived. */
+      isActiveTerminal: boolean;
+      /** ISO timestamp for the event (stamps `workingSince`). */
+      now: string;
+    }
+  | { type: "activated" };
+
+export function initialState(kind: TerminalKind): TerminalAgentState {
+  return {
+    kind,
+    isAgent: kind !== "shell",
+    activity: "none",
+    needsAttention: false,
+    workingSince: null,
+  };
+}
+
+/**
+ * Apply one event. Returns `prev` **by identity** when nothing changed — the
+ * caller uses that to skip invalidations, which matters because Claude Code's
+ * braille spinner emits an OSC 0 per animation frame.
+ */
+export function reduce(
+  prev: TerminalAgentState,
+  ev: AgentEvent,
+): TerminalAgentState {
+  if (ev.type === "activated") {
+    return prev.needsAttention ? { ...prev, needsAttention: false } : prev;
+  }
+
+  // Promotion first: an agent-specific detector marks this terminal as an
+  // agent whatever its kind, and before the activity transition so the
+  // transition sees the promoted flag.
+  let isAgent = prev.isAgent || ev.source === "agent";
+
+  let { activity, needsAttention, workingSince } = prev;
+  if (ev.status !== activity) {
+    if (ev.status === "working") {
+      workingSince = ev.now;
+      needsAttention = false;
+    } else {
+      if (
+        activity === "working" &&
+        (ev.status === "waiting" || ev.status === "done")
+      ) {
+        // Work just stopped: flag for attention unless the user is already
+        // looking at this terminal.
+        needsAttention = isAgent && !ev.isActiveTerminal;
+      }
+      workingSince = null;
+    }
+    activity = ev.status;
+  }
+
+  // Demotion last: plain shell-integration traffic on a kind-"shell" terminal
+  // means the agent process is gone (we're back at the zsh/bash prompt).
+  // Deferred while attention is pending so an unseen "agent finished" — set
+  // just above when the agent's exit ended a working phase — isn't lost; the
+  // next shell event after the user views it completes the demotion.
+  if (ev.source === "shell" && prev.kind === "shell" && !needsAttention) {
+    isAgent = false;
+  }
+
+  if (
+    isAgent === prev.isAgent &&
+    activity === prev.activity &&
+    needsAttention === prev.needsAttention &&
+    workingSince === prev.workingSince
+  ) {
+    return prev;
+  }
+  return { ...prev, isAgent, activity, needsAttention, workingSince };
+}
+
+/**
+ * The Workspaces-panel row for a terminal, or `null` for no row.
+ * Only agents get rows, and only while working or needing attention.
+ */
+export function deriveStatusRow(
+  s: TerminalAgentState,
+): { status: "busy" | "warn"; startedAt?: string } | null {
+  if (!s.isAgent) return null;
+  if (s.activity === "working") {
+    return { status: "busy", startedAt: s.workingSince ?? undefined };
+  }
+  if (s.needsAttention) return { status: "warn" };
+  return null;
+}
+
+export type TabBadge = "working" | "attention" | "waiting" | "done" | "error";
+
+/** The terminal-tab badge for a terminal, or `null` for none. Agents only. */
+export function deriveTabBadge(s: TerminalAgentState): TabBadge | null {
+  if (!s.isAgent) return null;
+  if (s.activity === "working") return "working";
+  if (s.needsAttention) return "attention";
+  switch (s.activity) {
+    case "waiting":
+      return "waiting";
+    case "done":
+      return "done";
+    case "error":
+      return "error";
+    default:
+      return null;
+  }
+}

--- a/examples/extensions/agent-monitor/src/css.d.ts
+++ b/examples/extensions/agent-monitor/src/css.d.ts
@@ -1,0 +1,5 @@
+// esbuild bundles .css files as plain strings when loader: { ".css": "text" } is set.
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/examples/extensions/agent-monitor/src/index.tsx
+++ b/examples/extensions/agent-monitor/src/index.tsx
@@ -1,0 +1,293 @@
+import type {
+  Extension,
+  ExtensionContext,
+  TerminalTabDecoration,
+  WorkspaceStatusRow,
+} from "@silo-code/sdk";
+import { AGENT_DETECTORS } from "./osc-detectors";
+import {
+  initialState,
+  reduce,
+  deriveStatusRow,
+  deriveTabBadge,
+  type Activity,
+  type AgentEvent,
+  type EventSource,
+  type TerminalAgentState,
+} from "./agent-status";
+import styles from "./styles.css";
+
+const STYLE_ID = "silo-agent-monitor-styles";
+
+function activate(ctx: ExtensionContext) {
+  // Per-terminal agent state, keyed by terminal record id. All transitions go
+  // through dispatch() → reduce(); this map is the single source of truth the
+  // status-row and tab-decoration providers read from.
+  const states = new Map<string, TerminalAgentState>();
+  // Disposables for per-terminal OSC subscriptions, keyed by terminal id.
+  const oscSubs = new Map<string, { dispose(): void }>();
+  // Per-terminal debounce timers for OSC 133 "working" → "waiting" fallback.
+  // Some agents (e.g. pi) emit 133;C for each step but never emit 133;A/D on
+  // completion. When the stream goes silent for SHELL_IDLE_MS we clear to waiting.
+  const SHELL_IDLE_MS = 3_000;
+  const shellIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  let activeTerminalId = ctx.terminals.getActive();
+
+  function dispatch(terminalId: string, ev: AgentEvent) {
+    const prev = states.get(terminalId);
+    if (!prev) return;
+    const next = reduce(prev, ev);
+    // reduce() returns prev by identity when nothing changed — critical here,
+    // since Claude Code's braille spinner emits an OSC 0 per animation frame
+    // and each invalidation re-renders the Workspaces panel and terminal tabs.
+    if (next === prev) return;
+    states.set(terminalId, next);
+    ctx.workspaces.invalidateStatus();
+    ctx.terminals.invalidateTabDecorations();
+  }
+
+  function detectedEvent(
+    terminalId: string,
+    status: Activity,
+    source: EventSource,
+  ): AgentEvent {
+    return {
+      type: "detected",
+      status,
+      source,
+      isActiveTerminal: terminalId === activeTerminalId,
+      now: new Date().toISOString(),
+    };
+  }
+
+  function clearShellIdleTimer(terminalId: string) {
+    const t = shellIdleTimers.get(terminalId);
+    if (t !== undefined) {
+      clearTimeout(t);
+      shellIdleTimers.delete(terminalId);
+    }
+  }
+
+  function scheduleShellIdle(terminalId: string) {
+    clearShellIdleTimer(terminalId);
+    shellIdleTimers.set(
+      terminalId,
+      setTimeout(() => {
+        shellIdleTimers.delete(terminalId);
+        dispatch(terminalId, detectedEvent(terminalId, "waiting", "timer"));
+      }, SHELL_IDLE_MS),
+    );
+  }
+
+  function subscribeTerminalOsc(terminalId: string) {
+    if (oscSubs.has(terminalId)) return;
+    const sub = ctx.terminals.subscribeOsc(terminalId, ({ code, payload }) => {
+      for (const detect of AGENT_DETECTORS) {
+        const result = detect(code, payload);
+        if (result) {
+          if (result.timer === "schedule") scheduleShellIdle(terminalId);
+          else if (result.timer === "clear") clearShellIdleTimer(terminalId);
+          dispatch(
+            terminalId,
+            detectedEvent(terminalId, result.status, result.source),
+          );
+          break;
+        }
+      }
+    });
+    oscSubs.set(terminalId, sub);
+    // Note: do NOT push into ctx.subscriptions — oscSubs manages the lifecycle
+    // of these per-terminal subscriptions (disposed in syncOscSubscriptions and
+    // the bulk disposable below). Pushing them would cause the array to grow
+    // unboundedly as terminals open and close, and stale entries would be
+    // double-disposed at deactivation.
+  }
+
+  function syncOscSubscriptions() {
+    const ws = ctx.workspaces.getState();
+    const live = new Set<string>();
+    for (const workspace of ws.all) {
+      for (const t of workspace.terminals) {
+        live.add(t.id);
+        if (!states.has(t.id)) states.set(t.id, initialState(t.kind));
+        subscribeTerminalOsc(t.id);
+      }
+    }
+    // Clean up state for terminals that no longer exist.
+    for (const [id, sub] of oscSubs) {
+      if (!live.has(id)) {
+        sub.dispose();
+        oscSubs.delete(id);
+        states.delete(id);
+        clearShellIdleTimer(id);
+      }
+    }
+  }
+
+  ctx.subscriptions.push(
+    ctx.workspaces.subscribe(() => {
+      // Terminal titles/names live on workspace state, so status-row labels
+      // may have changed even when our own state hasn't.
+      ctx.workspaces.invalidateStatus();
+      syncOscSubscriptions();
+    }),
+    ctx.terminals.subscribeActive((terminalId) => {
+      activeTerminalId = terminalId;
+      // Viewing a terminal clears its "needs attention" flag.
+      if (terminalId) dispatch(terminalId, { type: "activated" });
+    }),
+    // Bulk cleanup at deactivation for whatever per-terminal resources are
+    // still live at that point.
+    {
+      dispose() {
+        for (const sub of oscSubs.values()) sub.dispose();
+        oscSubs.clear();
+        for (const t of shellIdleTimers.values()) clearTimeout(t);
+        shellIdleTimers.clear();
+      },
+    },
+  );
+
+  // Subscribe to any terminals already open at activation time.
+  syncOscSubscriptions();
+
+  ctx.subscriptions.push(
+    ctx.workspaces.registerStatus({
+      id: "silo.agent-monitor.status",
+      provide(workspaceId): WorkspaceStatusRow[] {
+        const ws = ctx.workspaces.get(workspaceId);
+        if (!ws) return [];
+        const rows: WorkspaceStatusRow[] = [];
+        for (const t of ws.terminals) {
+          const s = states.get(t.id);
+          if (!s) continue;
+          const row = deriveStatusRow(s);
+          if (!row) continue;
+          rows.push({
+            id: t.id,
+            label: t.customName ?? t.title,
+            status: row.status,
+            startedAt: row.startedAt,
+          });
+        }
+        return rows;
+      },
+    }),
+  );
+
+  ctx.subscriptions.push(
+    ctx.terminals.registerTabDecoration({
+      id: "silo.agent-monitor.tab",
+      provide(terminalId): TerminalTabDecoration | null {
+        const s = states.get(terminalId);
+        if (!s) return null;
+        switch (deriveTabBadge(s)) {
+          case "working":
+            return {
+              icon: <SpinnerIcon />,
+              color: "accent",
+              tooltip: "Agent working",
+            };
+          case "attention":
+            return {
+              icon: <AttentionIcon />,
+              color: "warn",
+              tooltip: "Needs attention",
+            };
+          case "waiting":
+            return {
+              icon: <WaitingIcon />,
+              color: "muted",
+              tooltip: "Waiting for input",
+            };
+          case "done":
+            return { icon: <DoneIcon />, color: "ok", tooltip: "Done" };
+          case "error":
+            return { icon: <ErrorIcon />, color: "error", tooltip: "Error" };
+          default:
+            return null;
+        }
+      },
+    }),
+  );
+
+  injectStyles();
+}
+
+function deactivate() {
+  document.getElementById(STYLE_ID)?.remove();
+}
+
+function injectStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = styles;
+  document.head.appendChild(style);
+}
+
+function SpinnerIcon() {
+  return <div className="am-spinner" aria-hidden="true" />;
+}
+function AttentionIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M6 1a3.2 3.2 0 0 0-3.2 3.2v2.1L1.7 8.3a.5.5 0 0 0 .42.77h7.76a.5.5 0 0 0 .42-.77L9.2 6.3V4.2A3.2 3.2 0 0 0 6 1z" />
+      <path d="M4.8 9.9a1.2 1.2 0 0 0 2.4 0z" />
+    </svg>
+  );
+}
+function WaitingIcon() {
+  return (
+    <div className="am-waiting-icon" aria-hidden="true">
+      <span />
+      <span />
+    </div>
+  );
+}
+function DoneIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M10 3L5 9 2 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+function ErrorIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M6 1a5 5 0 1 0 0 10A5 5 0 0 0 6 1zm-.5 2.5h1v4h-1v-4zm0 5h1v1h-1v-1z" />
+    </svg>
+  );
+}
+
+export const extension: Extension = {
+  id: "silo.agent-monitor",
+  activate,
+  deactivate,
+};

--- a/examples/extensions/agent-monitor/src/index.tsx
+++ b/examples/extensions/agent-monitor/src/index.tsx
@@ -19,6 +19,14 @@ import styles from "./styles.css";
 
 const STYLE_ID = "silo-agent-monitor-styles";
 
+// Set to true to log OSC events and state transitions to the browser console.
+// Open devtools in Silo with Cmd+Option+I (Mac) or F12.
+const DEBUG = true;
+
+function log(...args: unknown[]) {
+  if (DEBUG) console.log("[agent-monitor]", ...args);
+}
+
 function activate(ctx: ExtensionContext) {
   // Per-terminal agent state, keyed by terminal record id. All transitions go
   // through dispatch() → reduce(); this map is the single source of truth the
@@ -42,6 +50,16 @@ function activate(ctx: ExtensionContext) {
     // since Claude Code's braille spinner emits an OSC 0 per animation frame
     // and each invalidation re-renders the Workspaces panel and terminal tabs.
     if (next === prev) return;
+    const tid = terminalId.slice(-8);
+    if (ev.type === "detected") {
+      log(
+        `${tid} ${prev.activity}→${next.activity}` +
+          ` isAgent=${next.isAgent} needsAttn=${next.needsAttention}` +
+          ` (src=${ev.source} status=${ev.status})`,
+      );
+    } else {
+      log(`${tid} activated → needsAttn cleared`);
+    }
     states.set(terminalId, next);
     ctx.workspaces.invalidateStatus();
     ctx.terminals.invalidateTabDecorations();
@@ -86,6 +104,11 @@ function activate(ctx: ExtensionContext) {
       for (const detect of AGENT_DETECTORS) {
         const result = detect(code, payload);
         if (result) {
+          log(
+            `osc${code} "${payload.slice(0, 40)}" → ${result.status}/${result.source}` +
+              (result.timer ? ` timer:${result.timer}` : "") +
+              ` tid=…${terminalId.slice(-8)}`,
+          );
           if (result.timer === "schedule") scheduleShellIdle(terminalId);
           else if (result.timer === "clear") clearShellIdleTimer(terminalId);
           dispatch(

--- a/examples/extensions/agent-monitor/src/osc-detectors.test.ts
+++ b/examples/extensions/agent-monitor/src/osc-detectors.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectClaudeCode,
+  detectCopilotCLI,
+  detectCodexCLI,
+  detectShellIntegration,
+} from "./osc-detectors";
+
+// ---------------------------------------------------------------------------
+// Claude Code
+// ---------------------------------------------------------------------------
+describe("detectClaudeCode", () => {
+  it("returns working+schedule for braille spinner frames", () => {
+    // ⠋ U+280B, ⠙ U+2819, ⠏ U+280F — sample Codex/Claude spinner frames
+    for (const ch of ["⠋", "⠙", "⠏", "⠀", "⣿"]) {
+      expect(detectClaudeCode(0, `${ch} my-project`)).toEqual({
+        status: "working",
+        source: "agent",
+        timer: "schedule",
+      });
+    }
+  });
+
+  it("returns waiting+clear for the ✳ idle char", () => {
+    expect(detectClaudeCode(0, "✳ waiting…")).toEqual({
+      status: "waiting",
+      source: "agent",
+      timer: "clear",
+    });
+  });
+
+  it("returns null for a plain title string", () => {
+    expect(detectClaudeCode(0, "my-project")).toBeNull();
+  });
+
+  it("returns null for non-OSC-0 codes", () => {
+    expect(detectClaudeCode(9, "⠋ spinner")).toBeNull();
+    expect(detectClaudeCode(133, "C")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHub Copilot CLI
+// ---------------------------------------------------------------------------
+describe("detectCopilotCLI", () => {
+  it("returns working for states 1, 2, 3", () => {
+    expect(detectCopilotCLI(9, "4;1")).toEqual({
+      status: "working",
+      source: "agent",
+    });
+    expect(detectCopilotCLI(9, "4;2;50")).toEqual({
+      status: "working",
+      source: "agent",
+    });
+    expect(detectCopilotCLI(9, "4;3;0")).toEqual({
+      status: "working",
+      source: "agent",
+    });
+  });
+
+  it("returns waiting for states 0 and 4", () => {
+    expect(detectCopilotCLI(9, "4;0;0")).toEqual({
+      status: "waiting",
+      source: "agent",
+    });
+    expect(detectCopilotCLI(9, "4;4")).toEqual({
+      status: "waiting",
+      source: "agent",
+    });
+  });
+
+  it("returns null for unknown state values", () => {
+    expect(detectCopilotCLI(9, "4;99")).toBeNull();
+  });
+
+  it("returns null for non-progress OSC 9 payloads", () => {
+    expect(detectCopilotCLI(9, "Agent turn complete")).toBeNull();
+    expect(detectCopilotCLI(9, "Approval requested: rm -rf")).toBeNull();
+  });
+
+  it("returns null for non-OSC-9 codes", () => {
+    expect(detectCopilotCLI(0, "4;3;0")).toBeNull();
+    expect(detectCopilotCLI(133, "4;3")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Codex CLI
+// ---------------------------------------------------------------------------
+describe("detectCodexCLI", () => {
+  it("returns waiting+clear for empty OSC 0 (exited)", () => {
+    expect(detectCodexCLI(0, "")).toEqual({
+      status: "waiting",
+      source: "agent",
+      timer: "clear",
+    });
+  });
+
+  it("returns waiting+clear for action-required OSC 0 prefixes", () => {
+    expect(detectCodexCLI(0, "[ ! ] Action Required - my-project")).toEqual({
+      status: "waiting",
+      source: "agent",
+      timer: "clear",
+    });
+    expect(detectCodexCLI(0, "[ . ] Action Required - my-project")).toEqual({
+      status: "waiting",
+      source: "agent",
+      timer: "clear",
+    });
+  });
+
+  it("returns null for a plain project-name OSC 0", () => {
+    expect(detectCodexCLI(0, "my-project")).toBeNull();
+  });
+
+  it("returns null for braille OSC 0 (handled by detectClaudeCode)", () => {
+    expect(detectCodexCLI(0, "⠋ my-project")).toBeNull();
+  });
+
+  it("returns waiting+clear for known OSC 9 notification payloads", () => {
+    expect(detectCodexCLI(9, "Agent turn complete")).toEqual({
+      status: "waiting",
+      source: "agent",
+      timer: "clear",
+    });
+    expect(detectCodexCLI(9, "Approval requested: rm -rf /")).toEqual({
+      status: "waiting",
+      source: "agent",
+      timer: "clear",
+    });
+    expect(detectCodexCLI(9, "Codex wants to edit src/main.ts")).toEqual({
+      status: "waiting",
+      source: "agent",
+      timer: "clear",
+    });
+  });
+
+  it("returns null for unrecognised OSC 9 payloads", () => {
+    expect(detectCodexCLI(9, "Some random notification")).toBeNull();
+    // Must not catch Copilot progress payloads
+    expect(detectCodexCLI(9, "4;3;0")).toBeNull();
+  });
+
+  it("returns null for non-OSC-0/9 codes", () => {
+    expect(detectCodexCLI(133, "")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shell integration (OSC 133)
+// ---------------------------------------------------------------------------
+describe("detectShellIntegration", () => {
+  it("returns working+schedule with shell source for 133;C", () => {
+    expect(detectShellIntegration(133, "C")).toEqual({
+      status: "working",
+      source: "shell",
+      timer: "schedule",
+    });
+  });
+
+  it("returns waiting+clear for 133;A (plain and with kitty params)", () => {
+    expect(detectShellIntegration(133, "A")).toEqual({
+      status: "waiting",
+      source: "shell",
+      timer: "clear",
+    });
+    expect(detectShellIntegration(133, "A;k=s")).toEqual({
+      status: "waiting",
+      source: "shell",
+      timer: "clear",
+    });
+  });
+
+  it("returns waiting+clear for 133;D (plain and with exit code)", () => {
+    for (const payload of ["D", "D;0", "D;1"]) {
+      expect(detectShellIntegration(133, payload)).toEqual({
+        status: "waiting",
+        source: "shell",
+        timer: "clear",
+      });
+    }
+  });
+
+  it("returns null for 133;B (command entered — not a status transition)", () => {
+    expect(detectShellIntegration(133, "B")).toBeNull();
+  });
+
+  it("returns null for non-OSC-133 codes", () => {
+    expect(detectShellIntegration(0, "C")).toBeNull();
+    expect(detectShellIntegration(9, "C")).toBeNull();
+  });
+});

--- a/examples/extensions/agent-monitor/src/osc-detectors.ts
+++ b/examples/extensions/agent-monitor/src/osc-detectors.ts
@@ -1,0 +1,155 @@
+/**
+ * Per-agent OSC sequence detectors for terminal status auto-detection.
+ *
+ * Each detector is a pure function that inspects one `{ code, payload }` pair
+ * and returns either `null` (not handled) or a `DetectionResult` describing
+ * the status to apply, which class of program produced it, and whether to
+ * start/cancel the idle debounce timer.
+ *
+ * The dispatcher in `index.tsx` runs `AGENT_DETECTORS` in order and takes the
+ * first non-null result. Adding support for a new agent means adding a new
+ * detector function and appending it to the array — nothing else changes.
+ *
+ * The `source` field is what separates agents from plain shells: the
+ * agent-specific detectors (Claude Code, Codex, Copilot) tag their results
+ * `"agent"`, while the generic OSC 133 shell-integration detector — which
+ * fires for ordinary zsh/bash commands too — tags `"shell"`. The state
+ * machine in `agent-status.ts` uses the tag to promote/demote terminals.
+ */
+
+import type { Activity } from "./agent-status";
+
+export type TimerAction = "schedule" | "clear";
+
+export interface DetectionResult {
+  status: Activity;
+  /** Which class of program emitted the sequence — see module doc above. */
+  source: "agent" | "shell";
+  /** "schedule" → reset the idle debounce timer; "clear" → cancel it. */
+  timer?: TimerAction;
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code  (OSC 0 title encoding)
+// ---------------------------------------------------------------------------
+// Uses braille block characters (U+2800–U+28FF) as a spinner while busy, and
+// ✳ (U+2733) as an explicit idle signal when waiting for input.
+// Note: Codex CLI uses the same braille spinner range, so the braille → working
+// branch covers both. The ✳ idle signal and debounce timer handle the difference:
+// Claude emits ✳ immediately; Codex relies on the timer after silence.
+const BRAILLE_START = 0x2800;
+const BRAILLE_END = 0x28ff;
+const CLAUDE_IDLE_CHAR = "✳"; // ✳
+
+export function detectClaudeCode(
+  code: number,
+  payload: string,
+): DetectionResult | null {
+  if (code !== 0) return null;
+  const first = payload.charCodeAt(0);
+  if (first >= BRAILLE_START && first <= BRAILLE_END) {
+    // Braille spinner: agent is busy. Schedule idle timer as a fallback for
+    // Codex (which doesn't emit an explicit done signal).
+    return { status: "working", source: "agent", timer: "schedule" };
+  }
+  if (payload.startsWith(CLAUDE_IDLE_CHAR)) {
+    // Explicit idle signal from Claude Code.
+    return { status: "waiting", source: "agent", timer: "clear" };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Codex CLI  (OSC 0 title + OSC 9 desktop notifications)
+// ---------------------------------------------------------------------------
+// Codex clears its title to empty on exit and emits "[ ! ]"/"[ . ]" when
+// awaiting user approval. It also emits OSC 9 desktop notifications when
+// TERM_PROGRAM=iTerm.app — matched on known payload prefixes only to avoid
+// stomping an active Copilot status on unrelated OSC 9 from other programs.
+const CODEX_ACTION_REQUIRED = ["[ ! ]", "[ . ]"];
+const CODEX_DONE_NOTIFICATIONS = [
+  "Agent turn complete",
+  "Approval requested",
+  "Codex wants to edit",
+];
+
+export function detectCodexCLI(
+  code: number,
+  payload: string,
+): DetectionResult | null {
+  if (code === 0) {
+    if (
+      payload === "" ||
+      CODEX_ACTION_REQUIRED.some((p) => payload.startsWith(p))
+    ) {
+      return { status: "waiting", source: "agent", timer: "clear" };
+    }
+    return null;
+  }
+  if (
+    code === 9 &&
+    CODEX_DONE_NOTIFICATIONS.some((p) => payload.startsWith(p))
+  ) {
+    return { status: "waiting", source: "agent", timer: "clear" };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Copilot CLI  (OSC 9;4 ConEmu/Windows Terminal progress protocol)
+// ---------------------------------------------------------------------------
+// Payload format: "4;<state>" or "4;<state>;<progress%>"
+// Copilot emits state=3 while actively running and state=0 on completion.
+// States 1/2/3 → working; states 0/4 → waiting.
+const COPILOT_PROGRESS_PREFIX = "4;";
+
+export function detectCopilotCLI(
+  code: number,
+  payload: string,
+): DetectionResult | null {
+  if (code !== 9 || !payload.startsWith(COPILOT_PROGRESS_PREFIX)) return null;
+  const state = parseInt(payload.slice(COPILOT_PROGRESS_PREFIX.length), 10);
+  if (state === 1 || state === 2 || state === 3) {
+    return { status: "working", source: "agent" };
+  }
+  if (state === 0 || state === 4) {
+    return { status: "waiting", source: "agent" };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Shell integration  (OSC 133 FTCS protocol — zsh/bash/fish, used by pi etc.)
+// ---------------------------------------------------------------------------
+// A=prompt start, B=command entered, C=command output start, D[;exit]=command done.
+// A and D may carry extra params (e.g. "A;k=s" kitty keyboard protocol), so
+// we use startsWith. Agents that emit 133;C per step but never emit A/D (e.g. pi)
+// rely on the idle debounce timer to clear the status after silence.
+const SHELL_COMMAND_RUNNING = "C";
+const SHELL_PROMPT_START = "A";
+
+export function detectShellIntegration(
+  code: number,
+  payload: string,
+): DetectionResult | null {
+  if (code !== 133) return null;
+  if (payload === SHELL_COMMAND_RUNNING) {
+    return { status: "working", source: "shell", timer: "schedule" };
+  }
+  if (payload.startsWith(SHELL_PROMPT_START) || payload.startsWith("D")) {
+    return { status: "waiting", source: "shell", timer: "clear" };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Ordered detector list — first non-null result wins.
+// ---------------------------------------------------------------------------
+// Copilot before Codex: both use OSC 9 but with non-overlapping payloads.
+// Copilot's "4;" prefix is checked first; Codex uses known notification strings.
+export const AGENT_DETECTORS = [
+  detectCopilotCLI,
+  detectClaudeCode,
+  detectCodexCLI,
+  detectShellIntegration,
+];

--- a/examples/extensions/agent-monitor/src/styles.css
+++ b/examples/extensions/agent-monitor/src/styles.css
@@ -1,0 +1,27 @@
+/* Tab decoration icons — colors come from the host via `currentColor`
+   (the decoration's semantic `color` maps to --silo-color-* tokens). */
+.am-spinner {
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: am-spin 0.7s linear infinite;
+}
+@keyframes am-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.am-waiting-icon {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+.am-waiting-icon span {
+  display: block;
+  width: 2.5px;
+  height: 8px;
+  background: currentColor;
+  border-radius: 1px;
+}

--- a/examples/extensions/agent-monitor/tsconfig.json
+++ b/examples/extensions/agent-monitor/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["react"]
+  },
+  "include": ["src"]
+}

--- a/examples/extensions/agent-monitor/vitest.config.ts
+++ b/examples/extensions/agent-monitor/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    name: "unit",
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,27 @@ importers:
         specifier: ^2.0.17
         version: 2.0.17(mermaid@11.15.0)(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@25.9.1)(@types/react@19.2.16)(postcss@8.5.15)(react@19.2.7)(search-insights@2.17.3)(typescript@5.8.3))
 
+  examples/extensions/agent-monitor:
+    devDependencies:
+      '@silo-code/sdk':
+        specifier: workspace:*
+        version: link:../../../packages/sdk
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.16
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      typescript:
+        specifier: ^5.6.0
+        version: 5.8.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.8(@types/node@25.9.1)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
+
   examples/extensions/clock-extension:
     devDependencies:
       '@silo-code/sdk':


### PR DESCRIPTION
## What

A new example extension, **`silo.agent-monitor`**, that answers one question at a glance from the Workspaces panel: *which agents are working, and which finished and need me to move them forward?*

- **Busy row** (with elapsed time) while a coding agent — Claude Code, Codex, Copilot, pi — is working, in any workspace.
- **Sticky warn row** when an agent stops working and needs looking at. Suppressed if you were already viewing that terminal.
- **Clears on view**: activating the terminal clears the attention flag (built on the new `ctx.terminals.getActive`/`subscribeActive` API from #161).
- **Nothing else**: idle agents and plain shells contribute no rows — unlike the `terminal-monitor` example, which lists every terminal.
- Matching tab badges via `registerTabDecoration` (spinner / bell / waiting bars).

## How

- `agent-status.ts` — a pure state machine, fully unit-tested (34 cases): agent identity comes from the terminal kind (`claude`/`pi`) or **promotion** when an agent-specific OSC detector fires in a plain shell tab (covers typing `claude` into zsh); **demotion** back to plain shell once shell-integration traffic resumes after the agent exits, deferred while attention is pending so an unseen "agent finished" isn't lost.
- `osc-detectors.ts` — the four detectors from `terminal-monitor`, with results tagged `source: "agent" | "shell"`; the tag is what keeps ordinary shell commands out of the panel.
- `index.tsx` — thin glue. Invalidates only when the reducer returns a new state reference, so Claude's per-frame braille-spinner OSC doesn't cause an invalidate storm. All per-terminal OSC subs and debounce timers are released on deactivate.
- Touches the app only through `ctx` + `@silo-code/sdk`, like every example.

## Behavioral judgment call

Demotion of a promoted shell terminal happens on the next plain OSC 133 event (agent exited to prompt). Claude/Codex/Copilot don't emit 133 mid-run, so flapping shouldn't occur in practice — flagged here since it's the one heuristic in the state machine.

## Testing

- `pnpm --filter agent-monitor test` — 46 tests green (state machine + detectors).
- `pnpm --filter agent-monitor typecheck` — clean.
- `node build.mjs` — bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
