### PR TITLE
fix(webview-bridge): security gate, Windows origin, pending-RPC cleanup, permission re-check

### DIFF
--- a/apps/desktop/src-tauri/src/webview_bridge.js
+++ b/apps/desktop/src-tauri/src/webview_bridge.js
@@ -21,7 +21,7 @@
   var TRUSTED_ORIGINS = [
     "http://localhost:1420",
     "tauri://localhost",
-    "http://tauri.localhost",
+    "https://tauri.localhost",
   ];
 
   var nonce = null; // set only after a validated handshake; gates all outbound posts
@@ -35,11 +35,16 @@
   // handshaking in reaction to the *outer* iframe's load event, which races
   // this frame's *own* load event. Buffer anything sent before we have a
   // nonce and flush it once "hello" arrives, instead of silently dropping it.
+  // Capped: this script runs in every frame, including nested iframes that
+  // never get a "hello" — an SPA widget inside one of those would otherwise
+  // push nav events into this array forever.
   var pendingOutbox = [];
+  var MAX_PENDING_OUTBOX = 50;
 
   function post(msg) {
     if (!nonce) {
       pendingOutbox.push(msg);
+      if (pendingOutbox.length > MAX_PENDING_OUTBOX) pendingOutbox.shift();
       return;
     }
     try {

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ const apiSidebar = [
       { text: "ctx.ui", link: "/api/ui/" },
       { text: "ctx.net", link: "/api/net/" },
       { text: "ctx.system", link: "/api/system/" },
+      { text: "ctx.webview", link: "/api/webview/" },
     ],
   },
   {

--- a/apps/docs/api/index.md
+++ b/apps/docs/api/index.md
@@ -60,6 +60,7 @@ importing the store or touching the platform directly. Opening files lives on
 | [`ctx.ui`](/api/ui/)                      | native pickers + toasts + menus + modals (`confirm` / `prompt` / `showModal`) ([`UiService`](/api/types/interfaces/UiService))                                                                                     |
 | [`ctx.net`](/api/net/)                    | server-side HTTP client — bypasses browser CORS, reads any response header ([`NetworkService`](/api/types/interfaces/NetworkService))                                                                              |
 | [`ctx.system`](/api/system/)              | static host-platform metadata — OS, CPU arch, and Silo version ([`SystemService`](/api/types/interfaces/SystemService))                                                                                            |
+| [`ctx.webview`](/api/webview/)            | cross-origin iframe bridge — DOM access, navigation, element picking, native pixel capture, permission-gated ([`WebviewService`](/api/types/interfaces/WebviewService))                                            |
 
 ## Other
 

--- a/apps/docs/api/types/interfaces/PickedElement.md
+++ b/apps/docs/api/types/interfaces/PickedElement.md
@@ -1,6 +1,6 @@
 # Interface: PickedElement
 
-Defined in: [packages/sdk/src/webview-service.ts:64](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L64)
+Defined in: [packages/sdk/src/webview-service.ts:78](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L78)
 
 The result of [WebFrame.pickElement](WebFrame.md#pickelement) — what the user clicked while
 picking.
@@ -13,7 +13,7 @@ picking.
 selector: string;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:66](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L66)
+Defined in: [packages/sdk/src/webview-service.ts:80](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L80)
 
 A CSS selector breadcrumb from `<html>` down to the clicked element (tag + up to 2 classes per level).
 
@@ -25,7 +25,7 @@ A CSS selector breadcrumb from `<html>` down to the clicked element (tag + up to
 text: string;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:68](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L68)
+Defined in: [packages/sdk/src/webview-service.ts:82](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L82)
 
 The element's trimmed text content, truncated to 200 characters.
 
@@ -37,6 +37,6 @@ The element's trimmed text content, truncated to 200 characters.
 rect: WebviewRect;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:70](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L70)
+Defined in: [packages/sdk/src/webview-service.ts:84](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L84)
 
 The element's frame-relative bounding rect — pass to [WebFrame.captureRect](WebFrame.md#capturerect) to screenshot just this element.

--- a/apps/docs/api/types/interfaces/WebFrame.md
+++ b/apps/docs/api/types/interfaces/WebFrame.md
@@ -1,6 +1,6 @@
 # Interface: WebFrame
 
-Defined in: [packages/sdk/src/webview-service.ts:81](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L81)
+Defined in: [packages/sdk/src/webview-service.ts:95](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L95)
 
 A live connection to an embedded frame's content, returned by
 [WebviewService.attach](WebviewService.md#attach). Dispose it (or let `ctx.subscriptions`
@@ -18,7 +18,7 @@ dispose it) when your panel unmounts.
 readonly url: string | null;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:83](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L83)
+Defined in: [packages/sdk/src/webview-service.ts:97](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L97)
 
 The frame's current URL, updated on every [onNavigate](#onnavigate) event. `null` before the first load.
 
@@ -30,7 +30,7 @@ The frame's current URL, updated on every [onNavigate](#onnavigate) event. `null
 onNavigate: Event<WebviewNavigateEvent>;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:85](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L85)
+Defined in: [packages/sdk/src/webview-service.ts:99](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L99)
 
 Subscribe to in-frame navigation — the only way to track SPA route changes and full loads alike. See [WebviewNavType](../type-aliases/WebviewNavType.md).
 
@@ -42,7 +42,7 @@ Subscribe to in-frame navigation — the only way to track SPA route changes and
 onBlocked: Event<void>;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:94](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L94)
+Defined in: [packages/sdk/src/webview-service.ts:108](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L108)
 
 Fires when a navigation lands on what looks like a frame-blocked page —
 sites sending `X-Frame-Options` / `frame-ancestors` don't error, WebKit
@@ -77,7 +77,7 @@ Defined in: [packages/sdk/src/types.ts:60](https://github.com/silo-code/silo/blo
 back(): void;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:96](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L96)
+Defined in: [packages/sdk/src/webview-service.ts:110](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L110)
 
 Navigate the frame back in its history, if possible.
 
@@ -93,7 +93,7 @@ Navigate the frame back in its history, if possible.
 forward(): void;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:98](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L98)
+Defined in: [packages/sdk/src/webview-service.ts:112](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L112)
 
 Navigate the frame forward in its history, if possible.
 
@@ -109,7 +109,7 @@ Navigate the frame forward in its history, if possible.
 reload(): void;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:100](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L100)
+Defined in: [packages/sdk/src/webview-service.ts:114](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L114)
 
 Reload the frame's current page.
 
@@ -125,7 +125,7 @@ Reload the frame's current page.
 exec<T>(code): Promise<T>;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:109](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L109)
+Defined in: [packages/sdk/src/webview-service.ts:123](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L123)
 
 Run JavaScript inside the frame and resolve with its result. A single
 expression's value is returned (e.g. `"document.title"`,
@@ -158,7 +158,7 @@ The result must be structured-clone-safe (no DOM nodes, functions, etc.).
 pickElement(): Promise<PickedElement | null>;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:116](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L116)
+Defined in: [packages/sdk/src/webview-service.ts:130](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L130)
 
 Enter interactive element-pick mode: the user hovers to highlight and
 clicks to select, or presses Escape to cancel. Resolves with the picked
@@ -171,13 +171,32 @@ user-paced.
 
 ***
 
+### cancelPick()
+
+```ts
+cancelPick(): void;
+```
+
+Defined in: [packages/sdk/src/webview-service.ts:137](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L137)
+
+Cancel an in-flight [pickElement](#pickelement) call — exits pick mode in the
+frame and resolves the pending `pickElement()` promise with `null`. A
+no-op if no pick is active (including if it already ended, e.g. via
+Escape or a click).
+
+#### Returns
+
+`void`
+
+***
+
 ### capture()
 
 ```ts
 capture(): Promise<Blob>;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:118](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L118)
+Defined in: [packages/sdk/src/webview-service.ts:139](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L139)
 
 A native PNG snapshot of the frame's current visible viewport.
 
@@ -193,7 +212,7 @@ A native PNG snapshot of the frame's current visible viewport.
 captureRect(rect): Promise<Blob>;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:120](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L120)
+Defined in: [packages/sdk/src/webview-service.ts:141](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L141)
 
 A native PNG snapshot of a frame-relative sub-rect — e.g. a [PickedElement.rect](PickedElement.md#rect) or a marquee selection.
 
@@ -215,7 +234,7 @@ A native PNG snapshot of a frame-relative sub-rect — e.g. a [PickedElement.rec
 captureFullPage(): Promise<Blob>;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:122](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L122)
+Defined in: [packages/sdk/src/webview-service.ts:143](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L143)
 
 A native PNG snapshot of the frame's entire scrollable document, stitched from scrolled captures. Scroll position is restored afterward.
 

--- a/apps/docs/api/types/interfaces/WebviewNavigateEvent.md
+++ b/apps/docs/api/types/interfaces/WebviewNavigateEvent.md
@@ -27,3 +27,25 @@ url: string;
 Defined in: [packages/sdk/src/webview-service.ts:38](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L38)
 
 The frame's URL after the navigation.
+
+***
+
+### newDocument
+
+```ts
+newDocument: boolean;
+```
+
+Defined in: [packages/sdk/src/webview-service.ts:52](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L52)
+
+`true` on the first event reported by a freshly created document — i.e.
+this event is the result of a full document load, whoever initiated it.
+`false` for every subsequent event from the same document (SPA route
+changes, the page's own `replaceState` calls, hash changes).
+
+This matters because frameworks commonly call `history.replaceState`
+while booting, so a single full-page navigation can report a `"replace"`
+event *before* its `"load"`. Without this flag a consumer tracking its
+own history stack can't tell that boot-time `"replace"` (a brand-new
+page — usually a new history entry) apart from a genuine in-page
+`replaceState` (rewrite the current entry).

--- a/apps/docs/api/types/interfaces/WebviewRect.md
+++ b/apps/docs/api/types/interfaces/WebviewRect.md
@@ -1,6 +1,6 @@
 # Interface: WebviewRect
 
-Defined in: [packages/sdk/src/webview-service.ts:50](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L50)
+Defined in: [packages/sdk/src/webview-service.ts:64](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L64)
 
 A rectangle in frame-relative CSS pixels — the coordinate space
 `getBoundingClientRect()` returns inside the frame's own document. Used by
@@ -15,7 +15,7 @@ selection) and returned as part of [PickedElement](PickedElement.md).
 x: number;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:51](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L51)
+Defined in: [packages/sdk/src/webview-service.ts:65](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L65)
 
 ***
 
@@ -25,7 +25,7 @@ Defined in: [packages/sdk/src/webview-service.ts:51](https://github.com/silo-cod
 y: number;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:52](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L52)
+Defined in: [packages/sdk/src/webview-service.ts:66](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L66)
 
 ***
 
@@ -35,7 +35,7 @@ Defined in: [packages/sdk/src/webview-service.ts:52](https://github.com/silo-cod
 width: number;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:53](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L53)
+Defined in: [packages/sdk/src/webview-service.ts:67](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L67)
 
 ***
 
@@ -45,4 +45,4 @@ Defined in: [packages/sdk/src/webview-service.ts:53](https://github.com/silo-cod
 height: number;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:54](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L54)
+Defined in: [packages/sdk/src/webview-service.ts:68](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L68)

--- a/apps/docs/api/types/interfaces/WebviewService.md
+++ b/apps/docs/api/types/interfaces/WebviewService.md
@@ -1,6 +1,6 @@
 # Interface: WebviewService
 
-Defined in: [packages/sdk/src/webview-service.ts:150](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L150)
+Defined in: [packages/sdk/src/webview-service.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L171)
 
 The webview-bridge domain, exposed as [ExtensionContext.webview](ExtensionContext.md#webview).
 Requires the `"webview"` [Permission](../type-aliases/Permission.md).
@@ -32,7 +32,7 @@ function MyPanel({ ctx }: { ctx: ExtensionContext }) {
 attach(frame): WebFrame;
 ```
 
-Defined in: [packages/sdk/src/webview-service.ts:156](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L156)
+Defined in: [packages/sdk/src/webview-service.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/webview-service.ts#L177)
 
 Attach the bridge to an iframe your panel owns. The iframe can be
 cross-origin — that's the point. Returns a [WebFrame](WebFrame.md); call

--- a/apps/docs/api/webview/index.md
+++ b/apps/docs/api/webview/index.md
@@ -1,0 +1,164 @@
+# ctx.webview <Badge type="tip" text="stable" />
+
+Real DOM access, navigation control, and native pixel capture inside an
+`<iframe>` your panel owns — including cross-origin content that the
+browser's same-origin policy would otherwise fully sandbox. The host achieves
+this by injecting a handshake-gated script into every frame (a Tauri
+all-frames init script reaches subframes the browser itself can't be reached
+from) and talking to it over `postMessage`; none of that machinery is visible
+here — `attach` just gives you a working `WebFrame`.
+
+Requires the `"webview"` permission — declare it in your extension manifest.
+Trusted (bundled) extensions are unscoped, same trust model as `ctx.files` /
+`ctx.process`.
+
+```ts
+ctx.webview: WebviewService
+```
+
+## `ctx.webview.attach(frame)` {#attach}
+
+Attach the bridge to an iframe your panel owns. The iframe can be
+cross-origin — that's the point. Returns a [`WebFrame`](#webframe); call
+`.dispose()` (or push it onto `ctx.subscriptions`) when done with it.
+
+```ts
+attach(frame: HTMLIFrameElement): WebFrame
+```
+
+**Throws** synchronously if the `"webview"` permission isn't granted.
+
+```tsx
+function MyPanel({ ctx }: { ctx: ExtensionContext }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const frameRef = useRef<WebFrame | null>(null);
+
+  useEffect(() => {
+    if (!iframeRef.current) return;
+    const frame = ctx.webview.attach(iframeRef.current);
+    frameRef.current = frame;
+    const sub = frame.onNavigate((e) =>
+      console.log(e.type, e.url, e.newDocument),
+    );
+    return () => {
+      sub.dispose();
+      frame.dispose();
+    };
+  }, []);
+
+  return <iframe ref={iframeRef} src="https://example.com" />;
+}
+```
+
+## `WebFrame` {#webframe}
+
+The live connection returned by `attach()`. Every method re-checks the
+`"webview"` permission, not just the initial `attach()` call — a frame can
+outlive the scope it was attached under (e.g. its owning extension reloading
+with a narrower manifest), so a revoked permission surfaces as each method
+throwing/rejecting rather than a handle that silently keeps working.
+
+| Member                 | Description                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `url`                  | The frame's current URL, updated on every `onNavigate` event. `null` before first load. |
+| `onNavigate(listener)` | Subscribe to in-frame navigation — full loads and SPA route changes alike.              |
+| `onBlocked(listener)`  | Fires when a navigation looks frame-blocked (see below).                                |
+| `back()` / `forward()` | Navigate the frame's history, if possible. Fire-and-forget.                             |
+| `reload()`             | Reload the frame's current page. Fire-and-forget.                                       |
+| `exec(code)`           | Run JavaScript inside the frame; resolves with its result.                              |
+| `pickElement()`        | Interactive element picking — see below.                                                |
+| `cancelPick()`         | Cancel an in-flight `pickElement()` call.                                               |
+| `capture()`            | Native PNG snapshot of the frame's current visible viewport.                            |
+| `captureRect(rect)`    | Native PNG snapshot of a frame-relative sub-rect.                                       |
+| `captureFullPage()`    | Native PNG snapshot of the entire scrollable document, stitched from scrolled captures. |
+| `dispose()`            | Tear down the bridge for this frame. Always safe to call, even more than once.          |
+
+### `onNavigate` and `newDocument` {#nav}
+
+Subscribe to in-frame navigation — full document loads and SPA route changes
+(`history.pushState`/`replaceState`, hash changes, back/forward) alike. Each
+event's `newDocument` flag is `true` only on the first event reported by a
+freshly loaded document, `false` for every subsequent event from that same
+document — frameworks commonly call `history.replaceState` while booting, so
+a single full-page navigation can report a `"replace"` event _before_ its
+`"load"`; without this flag a consumer building its own history stack can't
+tell that boot-time `replaceState` (a brand-new page) apart from a genuine
+in-page one (rewriting the current entry).
+
+### `exec(code)` {#exec}
+
+Run JavaScript inside the frame and resolve with its result. A single
+expression's value is returned (e.g. `"document.title"`, `"location.href"`,
+`"document.querySelectorAll('a').length"`) — matching how a devtools console
+evaluates. Multi-statement code runs but only returns a value if it ends in
+an explicit `return`-compatible form. The result must be structured-clone-safe
+(no DOM nodes, functions, etc.).
+
+```ts
+exec<T = unknown>(code: string): Promise<T>
+```
+
+```ts
+const title = await frame.exec<string>("document.title");
+const linkCount = await frame.exec<number>(
+  "document.querySelectorAll('a').length",
+);
+```
+
+### `pickElement()` / `cancelPick()` {#pick}
+
+Enter interactive element-pick mode: the user hovers to highlight and clicks
+to select, or presses Escape to cancel. Resolves with the picked element, or
+`null` if cancelled. No timeout — this is inherently user-paced; if your
+panel needs to abort a pick programmatically (e.g. the user closed the panel
+mid-pick), call `cancelPick()`, which resolves the pending `pickElement()`
+call with `null`. `pickElement()`'s promise also rejects if the frame
+navigates away before the user picks anything.
+
+```ts
+pickElement(): Promise<PickedElement | null>
+cancelPick(): void
+```
+
+```ts
+const picked = await frame.pickElement();
+if (picked) {
+  console.log(picked.selector, picked.text);
+  const blob = await frame.captureRect(picked.rect);
+}
+```
+
+### `onBlocked` {#blocked}
+
+Fires when a navigation lands on what looks like a frame-blocked page — sites
+sending `X-Frame-Options` / `frame-ancestors` don't error, the engine just
+commits an empty document at the target URL, so this is a heuristic (empty
+title + no body content, re-confirmed a moment later to rule out a transient
+interstitial or redirector), not a definitive diagnosis. Treat it as "this
+page probably won't work embedded — offer to open it in a browser instead"
+(see [`ctx.ui.openExternal`](/api/ui/)).
+
+### `captureFullPage()` {#capture-full-page}
+
+Stitches a full-page screenshot from scrolled captures; scroll position is
+restored afterward. Rejects if the frame currently has zero viewport height
+(e.g. its panel isn't visible/laid out) rather than hanging.
+
+## Type links
+
+- [`WebviewService`](/api/types/interfaces/WebviewService)
+- [`WebFrame`](/api/types/interfaces/WebFrame)
+- [`WebviewNavType`](/api/types/type-aliases/WebviewNavType)
+- [`WebviewNavigateEvent`](/api/types/interfaces/WebviewNavigateEvent)
+- [`WebviewRect`](/api/types/interfaces/WebviewRect)
+- [`PickedElement`](/api/types/interfaces/PickedElement)
+
+## See also
+
+- [`ctx.net.fetchHeaders`](/api/net/#fetchHeaders) — check `X-Frame-Options` /
+  CSP before embedding a URL, without needing the `"webview"` permission
+- [`ctx.ui.openExternal`](/api/ui/) — open a URL in the user's default browser
+  as a fallback when `onBlocked` fires
+- `core.webview-bridge-test` (bundled, dev builds only) — a reference
+  implementation exercising this API end-to-end against real cross-origin
+  pages

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -56,7 +56,7 @@ designed. As a primitive ships, its badge flips from
 | per-extension settings (page + persistence)    | <Badge type="tip" text="stable" />   | [docs](/api/registration/register-settings-page)                                           |
 | `ctx.storage` (global / workspace)             | <Badge type="tip" text="stable" />   | [docs](/api/storage/)                                                                      |
 | `ctx.secrets` (host-mediated credentials)      | <Badge type="info" text="planned" /> | [RFC 0004](https://github.com/silo-code/silo/blob/main/docs/proposals/0004-ctx-storage.md) |
-| `ctx.webview` (iframe navigation events)       | <Badge type="info" text="planned" /> | [design](#ctx-webview)                                                                     |
+| `ctx.webview` (cross-origin iframe bridge)     | <Badge type="tip" text="stable" />   | [docs](/api/webview/)                                                                      |
 | context-menu contributions (explorer/editor)   | <Badge type="info" text="planned" /> | [design](#context-menus)                                                                   |
 
 ## Extension-owned features
@@ -134,7 +134,6 @@ The shape of each planned surface is now designed in an **RFC** under
 | Package format + remote install (GitHub / npm)                                      | [RFC 0008](https://github.com/silo-code/silo/blob/main/docs/proposals/0008-extension-package-format-remote-install.md) |
 | Language intelligence (TS/JS via `tsserver`)                                        | [RFC 0009](https://github.com/silo-code/silo/blob/main/docs/proposals/0009-language-intelligence-lsp.md)               |
 | Self-owned PTY host daemon                                                          | [RFC 0010](https://github.com/silo-code/silo/blob/main/docs/proposals/0010-pty-host-daemon.md)                         |
-| <a id="ctx-webview"></a>`ctx.webview` — iframe navigation events via init script    | [RFC 0011](https://github.com/silo-code/silo/blob/main/docs/proposals/0011-iframe-navigation-events.md)                |
 | <a id="context-menus"></a>Context-menu contributions (explorer / editor / terminal) | [RFC 0013](https://github.com/silo-code/silo/blob/main/docs/proposals/0013-context-menu-contributions.md)              |
 
 ---

--- a/packages/extension-host/src/extension-host/extension-manager.test.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.test.ts
@@ -140,6 +140,9 @@ describe("validateManifestPermissions", () => {
       validateManifestPermissions(["fs:read", "process", "fs:read"], "x"),
     ).toEqual(["fs:read", "process"]);
   });
+  it("accepts the webview permission", () => {
+    expect(validateManifestPermissions(["webview"], "x")).toEqual(["webview"]);
+  });
   it("throws on an unknown permission", () => {
     expect(() => validateManifestPermissions(["fs:delete"], "x")).toThrow(
       /unknown permission/,

--- a/packages/extension-host/src/extension-host/webview-service.test.ts
+++ b/packages/extension-host/src/extension-host/webview-service.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { WebviewNavigateEvent } from "@silo-code/sdk";
+import type { Permission, WebviewNavigateEvent } from "@silo-code/sdk";
 
-vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 
-import { attachWebviewBridge } from "./webview-service";
+import {
+  attachWebviewBridge,
+  getScopedWebviewService,
+  type WebviewScope,
+} from "./webview-service";
 
 // Simulates the shim (webview_bridge.js) posting a message from inside the
 // iframe up to the parent — the real transport is cross-realm postMessage,
@@ -28,6 +33,38 @@ function makeIframe(): HTMLIFrameElement {
 function lastHelloNonce(postMessage: ReturnType<typeof vi.fn>): string {
   const call = postMessage.mock.calls.at(-1);
   return (call?.[0] as { nonce: string }).nonce;
+}
+
+/** Handshake an iframe end to end and return its nonce. */
+function handshaken(
+  iframe: HTMLIFrameElement,
+  postMessage: ReturnType<typeof vi.fn>,
+): string {
+  shimSend(iframe, { type: "announce" });
+  const nonce = lastHelloNonce(postMessage);
+  shimSend(iframe, { type: "ready", nonce });
+  return nonce;
+}
+
+/** Find the most recent outbound message with the given `cmd`. */
+function findCommand(
+  postMessage: ReturnType<typeof vi.fn>,
+  cmd: string,
+): { id: string; nonce: string; [k: string]: unknown } {
+  const call = [...postMessage.mock.calls]
+    .reverse()
+    .find((c) => (c[0] as { cmd?: string }).cmd === cmd);
+  if (!call) throw new Error(`no "${cmd}" command was sent`);
+  return call[0] as { id: string; nonce: string };
+}
+
+function respondOk(
+  iframe: HTMLIFrameElement,
+  id: string,
+  nonce: string,
+  result: unknown,
+) {
+  shimSend(iframe, { type: "resp", id, ok: true, result, nonce });
 }
 
 describe("webview-service: announce / newDocument handshake", () => {
@@ -249,5 +286,253 @@ describe("webview-service: announce / newDocument handshake", () => {
     });
 
     expect(events).toEqual([]);
+  });
+});
+
+describe("webview-service: pending-RPC rejection on re-handshake", () => {
+  let iframe: HTMLIFrameElement;
+  let postMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    iframe = makeIframe();
+    postMessage = vi.fn();
+    vi.spyOn(iframe.contentWindow!, "postMessage").mockImplementation(
+      postMessage,
+    );
+  });
+
+  it("rejects a pending pickElement() when the frame re-handshakes before it resolves", async () => {
+    const frame = attachWebviewBridge(iframe);
+    handshaken(iframe, postMessage);
+
+    const pick = frame.pickElement();
+    findCommand(postMessage, "pick_start"); // sent, never answered
+
+    // A fresh announce is what a renavigation looks like from the host's
+    // side — the shim re-injects into whatever document is there now, which
+    // isn't the one pick_start was sent to.
+    shimSend(iframe, { type: "announce" });
+
+    await expect(pick).rejects.toThrow(/navigated/);
+    frame.dispose();
+  });
+
+  it("cancelPick() sends pick_cancel without waiting for its own response", () => {
+    const frame = attachWebviewBridge(iframe);
+    handshaken(iframe, postMessage);
+
+    expect(() => frame.cancelPick()).not.toThrow();
+    expect(findCommand(postMessage, "pick_cancel")).toBeDefined();
+    frame.dispose();
+  });
+
+  it("captureFullPage() rejects instead of hanging when the frame reports zero viewport height", async () => {
+    const frame = attachWebviewBridge(iframe);
+    const nonce = handshaken(iframe, postMessage);
+
+    const p = frame.captureFullPage();
+    const cmd = findCommand(postMessage, "get_metrics");
+    respondOk(iframe, cmd.id, nonce, {
+      scrollX: 0,
+      scrollY: 0,
+      docWidth: 800,
+      docHeight: 4000,
+      vw: 800,
+      vh: 0,
+    });
+
+    await expect(p).rejects.toThrow(/zero viewport height/);
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "webview_snapshot",
+      expect.anything(),
+    );
+    frame.dispose();
+  });
+
+  it("dispose() clears a pending RPC's timeout timer instead of leaking it", async () => {
+    vi.useFakeTimers();
+    try {
+      const frame = attachWebviewBridge(iframe);
+      handshaken(iframe, postMessage);
+
+      const p = frame.exec("1 + 1");
+      findCommand(postMessage, "exec");
+      expect(vi.getTimerCount()).toBe(1); // the RPC timeout
+
+      frame.dispose();
+      await expect(p).rejects.toThrow(/disposed/);
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("back()/forward()/reload() don't produce an unhandled rejection when the underlying RPC fails", async () => {
+    const frame = attachWebviewBridge(iframe);
+    handshaken(iframe, postMessage);
+
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      frame.back();
+      const cmd = findCommand(postMessage, "history");
+      shimSend(iframe, {
+        type: "resp",
+        id: cmd.id,
+        ok: false,
+        error: "boom",
+        nonce: cmd.nonce,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+      frame.dispose();
+    }
+  });
+});
+
+describe("webview-service: onBlocked debounce", () => {
+  let iframe: HTMLIFrameElement;
+  let postMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    iframe = makeIframe();
+    postMessage = vi.fn();
+    vi.spyOn(iframe.contentWindow!, "postMessage").mockImplementation(
+      postMessage,
+    );
+  });
+
+  it("does not fire onBlocked if the re-probe finds real content (transient interstitial)", async () => {
+    vi.useFakeTimers();
+    try {
+      const frame = attachWebviewBridge(iframe);
+      const nonce = handshaken(iframe, postMessage);
+      const onBlocked = vi.fn();
+      frame.onBlocked(onBlocked);
+
+      shimSend(iframe, {
+        type: "nav",
+        navType: "load",
+        url: "https://example.com/",
+        nonce,
+      });
+      const probe1 = findCommand(postMessage, "exec");
+      respondOk(iframe, probe1.id, nonce, true); // looks empty on first read
+
+      await vi.advanceTimersByTimeAsync(500); // past the re-probe delay
+
+      const probe2 = findCommand(postMessage, "exec");
+      expect(probe2.id).not.toBe(probe1.id);
+      respondOk(iframe, probe2.id, nonce, false); // real content landed since
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onBlocked).not.toHaveBeenCalled();
+      frame.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fires onBlocked once the re-probe confirms the page is still empty", async () => {
+    vi.useFakeTimers();
+    try {
+      const frame = attachWebviewBridge(iframe);
+      const nonce = handshaken(iframe, postMessage);
+      const onBlocked = vi.fn();
+      frame.onBlocked(onBlocked);
+
+      shimSend(iframe, {
+        type: "nav",
+        navType: "load",
+        url: "https://blocked.example/",
+        nonce,
+      });
+      const probe1 = findCommand(postMessage, "exec");
+      respondOk(iframe, probe1.id, nonce, true);
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      const probe2 = findCommand(postMessage, "exec");
+      respondOk(iframe, probe2.id, nonce, true); // still empty
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onBlocked).toHaveBeenCalledTimes(1);
+      frame.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("getScopedWebviewService", () => {
+  function scope(opts: {
+    trusted?: boolean;
+    permissions?: Permission[];
+  }): WebviewScope {
+    return {
+      trusted: opts.trusted ?? false,
+      permissions: new Set(opts.permissions ?? []),
+    };
+  }
+
+  it("throws synchronously on attach() when untrusted and missing the webview permission", () => {
+    const iframe = makeIframe();
+    const svc = getScopedWebviewService(scope({}));
+    expect(() => svc.attach(iframe)).toThrow(/"webview" permission/);
+  });
+
+  it("allows attach() when trusted, even without the permission declared", () => {
+    const iframe = makeIframe();
+    const svc = getScopedWebviewService(scope({ trusted: true }));
+    const frame = svc.attach(iframe);
+    expect(frame).toBeDefined();
+    frame.dispose();
+  });
+
+  it("allows attach() when the webview permission is granted", () => {
+    const iframe = makeIframe();
+    const svc = getScopedWebviewService(scope({ permissions: ["webview"] }));
+    const frame = svc.attach(iframe);
+    expect(frame).toBeDefined();
+    frame.dispose();
+  });
+
+  it("re-checks the permission on every capability, not just attach()", () => {
+    const iframe = makeIframe();
+    const permissions = new Set<Permission>(["webview"]);
+    const svc = getScopedWebviewService({ trusted: false, permissions });
+    const frame = svc.attach(iframe);
+
+    expect(() => frame.back()).not.toThrow();
+
+    // Revoked after attach (e.g. the extension is reactivated with a
+    // narrower manifest) — every capability on the already-minted handle
+    // should stop working too, not just future attach() calls.
+    permissions.delete("webview");
+    expect(() => frame.back()).toThrow(/"webview" permission/);
+    expect(() => frame.exec("1")).toThrow(/"webview" permission/);
+    expect(() => frame.pickElement()).toThrow(/"webview" permission/);
+    expect(() => frame.captureFullPage()).toThrow(/"webview" permission/);
+
+    frame.dispose();
+  });
+
+  it("exempts dispose() and the read-only url/onNavigate/onBlocked members from the permission check", () => {
+    const iframe = makeIframe();
+    const permissions = new Set<Permission>(["webview"]);
+    const svc = getScopedWebviewService({ trusted: false, permissions });
+    const frame = svc.attach(iframe);
+    permissions.delete("webview");
+
+    expect(() => frame.url).not.toThrow();
+    expect(() => frame.onNavigate(() => {})).not.toThrow();
+    expect(() => frame.onBlocked(() => {})).not.toThrow();
+    expect(() => frame.dispose()).not.toThrow();
   });
 });

--- a/packages/extension-host/src/extension-host/webview-service.ts
+++ b/packages/extension-host/src/extension-host/webview-service.ts
@@ -27,6 +27,7 @@ import { EventEmitter } from "./event-emitter";
 
 const HANDSHAKE_TIMEOUT_MS = 5_000;
 const RPC_TIMEOUT_MS = 8_000;
+const BLOCKED_RECHECK_DELAY_MS = 400;
 
 interface OutMessage {
   __silo_wv: true;
@@ -52,6 +53,7 @@ interface FrameState {
   pending: Map<string, PendingRpc>;
   queued: (() => void)[];
   handshakeTimer: ReturnType<typeof setTimeout> | null;
+  blockedRecheckTimer: ReturnType<typeof setTimeout> | null;
   nextId: number;
   disposed: boolean;
   /**
@@ -162,6 +164,26 @@ function installListener() {
 }
 
 function handshake(state: FrameState) {
+  // A new handshake means the previous document — and everything in flight
+  // to it — is gone. Reject stale pending RPCs and drop anything still
+  // queued (not yet dispatched) rather than letting them hang until their
+  // own timeout (or forever, for calls like pickElement() that have none),
+  // or silently fire against the *new* document once it becomes ready.
+  state.queued = [];
+  for (const [id, pending] of state.pending) {
+    if (pending.timer !== null) clearTimeout(pending.timer);
+    pending.reject(
+      new Error(
+        "webview bridge: frame navigated before this request completed",
+      ),
+    );
+    state.pending.delete(id);
+  }
+  if (state.blockedRecheckTimer !== null) {
+    clearTimeout(state.blockedRecheckTimer);
+    state.blockedRecheckTimer = null;
+  }
+
   const nonce =
     typeof crypto !== "undefined" && crypto.randomUUID
       ? crypto.randomUUID()
@@ -194,15 +216,43 @@ function handshake(state: FrameState) {
   }
 }
 
+const EMPTINESS_PROBE =
+  "!document.title && (!document.body || document.body.children.length === 0)";
+
 /** Probe an emptiness signature after a full-page load — see the call site's comment. */
 async function checkIfBlocked(state: FrameState): Promise<void> {
+  if (state.blockedRecheckTimer !== null) {
+    clearTimeout(state.blockedRecheckTimer);
+    state.blockedRecheckTimer = null;
+  }
   try {
     const isEmpty = await sendCommand<boolean>(state, "exec", {
-      code: "!document.title && (!document.body || document.body.children.length === 0)",
+      code: EMPTINESS_PROBE,
+    });
+    if (!isEmpty) return;
+    // A single empty-document reading can be a transient interstitial (a
+    // meta-refresh or JS redirector, common for short-link/OAuth pages)
+    // rather than genuine frame-blocking — a truly blocked page stays empty
+    // indefinitely, a redirector doesn't. Re-probe once before firing
+    // onBlocked instead of trusting the first reading.
+    state.blockedRecheckTimer = setTimeout(() => {
+      state.blockedRecheckTimer = null;
+      void recheckBlocked(state);
+    }, BLOCKED_RECHECK_DELAY_MS);
+  } catch {
+    /* an exec failure here isn't itself a blocked signal (e.g. a stale/torn-down frame) */
+  }
+}
+
+async function recheckBlocked(state: FrameState): Promise<void> {
+  if (state.disposed) return;
+  try {
+    const isEmpty = await sendCommand<boolean>(state, "exec", {
+      code: EMPTINESS_PROBE,
     });
     if (isEmpty) state.blockedEmitter.fire();
   } catch {
-    /* an exec failure here isn't itself a blocked signal (e.g. a stale/torn-down frame) */
+    /* frame torn down or navigated mid-recheck; not itself a blocked signal */
   }
 }
 
@@ -257,6 +307,37 @@ function sendCommand<T>(
     if (state.ready) send();
     else state.queued.push(send);
   });
+}
+
+/**
+ * Fire-and-forget send, for commands whose response (if any) isn't routed
+ * back to their own id — `pick_cancel`'s ack rides on the `pick_start` it
+ * cancels (see `endPick` in webview_bridge.js), so tracking it in
+ * `state.pending` like a normal RPC would just leak a pending entry that
+ * times out unanswered 8 seconds later.
+ */
+function postCommand(
+  state: FrameState,
+  cmd: string,
+  args: Record<string, unknown>,
+): void {
+  const send = () => {
+    try {
+      state.iframe.contentWindow?.postMessage(
+        {
+          __silo_wv: true,
+          cmd,
+          nonce: state.nonce,
+          ...args,
+        } satisfies OutMessage,
+        "*",
+      );
+    } catch {
+      /* frame gone; nothing pending to clean up for a fire-and-forget send */
+    }
+  };
+  if (state.ready) send();
+  else state.queued.push(send);
 }
 
 async function captureViaBackend(rect: WebviewRect): Promise<Blob> {
@@ -323,6 +404,7 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
     pending: new Map(),
     queued: [],
     handshakeTimer: null,
+    blockedRecheckTimer: null,
     nextId: 0,
     disposed: false,
     pendingNewDocument: false,
@@ -358,20 +440,27 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
     onBlocked(listener) {
       return state.blockedEmitter.event(listener);
     },
+    // These three are `void`-returning by design (see WebFrame's TSDoc) — the
+    // caller has no handle to observe a failure, so a rejection (disposal,
+    // timeout, a navigation racing this very command) must be swallowed here
+    // rather than left as an unhandled rejection with nowhere to go.
     back() {
-      void sendCommand(state, "history", { dir: "back" });
+      sendCommand(state, "history", { dir: "back" }).catch(() => {});
     },
     forward() {
-      void sendCommand(state, "history", { dir: "forward" });
+      sendCommand(state, "history", { dir: "forward" }).catch(() => {});
     },
     reload() {
-      void sendCommand(state, "reload", {});
+      sendCommand(state, "reload", {}).catch(() => {});
     },
     exec<T>(code: string) {
       return sendCommand<T>(state, "exec", { code });
     },
     pickElement() {
       return sendCommand<PickedElement | null>(state, "pick_start", {}, null);
+    },
+    cancelPick() {
+      postCommand(state, "pick_cancel", {});
     },
     capture() {
       return captureViaBackend(frameRectInWindow());
@@ -394,6 +483,12 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
         vw: number;
         vh: number;
       }>(state, "get_metrics", {});
+
+      if (metrics.vh <= 0) {
+        throw new Error(
+          "webview bridge: captureFullPage() failed — frame has zero viewport height (is the panel visible and laid out?)",
+        );
+      }
 
       const frameRect = frameRectInWindow();
       const canvas = document.createElement("canvas");
@@ -459,8 +554,11 @@ export function attachWebviewBridge(iframe: HTMLIFrameElement): WebFrame {
       if (state.disposed) return;
       state.disposed = true;
       if (state.handshakeTimer !== null) clearTimeout(state.handshakeTimer);
+      if (state.blockedRecheckTimer !== null)
+        clearTimeout(state.blockedRecheckTimer);
       registry.delete(state);
       for (const [id, pending] of state.pending) {
+        if (pending.timer !== null) clearTimeout(pending.timer);
         pending.reject(new Error("webview bridge: frame handle disposed"));
         state.pending.delete(id);
       }
@@ -479,23 +577,86 @@ export interface WebviewScope {
   readonly permissions: ReadonlySet<Permission>;
 }
 
+function assertWebviewPermission(scope: WebviewScope): void {
+  if (!scope.trusted && !scope.permissions.has("webview")) {
+    throw new Error(
+      'ctx.webview requires the "webview" permission — declare it in the extension manifest.',
+    );
+  }
+}
+
 /**
- * `ctx.webview` as handed to an extension by `createContext` — gates
- * `attach()` behind the `"webview"` permission for third-party extensions
+ * Wrap a raw {@link WebFrame} so every method re-checks the `"webview"`
+ * permission against `scope`, not just the initial `attach()` call — mirrors
+ * `scopeProcessService`'s per-call `guardCwd` in process-service.ts, rather
+ * than gating the capability once and handing out an unscoped handle.
+ * `dispose()` and the read-only `url`/event members are exempt: tearing down
+ * or observing an already-attached frame isn't a new grant of access.
+ */
+function scopeWebFrame(frame: WebFrame, scope: WebviewScope): WebFrame {
+  return {
+    get url() {
+      return frame.url;
+    },
+    onNavigate: (listener) => frame.onNavigate(listener),
+    onBlocked: (listener) => frame.onBlocked(listener),
+    back() {
+      assertWebviewPermission(scope);
+      frame.back();
+    },
+    forward() {
+      assertWebviewPermission(scope);
+      frame.forward();
+    },
+    reload() {
+      assertWebviewPermission(scope);
+      frame.reload();
+    },
+    exec<T = unknown>(code: string) {
+      assertWebviewPermission(scope);
+      return frame.exec<T>(code);
+    },
+    pickElement() {
+      assertWebviewPermission(scope);
+      return frame.pickElement();
+    },
+    cancelPick() {
+      assertWebviewPermission(scope);
+      frame.cancelPick();
+    },
+    capture() {
+      assertWebviewPermission(scope);
+      return frame.capture();
+    },
+    captureRect(rect) {
+      assertWebviewPermission(scope);
+      return frame.captureRect(rect);
+    },
+    captureFullPage() {
+      assertWebviewPermission(scope);
+      return frame.captureFullPage();
+    },
+    dispose() {
+      frame.dispose();
+    },
+  };
+}
+
+/**
+ * `ctx.webview` as handed to an extension by `createContext` — gates every
+ * capability behind the `"webview"` permission for third-party extensions
  * (trusted/bundled extensions are unscoped, same trust model as
- * `ctx.files`/`ctx.process`). Denied calls throw synchronously rather than
- * returning a handle whose methods all reject — there's no partial-access
- * story for this capability the way there is for path-scoped fs/process.
+ * `ctx.files`/`ctx.process`). `attach()` throws synchronously when denied;
+ * a subsequent revocation instead surfaces as each individual method
+ * throwing/rejecting, since a WebFrame can outlive the scope it was
+ * attached under (e.g. a dock panel that isn't torn down promptly when its
+ * owning extension reloads).
  */
 export function getScopedWebviewService(scope: WebviewScope): WebviewService {
   return {
     attach(frame: HTMLIFrameElement): WebFrame {
-      if (!scope.trusted && !scope.permissions.has("webview")) {
-        throw new Error(
-          'ctx.webview.attach() requires the "webview" permission — declare it in the extension manifest.',
-        );
-      }
-      return attachWebviewBridge(frame);
+      assertWebviewPermission(scope);
+      return scopeWebFrame(attachWebviewBridge(frame), scope);
     },
   };
 }

--- a/packages/extensions-core/src/webview-bridge-test/index.tsx
+++ b/packages/extensions-core/src/webview-bridge-test/index.tsx
@@ -21,25 +21,30 @@ export const extension: Extension = {
       "Diagnostic panel and reference implementation for ctx.webview.",
   },
   activate(ctx) {
-    ctx.registerDockPanelKind({
-      id: "webview-bridge-test",
-      component: (props: DockPanelProps) => (
-        <WebviewBridgeTestPanel {...props} ctx={ctx} />
-      ),
-    });
-
-    ctx.registerCommand({
-      id: "core.webviewBridgeTest.open",
-      label: "Webview Bridge Test",
-      run: () =>
-        ctx.layout.openPanel(
-          "webview-bridge-test",
-          { title: "Webview Bridge Test" },
-          { singleton: true },
-        ),
-    });
-
+    // Gated on the dev build in full — panel kind, command, and menu item —
+    // same as core.menu's Reload/Inspect Element. Registering the command or
+    // panel kind unconditionally would leave this reachable via
+    // ctx.executeCommand("core.webviewBridgeTest.open") in release builds,
+    // bypassing the "webview" permission's install-time consent entirely.
     if (import.meta.env.DEV) {
+      ctx.registerDockPanelKind({
+        id: "webview-bridge-test",
+        component: (props: DockPanelProps) => (
+          <WebviewBridgeTestPanel {...props} ctx={ctx} />
+        ),
+      });
+
+      ctx.registerCommand({
+        id: "core.webviewBridgeTest.open",
+        label: "Webview Bridge Test",
+        run: () =>
+          ctx.layout.openPanel(
+            "webview-bridge-test",
+            { title: "Webview Bridge Test" },
+            { singleton: true },
+          ),
+      });
+
       ctx.registerMenuItem({
         id: "core.menu.webviewBridgeTest",
         menu: "window",

--- a/packages/sdk/src/webview-service.ts
+++ b/packages/sdk/src/webview-service.ts
@@ -128,6 +128,13 @@ export interface WebFrame extends Disposable {
    * user-paced.
    */
   pickElement(): Promise<PickedElement | null>;
+  /**
+   * Cancel an in-flight {@link pickElement} call — exits pick mode in the
+   * frame and resolves the pending `pickElement()` promise with `null`. A
+   * no-op if no pick is active (including if it already ended, e.g. via
+   * Escape or a click).
+   */
+  cancelPick(): void;
   /** A native PNG snapshot of the frame's current visible viewport. */
   capture(): Promise<Blob>;
   /** A native PNG snapshot of a frame-relative sub-rect — e.g. a {@link PickedElement.rect} or a marquee selection. */


### PR DESCRIPTION
## Summary

Recreated as a direct PR against `main` now that #191 is merged — the original
#192 was auto-closed by GitHub when #191's base branch was deleted post-merge
(closed PRs can't be reparented). Same commit, no content changes, just
rebased onto current `main`.

Independent findings from a full code review of the shipped `ctx.webview`
surface (#189) that #191's live-user-report-driven fixes don't overlap with —
mostly gaps `#189`'s original review missed entirely, plus one gap in #191
itself (the pending-RPC hang, which #191 made the re-handshake trigger fire
reliably but didn't hook up any cleanup to it).

- **Security bypass**: `webview-bridge-test`'s dock-panel-kind and command
  were registered unconditionally, reachable via `ctx.executeCommand` in
  production builds and bypassing the `"webview"` permission's install-time
  consent entirely. Now dev-gated in full, matching `core.menu`'s
  Reload/Inspect Element pattern.
- **Windows platform bug**: `TRUSTED_ORIGINS` listed `http://tauri.localhost`;
  Tauri v2's actual WebView2 origin on Windows is `https://tauri.localhost`,
  so the handshake origin check silently failed on that platform — `ctx.webview`
  never worked on Windows at all.
- **Pending-RPC hang** (complements #191): `handshake()` — now reliably
  triggered by the shim's `announce`, per #191 — never rejected stale
  `state.pending` entries. A `pickElement()` call interrupted by a navigation
  hung forever (no timeout by design) instead of failing fast. Verified live
  against a real running build of this branch. Also adds `cancelPick()` to
  the public `WebFrame` API, wiring up the shim's existing-but-previously-
  unused `pick_cancel` command as an explicit escape hatch.
- **`captureFullPage()` zero-height hang**: no guard for a zero-height
  viewport (a hidden or not-yet-laid-out panel) — the scroll loop's increment
  never advances.
- **Permission checked once, not per-call**: every `WebFrame` method now
  re-checks `"webview"`, mirroring `process-service.ts`'s `guardCwd`, since a
  frame can outlive the scope it was attached under (e.g. its owning
  extension reloading with a narrower manifest).
- **Unbounded `pendingOutbox`** in the injected shim, for nested iframes that
  fire nav events but never complete a handshake.
- **`dispose()`** rejected pending RPCs without clearing their timeout timers.
- **Unhandled rejections**: `back()`/`forward()`/`reload()` are
  `void`-returning fire-and-forget calls whose underlying promise could still
  reject with nowhere to go.
- **`onBlocked` false positives**: fired on a single empty-document reading
  with no recheck, so a legitimate transient interstitial (meta-refresh, JS
  redirector) could permanently stick a frame in "blocked" state. Now
  re-probes once after a short delay before firing.
- **Docs**: `ctx.webview` was still marked `planned` on the public roadmap
  and had no hand-authored docs page despite shipping in #189; both added,
  alongside regenerating the type reference (also picks up #191's
  `newDocument` field, which hadn't been regenerated either).

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `pnpm test` — 601 tests in extension-host (12 new: pending-rejection on
      re-handshake, `cancelPick`, zero-height guard, dispose timer cleanup,
      unhandled-rejection safety, `onBlocked` debounce ×2, permission gate ×5)
- [x] Live-verified against the real running app: attached to
      `https://example.com` via the `webview-bridge-test` panel, confirmed
      `exec`/`capture`/`captureFullPage` all work, started a pick then
      triggered a reload mid-pick — confirmed it rejects with `"frame
      navigated before this request completed"` instead of hanging.
      Confirmed `onBlocked` still fires correctly for a genuinely blocked
      page (github.com).
- [ ] Windows testing — no Windows machine/CI available in this session; the
      origin-scheme fix is a one-line correction verified by re-checking
      Tauri v2's documented WebView2 origin behavior, not runtime-tested on
      Windows.