### PR TITLE
fix(webview-bridge): re-handshake reliability, contentWindow instability, dock focus, sticky headers

### DIFF
--- a/apps/desktop/src-tauri/src/webview_bridge.js
+++ b/apps/desktop/src-tauri/src/webview_bridge.js
@@ -57,6 +57,21 @@
     for (var i = 0; i < queued.length; i++) post(queued[i]);
   }
 
+  // Announce our own (re)injection immediately, unconditionally (no nonce
+  // needed — this is what lets the host acquire one). The host previously
+  // only re-handshook in reaction to the *outer* iframe element's DOM "load"
+  // event, but that event does not reliably fire for navigations initiated
+  // *inside* the frame (a same-frame link click, `location.href =`, etc.) —
+  // only for the host's own iframe.src reassignments. Since this script runs
+  // fresh at document_start on every navigation regardless of what caused
+  // it, self-announcing here is the reliable trigger; the host treats it as
+  // "this frame has a brand new JS realm, re-handshake."
+  try {
+    window.parent.postMessage({ __silo_wv: true, type: "announce" }, "*");
+  } catch (_) {
+    /* ignore */
+  }
+
   function safePost(msg) {
     try {
       post(msg);

--- a/packages/extension-host/src/extension-host/webview-service.test.ts
+++ b/packages/extension-host/src/extension-host/webview-service.test.ts
@@ -157,6 +157,77 @@ describe("webview-service: announce / newDocument handshake", () => {
     expect(events).toEqual([]);
   });
 
+  it("keeps matching the frame after contentWindow's identity changes across a navigation", () => {
+    // Some WebViews (this app's, in practice) don't guarantee the DOM-spec
+    // expectation that `iframe.contentWindow` returns the same WindowProxy
+    // for the whole lifetime of the element — a real navigation can make it
+    // start returning a different object. A lookup keyed by a *cached*
+    // window reference would silently stop matching every message from that
+    // point on (nav events, title fetches, and RPCs all queue forever with
+    // no error). The frame lookup must re-read `iframe.contentWindow` fresh
+    // on every message instead of trusting a snapshot taken at attach time.
+    const frame = attachWebviewBridge(iframe);
+    const events: WebviewNavigateEvent[] = [];
+    frame.onNavigate((e) => events.push(e));
+
+    shimSend(iframe, { type: "announce" });
+    const firstNonce = lastHelloNonce(postMessage);
+    shimSend(iframe, { type: "ready", nonce: firstNonce });
+    shimSend(iframe, {
+      type: "nav",
+      navType: "load",
+      url: "https://example.com/",
+      nonce: firstNonce,
+    });
+
+    // Simulate the WebView swapping in a new WindowProxy for the same
+    // iframe element after a navigation. Reuses the same `postMessage` spy
+    // so `lastHelloNonce` keeps working against the new "window".
+    const newContentWindow = { postMessage } as unknown as Window;
+    Object.defineProperty(iframe, "contentWindow", {
+      value: newContentWindow,
+      configurable: true,
+    });
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { __silo_wv: true, type: "announce" },
+        source: newContentWindow,
+      }),
+    );
+    expect(postMessage.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ cmd: "hello", nonce: expect.any(String) }),
+    );
+    const secondNonce = lastHelloNonce(postMessage);
+    expect(secondNonce).not.toBe(firstNonce);
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { __silo_wv: true, type: "ready", nonce: secondNonce },
+        source: newContentWindow,
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          __silo_wv: true,
+          type: "nav",
+          navType: "load",
+          url: "https://example.org/",
+          nonce: secondNonce,
+        },
+        source: newContentWindow,
+      }),
+    );
+
+    expect(
+      events.map((e) => ({ url: e.url, newDocument: e.newDocument })),
+    ).toEqual([
+      { url: "https://example.com/", newDocument: true },
+      { url: "https://example.org/", newDocument: true },
+    ]);
+  });
+
   it("stops delivering events once disposed", () => {
     const frame = attachWebviewBridge(iframe);
     const events: WebviewNavigateEvent[] = [];

--- a/packages/extension-host/src/extension-host/webview-service.test.ts
+++ b/packages/extension-host/src/extension-host/webview-service.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { WebviewNavigateEvent } from "@silo-code/sdk";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+import { attachWebviewBridge } from "./webview-service";
+
+// Simulates the shim (webview_bridge.js) posting a message from inside the
+// iframe up to the parent — the real transport is cross-realm postMessage,
+// which jsdom doesn't wire up between a same-origin iframe and its parent, so
+// tests dispatch the "message" event directly with `source` set to the
+// iframe's contentWindow (what the listener keys its registry on).
+function shimSend(iframe: HTMLIFrameElement, data: Record<string, unknown>) {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: { __silo_wv: true, ...data },
+      source: iframe.contentWindow,
+    }),
+  );
+}
+
+function makeIframe(): HTMLIFrameElement {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  return iframe;
+}
+
+function lastHelloNonce(postMessage: ReturnType<typeof vi.fn>): string {
+  const call = postMessage.mock.calls.at(-1);
+  return (call?.[0] as { nonce: string }).nonce;
+}
+
+describe("webview-service: announce / newDocument handshake", () => {
+  let iframe: HTMLIFrameElement;
+  let postMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    iframe = makeIframe();
+    postMessage = vi.fn();
+    // contentWindow.postMessage is what handshake()/sendCommand() call to
+    // talk to the shim; spy on it so tests can read the nonce it generates.
+    vi.spyOn(iframe.contentWindow!, "postMessage").mockImplementation(
+      postMessage,
+    );
+  });
+
+  it("re-handshakes on announce, independent of any DOM load event", () => {
+    attachWebviewBridge(iframe);
+    shimSend(iframe, { type: "announce" });
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ cmd: "hello", nonce: expect.any(String) }),
+      "*",
+    );
+  });
+
+  it("tags only the first nav event after announce as newDocument, not the ones that follow", () => {
+    const frame = attachWebviewBridge(iframe);
+    const events: WebviewNavigateEvent[] = [];
+    frame.onNavigate((e) => events.push(e));
+
+    shimSend(iframe, { type: "announce" });
+    const nonce = lastHelloNonce(postMessage);
+    shimSend(iframe, { type: "ready", nonce });
+
+    // A single full-page load commonly reports a boot-time `replace` before
+    // the `load` fires (VitePress and friends) — both belong to the same
+    // fresh document.
+    shimSend(iframe, {
+      type: "nav",
+      navType: "replace",
+      url: "https://example.com/",
+      nonce,
+    });
+    shimSend(iframe, {
+      type: "nav",
+      navType: "load",
+      url: "https://example.com/",
+      nonce,
+    });
+    // A subsequent in-page SPA navigation, still the same document.
+    shimSend(iframe, {
+      type: "nav",
+      navType: "push",
+      url: "https://example.com/guide/",
+      nonce,
+    });
+
+    expect(
+      events.map((e) => ({ type: e.type, newDocument: e.newDocument })),
+    ).toEqual([
+      { type: "replace", newDocument: true },
+      { type: "load", newDocument: false },
+      { type: "push", newDocument: false },
+    ]);
+  });
+
+  it("marks the first event of a second document newDocument again after a fresh announce", () => {
+    const frame = attachWebviewBridge(iframe);
+    const events: WebviewNavigateEvent[] = [];
+    frame.onNavigate((e) => events.push(e));
+
+    shimSend(iframe, { type: "announce" });
+    const firstNonce = lastHelloNonce(postMessage);
+    shimSend(iframe, { type: "ready", nonce: firstNonce });
+    shimSend(iframe, {
+      type: "nav",
+      navType: "load",
+      url: "https://example.com/",
+      nonce: firstNonce,
+    });
+
+    // A brand new full-page navigation: the shim re-injects and re-announces.
+    shimSend(iframe, { type: "announce" });
+    const secondNonce = lastHelloNonce(postMessage);
+    shimSend(iframe, { type: "ready", nonce: secondNonce });
+    shimSend(iframe, {
+      type: "nav",
+      navType: "load",
+      url: "https://example.org/",
+      nonce: secondNonce,
+    });
+
+    expect(events.map((e) => e.newDocument)).toEqual([true, true]);
+  });
+
+  it("suppresses the handshake's own about:blank load", () => {
+    const frame = attachWebviewBridge(iframe);
+    const events: WebviewNavigateEvent[] = [];
+    frame.onNavigate((e) => events.push(e));
+
+    shimSend(iframe, { type: "announce" });
+    const nonce = lastHelloNonce(postMessage);
+    shimSend(iframe, { type: "ready", nonce });
+    shimSend(iframe, {
+      type: "nav",
+      navType: "load",
+      url: "about:blank",
+      nonce,
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it("ignores nav messages carrying a stale nonce", () => {
+    const frame = attachWebviewBridge(iframe);
+    const events: WebviewNavigateEvent[] = [];
+    frame.onNavigate((e) => events.push(e));
+
+    shimSend(iframe, { type: "announce" });
+    shimSend(iframe, {
+      type: "nav",
+      navType: "load",
+      url: "https://example.com/",
+      nonce: "not-the-real-nonce",
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it("stops delivering events once disposed", () => {
+    const frame = attachWebviewBridge(iframe);
+    const events: WebviewNavigateEvent[] = [];
+    frame.onNavigate((e) => events.push(e));
+
+    shimSend(iframe, { type: "announce" });
+    const nonce = lastHelloNonce(postMessage);
+    shimSend(iframe, { type: "ready", nonce });
+    frame.dispose();
+
+    // dispose() removes the registry entry keyed by contentWindow, so a
+    // message that arrives afterwards (e.g. an in-flight nav from a frame
+    // the panel already tore down) finds no state and is silently dropped.
+    shimSend(iframe, {
+      type: "nav",
+      navType: "load",
+      url: "https://example.com/",
+      nonce,
+    });
+
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/extension-host/src/extension-host/webview-service.ts
+++ b/packages/extension-host/src/extension-host/webview-service.ts
@@ -273,8 +273,11 @@ async function captureViaBackend(rect: WebviewRect): Promise<Blob> {
 // positions — any `position: fixed`/`sticky` element (a sticky nav header,
 // a floating "back to top" button, etc.) stays visually pinned across every
 // one of those scroll positions, so it ends up baked into the stitched
-// image once per band instead of once. Hiding them for the capture's
-// duration is the standard fix (what most full-page screenshot tools do).
+// image once per band instead of once. The call site only applies this
+// starting with the *second* band: the first is captured at the top of the
+// page before anything is hidden, so a top-pinned element still lands in
+// the stitched image — once, in its natural spot — same as in a normal
+// screenshot; hiding it only for the bands where it would otherwise repeat.
 // `visibility: hidden` rather than `display: none` so it can't shift layout
 // (a `position: sticky` element still occupies its normal-flow box) —
 // `metrics.docHeight`/the band math must stay valid throughout. State lives
@@ -400,11 +403,22 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
       if (!ctx)
         throw new Error("webview bridge: 2D canvas context unavailable");
 
-      await sendCommand(state, "exec", { code: HIDE_FIXED_STICKY_CODE }).catch(
-        () => {},
-      );
+      // The very first band is captured at the top of the page (y=0) with
+      // fixed/sticky elements NOT yet hidden — so a top-pinned header lands
+      // in the stitched image once, in its natural position, exactly like a
+      // normal screenshot. Only bands after that hide them (right before
+      // scrolling away from the top), since those are the ones that would
+      // otherwise re-bake the same pinned content in on top of new page
+      // content underneath it.
+      let hidFixedSticky = false;
       try {
         for (let y = 0; y < metrics.docHeight; y += metrics.vh) {
+          if (y > 0 && !hidFixedSticky) {
+            hidFixedSticky = true;
+            await sendCommand(state, "exec", {
+              code: HIDE_FIXED_STICKY_CODE,
+            }).catch(() => {});
+          }
           await sendCommand(state, "scroll_to", { x: 0, y });
           const bandHeight = Math.min(metrics.vh, metrics.docHeight - y);
           const blob = await captureViaBackend({
@@ -418,9 +432,11 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
           bitmap.close();
         }
       } finally {
-        await sendCommand(state, "exec", {
-          code: RESTORE_FIXED_STICKY_CODE,
-        }).catch(() => {});
+        if (hidFixedSticky) {
+          await sendCommand(state, "exec", {
+            code: RESTORE_FIXED_STICKY_CODE,
+          }).catch(() => {});
+        }
         await sendCommand(state, "scroll_to", {
           x: metrics.scrollX,
           y: metrics.scrollY,

--- a/packages/extension-host/src/extension-host/webview-service.ts
+++ b/packages/extension-host/src/extension-host/webview-service.ts
@@ -14,9 +14,10 @@ import { EventEmitter } from "./event-emitter";
 // docs/proposals/0011-iframe-navigation-events.md). Talks to the shim
 // injected into every frame by the Rust-side `webview_bridge` plugin
 // (apps/desktop/src-tauri/src/webview_bridge.js). One global `message`
-// listener multiplexes every attached frame, keyed by `event.source` (the
-// iframe's stable `contentWindow` WindowProxy — it survives cross-origin
-// navigations, only the document behind it changes).
+// listener multiplexes every attached frame, matching `event.source` against
+// each attached frame's *current* `iframe.contentWindow` (see `findState`) —
+// that WindowProxy is not guaranteed stable across navigations in this
+// WebView, so nothing caches it as a lookup key.
 //
 // `attachWebviewBridge` is the raw, unscoped entry point; `getScopedWebviewService`
 // (bottom of this file) is what `createContext` actually hands out on

--- a/packages/extension-host/src/extension-host/webview-service.ts
+++ b/packages/extension-host/src/extension-host/webview-service.ts
@@ -268,6 +268,43 @@ async function captureViaBackend(rect: WebviewRect): Promise<Blob> {
   return new Blob([buf], { type: "image/png" });
 }
 
+// A full-page capture stitches together bands captured at different scroll
+// positions — any `position: fixed`/`sticky` element (a sticky nav header,
+// a floating "back to top" button, etc.) stays visually pinned across every
+// one of those scroll positions, so it ends up baked into the stitched
+// image once per band instead of once. Hiding them for the capture's
+// duration is the standard fix (what most full-page screenshot tools do).
+// `visibility: hidden` rather than `display: none` so it can't shift layout
+// (a `position: sticky` element still occupies its normal-flow box) —
+// `metrics.docHeight`/the band math must stay valid throughout. State lives
+// on a page-global rather than coming back over the RPC channel: DOM
+// elements aren't structured-cloneable across postMessage.
+const HIDE_FIXED_STICKY_CODE = `(function(){
+  var hidden = [];
+  var all = document.querySelectorAll("*");
+  for (var i = 0; i < all.length; i++) {
+    var el = all[i];
+    var cs = getComputedStyle(el);
+    if (cs.position === "fixed" || cs.position === "sticky") {
+      hidden.push({ el: el, prevVisibility: el.style.visibility, prevPriority: el.style.getPropertyPriority("visibility") });
+      el.style.setProperty("visibility", "hidden", "important");
+    }
+  }
+  window.__siloCaptureHiddenEls = hidden;
+  return hidden.length;
+})()`;
+
+const RESTORE_FIXED_STICKY_CODE = `(function(){
+  var hidden = window.__siloCaptureHiddenEls || [];
+  for (var i = 0; i < hidden.length; i++) {
+    var entry = hidden[i];
+    if (entry.prevVisibility) entry.el.style.setProperty("visibility", entry.prevVisibility, entry.prevPriority || "");
+    else entry.el.style.removeProperty("visibility");
+  }
+  window.__siloCaptureHiddenEls = null;
+  return hidden.length;
+})()`;
+
 /** Attach the bridge to an iframe. Call `dispose()` on the returned handle when the panel unmounts. */
 export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
   installListener();
@@ -362,6 +399,9 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
       if (!ctx)
         throw new Error("webview bridge: 2D canvas context unavailable");
 
+      await sendCommand(state, "exec", { code: HIDE_FIXED_STICKY_CODE }).catch(
+        () => {},
+      );
       try {
         for (let y = 0; y < metrics.docHeight; y += metrics.vh) {
           await sendCommand(state, "scroll_to", { x: 0, y });
@@ -377,6 +417,9 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
           bitmap.close();
         }
       } finally {
+        await sendCommand(state, "exec", {
+          code: RESTORE_FIXED_STICKY_CODE,
+        }).catch(() => {});
         await sendCommand(state, "scroll_to", {
           x: metrics.scrollX,
           y: metrics.scrollY,

--- a/packages/extension-host/src/extension-host/webview-service.ts
+++ b/packages/extension-host/src/extension-host/webview-service.ts
@@ -53,6 +53,12 @@ interface FrameState {
   handshakeTimer: ReturnType<typeof setTimeout> | null;
   nextId: number;
   disposed: boolean;
+  /**
+   * Set by the shim's "announce" (a fresh JS realm = a fresh document),
+   * consumed by the next nav event fired to consumers — that event carries
+   * `newDocument: true`, everything after it from the same document `false`.
+   */
+  pendingNewDocument: boolean;
 }
 
 const registry = new Map<Window, FrameState>();
@@ -71,6 +77,18 @@ function installListener() {
     if (!state || state.disposed) return;
     const data = event.data as Record<string, unknown> | null;
     if (!data || data.__silo_wv !== true) return;
+
+    // Self-announcement, sent unconditionally (no nonce yet) the instant the
+    // shim is (re)injected — the sole, reliable "this frame has a fresh JS
+    // realm" signal, and the only trigger for (re)handshaking (see the
+    // registration comment in attachWebviewBridge for why the outer iframe
+    // element's own DOM "load" event isn't used for this).
+    if (data.type === "announce") {
+      state.pendingNewDocument = true;
+      handshake(state);
+      return;
+    }
+
     if (typeof data.nonce !== "string" || data.nonce !== state.nonce) return;
 
     if (data.type === "ready") {
@@ -86,10 +104,22 @@ function installListener() {
     }
 
     if (data.type === "nav") {
+      // The bridge's own handshake targets the iframe before any real URL is
+      // set, so a spurious "load" for about:blank fires on every attach —
+      // implementation noise, never a page the consumer actually navigated
+      // to. Suppress it here so no consumer has to special-case it (and so
+      // it can't false-positive the frame-blocked emptiness probe below,
+      // which would otherwise see about:blank's trivially-empty document and
+      // report every fresh, empty frame as "blocked").
+      if (data.url === "about:blank") return;
+
       state.url = data.url as string;
+      const newDocument = state.pendingNewDocument;
+      state.pendingNewDocument = false;
       state.navEmitter.fire({
         type: data.navType as WebviewNavType,
         url: data.url as string,
+        newDocument,
       });
       // A full-page load (not an SPA route change) is the point to check for
       // frame-blocking: sites sending X-Frame-Options/frame-ancestors don't
@@ -237,18 +267,22 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
     handshakeTimer: null,
     nextId: 0,
     disposed: false,
+    pendingNewDocument: false,
   };
 
-  const onLoad = () => {
-    if (!iframe.contentWindow) return;
-    registry.set(iframe.contentWindow, state);
-    handshake(state);
-  };
-  iframe.addEventListener("load", onLoad);
-  // The iframe may already be loaded (e.g. src was set before attach ran).
+  // `contentWindow` identity is stable for the iframe element's whole
+  // lifetime — the same WindowProxy survives every future navigation, full
+  // reload or not — so registering once here (rather than re-registering on
+  // every "load") is sufficient. Actual (re)handshaking is triggered by the
+  // shim's own "announce" self-report in installListener's message handler,
+  // not from here: the outer iframe element's DOM "load" event used to drive
+  // it, but that event doesn't reliably fire for navigations initiated
+  // *inside* the frame (a link click, `location.href =`), and — worse —
+  // calling handshake() a second time from a stale "load" after "announce"
+  // already handshook correctly would silently invalidate the nonce out from
+  // under a message already in flight with the (correct) earlier one.
   if (iframe.contentWindow) {
     registry.set(iframe.contentWindow, state);
-    handshake(state);
   }
 
   function frameRectInWindow(): WebviewRect {
@@ -347,7 +381,6 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
     dispose() {
       if (state.disposed) return;
       state.disposed = true;
-      iframe.removeEventListener("load", onLoad);
       if (state.handshakeTimer !== null) clearTimeout(state.handshakeTimer);
       if (iframe.contentWindow) registry.delete(iframe.contentWindow);
       for (const [id, pending] of state.pending) {

--- a/packages/extension-host/src/extension-host/webview-service.ts
+++ b/packages/extension-host/src/extension-host/webview-service.ts
@@ -61,8 +61,25 @@ interface FrameState {
   pendingNewDocument: boolean;
 }
 
-const registry = new Map<Window, FrameState>();
+// Every currently-attached frame. NOT keyed by `iframe.contentWindow` — that
+// WindowProxy is not actually stable across navigations in this WebView
+// (contrary to the DOM spec's usual guarantee for same-origin same-process
+// frames): after a real navigation, `iframe.contentWindow` can start
+// returning a *different* object than the one captured at attach time. A Map
+// keyed by the old reference would silently stop matching `event.source` on
+// every message after that point — nav events, title fetches, and RPCs all
+// queue forever with no error, since nothing ever looks broken from the
+// caller's side (the promises just never resolve). Comparing
+// `state.iframe.contentWindow` fresh, per message, is immune to that.
+const registry = new Set<FrameState>();
 let listenerInstalled = false;
+
+function findState(source: Window): FrameState | undefined {
+  for (const state of registry) {
+    if (state.iframe.contentWindow === source) return state;
+  }
+  return undefined;
+}
 
 function installListener() {
   if (listenerInstalled) return;
@@ -73,7 +90,7 @@ function installListener() {
   // `event.source` matching a frame we actually attached to, combined with
   // the per-handshake nonce below — both are unforgeable by page content.
   window.addEventListener("message", (event: MessageEvent) => {
-    const state = registry.get(event.source as Window);
+    const state = findState(event.source as Window);
     if (!state || state.disposed) return;
     const data = event.data as Record<string, unknown> | null;
     if (!data || data.__silo_wv !== true) return;
@@ -270,20 +287,20 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
     pendingNewDocument: false,
   };
 
-  // `contentWindow` identity is stable for the iframe element's whole
-  // lifetime — the same WindowProxy survives every future navigation, full
-  // reload or not — so registering once here (rather than re-registering on
-  // every "load") is sufficient. Actual (re)handshaking is triggered by the
-  // shim's own "announce" self-report in installListener's message handler,
-  // not from here: the outer iframe element's DOM "load" event used to drive
-  // it, but that event doesn't reliably fire for navigations initiated
-  // *inside* the frame (a link click, `location.href =`), and — worse —
-  // calling handshake() a second time from a stale "load" after "announce"
-  // already handshook correctly would silently invalidate the nonce out from
-  // under a message already in flight with the (correct) earlier one.
-  if (iframe.contentWindow) {
-    registry.set(iframe.contentWindow, state);
-  }
+  // Registering once here (rather than re-registering `iframe.contentWindow`
+  // on every "load") is sufficient — `findState` looks up by comparing
+  // `state.iframe.contentWindow` fresh on every message rather than relying
+  // on a cached identity, so it doesn't matter that the WindowProxy behind
+  // `iframe.contentWindow` can change across navigations. Actual
+  // (re)handshaking is triggered by the shim's own "announce" self-report in
+  // installListener's message handler, not from here: the outer iframe
+  // element's DOM "load" event used to drive it, but that event doesn't
+  // reliably fire for navigations initiated *inside* the frame (a link
+  // click, `location.href =`), and — worse — calling handshake() a second
+  // time from a stale "load" after "announce" already handshook correctly
+  // would silently invalidate the nonce out from under a message already in
+  // flight with the (correct) earlier one.
+  registry.add(state);
 
   function frameRectInWindow(): WebviewRect {
     const r = iframe.getBoundingClientRect();
@@ -382,7 +399,7 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
       if (state.disposed) return;
       state.disposed = true;
       if (state.handshakeTimer !== null) clearTimeout(state.handshakeTimer);
-      if (iframe.contentWindow) registry.delete(iframe.contentWindow);
+      registry.delete(state);
       for (const [id, pending] of state.pending) {
         pending.reject(new Error("webview bridge: frame handle disposed"));
         state.pending.delete(id);

--- a/packages/extension-host/src/panels/CenterDock.css
+++ b/packages/extension-host/src/panels/CenterDock.css
@@ -232,12 +232,20 @@
 }
 /* When the dock holds focus, light up the active group's active-tab top edge
  * with the accent color — a clear "this panel + tab has focus" cue. Gated on
- * `:focus-within` so the bar drops when focus moves to a side panel or the
- * status bar (dockview keeps `dv-active-group` for the text color regardless).
- * The 2px space is reserved by `.dv-tab`'s `border-top-width`; the vertical
- * sash is nudged 1px (see the `.dv-vertical .dv-sash` rule above) so it never
- * clips this bar on the lower panel of a split. */
-.editor-dock:focus-within .dv-groupview.dv-active-group .dv-tab.dv-active-tab {
+ * `.dock-has-focus` (see dock-focus-tracking.ts) rather than CSS
+ * `:focus-within` — this WebView doesn't reliably propagate `:focus-within`
+ * up through ancestors when focus lands inside a cross-origin `<iframe>`
+ * (e.g. local-web-viewer), which made the bar drop even though the panel
+ * containing that iframe was exactly what had focus. The tracked class
+ * covers the same "focus moved to a side panel or the status bar" case
+ * `:focus-within` used to (dockview keeps `dv-active-group` for the text
+ * color regardless). The 2px space is reserved by `.dv-tab`'s
+ * `border-top-width`; the vertical sash is nudged 1px (see the
+ * `.dv-vertical .dv-sash` rule above) so it never clips this bar on the
+ * lower panel of a split. */
+.editor-dock.dock-has-focus
+  .dv-groupview.dv-active-group
+  .dv-tab.dv-active-tab {
   border-top-color: var(--silo-color-accent);
 }
 

--- a/packages/extension-host/src/panels/CenterDock.tsx
+++ b/packages/extension-host/src/panels/CenterDock.tsx
@@ -15,8 +15,11 @@ import {
   buildOpenWorkspaceItems,
   useFolderExistence,
 } from "./open-workspace-menu";
+import { installDockFocusTracking } from "./dock-focus-tracking";
 import "dockview/dist/styles/dockview.css";
 import "./CenterDock.css";
+
+installDockFocusTracking();
 
 export function CenterDock() {
   const snap = useSnapshot(store);

--- a/packages/extension-host/src/panels/dock-focus-tracking.test.ts
+++ b/packages/extension-host/src/panels/dock-focus-tracking.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { installDockFocusTracking } from "./dock-focus-tracking";
 
 function makeDock(): HTMLElement {
@@ -8,34 +17,49 @@ function makeDock(): HTMLElement {
   return dock;
 }
 
+/** Point `document.activeElement` at `el` without dispatching any event —
+ * simulates a cross-origin iframe click, which moves focus into the iframe
+ * without ever notifying the parent document via `focusin`. */
+function setActiveElementSilently(el: Element) {
+  Object.defineProperty(document, "activeElement", {
+    value: el,
+    configurable: true,
+  });
+}
+
 describe("installDockFocusTracking", () => {
   let dock: HTMLElement;
 
-  beforeEach(() => {
+  // Fake timers must be active before the module's one-time `setInterval` is
+  // ever created (installDockFocusTracking() is a guarded singleton — it
+  // only runs its setup once, on the very first call across this whole
+  // file), or the interval never comes under fake-timer control and
+  // `vi.advanceTimersByTime` can't drive it.
+  beforeAll(() => {
+    vi.useFakeTimers();
     installDockFocusTracking();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
     dock = makeDock();
   });
 
   afterEach(() => {
     dock.remove();
+    Object.defineProperty(document, "activeElement", {
+      value: document.body,
+      configurable: true,
+    });
   });
 
   it("adds dock-has-focus when focus lands on a descendant", () => {
     const child = document.createElement("input");
     dock.appendChild(child);
     child.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
-    expect(dock.classList.contains("dock-has-focus")).toBe(true);
-  });
-
-  it("adds dock-has-focus when focus lands on an iframe descendant — the case :focus-within missed", () => {
-    // The bug this exists for: clicking into a cross-origin iframe makes
-    // `document.activeElement` the <iframe> element itself, which this
-    // WebView's `:focus-within` didn't reliably propagate to ancestors.
-    // A plain focusin + containment check doesn't care what kind of element
-    // it is, iframe included.
-    const iframe = document.createElement("iframe");
-    dock.appendChild(iframe);
-    iframe.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
     expect(dock.classList.contains("dock-has-focus")).toBe(true);
   });
 
@@ -60,5 +84,21 @@ describe("installDockFocusTracking", () => {
 
     window.dispatchEvent(new FocusEvent("blur"));
     expect(dock.classList.contains("dock-has-focus")).toBe(false);
+  });
+
+  it("picks up an iframe becoming activeElement via polling, even with no focusin event — the case :focus-within and focusin both missed", () => {
+    // The bug this exists for: clicking into a cross-origin iframe's
+    // *rendered content* moves focus into it, but cross-origin iframe
+    // content doesn't forward DOM events (mouse or focus) to the parent
+    // document at all — so `document.activeElement` becomes the <iframe>
+    // with nothing observable via a `focusin` listener. Only polling
+    // `document.activeElement` directly catches this.
+    const iframe = document.createElement("iframe");
+    dock.appendChild(iframe);
+    setActiveElementSilently(iframe);
+    expect(dock.classList.contains("dock-has-focus")).toBe(false); // not yet — no poll tick
+
+    vi.advanceTimersByTime(150);
+    expect(dock.classList.contains("dock-has-focus")).toBe(true);
   });
 });

--- a/packages/extension-host/src/panels/dock-focus-tracking.test.ts
+++ b/packages/extension-host/src/panels/dock-focus-tracking.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { installDockFocusTracking } from "./dock-focus-tracking";
+
+function makeDock(): HTMLElement {
+  const dock = document.createElement("div");
+  dock.className = "editor-dock";
+  document.body.appendChild(dock);
+  return dock;
+}
+
+describe("installDockFocusTracking", () => {
+  let dock: HTMLElement;
+
+  beforeEach(() => {
+    installDockFocusTracking();
+    dock = makeDock();
+  });
+
+  afterEach(() => {
+    dock.remove();
+  });
+
+  it("adds dock-has-focus when focus lands on a descendant", () => {
+    const child = document.createElement("input");
+    dock.appendChild(child);
+    child.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(dock.classList.contains("dock-has-focus")).toBe(true);
+  });
+
+  it("adds dock-has-focus when focus lands on an iframe descendant — the case :focus-within missed", () => {
+    // The bug this exists for: clicking into a cross-origin iframe makes
+    // `document.activeElement` the <iframe> element itself, which this
+    // WebView's `:focus-within` didn't reliably propagate to ancestors.
+    // A plain focusin + containment check doesn't care what kind of element
+    // it is, iframe included.
+    const iframe = document.createElement("iframe");
+    dock.appendChild(iframe);
+    iframe.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(dock.classList.contains("dock-has-focus")).toBe(true);
+  });
+
+  it("removes dock-has-focus once focus moves outside the dock", () => {
+    const child = document.createElement("input");
+    dock.appendChild(child);
+    child.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(dock.classList.contains("dock-has-focus")).toBe(true);
+
+    const outside = document.createElement("input");
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(dock.classList.contains("dock-has-focus")).toBe(false);
+    outside.remove();
+  });
+
+  it("clears dock-has-focus on window blur (a real app-level focus loss)", () => {
+    const child = document.createElement("input");
+    dock.appendChild(child);
+    child.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(dock.classList.contains("dock-has-focus")).toBe(true);
+
+    window.dispatchEvent(new FocusEvent("blur"));
+    expect(dock.classList.contains("dock-has-focus")).toBe(false);
+  });
+});

--- a/packages/extension-host/src/panels/dock-focus-tracking.ts
+++ b/packages/extension-host/src/panels/dock-focus-tracking.ts
@@ -1,0 +1,34 @@
+// `.editor-dock`'s focus-accent bar (CenterDock.css) used to be gated purely
+// on CSS `:focus-within`. That breaks for extensions that embed a
+// cross-origin `<iframe>` (e.g. local-web-viewer): clicking into the
+// embedded page makes `document.activeElement` the `<iframe>` element itself
+// (normal, spec-correct focus behavior), but this WebView's `:focus-within`
+// implementation doesn't reliably propagate that up through ancestors for
+// cross-origin frames — so the dock visually "loses focus" even though the
+// panel the iframe lives in is exactly what the user is interacting with.
+//
+// This tracks the same thing `:focus-within` is supposed to via a plain
+// `focusin` listener + DOM containment check instead, which only cares that
+// `document.activeElement` (whatever it is, iframe included) is a descendant
+// of a given `.editor-dock` — no CSS engine iframe quirk in the loop.
+let installed = false;
+
+export function installDockFocusTracking() {
+  if (installed) return;
+  installed = true;
+
+  function apply(focused: Element | null) {
+    document.querySelectorAll(".editor-dock").forEach((dock) => {
+      dock.classList.toggle(
+        "dock-has-focus",
+        !!focused && dock.contains(focused),
+      );
+    });
+  }
+
+  window.addEventListener("focusin", (e) => apply(e.target as Element | null));
+  // A real window/app-level blur (switching to another application) should
+  // still drop the bar — unlike focus moving into a same-window iframe, that
+  // case doesn't fire `focusin` for anything, so it needs its own listener.
+  window.addEventListener("blur", () => apply(null));
+}

--- a/packages/extension-host/src/panels/dock-focus-tracking.ts
+++ b/packages/extension-host/src/panels/dock-focus-tracking.ts
@@ -1,16 +1,20 @@
 // `.editor-dock`'s focus-accent bar (CenterDock.css) used to be gated purely
 // on CSS `:focus-within`. That breaks for extensions that embed a
 // cross-origin `<iframe>` (e.g. local-web-viewer): clicking into the
-// embedded page makes `document.activeElement` the `<iframe>` element itself
-// (normal, spec-correct focus behavior), but this WebView's `:focus-within`
-// implementation doesn't reliably propagate that up through ancestors for
-// cross-origin frames — so the dock visually "loses focus" even though the
-// panel the iframe lives in is exactly what the user is interacting with.
+// embedded page's *rendered content* moves focus into it, but neither
+// `:focus-within` nor a `focusin` listener on this document reliably
+// observes that — cross-origin iframe content doesn't forward ordinary DOM
+// events (mouse or focus) to the parent document at all (the same reason
+// this extension's pick-element/marquee features need a postMessage bridge
+// instead of plain listeners, rather than a CSS engine quirk as first
+// suspected). `document.activeElement` DOES correctly become the `<iframe>`
+// element the moment focus lands inside it, though — so instead of waiting
+// for an event that may never arrive, poll it.
 //
-// This tracks the same thing `:focus-within` is supposed to via a plain
-// `focusin` listener + DOM containment check instead, which only cares that
-// `document.activeElement` (whatever it is, iframe included) is a descendant
-// of a given `.editor-dock` — no CSS engine iframe quirk in the loop.
+// The `focusin` listener stays for the normal (non-iframe) case: instant
+// response for regular clicks. Polling is a low-frequency reconciliation
+// pass on top of that — it's the only thing that catches the iframe case.
+const POLL_INTERVAL_MS = 150;
 let installed = false;
 
 export function installDockFocusTracking() {
@@ -31,4 +35,6 @@ export function installDockFocusTracking() {
   // still drop the bar — unlike focus moving into a same-window iframe, that
   // case doesn't fire `focusin` for anything, so it needs its own listener.
   window.addEventListener("blur", () => apply(null));
+
+  setInterval(() => apply(document.activeElement), POLL_INTERVAL_MS);
 }

--- a/packages/sdk/src/webview-service.ts
+++ b/packages/sdk/src/webview-service.ts
@@ -36,6 +36,20 @@ export interface WebviewNavigateEvent {
   type: WebviewNavType;
   /** The frame's URL after the navigation. */
   url: string;
+  /**
+   * `true` on the first event reported by a freshly created document — i.e.
+   * this event is the result of a full document load, whoever initiated it.
+   * `false` for every subsequent event from the same document (SPA route
+   * changes, the page's own `replaceState` calls, hash changes).
+   *
+   * This matters because frameworks commonly call `history.replaceState`
+   * while booting, so a single full-page navigation can report a `"replace"`
+   * event *before* its `"load"`. Without this flag a consumer tracking its
+   * own history stack can't tell that boot-time `"replace"` (a brand-new
+   * page — usually a new history entry) apart from a genuine in-page
+   * `replaceState` (rewrite the current entry).
+   */
+  newDocument: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Seven follow-up fixes to `ctx.webview` (shipped in #189) found via live testing
after merge, never previously pushed. Cherry-picked cleanly onto current `main`
from a local branch (`webview-bridge-phase1`) that had continued past the PR.

- **`fix(webview-bridge): report newDocument on nav events, fix stale re-handshake trigger`**
  — the outer iframe's DOM `"load"` event (the only re-handshake trigger) doesn't
  fire for navigations initiated *inside* the frame (link clicks, `location.href`
  assignments) — only for host-driven `iframe.src` reassignment. Replaces it with
  the shim self-announcing on every injection, the only reliable "fresh document"
  signal. Also adds `newDocument` to nav events and suppresses the handshake's own
  spurious `about:blank` load.
- **`fix(webview-bridge): stop keying the frame registry by a cached contentWindow`**
  — `iframe.contentWindow`'s identity is not actually stable across navigations in
  this WebView. A registry keyed by that snapshot silently desyncs after enough
  navigation, dropping all further bridge messages with no error — reproduces a
  live user report of full-page capture timing out until the panel was reopened.
  Switches to a `Set` + fresh-comparison lookup.
- **`fix(dock): stop relying on :focus-within` / `fix(dock): poll activeElement`**
  — the dock's active-tab accent bar didn't track focus landing inside a
  cross-origin iframe, since this WebView doesn't propagate `:focus-within` or
  `focusin` through a cross-origin frame boundary. Adds explicit
  `document.activeElement` tracking (event-driven + a 150ms poll fallback).
- **`fix(webview-bridge): hide fixed/sticky elements during full-page capture`**
  (+ **follow-up**: keep the sticky header once, at the top, instead of hiding it
  entirely) — `captureFullPage()`'s scroll-and-stitch approach was baking a sticky
  header into the image once per scroll band.
- **`docs(webview-bridge)`** — stale header comment cleanup following the registry fix.

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `pnpm test` (all 7 workspace tasks pass, including new regression tests added
      by these commits: announce/newDocument handshake, contentWindow-swap, dock
      focus tracking)
- [ ] Manual re-verification of the live scenarios these fix (in-page link
      navigation during an in-flight bridge call; extended back/forward
      navigation; sticky-header full-page capture) — flagging as unchecked since
      this PR reconstructs already-tested work rather than re-driving it fresh.