### PR TITLE
feat(extensions): track install source, support updates, revamp settings UI

### DIFF
--- a/packages/extension-host/src/extension-host/extension-manager.test.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.test.ts
@@ -16,8 +16,12 @@ const { fsMap, loaderMock, invokeMock, fsDeleteSpy } = vi.hoisted(() => {
       needsReload: vi.fn(() => false),
     },
     invokeMock: vi.fn(async () => {}),
+    // Directory semantics over the flat map: deleting a path also deletes
+    // everything under it (the update flow deletes/renames whole install dirs).
     fsDeleteSpy: vi.fn(async (p: string) => {
-      fsMap.delete(p);
+      for (const key of [...fsMap.keys()]) {
+        if (key === p || key.startsWith(`${p}/`)) fsMap.delete(key);
+      }
     }),
   };
 });
@@ -33,9 +37,25 @@ vi.mock("../services/tauri-fs", () => ({
     return v;
   },
   fsWriteText: async (p: string, c: string) => void fsMap.set(p, c),
-  fsCopyDir: async () => {},
+  // Real directory copy/move/exists over the flat map, so the update flow's
+  // backup-rename-swap can be asserted on actual file contents.
+  fsCopyDir: async (src: string, dst: string) => {
+    for (const [key, val] of [...fsMap.entries()]) {
+      if (key.startsWith(`${src}/`))
+        fsMap.set(`${dst}${key.slice(src.length)}`, val);
+    }
+  },
   fsDelete: fsDeleteSpy,
-  fsPathExists: async (p: string) => fsMap.has(p),
+  fsPathExists: async (p: string) =>
+    fsMap.has(p) || [...fsMap.keys()].some((k) => k.startsWith(`${p}/`)),
+  fsRename: async (from: string, to: string) => {
+    for (const [key, val] of [...fsMap.entries()]) {
+      if (key === from || key.startsWith(`${from}/`)) {
+        fsMap.delete(key);
+        fsMap.set(`${to}${key.slice(from.length)}`, val);
+      }
+    }
+  },
   // Remaining surface the scoped file service binds when a built-in activates
   // (createContext → getScopedFileService). Not exercised by these tests.
   fsReadBytes: vi.fn(),
@@ -43,7 +63,6 @@ vi.mock("../services/tauri-fs", () => ({
   fsCreateDir: vi.fn(),
   fsWriteBytes: vi.fn(),
   fsStat: vi.fn(),
-  fsRename: vi.fn(),
   fsReveal: vi.fn(),
   fsCopy: vi.fn(),
 }));
@@ -74,6 +93,7 @@ import {
   validateManifestPermissions,
   resolveNpmTarball,
   findPackageRoot,
+  updateNeedsConsent,
 } from "./extension-manager";
 import { registerBuiltins } from "./builtins-registry";
 import type { Extension } from "@silo-code/sdk";
@@ -505,6 +525,299 @@ describe("installFromUrl (integration)", () => {
     expect(invokeMock).toHaveBeenCalledWith(
       "download_extract",
       expect.objectContaining({ url: tarball }),
+    );
+  });
+});
+
+// ---- install source + in-place update -----------------------------------
+
+function installedRecord(id = "acme.x") {
+  return JSON.parse(fsMap.get(INSTALLED)!).extensions.find(
+    (e: { id: string }) => e.id === id,
+  );
+}
+
+describe("install source recording", () => {
+  /** Stage a tarball extraction: manifest + a bundle file with `content`. */
+  function stageWith(content: string) {
+    return async (_cmd: string, args: { destDir?: string }) => {
+      if (args.destDir) {
+        fsMap.set(
+          `${args.destDir}/package/package.json`,
+          manifest(["fs:read"]),
+        );
+        fsMap.set(`${args.destDir}/package/dist/index.js`, content);
+      }
+    };
+  }
+
+  it("installFromFolder records a folder source (trailing slash trimmed)", async () => {
+    fsMap.set("/src/ext/package.json", manifest());
+    await mgr.installFromFolder("/src/ext/");
+    expect(installedRecord().source).toEqual({
+      kind: "folder",
+      value: "/src/ext",
+    });
+  });
+
+  it("installFromUrl records the URL, not the staging dir", async () => {
+    invokeMock.mockImplementation(stageWith("v1"));
+    await mgr.installFromUrl("https://example.com/ext.tgz", async () => true);
+    expect(installedRecord().source).toEqual({
+      kind: "url",
+      value: "https://example.com/ext.tgz",
+    });
+  });
+
+  it("installFromNpm records the original spec, not the resolved tarball", async () => {
+    global.fetch = okFetch(npmMeta());
+    invokeMock.mockImplementation(stageWith("v1"));
+    await mgr.installFromNpm("pkg", async () => true);
+    expect(installedRecord().source).toEqual({ kind: "npm", value: "pkg" });
+  });
+
+  it("reinstalling the same id replaces the recorded source", async () => {
+    fsMap.set("/src/a/package.json", manifest());
+    fsMap.set("/src/b/package.json", manifest());
+    await mgr.installFromFolder("/src/a");
+    await mgr.installFromFolder("/src/b");
+    const recs = JSON.parse(fsMap.get(INSTALLED)!).extensions;
+    expect(recs).toHaveLength(1);
+    expect(recs[0].source).toEqual({ kind: "folder", value: "/src/b" });
+  });
+});
+
+describe("updateNeedsConsent", () => {
+  it("skips the prompt when permissions are unchanged or narrowed", () => {
+    expect(
+      updateNeedsConsent(["fs:read"], {
+        permissions: ["fs:read"],
+        engineCompatible: true,
+      }),
+    ).toBe(false);
+    expect(
+      updateNeedsConsent(["fs:read", "process"], {
+        permissions: ["fs:read"],
+        engineCompatible: true,
+      }),
+    ).toBe(false);
+    expect(
+      updateNeedsConsent([], { permissions: [], engineCompatible: true }),
+    ).toBe(false);
+  });
+
+  it("prompts when the set widens", () => {
+    expect(
+      updateNeedsConsent(["fs:read"], {
+        permissions: ["fs:read", "network"],
+        engineCompatible: true,
+      }),
+    ).toBe(true);
+    expect(
+      updateNeedsConsent([], {
+        permissions: ["fs:read"],
+        engineCompatible: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("prompts when the engine floor is unmet, even with equal permissions", () => {
+    expect(
+      updateNeedsConsent(["fs:read"], {
+        permissions: ["fs:read"],
+        engineCompatible: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("update", () => {
+  const DEST = "/cfg/extensions/acme.x";
+
+  /** Install acme.x from a source folder with a v1 bundle, then reset spies. */
+  async function installV1(perms: unknown = ["fs:read"]) {
+    fsMap.set("/src/ext/package.json", manifest(perms));
+    fsMap.set("/src/ext/dist/index.js", "v1");
+    await mgr.installFromFolder("/src/ext");
+    loaderMock.loadExtension.mockClear();
+    loaderMock.unloadExtension.mockClear();
+  }
+
+  it("swaps files in place from the folder source and reloads, without a prompt", async () => {
+    await installV1(["fs:read"]);
+    loaderMock.isLoaded.mockReturnValue(true);
+    fsMap.set("/src/ext/dist/index.js", "v2");
+    const consent = vi.fn(async () => true);
+
+    await mgr.update("acme.x", consent);
+
+    expect(consent).not.toHaveBeenCalled(); // permissions unchanged
+    expect(loaderMock.unloadExtension).toHaveBeenCalledWith("acme.x");
+    expect(fsMap.get(`${DEST}/dist/index.js`)).toBe("v2");
+    expect(loaderMock.loadExtension).toHaveBeenCalledWith({
+      id: "acme.x",
+      dir: DEST,
+      main: "dist/index.js",
+      permissions: ["fs:read"],
+    });
+    // Backup committed away; record keeps its identity, source, and enabled state.
+    expect([...fsMap.keys()].some((k) => k.includes(".update-"))).toBe(false);
+    expect(installedRecord()).toMatchObject({
+      id: "acme.x",
+      dir: "acme.x",
+      enabled: true,
+      source: { kind: "folder", value: "/src/ext" },
+    });
+  });
+
+  it("prompts when the new manifest widens permissions, and records the new set", async () => {
+    await installV1(["fs:read"]);
+    fsMap.set("/src/ext/package.json", manifest(["fs:read", "network"]));
+    const consent = vi.fn(async () => true);
+
+    await mgr.update("acme.x", consent);
+
+    expect(consent).toHaveBeenCalledWith(
+      expect.objectContaining({ permissions: ["fs:read", "network"] }),
+    );
+    expect(installedRecord().permissions).toEqual(["fs:read", "network"]);
+    expect(loaderMock.loadExtension).toHaveBeenCalledWith(
+      expect.objectContaining({ permissions: ["fs:read", "network"] }),
+    );
+  });
+
+  it("aborts silently when consent is denied — nothing changes", async () => {
+    await installV1(["fs:read"]);
+    fsMap.set("/src/ext/package.json", manifest(["fs:read", "network"]));
+    fsMap.set("/src/ext/dist/index.js", "v2");
+
+    await mgr.update("acme.x", async () => false);
+
+    expect(fsMap.get(`${DEST}/dist/index.js`)).toBe("v1");
+    expect(installedRecord().permissions).toEqual(["fs:read"]);
+    expect(loaderMock.loadExtension).not.toHaveBeenCalled();
+  });
+
+  it("re-resolves an unpinned npm spec and downloads the new tarball", async () => {
+    const stage =
+      (content: string) => async (_cmd: string, args: { destDir?: string }) => {
+        if (args.destDir) {
+          fsMap.set(
+            `${args.destDir}/package/package.json`,
+            manifest(["fs:read"]),
+          );
+          fsMap.set(`${args.destDir}/package/dist/index.js`, content);
+        }
+      };
+    global.fetch = okFetch(npmMeta("1.0.0", "https://reg/pkg-1.tgz"));
+    invokeMock.mockImplementation(stage("v1"));
+    await mgr.installFromNpm("pkg", async () => true);
+
+    global.fetch = okFetch(npmMeta("2.0.0", "https://reg/pkg-2.tgz"));
+    invokeMock.mockClear().mockImplementation(stage("v2"));
+    await mgr.update(
+      "acme.x",
+      vi.fn(async () => true),
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      "download_extract",
+      expect.objectContaining({ url: "https://reg/pkg-2.tgz" }),
+    );
+    expect(fsMap.get(`${DEST}/dist/index.js`)).toBe("v2");
+    // Staging cleaned up on the way out.
+    expect(
+      [...fsMap.keys()].some((k) => k.startsWith("/tmp/silo-install-")),
+    ).toBe(false);
+  });
+
+  it("restores files, record, and the running version when the new load fails", async () => {
+    await installV1(["fs:read"]);
+    loaderMock.isLoaded.mockReturnValue(true);
+    fsMap.set("/src/ext/package.json", manifest(["fs:read", "network"]));
+    fsMap.set("/src/ext/dist/index.js", "v2");
+    loaderMock.loadExtension
+      .mockRejectedValueOnce(new Error("activate exploded"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(mgr.update("acme.x", async () => true)).rejects.toThrow(
+      "activate exploded",
+    );
+
+    // Old files back in place.
+    expect(fsMap.get(`${DEST}/dist/index.js`)).toBe("v1");
+    expect(fsMap.get(`${DEST}/package.json`)).toBe(manifest(["fs:read"]));
+    // Record restored byte-for-byte (old grant, still enabled).
+    expect(installedRecord()).toMatchObject({
+      permissions: ["fs:read"],
+      enabled: true,
+    });
+    // Old version reloaded with the previously granted set, not the manifest.
+    expect(loaderMock.loadExtension).toHaveBeenLastCalledWith(
+      expect.objectContaining({ permissions: ["fs:read"] }),
+    );
+    expect([...fsMap.keys()].some((k) => k.includes(".update-"))).toBe(false);
+  });
+
+  it("updates a disabled extension in place without loading it", async () => {
+    await installV1(["fs:read"]);
+    await mgr.disable("acme.x");
+    loaderMock.loadExtension.mockClear();
+    fsMap.set("/src/ext/dist/index.js", "v2");
+
+    await mgr.update("acme.x", async () => true);
+
+    expect(loaderMock.loadExtension).not.toHaveBeenCalled();
+    expect(fsMap.get(`${DEST}/dist/index.js`)).toBe("v2");
+    expect(installedRecord().enabled).toBe(false);
+  });
+
+  it("rejects for built-ins, unknown ids, and legacy records without a source", async () => {
+    const consent = vi.fn(async () => true);
+    registerBuiltins([fakeBuiltin("silo.demo", "Demo")], new Set());
+    await expect(mgr.update("silo.demo", consent)).rejects.toThrow(
+      /update with the app/,
+    );
+    await expect(mgr.update("acme.gone", consent)).rejects.toThrow(
+      /not installed/,
+    );
+
+    fsMap.set(
+      INSTALLED,
+      JSON.stringify({
+        version: 1,
+        extensions: [
+          { id: "acme.x", dir: "acme.x", enabled: true, permissions: [] },
+        ],
+      }),
+    );
+    await expect(mgr.update("acme.x", consent)).rejects.toThrow(
+      /before update support/,
+    );
+  });
+
+  it("rejects when the source folder is gone or now declares a different id", async () => {
+    await installV1();
+
+    fsMap.set(
+      "/src/ext/package.json",
+      JSON.stringify({
+        name: "Other",
+        version: "1.0.0",
+        silo: { id: "acme.y", main: "dist/index.js" },
+      }),
+    );
+    await expect(mgr.update("acme.x", async () => true)).rejects.toThrow(
+      /expected "acme.x"/,
+    );
+    // The failed attempt never touched the install.
+    expect(fsMap.get(`${DEST}/dist/index.js`)).toBe("v1");
+
+    for (const k of [...fsMap.keys()]) {
+      if (k.startsWith("/src/ext/")) fsMap.delete(k);
+    }
+    await expect(mgr.update("acme.x", async () => true)).rejects.toThrow(
+      /no longer exists/,
     );
   });
 });

--- a/packages/extension-host/src/extension-host/extension-manager.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.ts
@@ -20,6 +20,7 @@ import {
   fsDelete,
   fsPathExists,
   fsCreateDir,
+  fsRename,
 } from "../services/tauri-fs";
 import {
   loadExtension,
@@ -76,6 +77,20 @@ export function validateManifestPermissions(
   return out;
 }
 
+/**
+ * Where an install came from, persisted so {@link ExtensionManager.update} can
+ * re-fetch the same package later without an uninstall/reinstall round-trip.
+ */
+export interface InstallSource {
+  kind: "folder" | "url" | "npm";
+  /**
+   * `folder`: absolute path to the source folder; `url`: the tarball URL;
+   * `npm`: the original spec as typed (`"pkg"` or `"@scope/pkg@1.2.0"`), so an
+   * unpinned spec re-resolves to latest on update while a pinned one stays pinned.
+   */
+  value: string;
+}
+
 /** One row in the manager's UI list. */
 export interface InstalledExtension {
   /** The extension id (e.g. `"acme.hello"`). */
@@ -119,6 +134,12 @@ export interface InstalledExtension {
    * warning, not a hard block.
    */
   engineCompatible: boolean;
+  /**
+   * Where the extension was installed from, when recorded. Absent for built-ins
+   * and for records installed before source tracking existed — the UI hides the
+   * Update action for those (a one-time reinstall records it).
+   */
+  source?: InstallSource;
 }
 
 export interface ExtensionManagerState {
@@ -126,8 +147,12 @@ export interface ExtensionManagerState {
 }
 
 export interface ExtensionManager extends ReactiveService<ExtensionManagerState> {
-  /** Install from a source folder (copied into the extensions dir), then load. */
-  installFromFolder(srcDir: string): Promise<void>;
+  /**
+   * Install from a source folder (copied into the extensions dir), then load.
+   * `source` overrides the recorded {@link InstallSource} — the URL/npm paths
+   * pass their true origin here so the temp staging dir is never recorded.
+   */
+  installFromFolder(srcDir: string, source?: InstallSource): Promise<void>;
   /** Unload (if loaded), delete the folder, and drop the record. Rejects for built-ins. */
   uninstall(id: string): Promise<void>;
   /** Enable: load a third-party extension, or hot-enable a built-in. */
@@ -170,9 +195,32 @@ export interface ExtensionManager extends ReactiveService<ExtensionManagerState>
    *
    * The tarball must contain a `package.json` with a `silo.*` manifest at its
    * root or under a `package/` prefix (the npm standard layout).
+   *
+   * `source` overrides the recorded {@link InstallSource} (the npm path passes
+   * the original package spec here instead of the resolved tarball URL).
    */
   installFromUrl(
     url: string,
+    requestConsent: (preview: ManifestPreview) => Promise<boolean>,
+    source?: InstallSource,
+  ): Promise<void>;
+  /**
+   * Update an installed extension in place from its recorded
+   * {@link InstallSource}: re-fetch the package (folder: re-copy; url/npm:
+   * re-download), unload the running version, swap the files, and reload —
+   * keeping the extension id and record so panel/dock state survives.
+   *
+   * Consent is re-requested via `requestConsent` **only** when the new manifest
+   * widens the granted permission set or the engine floor is unmet (see
+   * {@link updateNeedsConsent}); returning `false` aborts silently. If loading
+   * the new version fails, the previous files, record, and running version are
+   * restored and the original error is rethrown.
+   *
+   * Rejects for built-ins and for records with no recorded source (installed
+   * before source tracking — reinstall once from the original source).
+   */
+  update(
+    id: string,
     requestConsent: (preview: ManifestPreview) => Promise<boolean>,
   ): Promise<void>;
 }
@@ -214,6 +262,8 @@ interface InstalledRecord {
   dir: string;
   enabled: boolean;
   permissions?: Permission[];
+  /** Where the install came from; absent on records from before source tracking. */
+  source?: InstallSource;
 }
 
 interface InstalledFile {
@@ -364,6 +414,7 @@ async function refresh(): Promise<void> {
         engine: m.engine,
         hostVersion,
         engineCompatible: isEngineCompatible(m.engine, hostVersion),
+        source: rec.source,
       });
     } catch {
       rows.push({
@@ -379,6 +430,7 @@ async function refresh(): Promise<void> {
         permissions: rec.permissions ?? [],
         hostVersion,
         engineCompatible: true, // can't read manifest → no constraint to check
+        source: rec.source,
       });
     }
   }
@@ -426,6 +478,21 @@ async function setBuiltinDisabled(
     else set.delete(id);
     file.disabledBuiltins = [...set];
   });
+}
+
+/**
+ * Whether an update must re-prompt for consent: only when the new manifest
+ * widens the already-granted permission set, or the host no longer meets the
+ * declared engine floor. Equal or narrowed permissions update silently.
+ */
+export function updateNeedsConsent(
+  granted: readonly Permission[],
+  preview: Pick<ManifestPreview, "permissions" | "engineCompatible">,
+): boolean {
+  return (
+    !preview.engineCompatible ||
+    preview.permissions.some((p) => !granted.includes(p))
+  );
 }
 
 // ---- npm / URL install helpers -----------------------------------------------
@@ -507,7 +574,7 @@ export function getExtensionManager(): ExtensionManager {
       return d;
     },
 
-    async installFromFolder(srcDir) {
+    async installFromFolder(srcDir, source) {
       const cleanedSrc = srcDir.replace(/\/+$/, "");
       const manifest = await readManifest(cleanedSrc);
       const root = await extensionsRoot();
@@ -520,17 +587,23 @@ export function getExtensionManager(): ExtensionManager {
       // Persist the consented permissions as the granted set (the UI has
       // already prompted via previewInstall). On reinstall/upgrade, re-record
       // them from the new manifest — the user re-consented to install.
+      const recordedSource: InstallSource = source ?? {
+        kind: "folder",
+        value: cleanedSrc,
+      };
       await upsertRecord((file) => {
         const existing = file.extensions.find((e) => e.id === manifest.id);
         if (existing) {
           existing.enabled = true;
           existing.permissions = manifest.permissions;
+          existing.source = recordedSource;
         } else
           file.extensions.push({
             id: manifest.id,
             dir: manifest.id,
             enabled: true,
             permissions: manifest.permissions,
+            source: recordedSource,
           });
       });
 
@@ -656,19 +729,140 @@ export function getExtensionManager(): ExtensionManager {
 
     async installFromNpm(packageName, requestConsent) {
       const tarballUrl = await resolveNpmTarball(packageName);
-      await service!.installFromUrl(tarballUrl, requestConsent);
+      // Record the original spec, not the resolved tarball URL — an unpinned
+      // spec then re-resolves to the latest version on update.
+      await service!.installFromUrl(tarballUrl, requestConsent, {
+        kind: "npm",
+        value: packageName,
+      });
     },
 
-    async installFromUrl(url, requestConsent) {
+    async installFromUrl(url, requestConsent, source) {
       const stagingDir = await stageFromUrl(url);
       try {
         const pkgRoot = await findPackageRoot(stagingDir);
         const preview = await service!.previewInstall(pkgRoot);
         const granted = await requestConsent(preview);
         if (!granted) return;
-        await service!.installFromFolder(pkgRoot);
+        await service!.installFromFolder(
+          pkgRoot,
+          source ?? { kind: "url", value: url },
+        );
       } finally {
         await fsDelete(stagingDir).catch(() => {});
+      }
+    },
+
+    async update(id, requestConsent) {
+      if (isBuiltin(id)) {
+        throw new Error("Built-in extensions update with the app.");
+      }
+      const rec = (await readInstalledFile()).extensions.find(
+        (e) => e.id === id,
+      );
+      if (!rec) throw new Error(`${id} is not installed.`);
+      if (!rec.source) {
+        throw new Error(
+          `${id} was installed before update support — reinstall it once from its original source to enable updates.`,
+        );
+      }
+
+      // Resolve a fresh copy of the package from the recorded source.
+      let stagingDir: string | null = null;
+      let pkgRoot: string;
+      if (rec.source.kind === "folder") {
+        pkgRoot = rec.source.value.replace(/\/+$/, "");
+        if (!(await fsPathExists(`${pkgRoot}/package.json`))) {
+          throw new Error(`Source folder no longer exists: ${pkgRoot}`);
+        }
+      } else {
+        const url =
+          rec.source.kind === "npm"
+            ? await resolveNpmTarball(rec.source.value)
+            : rec.source.value;
+        stagingDir = await stageFromUrl(url);
+        pkgRoot = await findPackageRoot(stagingDir);
+      }
+
+      try {
+        const preview = await service!.previewInstall(pkgRoot);
+        if (preview.id !== id) {
+          throw new Error(
+            `Source now declares id "${preview.id}" — expected "${id}". Uninstall and install it fresh.`,
+          );
+        }
+        if (
+          updateNeedsConsent(rec.permissions ?? [], preview) &&
+          !(await requestConsent(preview))
+        ) {
+          return;
+        }
+
+        // In-place swap: park the old install as a backup so a failed load of
+        // the new version can restore it. The "." prefix can't collide with an
+        // extension dir (ids must start alphanumeric).
+        const root = await extensionsRoot();
+        const destDir = `${root}/${rec.dir}`;
+        const backupDir = `${root}/.update-${id}`;
+        const oldRecord: InstalledRecord = { ...rec };
+        const wasEnabled = rec.enabled;
+        if (isLoaded(id)) unloadExtension(id);
+        if (await fsPathExists(backupDir)) await fsDelete(backupDir);
+        await fsRename(destDir, backupDir);
+        try {
+          await fsCopyDir(pkgRoot, destDir);
+          const manifest = await readManifest(destDir);
+          await upsertRecord((f) => {
+            const r = f.extensions.find((e) => e.id === id);
+            if (r) {
+              r.permissions = manifest.permissions;
+              r.enabled = wasEnabled;
+            }
+          });
+          if (wasEnabled) {
+            await loadExtension({
+              id,
+              dir: destDir,
+              main: manifest.main,
+              permissions: manifest.permissions,
+            });
+          }
+          await fsDelete(backupDir).catch(() => {});
+        } catch (err) {
+          // Restore files, then record, then the running version — best-effort
+          // each, without masking the original failure.
+          try {
+            if (await fsPathExists(destDir)) await fsDelete(destDir);
+            await fsRename(backupDir, destDir);
+            await upsertRecord((f) => {
+              const i = f.extensions.findIndex((e) => e.id === id);
+              if (i >= 0) f.extensions[i] = oldRecord;
+            });
+            if (wasEnabled) {
+              const old = await readManifest(destDir);
+              // Reload with the previously granted set, not the manifest.
+              await loadExtension({
+                id,
+                dir: destDir,
+                main: old.main,
+                permissions: oldRecord.permissions ?? [],
+              });
+            }
+          } catch (restoreErr) {
+            reportError(`Extension update rollback failed: ${id}`, {
+              extensionId: id,
+              error:
+                restoreErr instanceof Error
+                  ? restoreErr.message
+                  : String(restoreErr),
+            });
+          }
+          throw err;
+        } finally {
+          await refresh();
+        }
+      } finally {
+        if (stagingDir) await fsDelete(stagingDir).catch(() => {});
       }
     },
   };

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -68,6 +68,7 @@ export type {
   ExtensionManager,
   ExtensionManagerState,
   InstalledExtension,
+  InstallSource,
   ManifestPreview,
 } from "./extension-manager";
 export { getExtensionManager } from "./extension-manager";

--- a/packages/extensions-core/src/extensions/ExtensionsPage.css
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.css
@@ -96,13 +96,25 @@
 
 .ext-row {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  flex-direction: column;
+  gap: 4px;
   /* Left inset = pane pad so row text lines up with the page title; the row
      itself (and its separator) reaches the pane's left edge via the list bleed. */
   padding: 7px 8px 7px var(--settings-pane-pad);
   border-bottom: 1px solid var(--silo-color-border);
+}
+
+/* Name/description + actions, side by side. The source line (below) is its own
+   full-width line rather than squeezed into this row's leftover space — a long
+   path/URL needs the room a lot more than it needs to share a line with the
+   buttons. Top-aligned rather than centered: the text block can grow to two or
+   three lines (hints/warnings), and the action menu should stay pinned to the
+   row's top rather than drift toward its vertical middle. */
+.ext-row-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
 }
 
 .ext-row-text {
@@ -120,7 +132,9 @@
 .ext-brand {
   font-size: calc(var(--settings-font) - 2px);
   color: var(--silo-color-accent);
-  border: 1px solid var(--silo-color-accent);
+  background: color-mix(in srgb, var(--silo-color-accent) 14%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--silo-color-accent) 35%, transparent);
   border-radius: var(--silo-radius-sm);
   padding: 0 5px;
 }
@@ -132,14 +146,17 @@
 .ext-badge-builtin {
   font-size: calc(var(--settings-font) - 2px);
   color: var(--silo-color-ok);
-  border: 1px solid var(--silo-color-ok);
+  background: color-mix(in srgb, var(--silo-color-ok) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--silo-color-ok) 35%, transparent);
   border-radius: var(--silo-radius-sm);
   padding: 0 5px;
 }
 .ext-badge {
   font-size: calc(var(--settings-font) - 2px);
   color: var(--silo-color-text-lo);
-  border: 1px solid var(--silo-color-border-strong);
+  background: color-mix(in srgb, var(--silo-color-text-lo) 12%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--silo-color-text-lo) 30%, transparent);
   border-radius: var(--silo-radius-sm);
   padding: 0 5px;
 }
@@ -151,23 +168,45 @@
 .ext-hint-warn {
   color: var(--silo-color-warn);
 }
+.ext-source {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  font-family: var(--silo-font-mono, monospace);
+}
+.ext-source svg {
+  flex: 0 0 auto;
+}
+.ext-source-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* Truncate from the left: the tail of a path/URL (the filename, the last
+     path segment) is the useful part, not the leading /Users/you/... or
+     https://... that's the same for every row. */
+  direction: rtl;
+  text-align: left;
+}
 
 .ext-actions {
   flex: 0 0 auto;
   display: flex;
-  gap: 6px;
+  gap: 4px;
 }
 
-/* Buttons mirror .kb-edit-btn. */
+/* Buttons mirror .kb-edit-btn, sized down from that shared baseline so a row's
+   text (often a long path/URL) keeps most of the row's width. */
 .ext-btn {
   background: var(--silo-color-bg-active);
   border: 1px solid var(--silo-color-border);
   color: var(--silo-color-text-hi);
-  padding: 5px 10px;
+  padding: 4px 8px;
   border-radius: var(--silo-radius-sm);
   cursor: pointer;
   font: inherit;
-  font-size: calc(var(--settings-font) - 1px);
+  font-size: calc(var(--settings-font) - 2px);
 }
 .ext-btn:hover {
   background: var(--silo-color-bg-hover);
@@ -176,13 +215,19 @@
   opacity: 0.5;
   cursor: default;
 }
-.ext-btn-danger:hover {
-  background: var(--silo-color-err);
-  border-color: var(--silo-color-err);
-  color: var(--silo-button-danger-text, #fff);
+/* The per-row overflow-menu trigger sits on every row, so it should read as a
+   quiet affordance, not compete with the page-level buttons above (Install
+   from folder…, Install) — transparent until hovered. */
+.ext-row-btn {
+  background: transparent;
+  border-color: transparent;
+}
+.ext-row-btn:hover {
+  background: var(--silo-color-bg-hover);
+  border-color: var(--silo-color-border);
 }
 .ext-btn-icon {
-  padding: 5px 7px;
+  padding: 4px 6px;
   display: flex;
   align-items: center;
 }

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -1,21 +1,39 @@
 import { useState, useRef } from "react";
-import { ArrowsClockwise } from "@phosphor-icons/react";
-import type { ExtensionContext } from "@silo-code/sdk";
+import {
+  ArrowsClockwise,
+  DotsThreeVertical,
+  Folder,
+  LinkSimple,
+  Package,
+} from "@phosphor-icons/react";
+import type { ExtensionContext, MenuEntry } from "@silo-code/sdk";
 import { useServiceState } from "@silo-code/sdk";
 import {
   getExtensionManager,
+  type InstallSource,
   type InstalledExtension,
   type ManifestPreview,
 } from "@silo-code/extension-host/internal";
 import { PermissionConsent } from "./PermissionConsent";
 import {
+  describeSource,
   filterExtensions,
   hasBuiltins,
   showsReloadHint,
+  showsUpdateAction,
 } from "./extensions-list-model";
 import "./ExtensionsPage.css";
 
 const mgr = getExtensionManager();
+
+// The label prefix ("Folder: ", "URL: ", "npm: ") is redundant once the kind
+// is legible at a glance — an icon says the same thing in less width, leaving
+// more room for the (often long) path/URL itself.
+const SOURCE_ICON: Record<InstallSource["kind"], typeof Folder> = {
+  folder: Folder,
+  url: LinkSimple,
+  npm: Package,
+};
 
 /**
  * Factory: the Extensions settings page closes over `ctx` so it can drive the
@@ -112,10 +130,10 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       );
     }
 
-    function reload(ext: InstalledExtension) {
+    function update(ext: InstalledExtension) {
       void run(ext.id, async () => {
-        await mgr.disable(ext.id);
-        await mgr.enable(ext.id);
+        await mgr.update(ext.id, requestConsent);
+        ctx.ui.notify("info", `Updated ${ext.name}`);
       });
     }
 
@@ -131,6 +149,33 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
         await mgr.uninstall(ext.id);
         ctx.ui.notify("info", `Uninstalled ${ext.name}`);
       });
+    }
+
+    // Every row action lives behind one overflow menu rather than a row of
+    // buttons — Reload only applies to rows with a recorded install source,
+    // Uninstall only to non-built-ins, Disable/Enable always applies.
+    function openRowMenu(ext: InstalledExtension, anchor: HTMLElement) {
+      const items: MenuEntry[] = [];
+      if (showsUpdateAction(ext)) {
+        items.push({
+          label: "Reload",
+          icon: <ArrowsClockwise size={14} />,
+          run: () => update(ext),
+        });
+      }
+      items.push({
+        label: ext.enabled ? "Disable" : "Enable",
+        run: () => toggle(ext),
+      });
+      if (!ext.builtin) {
+        items.push({ type: "separator" });
+        items.push({
+          label: "Uninstall",
+          danger: true,
+          run: () => uninstall(ext),
+        });
+      }
+      void ctx.ui.showMenu({ items, anchor, align: "end" });
     }
 
     return (
@@ -200,59 +245,60 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
           <div className="ext-list">
             {visible.map((ext) => (
               <div key={ext.id} className="ext-row">
-                <div className="ext-row-text">
-                  <span className="ext-label">
-                    {ext.name}
-                    <span className="ext-brand">{ext.publisher}</span>
-                    {ext.builtin && (
-                      <span className="ext-badge-builtin">Built-in</span>
-                    )}
-                    <span className="ext-version">v{ext.version}</span>
-                    {!ext.enabled && (
-                      <span className="ext-badge">disabled</span>
-                    )}
-                  </span>
-                  <span className="ext-hint">{ext.description ?? ext.id}</span>
-                  {showsReloadHint(ext) && (
-                    <span className="ext-hint ext-hint-warn">
-                      Reload the window to finish disabling this extension.
+                <div className="ext-row-top">
+                  <div className="ext-row-text">
+                    <span className="ext-label">
+                      {ext.name}
+                      <span className="ext-brand">{ext.publisher}</span>
+                      {ext.builtin && (
+                        <span className="ext-badge-builtin">Built-in</span>
+                      )}
+                      <span className="ext-version">v{ext.version}</span>
+                      {!ext.enabled && (
+                        <span className="ext-badge">disabled</span>
+                      )}
                     </span>
-                  )}
-                  {!ext.engineCompatible && (
-                    <span className="ext-hint ext-hint-warn">
-                      Needs Silo {ext.engine} — you&rsquo;re on{" "}
-                      {ext.hostVersion}. Update Silo to use this extension.
+                    <span className="ext-hint">
+                      {ext.description ?? ext.id}
                     </span>
-                  )}
-                </div>
-                <div className="ext-actions">
-                  <button
-                    className="ext-btn"
-                    onClick={() => toggle(ext)}
-                    disabled={busy === ext.id}
-                  >
-                    {ext.enabled ? "Disable" : "Enable"}
-                  </button>
-                  {import.meta.env.DEV && !ext.builtin && ext.enabled && (
+                    {showsReloadHint(ext) && (
+                      <span className="ext-hint ext-hint-warn">
+                        Reload the window to finish disabling this extension.
+                      </span>
+                    )}
+                    {!ext.engineCompatible && (
+                      <span className="ext-hint ext-hint-warn">
+                        Needs Silo {ext.engine} — you&rsquo;re on{" "}
+                        {ext.hostVersion}. Update Silo to use this extension.
+                      </span>
+                    )}
+                  </div>
+                  <div className="ext-actions">
                     <button
-                      className="ext-btn ext-btn-icon"
-                      onClick={() => reload(ext)}
+                      className="ext-btn ext-row-btn ext-btn-icon"
+                      onClick={(e) => openRowMenu(ext, e.currentTarget)}
                       disabled={busy === ext.id}
-                      title="Reload extension"
+                      title="Extension actions"
                     >
-                      <ArrowsClockwise size={14} />
+                      <DotsThreeVertical size={16} weight="bold" />
                     </button>
-                  )}
-                  {!ext.builtin && (
-                    <button
-                      className="ext-btn ext-btn-danger"
-                      onClick={() => uninstall(ext)}
-                      disabled={busy === ext.id}
-                    >
-                      Uninstall
-                    </button>
-                  )}
+                  </div>
                 </div>
+                {ext.source &&
+                  (() => {
+                    const SourceIcon = SOURCE_ICON[ext.source.kind];
+                    return (
+                      <span
+                        className="ext-hint ext-source"
+                        title={describeSource(ext.source)}
+                      >
+                        <SourceIcon size={12} />
+                        <span className="ext-source-value">
+                          {ext.source.value}
+                        </span>
+                      </span>
+                    );
+                  })()}
               </div>
             ))}
           </div>

--- a/packages/extensions-core/src/extensions/extensions-list-model.test.ts
+++ b/packages/extensions-core/src/extensions/extensions-list-model.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type { InstalledExtension } from "@silo-code/extension-host/internal";
 import {
+  describeSource,
   filterExtensions,
   hasBuiltins,
   showsReloadHint,
+  showsUpdateAction,
 } from "./extensions-list-model";
 
 function ext(over: Partial<InstalledExtension>): InstalledExtension {
@@ -73,6 +75,39 @@ describe("hasBuiltins", () => {
   });
   it("is false for a third-party-only list", () => {
     expect(hasBuiltins([ext({ id: "acme.hello" })])).toBe(false);
+  });
+});
+
+describe("showsUpdateAction", () => {
+  const source = { kind: "folder", value: "/src/ext" } as const;
+
+  it("offers Update for a third-party row with a recorded source", () => {
+    expect(showsUpdateAction(ext({ source }))).toBe(true);
+    // Visible even while disabled — updating doesn't require it to be running.
+    expect(showsUpdateAction(ext({ source, enabled: false }))).toBe(true);
+  });
+
+  it("hides Update for built-ins and legacy records without a source", () => {
+    expect(showsUpdateAction(ext({ builtin: true, source }))).toBe(false);
+    expect(showsUpdateAction(ext({}))).toBe(false);
+  });
+});
+
+describe("describeSource", () => {
+  it("formats each source kind with its label", () => {
+    expect(describeSource({ kind: "folder", value: "/src/ext" })).toBe(
+      "Folder: /src/ext",
+    );
+    expect(
+      describeSource({ kind: "url", value: "https://example.com/ext.tgz" }),
+    ).toBe("URL: https://example.com/ext.tgz");
+    expect(describeSource({ kind: "npm", value: "acme-ext@1.2.0" })).toBe(
+      "npm: acme-ext@1.2.0",
+    );
+  });
+
+  it("is undefined when there's no recorded source", () => {
+    expect(describeSource(undefined)).toBeUndefined();
   });
 });
 

--- a/packages/extensions-core/src/extensions/extensions-list-model.ts
+++ b/packages/extensions-core/src/extensions/extensions-list-model.ts
@@ -2,7 +2,10 @@
 // filter — factored out of the component so the rules are unit-testable (the
 // component stays thin glue). See ExtensionsPage.tsx.
 
-import type { InstalledExtension } from "@silo-code/extension-host/internal";
+import type {
+  InstalledExtension,
+  InstallSource,
+} from "@silo-code/extension-host/internal";
 
 export interface ExtensionsFilter {
   /** Free-text search; matched against name, id, publisher, and description. */
@@ -43,4 +46,27 @@ export function hasBuiltins(
  */
 export function showsReloadHint(ext: InstalledExtension): boolean {
   return !ext.enabled && ext.reloadRequired === true;
+}
+
+/**
+ * Whether to offer the Update action: third-party rows whose install source was
+ * recorded. Records from before source tracking have nothing to re-fetch from,
+ * so the action is hidden until a one-time reinstall records it.
+ */
+export function showsUpdateAction(ext: InstalledExtension): boolean {
+  return !ext.builtin && ext.source !== undefined;
+}
+
+/**
+ * Human-readable "where this came from" line for a row, e.g. `Folder:
+ * /path/to/ext` or `URL: https://example.com/ext.tgz`. `undefined` for
+ * built-ins and legacy records with no recorded source — the row hides the
+ * line entirely rather than showing a label with nothing after it.
+ */
+export function describeSource(
+  source: InstallSource | undefined,
+): string | undefined {
+  if (!source) return undefined;
+  const label = { folder: "Folder", url: "URL", npm: "npm" }[source.kind];
+  return `${label}: ${source.value}`;
 }


### PR DESCRIPTION
## Summary
- `ExtensionManager` now records where each extension was installed from (folder / URL / npm spec) and adds `update(id, requestConsent)`, which re-fetches from that recorded source and swaps the extension in place — re-prompting for consent only if permissions widen or the engine floor is unmet, and rolling back to the previous files/record if the new version fails to load.
- The Extensions settings page shows each row's install source (icon + left-truncated path/URL, full width under the name/description) and collapses Disable/Enable, Reload, and Uninstall into a single overflow menu anchored to the top of the row.
- Publisher and Built-in badges get a subtle color-matched background tint instead of a plain outline, matching the `color-mix()` convention already used elsewhere (e.g. `PermissionConsent.css`).

## Test plan
- [x] `pnpm --filter @silo-code/extension-host exec vitest run` — 577/577 passing
- [x] `pnpm --filter @silo-code/extensions-core exec vitest run` — 151/151 passing
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` (boundary + design-token stylelint) — clean
- [x] Manually verified in the running dev app: install from a local tarball URL, install source displayed correctly, overflow menu (Reload/Disable/Uninstall) opens and behaves as expected, badges render with the new tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)