### PR TITLE
feat(workspaces): close and restore workspace groups

### DIFF
--- a/docs/decisions/0023-workspace-groups-host-internal.md
+++ b/docs/decisions/0023-workspace-groups-host-internal.md
@@ -36,10 +36,14 @@ Workspace panel groups stay a **host-internal, `core.*`-only** concern. Group
 state (`AppState.groups` / `panelOrder`) and its mutators (`createGroup`,
 `renameGroup`, `deleteGroup`, `setGroupColor`, `reorderPanel`,
 `moveWorkspaceToGroup`, `ungroupWorkspace`, `reorderWorkspaceInGroup`,
-`toggleGroupCollapsed`) plus the derived lookups (`groupIdForWorkspace`,
-`workspaceGroupMap`) are exported from `@silo-code/extension-host/internal` and
-consumed only by `core.workspaces`. They are **not** added to the public
-`WorkspaceService` and carry no SDK docs or roadmap entry.
+`toggleGroupCollapsed`, `closeGroup`, `restoreGroup`) plus the derived lookups
+(`groupIdForWorkspace`, `workspaceGroupMap`) are exported from
+`@silo-code/extension-host/internal` and consumed only by `core.workspaces`.
+They are **not** added to the public `WorkspaceService` and carry no SDK docs
+or roadmap entry. `closeGroup`/`restoreGroup` soft-close and reopen a group's
+members through the existing workspace lifecycle (`Workspace.closedAt`) —
+extending the same internal channel rather than crossing onto the public
+service.
 
 Two orders back the panel. `panelOrder` is a single interleaved list of
 top-level entries — ungrouped workspace ids and group ids — so a group can be

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -113,6 +113,8 @@ export {
   toggleGroupCollapsed,
   groupIdForWorkspace,
   workspaceGroupMap,
+  closeGroup,
+  restoreGroup,
 } from "../state/workspaces";
 export type { WorkspaceGroup, WorkspaceInternal } from "../state/types";
 

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -299,6 +299,59 @@ describe("buildIndex", () => {
     expect(index.groups).toBeUndefined();
     expect(index.panelOrder).toBeUndefined();
   });
+
+  it("round-trips closedAt and closedMemberIds on a closed group", () => {
+    const groups = {
+      grp_1: {
+        id: "grp_1",
+        name: "Xerro",
+        collapsed: false,
+        workspaceOrder: ["ws_a", "ws_b"],
+        closedAt: "2026-01-01T00:00:00.000Z",
+        closedMemberIds: ["ws_a"],
+      },
+    };
+    const index = buildIndex({
+      workspaceOrder: ["ws_a", "ws_b"],
+      activeWorkspaceId: null,
+      groups,
+    });
+    expect(index.groups!["grp_1"].closedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(index.groups!["grp_1"].closedMemberIds).toEqual(["ws_a"]);
+  });
+
+  it("deep-clones closedMemberIds so mutating the source doesn't alias the snapshot", () => {
+    const closedMemberIds = ["ws_a"];
+    const groups = {
+      grp_1: {
+        id: "grp_1",
+        name: "G",
+        collapsed: false,
+        workspaceOrder: ["ws_a"],
+        closedAt: "2026-01-01T00:00:00.000Z",
+        closedMemberIds,
+      },
+    };
+    const index = buildIndex({
+      workspaceOrder: [],
+      activeWorkspaceId: null,
+      groups,
+    });
+    closedMemberIds.push("ws_b");
+    expect(index.groups!["grp_1"].closedMemberIds).toEqual(["ws_a"]);
+  });
+
+  it("omits closedMemberIds on an open group", () => {
+    const groups = {
+      grp_1: { id: "grp_1", name: "G", collapsed: false, workspaceOrder: [] },
+    };
+    const index = buildIndex({
+      workspaceOrder: [],
+      activeWorkspaceId: null,
+      groups,
+    });
+    expect(index.groups!["grp_1"].closedMemberIds).toBeUndefined();
+  });
 });
 
 describe("reconcilePanelOrder", () => {
@@ -335,6 +388,15 @@ describe("reconcilePanelOrder", () => {
   it("never lists a grouped workspace at the top level even if saved does", () => {
     expect(
       reconcilePanelOrder(["ws_b", "ws_a"], groups, ["ws_a", "ws_b"]),
+    ).toEqual(["ws_a", "grp_1"]);
+  });
+
+  it("keeps a closed group at its saved position — closedAt doesn't affect placement", () => {
+    const closedGroups = {
+      grp_1: { workspaceOrder: ["ws_b"], closedAt: "2026-01-01T00:00:00.000Z" },
+    };
+    expect(
+      reconcilePanelOrder(["ws_a", "grp_1"], closedGroups, ["ws_a", "ws_b"]),
     ).toEqual(["ws_a", "grp_1"]);
   });
 });

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -153,7 +153,13 @@ function cloneGroups(
 ): Record<string, WorkspaceGroup> {
   const out: Record<string, WorkspaceGroup> = {};
   for (const [id, group] of Object.entries(src)) {
-    out[id] = { ...group, workspaceOrder: [...group.workspaceOrder] };
+    out[id] = {
+      ...group,
+      workspaceOrder: [...group.workspaceOrder],
+      ...(group.closedMemberIds
+        ? { closedMemberIds: [...group.closedMemberIds] }
+        : {}),
+    };
   }
   return out;
 }

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -64,6 +64,14 @@ export interface WorkspaceGroup {
   collapsed: boolean;
   workspaceOrder: string[]; // workspace IDs in this group, in user-defined order
   color?: string; // optional accent color, e.g. "#e06c75"
+  /** ISO timestamp when the group was closed via `closeGroup`; absent/null = open.
+   *  Mirrors `Workspace.closedAt`. A closed group stays in `panelOrder` (position
+   *  is preserved for restore) but is filtered out of rendering/nav. */
+  closedAt?: string | null;
+  /** Member ids that were open at close time — the exact set `restoreGroup`
+   *  reopens. Present iff `closedAt` is set; a member closed before the group
+   *  was closed is excluded and stays individually closed after restore. */
+  closedMemberIds?: string[];
 }
 
 export interface AppState {

--- a/packages/extension-host/src/state/workspaces-groups.test.ts
+++ b/packages/extension-host/src/state/workspaces-groups.test.ts
@@ -25,6 +25,11 @@ import {
   workspaceGroupMap,
   createWorkspace,
   deleteWorkspace,
+  closeGroup,
+  restoreGroup,
+  activateWorkspace,
+  reopenWorkspace,
+  closeWorkspace,
 } from "./workspaces";
 
 function makeGroup(name: string): WorkspaceGroup {
@@ -400,5 +405,234 @@ describe("workspaceGroupMap", () => {
     expect(map.get("ws_b")).toBe("grp_1");
     expect(map.get("ws_c")).toBe("grp_2");
     expect(map.has("ws_d")).toBe(false);
+  });
+});
+
+// ── closeGroup ───────────────────────────────────────────────────────────────
+
+describe("closeGroup", () => {
+  it("sets closedAt on the group and every open member", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeGroup(group.id);
+    expect(store.groups[group.id].closedAt).not.toBeNull();
+    expect(store.workspaces[a.id].closedAt).not.toBeNull();
+    expect(store.workspaces[b.id].closedAt).not.toBeNull();
+  });
+
+  it("records only members that were open at close time", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeWorkspace(a.id); // pre-closed before the group-close
+    closeGroup(group.id);
+    expect(store.groups[group.id].closedMemberIds).toEqual([b.id]);
+  });
+
+  it("records an empty list for an empty group", () => {
+    const group = makeGroup("G");
+    closeGroup(group.id);
+    expect(store.groups[group.id].closedAt).not.toBeNull();
+    expect(store.groups[group.id].closedMemberIds).toEqual([]);
+  });
+
+  it("records an empty list when all members are already closed", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    moveWorkspaceToGroup(a.id, group.id);
+    closeWorkspace(a.id);
+    closeGroup(group.id);
+    expect(store.groups[group.id].closedMemberIds).toEqual([]);
+  });
+
+  it("falls back the active workspace to the next open non-member", () => {
+    const other = createWorkspace({ folder: "/other", name: "other" });
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    activateWorkspace(b.id);
+    closeGroup(group.id);
+    expect(store.activeWorkspaceId).toBe(other.id);
+  });
+
+  it("falls back the active workspace to null when nothing else is open", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    activateWorkspace(b.id);
+    closeGroup(group.id);
+    expect(store.activeWorkspaceId).toBeNull();
+  });
+
+  it("does not move the group's slot in panelOrder", () => {
+    const before = createWorkspace({ folder: "/before", name: "before" });
+    const group = makeGroup("G");
+    const after = createWorkspace({ folder: "/after", name: "after" });
+    const order = [...store.panelOrder];
+    closeGroup(group.id);
+    expect(store.panelOrder).toEqual(order);
+    expect(store.panelOrder).toEqual([before.id, group.id, after.id]);
+  });
+
+  it("no-ops for an unknown id", () => {
+    expect(() => closeGroup("grp_ghost")).not.toThrow();
+  });
+
+  it("no-ops for an already-closed group", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    moveWorkspaceToGroup(a.id, group.id);
+    closeGroup(group.id);
+    const closedAt = store.groups[group.id].closedAt;
+    closeGroup(group.id);
+    expect(store.groups[group.id].closedAt).toBe(closedAt);
+    expect(store.groups[group.id].closedMemberIds).toEqual([a.id]);
+  });
+});
+
+// ── restoreGroup ─────────────────────────────────────────────────────────────
+
+describe("restoreGroup", () => {
+  it("reopens exactly the members recorded at close time", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeWorkspace(a.id); // pre-closed before the group-close
+    closeGroup(group.id);
+    restoreGroup(group.id);
+    expect(store.groups[group.id].closedAt).toBeNull();
+    expect(store.groups[group.id].closedMemberIds).toBeUndefined();
+    expect(store.workspaces[b.id].closedAt).toBeNull();
+    // The pre-closed member is left closed — restore only reverses the group-close.
+    expect(store.workspaces[a.id].closedAt).not.toBeNull();
+  });
+
+  it("activates the first reopened member", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeGroup(group.id);
+    restoreGroup(group.id);
+    expect(store.activeWorkspaceId).toBe(a.id);
+  });
+
+  it("skips a recorded member that was deleted while the group was closed", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeGroup(group.id);
+    deleteWorkspace(a.id);
+    expect(() => restoreGroup(group.id)).not.toThrow();
+    expect(store.workspaces[b.id].closedAt).toBeNull();
+    expect(store.activeWorkspaceId).toBe(b.id);
+  });
+
+  it("skips a recorded member that was moved to another group while closed", () => {
+    const group = makeGroup("G");
+    const other = makeGroup("Other");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    moveWorkspaceToGroup(a.id, group.id);
+    closeGroup(group.id);
+    moveWorkspaceToGroup(a.id, other.id); // allowed: destination group is open
+    restoreGroup(group.id);
+    expect(store.workspaces[a.id].closedAt).not.toBeNull();
+    expect(groupIdForWorkspace(a.id)).toBe(other.id);
+  });
+
+  it("leaves activeWorkspaceId unchanged when nothing is reopened", () => {
+    const group = makeGroup("G"); // empty group
+    const active = createWorkspace({ folder: "/active", name: "active" });
+    closeGroup(group.id);
+    restoreGroup(group.id);
+    expect(store.groups[group.id].closedAt).toBeNull();
+    expect(store.activeWorkspaceId).toBe(active.id);
+  });
+
+  it("no-ops for an unknown id", () => {
+    expect(() => restoreGroup("grp_ghost")).not.toThrow();
+  });
+
+  it("no-ops for a group that is not closed", () => {
+    const group = makeGroup("G");
+    expect(() => restoreGroup(group.id)).not.toThrow();
+    expect(store.groups[group.id].closedAt).toBeUndefined();
+  });
+});
+
+// ── activateWorkspace / reopenWorkspace reopen a closed group's shell ────────
+
+describe("activateWorkspace / reopenWorkspace on a member of a closed group", () => {
+  it("activateWorkspace reopens the group shell but leaves siblings closed", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeGroup(group.id);
+    activateWorkspace(a.id);
+    expect(store.groups[group.id].closedAt).toBeNull();
+    expect(store.groups[group.id].closedMemberIds).toBeUndefined();
+    expect(store.workspaces[a.id].closedAt).toBeNull();
+    expect(store.workspaces[b.id].closedAt).not.toBeNull();
+  });
+
+  it("reopenWorkspace reopens the group shell but leaves siblings closed", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeGroup(group.id);
+    reopenWorkspace(b.id);
+    expect(store.groups[group.id].closedAt).toBeNull();
+    expect(store.workspaces[b.id].closedAt).toBeNull();
+    expect(store.workspaces[a.id].closedAt).not.toBeNull();
+  });
+});
+
+// ── moveWorkspaceToGroup guard against closed groups ─────────────────────────
+
+describe("moveWorkspaceToGroup into a closed group", () => {
+  it("no-ops, leaving the workspace where it was", () => {
+    const group = makeGroup("G");
+    closeGroup(group.id);
+    const ws = createWorkspace({ folder: "/p", name: "p" });
+    moveWorkspaceToGroup(ws.id, group.id);
+    expect(groupIdForWorkspace(ws.id)).toBeUndefined();
+    expect(store.panelOrder).toContain(ws.id);
+    expect(store.groups[group.id].workspaceOrder).not.toContain(ws.id);
+  });
+});
+
+// ── deleteGroup on a closed group ─────────────────────────────────────────────
+
+describe("deleteGroup on a closed group", () => {
+  it("splices members into panelOrder at the group's slot and leaves them closed", () => {
+    const group = makeGroup("G");
+    const a = createWorkspace({ folder: "/a", name: "a" });
+    const b = createWorkspace({ folder: "/b", name: "b" });
+    moveWorkspaceToGroup(a.id, group.id);
+    moveWorkspaceToGroup(b.id, group.id);
+    closeGroup(group.id);
+    deleteGroup(group.id);
+    expect(store.groups[group.id]).toBeUndefined();
+    expect(store.panelOrder).toEqual([a.id, b.id]);
+    expect(store.workspaces[a.id].closedAt).not.toBeNull();
+    expect(store.workspaces[b.id].closedAt).not.toBeNull();
   });
 });

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -90,6 +90,7 @@ export function activateWorkspace(id: string): void {
   const ws = store.workspaces[id];
   if (!ws) return;
   if (ws.closedAt) ws.closedAt = null;
+  ensureGroupVisible(id);
   if (store.activeWorkspaceId === id) return;
   // Capture outgoing panel state before switching.
   if (store.activeWorkspaceId)
@@ -115,6 +116,7 @@ export function reopenWorkspace(id: string): void {
   if (!ws) return;
   ws.closedAt = null;
   ws.lastOpenedAt = new Date().toISOString();
+  ensureGroupVisible(id);
   store.activeWorkspaceId = id;
 }
 
@@ -318,7 +320,7 @@ export function moveWorkspaceToGroup(
   anchor?: { toId: string; position: "before" | "after" },
 ): void {
   const group = store.groups[groupId];
-  if (!group) return;
+  if (!group || group.closedAt) return;
   removeWorkspaceFromGroup(wsId);
   // The workspace leaves the top level — it now lives inside the group.
   store.panelOrder = store.panelOrder.filter((id) => id !== wsId);
@@ -394,6 +396,55 @@ export function toggleGroupCollapsed(id: string): void {
   const group = store.groups[id];
   if (!group) return;
   group.collapsed = !group.collapsed;
+}
+
+/**
+ * Soft-close a group: close every currently-open member (via `closeWorkspace`,
+ * so active-workspace fallback runs per member) and record exactly which
+ * members that was, so `restoreGroup` reopens only those. No-op if the group
+ * is unknown or already closed.
+ */
+export function closeGroup(id: string): void {
+  const group = store.groups[id];
+  if (!group || group.closedAt) return;
+  const openMembers = group.workspaceOrder.filter(
+    (wsId) => store.workspaces[wsId] && !store.workspaces[wsId].closedAt,
+  );
+  for (const wsId of openMembers) closeWorkspace(wsId);
+  group.closedMemberIds = openMembers;
+  group.closedAt = new Date().toISOString();
+}
+
+/**
+ * Reopen a closed group: reopen the members recorded by `closeGroup` (skipping
+ * any since deleted or moved out of the group) and activate the first of them.
+ * No-op if the group is unknown or already open.
+ */
+export function restoreGroup(id: string): void {
+  const group = store.groups[id];
+  if (!group || !group.closedAt) return;
+  const toReopen = (group.closedMemberIds ?? []).filter(
+    (wsId) => group.workspaceOrder.includes(wsId) && store.workspaces[wsId],
+  );
+  group.closedAt = null;
+  delete group.closedMemberIds;
+  const now = new Date().toISOString();
+  for (const wsId of toReopen) {
+    store.workspaces[wsId].closedAt = null;
+    store.workspaces[wsId].lastOpenedAt = now;
+  }
+  if (toReopen[0]) activateWorkspace(toReopen[0]);
+}
+
+/** If `wsId`'s group is closed, reopen the group shell only (siblings stay
+ * closed) — a reopened workspace must render somewhere. */
+function ensureGroupVisible(wsId: string): void {
+  const groupId = groupIdForWorkspace(wsId);
+  const group = groupId ? store.groups[groupId] : undefined;
+  if (group?.closedAt) {
+    group.closedAt = null;
+    delete group.closedMemberIds;
+  }
 }
 
 export function addTerminal(

--- a/packages/extensions-core/src/workspaces/WorkspaceStatusItem.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspaceStatusItem.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useSnapshot } from "valtio";
 import { SquaresFour } from "@phosphor-icons/react";
 import {
   useServiceState,
   type ExtensionContext,
   type MenuEntry,
 } from "@silo-code/sdk";
-import { homeDir, Tooltip } from "@silo-code/extension-host/internal";
+import { homeDir, store, Tooltip } from "@silo-code/extension-host/internal";
 import { useFolderExistence } from "./workspace-helpers";
 import { buildAddWorkspaceItems } from "./workspace-add-menu";
+import { partitionSavedEntries } from "./workspace-add-menu-model";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import { openWorkspaceProperties } from "./workspace-properties";
 import "./WorkspaceStatusItem.css";
@@ -24,6 +26,7 @@ import "./WorkspaceStatusItem.css";
 export function WorkspaceStatusItem({ ctx }: { ctx: ExtensionContext }) {
   const service = ctx.workspaces;
   const snap = useServiceState(service);
+  const storeSnap = useSnapshot(store);
   const [home, setHome] = useState("");
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -33,9 +36,13 @@ export function WorkspaceStatusItem({ ctx }: { ctx: ExtensionContext }) {
       .catch(() => {});
   }, []);
 
+  const savedEntries = useMemo(
+    () => partitionSavedEntries(snap.closed, storeSnap.groups),
+    [snap.closed, storeSnap.groups],
+  );
   const closedFolders = useMemo(
-    () => snap.closed.map((ws) => ws.folder),
-    [snap.closed],
+    () => savedEntries.workspaces.map((ws) => ws.folder),
+    [savedEntries.workspaces],
   );
   const folderExistence = useFolderExistence(closedFolders, ctx.files);
 
@@ -81,7 +88,8 @@ export function WorkspaceStatusItem({ ctx }: { ctx: ExtensionContext }) {
       label: "Open",
       submenu: buildAddWorkspaceItems({
         ctx,
-        closed: snap.closed,
+        closed: savedEntries.workspaces,
+        closedGroups: savedEntries.groupEntries,
         folderExistence,
         onNew,
       }),

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -177,9 +177,9 @@
   line-height: 1.5;
 }
 
-.ws-item .ws-close {
+.ws-item .ws-close,
+.ws-group-header .ws-close {
   position: absolute;
-  top: 4px;
   right: 4px;
   border: none;
   background: transparent;
@@ -192,11 +192,23 @@
   cursor: pointer;
 }
 
+/* The workspace row is a tall, multi-line card — pin to the top corner. The
+   group header is a single short line, so its close button centers instead. */
+.ws-item .ws-close {
+  top: 4px;
+}
+
+.ws-group-header .ws-close {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .ws-item:hover .ws-close {
   opacity: 1;
 }
 
-.ws-item .ws-close:hover {
+.ws-item .ws-close:hover,
+.ws-group-header .ws-close:hover {
   color: var(--silo-color-text-hi);
   background: var(--silo-color-button-bg);
 }
@@ -509,6 +521,10 @@
 .ws-group-header:hover {
   background: var(--silo-color-bg-hover);
   color: var(--silo-color-text);
+}
+
+.ws-group-header:hover .ws-close {
+  opacity: 1;
 }
 
 .ws-group-caret {

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
@@ -10,6 +10,7 @@ import { useSnapshot } from "valtio";
 import {
   store,
   deleteGroup,
+  closeGroup,
   moveWorkspaceToGroup,
   ungroupWorkspace,
   toggleGroupCollapsed,
@@ -36,6 +37,7 @@ import {
   type Workspace,
 } from "./workspace-helpers";
 import { buildAddWorkspaceItems } from "./workspace-add-menu";
+import { partitionSavedEntries } from "./workspace-add-menu-model";
 import { openWorkspaceProperties } from "./workspace-properties";
 import {
   openGroupProperties,
@@ -163,7 +165,9 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
   const renderedEntryIds = useMemo(
     () =>
       storeSnap.panelOrder.filter(
-        (id) => storeSnap.groups[id] || openById.has(id),
+        (id) =>
+          (storeSnap.groups[id] && !storeSnap.groups[id].closedAt) ||
+          openById.has(id),
       ),
     [storeSnap.panelOrder, storeSnap.groups, openById],
   );
@@ -194,9 +198,13 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
     },
   });
 
+  const savedEntries = useMemo(
+    () => partitionSavedEntries(snap.closed, storeSnap.groups),
+    [snap.closed, storeSnap.groups],
+  );
   const closedFolders = useMemo(
-    () => snap.closed.map((ws) => ws.folder),
-    [snap.closed],
+    () => savedEntries.workspaces.map((ws) => ws.folder),
+    [savedEntries.workspaces],
   );
   const folderExistence = useFolderExistence(closedFolders, ctx.files);
 
@@ -215,7 +223,8 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
   function openClosedMenu() {
     const items = buildAddWorkspaceItems({
       ctx,
-      closed: snap.closed,
+      closed: savedEntries.workspaces,
+      closedGroups: savedEntries.groupEntries,
       folderExistence,
       onNew,
       onNewGroup,
@@ -235,7 +244,7 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
     const currentGroupId = groupMap.get(ws.id);
     const groups = storeSnap.panelOrder
       .map((id) => storeSnap.groups[id])
-      .filter(Boolean);
+      .filter((g) => g && !g.closedAt);
     if (currentGroupId) {
       items.push({
         label: "Remove from Group",
@@ -277,6 +286,10 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
         {
           label: "Properties…",
           run: () => void openGroupProperties(ctx, group),
+        },
+        {
+          label: "Close Group",
+          run: () => closeGroup(group.id),
         },
         {
           label: "Delete Group",
@@ -427,6 +440,17 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
             weight="bold"
           />
           <span className="ws-group-name">{group.name}</span>
+          <button
+            className="ws-close"
+            tabIndex={-1}
+            aria-label="Close group"
+            onClick={(e) => {
+              e.stopPropagation();
+              closeGroup(group.id);
+            }}
+          >
+            ×
+          </button>
         </div>
         {!group.collapsed && (
           <ul className="ws-group-body">
@@ -458,7 +482,8 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
             >
               {storeSnap.panelOrder.map((entryId) => {
                 const group = storeSnap.groups[entryId];
-                if (group) return renderGroupCard(group);
+                if (group)
+                  return group.closedAt ? null : renderGroupCard(group);
                 const ws = openById.get(entryId);
                 if (!ws) return null; // closed or stale ungrouped workspace
                 return renderWorkspaceItem(ws);

--- a/packages/extensions-core/src/workspaces/group-properties.tsx
+++ b/packages/extensions-core/src/workspaces/group-properties.tsx
@@ -15,6 +15,7 @@ export interface GroupSnapshot {
   color?: string;
   collapsed: boolean;
   workspaceOrder: readonly string[] | string[];
+  closedAt?: string | null;
 }
 
 type Swatch = { label: string; value: string | undefined };

--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -1,4 +1,5 @@
 import type { Extension } from "@silo-code/sdk";
+import { store, groupIdForWorkspace } from "@silo-code/extension-host/internal";
 import { WorkspacesPanel } from "./WorkspacesPanel";
 import { WorkspaceStatusItem } from "./WorkspaceStatusItem";
 import { registerWorkspaceCycle } from "./workspace-cycle";
@@ -78,8 +79,13 @@ export const extension: Extension = {
       id: "workspace.reopenLast",
       label: "Reopen Last Closed Workspace",
       run: () => {
+        // Skip workspaces hidden inside a closed group — those are only
+        // reachable by restoring the group from the Saved picker.
         const { closed } = ctx.workspaces.getState();
-        const last = closed[0];
+        const last = closed.find((ws) => {
+          const groupId = groupIdForWorkspace(ws.id);
+          return !groupId || !store.groups[groupId]?.closedAt;
+        });
         if (last) ctx.workspaces.reopen(last.id);
       },
     });

--- a/packages/extensions-core/src/workspaces/workspace-add-menu-model.test.ts
+++ b/packages/extensions-core/src/workspaces/workspace-add-menu-model.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { partitionSavedEntries } from "./workspace-add-menu-model";
+import type { Workspace } from "./workspace-helpers";
+
+function ws(
+  id: string,
+  closedAt: string | null = "2026-01-01T00:00:00.000Z",
+): Workspace {
+  return {
+    id,
+    name: id,
+    folder: `/tmp/${id}`,
+    createdAt: "2025-01-01T00:00:00.000Z",
+    lastOpenedAt: "2025-01-01T00:00:00.000Z",
+    closedAt,
+    terminals: [],
+    editors: [],
+  };
+}
+
+describe("partitionSavedEntries", () => {
+  it("passes through closed workspaces that are ungrouped", () => {
+    const { groupEntries, workspaces } = partitionSavedEntries(
+      [ws("a"), ws("b")],
+      {},
+    );
+    expect(groupEntries).toEqual([]);
+    expect(workspaces.map((w) => w.id)).toEqual(["a", "b"]);
+  });
+
+  it("passes through closed workspaces belonging to an open group", () => {
+    const { groupEntries, workspaces } = partitionSavedEntries([ws("a")], {
+      grp_1: { name: "Open Group", workspaceOrder: ["a"], closedAt: null },
+    });
+    expect(groupEntries).toEqual([]);
+    expect(workspaces.map((w) => w.id)).toEqual(["a"]);
+  });
+
+  it("hides members of a closed group and lists the group instead", () => {
+    const { groupEntries, workspaces } = partitionSavedEntries(
+      [ws("a"), ws("b"), ws("solo")],
+      {
+        grp_1: {
+          name: "Xerro",
+          workspaceOrder: ["a", "b"],
+          closedAt: "2026-02-01T00:00:00.000Z",
+        },
+      },
+    );
+    expect(workspaces.map((w) => w.id)).toEqual(["solo"]);
+    expect(groupEntries).toEqual([
+      {
+        id: "grp_1",
+        name: "Xerro",
+        memberCount: 2,
+        closedAt: "2026-02-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("hides a member closed before the group closed too", () => {
+    // "a" was individually closed before "grp_1" was closed as a whole.
+    const { workspaces } = partitionSavedEntries([ws("a")], {
+      grp_1: {
+        name: "Xerro",
+        workspaceOrder: ["a"],
+        closedAt: "2026-02-01T00:00:00.000Z",
+      },
+    });
+    expect(workspaces).toEqual([]);
+  });
+
+  it("sorts multiple closed groups by closedAt descending", () => {
+    const { groupEntries } = partitionSavedEntries([], {
+      old: {
+        name: "Old",
+        workspaceOrder: [],
+        closedAt: "2026-01-01T00:00:00.000Z",
+      },
+      recent: {
+        name: "Recent",
+        workspaceOrder: [],
+        closedAt: "2026-03-01T00:00:00.000Z",
+      },
+    });
+    expect(groupEntries.map((g) => g.id)).toEqual(["recent", "old"]);
+  });
+
+  it("returns empty lists for empty input", () => {
+    expect(partitionSavedEntries([], {})).toEqual({
+      groupEntries: [],
+      workspaces: [],
+    });
+  });
+});

--- a/packages/extensions-core/src/workspaces/workspace-add-menu-model.ts
+++ b/packages/extensions-core/src/workspaces/workspace-add-menu-model.ts
@@ -1,0 +1,53 @@
+import type { Workspace } from "./workspace-helpers";
+
+// Pure partitioning logic for the "Saved" reopen menu: while a group is
+// closed, its members are hidden from the individual closed-workspace list —
+// only the group entry appears, and restoring it brings the members back.
+
+export interface ClosedGroupEntry {
+  id: string;
+  name: string;
+  memberCount: number;
+  closedAt: string;
+}
+
+interface SavedGroupInput {
+  name: string;
+  workspaceOrder: readonly string[] | string[];
+  closedAt?: string | null;
+}
+
+/**
+ * Split the closed-workspace list into the individually-listed workspaces and
+ * the closed-group entries, per the Saved-picker rule: a workspace that
+ * belongs to a currently-closed group is omitted from the individual list
+ * (whether or not it was open when the group closed) — its group is the sole
+ * entry until restored.
+ */
+export function partitionSavedEntries(
+  closed: readonly Workspace[],
+  groups: Record<string, SavedGroupInput>,
+): { groupEntries: ClosedGroupEntry[]; workspaces: Workspace[] } {
+  const closedGroups = Object.entries(groups).filter(([, g]) => g.closedAt) as [
+    string,
+    SavedGroupInput & { closedAt: string },
+  ][];
+
+  const hiddenMemberIds = new Set<string>();
+  for (const [, group] of closedGroups) {
+    for (const wsId of group.workspaceOrder) hiddenMemberIds.add(wsId);
+  }
+
+  const groupEntries = closedGroups
+    .map(([id, group]) => ({
+      id,
+      name: group.name,
+      memberCount: group.workspaceOrder.length,
+      closedAt: group.closedAt,
+    }))
+    .sort((a, b) => Date.parse(b.closedAt) - Date.parse(a.closedAt));
+
+  const workspaces = closed.filter((ws) => !hiddenMemberIds.has(ws.id));
+
+  return { groupEntries, workspaces };
+}

--- a/packages/extensions-core/src/workspaces/workspace-add-menu.tsx
+++ b/packages/extensions-core/src/workspaces/workspace-add-menu.tsx
@@ -5,8 +5,10 @@ import {
   Trash,
   Warning,
 } from "@phosphor-icons/react";
+import { deleteGroup, restoreGroup } from "@silo-code/extension-host/internal";
 import type { ExtensionContext, MenuEntry } from "@silo-code/sdk";
 import type { Workspace } from "./workspace-helpers";
+import type { ClosedGroupEntry } from "./workspace-add-menu-model";
 
 // The "Add workspace" menu rows — closed workspaces to reopen, a separator, then
 // "New workspace…". Shared by the workspaces panel's add button (a standalone
@@ -33,20 +35,61 @@ export async function confirmAndDeleteWorkspace(
   ctx.workspaces.delete(id);
 }
 
+/** Confirm, then delete a closed group. Member workspaces are kept and reappear
+ * individually in Saved (deleting a group only ungroups its members). */
+export async function confirmAndDeleteGroup(
+  ctx: ExtensionContext,
+  id: string,
+  name: string,
+): Promise<void> {
+  const ok = await ctx.ui.confirm({
+    title: "Delete group?",
+    body: `${name} will be removed. Its workspaces stay saved and will appear individually.`,
+    confirmLabel: "Delete",
+    danger: true,
+  });
+  if (!ok) return;
+  deleteGroup(id);
+}
+
 /**
- * Build the "Add workspace" menu entries. `closed` is the closed-workspace list,
- * `folderExistence` the result of `useFolderExistence` over their folders (a
- * missing folder gets a warning icon), and `onNew` runs the new-workspace flow.
+ * Build the "Add workspace" menu entries. `closed` is the closed-workspace list
+ * (already filtered to exclude members of a closed group — see
+ * `partitionSavedEntries`), `closedGroups` the closed-group entries shown above
+ * them, `folderExistence` the result of `useFolderExistence` over the closed
+ * workspaces' folders (a missing folder gets a warning icon), and `onNew` runs
+ * the new-workspace flow.
  */
 export function buildAddWorkspaceItems(opts: {
   ctx: ExtensionContext;
   closed: readonly Workspace[];
+  closedGroups?: readonly ClosedGroupEntry[];
   folderExistence: Map<string, boolean>;
   onNew: () => void;
   onNewGroup?: () => void;
 }): MenuEntry[] {
-  const { ctx, closed, folderExistence, onNew, onNewGroup } = opts;
+  const {
+    ctx,
+    closed,
+    closedGroups = [],
+    folderExistence,
+    onNew,
+    onNewGroup,
+  } = opts;
   const items: MenuEntry[] = [{ type: "header", label: "Saved" }];
+  for (const group of closedGroups) {
+    items.push({
+      label: group.name,
+      icon: <FolderSimple size={16} weight="duotone" />,
+      title: `${group.memberCount} workspace${group.memberCount === 1 ? "" : "s"}`,
+      run: () => restoreGroup(group.id),
+      trailing: {
+        icon: <Trash size={14} weight="regular" />,
+        title: "Delete group permanently",
+        onClick: () => void confirmAndDeleteGroup(ctx, group.id, group.name),
+      },
+    });
+  }
   if (closed.length > 0) {
     for (const ws of closed) {
       const missing = folderExistence.get(ws.folder) === false;
@@ -68,7 +111,7 @@ export function buildAddWorkspaceItems(opts: {
         },
       });
     }
-  } else {
+  } else if (closedGroups.length === 0) {
     items.push({
       label: "No existing workspaces",
       disabled: true,

--- a/packages/extensions-core/src/workspaces/workspace-nav.test.ts
+++ b/packages/extensions-core/src/workspaces/workspace-nav.test.ts
@@ -62,6 +62,43 @@ describe("buildNavItems", () => {
     ]);
   });
 
+  it("omits a closed group's header and its members entirely", () => {
+    const items = buildNavItems(
+      ["top", "grp_1", "bottom"],
+      {
+        grp_1: {
+          collapsed: false,
+          workspaceOrder: ["a", "b"],
+          closedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      openAll,
+    );
+    expect(items).toEqual([
+      { kind: "workspace", id: "top" },
+      { kind: "workspace", id: "bottom" },
+    ]);
+  });
+
+  it("still renders an open group next to a closed one, in panel order", () => {
+    const items = buildNavItems(
+      ["grp_closed", "grp_open"],
+      {
+        grp_closed: {
+          collapsed: false,
+          workspaceOrder: ["a"],
+          closedAt: "2026-01-01T00:00:00.000Z",
+        },
+        grp_open: { collapsed: false, workspaceOrder: ["b"] },
+      },
+      openAll,
+    );
+    expect(items).toEqual([
+      { kind: "group", id: "grp_open" },
+      { kind: "workspace", id: "b" },
+    ]);
+  });
+
   it("yields sequential indices matching render order (via the resulting map)", () => {
     const items = buildNavItems(
       ["grp_1", "solo"],

--- a/packages/extensions-core/src/workspaces/workspace-nav.ts
+++ b/packages/extensions-core/src/workspaces/workspace-nav.ts
@@ -8,6 +8,7 @@ export type NavItem =
 interface NavGroup {
   collapsed: boolean;
   workspaceOrder: readonly string[] | string[];
+  closedAt?: string | null;
 }
 
 /**
@@ -16,7 +17,8 @@ interface NavGroup {
  * by its member workspaces (only while expanded — a collapsed group's members
  * aren't in the DOM, so they're skipped and the header stands in for them), and
  * an ungrouped entry contributes itself. `isOpen` filters out closed/stale ids
- * so the indices line up with what actually renders.
+ * so the indices line up with what actually renders. A closed group renders
+ * nothing (header or members), so it's skipped entirely.
  */
 export function buildNavItems(
   panelOrder: readonly string[],
@@ -27,6 +29,7 @@ export function buildNavItems(
   for (const entryId of panelOrder) {
     const group = groups[entryId];
     if (group) {
+      if (group.closedAt) continue;
       items.push({ kind: "group", id: entryId });
       if (!group.collapsed) {
         for (const wsId of group.workspaceOrder) {


### PR DESCRIPTION
## Summary
- Closing a group now soft-closes its open members and hides the group from the workspaces panel; restoring it (from the "Saved" reopen picker) reopens exactly the members that were open at close time — a member closed before the group-close stays closed.
- While a group is closed, only its group entry appears in Saved; member workspaces are hidden from the individual closed-workspace list until the group is restored (or deleted, which ungroups them).
- Adds a "Close Group" context-menu item and a hover close (×) button on the group header, matching the existing per-workspace affordances.
- Group close/restore stays host-internal per ADR 0023 (amended to record the new mutators), consistent with the rest of the group surface.

## Test plan
- [x] `pnpm test` — all packages green (new coverage in `workspaces-groups.test.ts`, `persistence-model.test.ts`, `workspace-nav.test.ts`, new `workspace-add-menu-model.test.ts`)
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] Verified end-to-end in the running dev app via the automation bridge: create group → move members in → individually close one member → Close Group → group disappears → Saved shows one group entry (not the individual members) → restore reopens the previously-open member and activates it while the pre-closed member stays closed → a full app reload confirms the closed state persists correctly to disk and back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CELDnfXYvyVgn2BNxWmZBG