### PR TITLE
fix(agent-monitor): debounce ✳ idle signal with subscribeOutput

### DIFF
--- a/examples/extensions/agent-monitor/build.mjs
+++ b/examples/extensions/agent-monitor/build.mjs
@@ -1,6 +1,4 @@
 import { build } from "esbuild";
-import { copyFileSync, existsSync } from "fs";
-import { homedir } from "os";
 
 await build({
   entryPoints: ["src/index.tsx"],
@@ -15,12 +13,3 @@ await build({
   loader: { ".css": "text" },
   logLevel: "info",
 });
-
-// Sync to the dev install so "Reload" in the Extensions page picks up the
-// new bundle without a full reinstall. Prod (~/.config/silo/) is intentionally
-// excluded — reinstall there manually via "Install from folder".
-const devTarget = `${homedir()}/.config/silo-dev/extensions/silo.agent-monitor/dist/index.js`;
-if (existsSync(devTarget)) {
-  copyFileSync("dist/index.js", devTarget);
-  console.log(`  synced → ${devTarget.replace(homedir(), "~")}`);
-}

--- a/examples/extensions/agent-monitor/build.mjs
+++ b/examples/extensions/agent-monitor/build.mjs
@@ -16,15 +16,11 @@ await build({
   logLevel: "info",
 });
 
-// Sync to every installed location so "Reload" in the Extensions page picks
-// up the new bundle without a full reinstall.
-const installTargets = [
-  `${homedir()}/.config/silo-dev/extensions/silo.agent-monitor/dist/index.js`,
-  `${homedir()}/.config/silo/extensions/silo.agent-monitor/dist/index.js`,
-];
-for (const target of installTargets) {
-  if (existsSync(target)) {
-    copyFileSync("dist/index.js", target);
-    console.log(`  synced → ${target.replace(homedir(), "~")}`);
-  }
+// Sync to the dev install so "Reload" in the Extensions page picks up the
+// new bundle without a full reinstall. Prod (~/.config/silo/) is intentionally
+// excluded — reinstall there manually via "Install from folder".
+const devTarget = `${homedir()}/.config/silo-dev/extensions/silo.agent-monitor/dist/index.js`;
+if (existsSync(devTarget)) {
+  copyFileSync("dist/index.js", devTarget);
+  console.log(`  synced → ${devTarget.replace(homedir(), "~")}`);
 }

--- a/examples/extensions/agent-monitor/package.json
+++ b/examples/extensions/agent-monitor/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "silo": {
     "id": "silo.agent-monitor",
-    "engine": "^0.9",
+    "engine": ">=0.23.0",
     "main": "dist/index.js",
     "permissions": []
   },

--- a/examples/extensions/agent-monitor/src/index.tsx
+++ b/examples/extensions/agent-monitor/src/index.tsx
@@ -38,11 +38,21 @@ function activate(ctx: ExtensionContext) {
   // An empty string means "subscribed while the PTY hadn't spawned yet".
   // When the sessionId changes (PTY spawns or restarts), we re-subscribe.
   const oscSubSessionIds = new Map<string, string>();
+  // Disposables for per-terminal raw output subscriptions. These cancel pending
+  // agent-idle timers when output arrives, preventing false "needs attention"
+  // when Claude emits ✳ briefly between tool calls.
+  const outputSubs = new Map<string, { dispose(): void }>();
   // Per-terminal debounce timers for OSC 133 "working" → "waiting" fallback.
   // Some agents (e.g. pi) emit 133;C for each step but never emit 133;A/D on
   // completion. When the stream goes silent for SHELL_IDLE_MS we clear to waiting.
   const SHELL_IDLE_MS = 3_000;
   const shellIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Pending debounced ✳ → "waiting" transitions. Claude Code emits ✳ briefly
+  // between tool calls while computing the next action. subscribeOutput cancels
+  // this timer when the next output chunk arrives, so we only transition to
+  // "waiting" if the terminal actually goes quiet for AGENT_IDLE_DEBOUNCE_MS.
+  const AGENT_IDLE_DEBOUNCE_MS = 1_500;
+  const agentIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   let activeTerminalId = ctx.terminals.getActive();
 
@@ -102,6 +112,25 @@ function activate(ctx: ExtensionContext) {
     );
   }
 
+  function clearAgentIdleTimer(terminalId: string) {
+    const t = agentIdleTimers.get(terminalId);
+    if (t !== undefined) {
+      clearTimeout(t);
+      agentIdleTimers.delete(terminalId);
+    }
+  }
+
+  function scheduleAgentIdle(terminalId: string) {
+    clearAgentIdleTimer(terminalId);
+    agentIdleTimers.set(
+      terminalId,
+      setTimeout(() => {
+        agentIdleTimers.delete(terminalId);
+        dispatch(terminalId, detectedEvent(terminalId, "waiting", "agent"));
+      }, AGENT_IDLE_DEBOUNCE_MS),
+    );
+  }
+
   function subscribeTerminalOsc(terminalId: string, sessionId: string) {
     const prevSessionId = oscSubSessionIds.get(terminalId);
     // Skip if we already have a live sub for this exact session. If sessionId
@@ -132,15 +161,35 @@ function activate(ctx: ExtensionContext) {
           );
           if (result.timer === "schedule") scheduleShellIdle(terminalId);
           else if (result.timer === "clear") clearShellIdleTimer(terminalId);
-          dispatch(
-            terminalId,
-            detectedEvent(terminalId, result.status, result.source),
-          );
+          if (result.status === "waiting" && result.source === "agent") {
+            // Debounce: Claude emits ✳ briefly between tool calls. Only transition
+            // to "waiting" if the terminal goes quiet for AGENT_IDLE_DEBOUNCE_MS.
+            // subscribeOutput cancels this timer when the next output chunk arrives.
+            scheduleAgentIdle(terminalId);
+          } else {
+            if (result.status === "working") clearAgentIdleTimer(terminalId);
+            dispatch(
+              terminalId,
+              detectedEvent(terminalId, result.status, result.source),
+            );
+          }
           break;
         }
       }
     });
     oscSubs.set(terminalId, sub);
+    // Subscribe to raw output for this terminal (once per terminal record id).
+    // On every PTY chunk, cancel any pending agent-idle timer — if the agent is
+    // still producing output it's not truly idle yet. Subscribed only once; the
+    // host's subscribeOutput handles sessionId resolution and polling internally.
+    if (!outputSubs.has(terminalId)) {
+      outputSubs.set(
+        terminalId,
+        ctx.terminals.subscribeOutput(terminalId, () => {
+          clearAgentIdleTimer(terminalId);
+        }),
+      );
+    }
     // Note: do NOT push into ctx.subscriptions — oscSubs manages the lifecycle
     // of these per-terminal subscriptions (disposed in syncOscSubscriptions and
     // the bulk disposable below). Pushing them would cause the array to grow
@@ -164,8 +213,11 @@ function activate(ctx: ExtensionContext) {
         sub.dispose();
         oscSubs.delete(id);
         oscSubSessionIds.delete(id);
+        outputSubs.get(id)?.dispose();
+        outputSubs.delete(id);
         states.delete(id);
         clearShellIdleTimer(id);
+        clearAgentIdleTimer(id);
       }
     }
   }
@@ -189,8 +241,12 @@ function activate(ctx: ExtensionContext) {
         for (const sub of oscSubs.values()) sub.dispose();
         oscSubs.clear();
         oscSubSessionIds.clear();
+        for (const sub of outputSubs.values()) sub.dispose();
+        outputSubs.clear();
         for (const t of shellIdleTimers.values()) clearTimeout(t);
         shellIdleTimers.clear();
+        for (const t of agentIdleTimers.values()) clearTimeout(t);
+        agentIdleTimers.clear();
       },
     },
   );

--- a/examples/extensions/agent-monitor/src/index.tsx
+++ b/examples/extensions/agent-monitor/src/index.tsx
@@ -182,7 +182,8 @@ function activate(ctx: ExtensionContext) {
     // On every PTY chunk, cancel any pending agent-idle timer — if the agent is
     // still producing output it's not truly idle yet. Subscribed only once; the
     // host's subscribeOutput handles sessionId resolution and polling internally.
-    if (!outputSubs.has(terminalId)) {
+    // Guard: subscribeOutput requires SDK ≥ 0.23.0 / Silo host ≥ 0.23.0.
+    if (!outputSubs.has(terminalId) && ctx.terminals.subscribeOutput) {
       outputSubs.set(
         terminalId,
         ctx.terminals.subscribeOutput(terminalId, () => {


### PR DESCRIPTION
## Summary

- Fixes the false orange "needs attention" dot that appeared in the Workspaces panel while Claude was still actively running between tool calls.
- Uses `ctx.terminals.subscribeOutput` (new in SDK v0.23.0 / #174) to cancel a debounce timer when raw PTY output arrives, so ✳ → "waiting" only fires if the terminal actually goes quiet.

## Root cause

Claude Code emits ✳ (`U+2733`) briefly between tool calls while computing the next action. Previously this was dispatched immediately as "waiting", stamping `needsAttention = true` and showing an orange dot in the panel — even though the agent was still running.

## Fix

When an agent-source "waiting" signal (✳ or Codex empty title) is detected, instead of dispatching immediately, a **1.5 s debounce timer** (`agentIdleTimers`) is scheduled. `ctx.terminals.subscribeOutput` fires on every raw PTY chunk and cancels that timer. Since output listeners fire before OSC listeners for the same chunk (see `tauri-terminal-client.ts`), the braille spinner chunk of the next tool call cancels the timer before "working" is even dispatched — no state transition occurs during inter-tool gaps.

Only if the terminal stays completely quiet for 1.5 s (true end-of-turn) does the timer fire and dispatch "waiting".

## Test plan

- [ ] Start a Claude Code session running several tool calls in sequence → workspace panel should stay green/working throughout, no orange dot between calls
- [ ] Wait for Claude to finish its entire turn → orange dot (needs attention) appears after ~1.5 s
- [ ] Activate the terminal → orange dot clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)