### PR TITLE
fix(git-explorer): persist per-repo collapse state across workspace switches

### DIFF
--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.tsx
@@ -1,4 +1,9 @@
-import { useServiceState, type ExtensionContext } from "@silo-code/sdk";
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  useServiceState,
+  type ExtensionContext,
+  type ExtensionStorage,
+} from "@silo-code/sdk";
 import { GitView } from "./GitView";
 import "./GitExplorerPanel.css";
 
@@ -6,19 +11,49 @@ function rootName(path: string): string {
   return path.split("/").filter(Boolean).pop() ?? path;
 }
 
+const COLLAPSED_KEY = "collapsed";
+
+type CollapsedMap = Record<string, boolean>;
+
+// Stable reference so useSyncExternalStore's snapshot doesn't change identity
+// (and re-render in a loop) while no repo has ever been collapsed.
+const EMPTY_COLLAPSED: CollapsedMap = {};
+
 export function GitExplorerPanel({
   ctx,
+  storage,
   paused = false,
 }: {
   ctx: ExtensionContext;
+  storage: ExtensionStorage;
   paused?: boolean;
 }) {
   const wsState = useServiceState(ctx.workspaces);
   const ws = wsState.all.find((w) => w.id === wsState.activeId) ?? null;
+
+  // Per-workspace, per-repo collapse state lives in the panel's storage bag
+  // (which the host swaps and persists per active workspace), not on GitView's
+  // own component state — otherwise it resets whenever the view remounts.
+  // Subscribed via useSyncExternalStore so toggling a repo re-renders this
+  // panel immediately instead of waiting for some unrelated state change.
+  const collapsedMap = useSyncExternalStore(
+    useCallback((cb) => storage.subscribe(cb).dispose, [storage]),
+    useCallback(
+      () => storage.get<CollapsedMap>(COLLAPSED_KEY, EMPTY_COLLAPSED),
+      [storage],
+    ),
+  );
+
   if (!ws) return <div className="placeholder">No active workspace.</div>;
 
   const allFolders = [ws.folder, ...(ws.extraFolders ?? [])];
   const showLabel = allFolders.length > 1;
+
+  const persistCollapsed = (folder: string, value: boolean) =>
+    storage.set(COLLAPSED_KEY, {
+      ...storage.get<CollapsedMap>(COLLAPSED_KEY, EMPTY_COLLAPSED),
+      [folder]: value,
+    });
 
   return (
     <div className="git-explorer-scroll">
@@ -31,6 +66,12 @@ export function GitExplorerPanel({
           folder={folder}
           rootLabel={showLabel ? rootName(folder) : undefined}
           paused={paused}
+          collapsed={showLabel && (collapsedMap[folder] ?? false)}
+          onToggleCollapsed={
+            showLabel
+              ? () => persistCollapsed(folder, !(collapsedMap[folder] ?? false))
+              : undefined
+          }
         />
       ))}
     </div>

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -36,6 +36,8 @@ export function GitView({
   folder,
   rootLabel,
   paused,
+  collapsed,
+  onToggleCollapsed,
 }: {
   ctx: ExtensionContext;
   cacheKey: string;
@@ -43,6 +45,8 @@ export function GitView({
   folder: string;
   rootLabel?: string;
   paused: boolean;
+  collapsed: boolean;
+  onToggleCollapsed?: () => void;
 }) {
   // Public primitives, read through ctx (stable per extension).
   const editors = ctx.editors;
@@ -69,7 +73,6 @@ export function GitView({
   const [pendingPull, setPendingPull] = useState(false);
   const [stagedOpen, setStagedOpen] = useState(true);
   const [changesOpen, setChangesOpen] = useState(true);
-  const [collapsed, setCollapsed] = useState(false);
 
   const refresh = useCallback(() => {
     setBusy(true);
@@ -544,10 +547,7 @@ export function GitView({
   return (
     <div className="git-panel">
       {rootLabel ? (
-        <button
-          className="git-root-label"
-          onClick={() => setCollapsed((v) => !v)}
-        >
+        <button className="git-root-label" onClick={onToggleCollapsed}>
           <span className="git-root-top">
             <span className="git-root-chev">
               {collapsed ? (

--- a/packages/extensions-silo/src/git-explorer/index.tsx
+++ b/packages/extensions-silo/src/git-explorer/index.tsx
@@ -21,8 +21,8 @@ export const extension: Extension = {
       title: "Git",
       // Inject ctx so the panel/view reach workspaces/editors/files through
       // the public primitives, not host getters.
-      component: ({ active }) => (
-        <GitExplorerPanel ctx={ctx} paused={!active} />
+      component: ({ active, storage }) => (
+        <GitExplorerPanel ctx={ctx} storage={storage} paused={!active} />
       ),
       order: 2,
       lazyMount: true,


### PR DESCRIPTION
## Summary
- Each repo section's collapsed/expanded state in the Git panel lived in `GitView`'s local `useState`, so it reset whenever the panel remounted on workspace switch.
- Moved it into the panel's per-workspace storage bag (`SidePanelProps.storage`), the same pattern `file-explorer` already uses for its tree state — the host swaps/persists this bag per active workspace automatically.
- Subscribed via `useSyncExternalStore` so toggling a repo's collapse re-renders the panel immediately instead of waiting on an unrelated state change.

## Test plan
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm --filter @silo-code/extensions-silo exec vitest run src/git-explorer` — 26/26 passing
- [x] `pnpm lint` — clean
- [x] Manually verified in the running dev app: created a sandbox workspace with two git repos, collapsed one, switched to a different workspace and back — collapsed state persisted correctly per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MuYF3LEK5iajgyCJ2i2jF