### PR TITLE
fix(markdown-preview): persist scroll position across workspace switches

### DIFF
--- a/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
+++ b/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { MouseEvent } from "react";
+import type { MouseEvent, UIEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
@@ -10,7 +10,11 @@ import { classifyMarkdownLink } from "./links";
 import { parseFrontmatter, formatFrontmatterValue } from "./frontmatter";
 import { GITHUB_SANITIZE_SCHEMA } from "./sanitize-schema";
 import { isExternalImageUrl, resolveLocalImagePath } from "./resolveImageSrc";
+import { isValidScrollTop, scrollStorageKey } from "./scroll";
 import "./MarkdownPreview.css";
+
+// Matches TextViewer's Monaco scroll-save debounce.
+const SCROLL_SAVE_DEBOUNCE_MS = 300;
 
 const MIME_BY_EXT: Record<string, string> = {
   png: "image/png",
@@ -106,12 +110,17 @@ function FrontmatterBlock({ fields }: { fields: Record<string, unknown> }) {
  * handler — it's a presenter.
  */
 export function MarkdownPreview({
+  editorId,
   filePath,
   ctx,
 }: EditorProps & { ctx: ExtensionContext }) {
   const [content, setContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const bodyRef = useRef<HTMLElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hasRestoredScrollRef = useRef(false);
+  const lastScrollTopRef = useRef(0);
+  const scrollSaveTimerRef = useRef<number | null>(null);
 
   const components = useMemo(
     () => ({
@@ -162,6 +171,46 @@ export function MarkdownPreview({
       sub.dispose();
     };
   }, [filePath]);
+
+  // Restore the saved scroll position once, the first time content lands (the
+  // article's height needs to be present before a scrollTop assignment sticks).
+  // Later reloads (file-watch re-renders) don't re-trigger this.
+  useEffect(() => {
+    if (content === null || hasRestoredScrollRef.current) return;
+    hasRestoredScrollRef.current = true;
+    const saved = ctx.storage.workspace.get<number>(scrollStorageKey(editorId));
+    if (!isValidScrollTop(saved)) return;
+    lastScrollTopRef.current = saved;
+    requestAnimationFrame(() => {
+      if (containerRef.current) containerRef.current.scrollTop = saved;
+    });
+  }, [content, editorId, ctx]);
+
+  // Persist the final scroll position on unmount (tab close, app quit) in case
+  // a debounced save hasn't fired yet. Reads from the live-updated ref rather
+  // than the DOM node, since React may have already cleared the element ref.
+  useEffect(() => {
+    return () => {
+      if (scrollSaveTimerRef.current !== null) {
+        window.clearTimeout(scrollSaveTimerRef.current);
+      }
+      ctx.storage.workspace.set(
+        scrollStorageKey(editorId),
+        lastScrollTopRef.current,
+      );
+    };
+  }, [editorId, ctx]);
+
+  const onScroll = (e: UIEvent<HTMLDivElement>) => {
+    const top = e.currentTarget.scrollTop;
+    lastScrollTopRef.current = top;
+    if (scrollSaveTimerRef.current !== null) {
+      window.clearTimeout(scrollSaveTimerRef.current);
+    }
+    scrollSaveTimerRef.current = window.setTimeout(() => {
+      ctx.storage.workspace.set(scrollStorageKey(editorId), top);
+    }, SCROLL_SAVE_DEBOUNCE_MS);
+  };
 
   const selectAll = () => {
     const el = bodyRef.current;
@@ -222,9 +271,11 @@ export function MarkdownPreview({
   return (
     <div
       className="markdown-preview"
+      ref={containerRef}
       tabIndex={0}
       onClick={onClick}
       onContextMenu={onContextMenu}
+      onScroll={onScroll}
     >
       {error ? (
         <div className="placeholder error">Failed: {error}</div>

--- a/packages/extensions-silo/src/markdown-preview/scroll.test.ts
+++ b/packages/extensions-silo/src/markdown-preview/scroll.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isValidScrollTop, scrollStorageKey } from "./scroll";
+
+describe("scrollStorageKey", () => {
+  it("namespaces the key by editor id", () => {
+    expect(scrollStorageKey("editor-1")).toBe("scrollTop:editor-1");
+  });
+
+  it("keeps distinct editor ids distinct", () => {
+    expect(scrollStorageKey("a")).not.toBe(scrollStorageKey("b"));
+  });
+});
+
+describe("isValidScrollTop", () => {
+  it("accepts zero and positive finite numbers", () => {
+    expect(isValidScrollTop(0)).toBe(true);
+    expect(isValidScrollTop(120.5)).toBe(true);
+  });
+
+  it("rejects negative numbers", () => {
+    expect(isValidScrollTop(-1)).toBe(false);
+  });
+
+  it("rejects non-finite numbers", () => {
+    expect(isValidScrollTop(Number.NaN)).toBe(false);
+    expect(isValidScrollTop(Infinity)).toBe(false);
+  });
+
+  it("rejects undefined and non-number values", () => {
+    expect(isValidScrollTop(undefined)).toBe(false);
+    expect(isValidScrollTop("120")).toBe(false);
+    expect(isValidScrollTop(null)).toBe(false);
+  });
+});

--- a/packages/extensions-silo/src/markdown-preview/scroll.ts
+++ b/packages/extensions-silo/src/markdown-preview/scroll.ts
@@ -1,0 +1,11 @@
+// Pure logic for persisting preview scroll position via ctx.storage.workspace —
+// kept out of React so it's unit-testable.
+
+export function scrollStorageKey(editorId: string): string {
+  return `scrollTop:${editorId}`;
+}
+
+/** Guards against corrupt/missing storage values before applying them as a scrollTop. */
+export function isValidScrollTop(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}


### PR DESCRIPTION
## Summary
- Markdown Preview didn't retain scroll position across a reload/workspace switch, unlike the Monaco text editor
- Save/restore it via `ctx.storage.workspace` (per-workspace persisted key/value store, the correct SDK surface for a `silo.*` extension), mirroring `TextViewer`'s existing debounced Monaco scroll persistence pattern
- Adds `scroll.ts` (pure `scrollStorageKey`/`isValidScrollTop` helpers) + `scroll.test.ts`

## Test plan
- [x] `pnpm test` (extensions-silo) green
- [x] `pnpm lint` clean
- [x] Verified live in the dev app: scrolled a markdown file in Preview mode, triggered a full frontend reload (the scenario this fix targets — cold remount, same as an app restart), confirmed the preview reopened at the same scroll offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MuYF3LEK5iajgyCJ2i2jF