### PR TITLE
fix(release): bump create-silo-extension past its already-published version

### DIFF
--- a/packages/create-silo-extension/CHANGELOG.md
+++ b/packages/create-silo-extension/CHANGELOG.md
@@ -1,0 +1,16 @@
+# create-silo-extension
+
+## 0.2.2
+
+### Patch Changes
+
+- No functional change — bumps past `0.2.1`, which is already published on npm
+  without a matching git tag or changelog entry in this repo (an earlier
+  release run appears to have published it but not completed its bookkeeping
+  step). `changeset publish` keeps re-attempting `0.2.1` and npm rejects it
+  every time, since a published version can never be overwritten; this failure
+  was also visible as a collateral failure in unrelated `release-sdk` runs,
+  since `changeset publish` processes every eligible package, not just the one
+  the workflow intends to release. Cutting a new version resolves the mismatch
+  without needing to reconstruct exactly why the previous release's bookkeeping
+  was incomplete.

--- a/packages/create-silo-extension/package.json
+++ b/packages/create-silo-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-silo-extension",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Scaffold a new Silo extension",
   "license": "MIT",
   "author": "Dave Weaver",


### PR DESCRIPTION
## Summary

Fixes the failure in https://github.com/silo-code/silo/actions/runs/29194625457/job/86655283170.

npm already has `create-silo-extension@0.2.1` published, but this repo has no
matching git tag or CHANGELOG entry for it — an earlier release run appears
to have published it without completing its bookkeeping step. `changeset
publish` keeps re-attempting `0.2.1` on every `release-create.yml`/
`release-sdk.yml` run, and npm rejects it every time since a published
version can never be overwritten. This also surfaces as a collateral failure
in unrelated `release-sdk` runs, since `changeset publish` processes every
eligible package, not just the one each workflow intends to release — that's
why publishing `@silo-code/sdk@0.24.0` (which succeeded) still reported the
job as failed.

Bumped via `pnpm changeset version`, targeting only `create-silo-extension`
(no functional change to the package itself). That command also picked up a
pre-existing, unrelated pending changeset for `@silo-code/sdk` (a leftover
`ctx.storage` changeset) and bumped it 0.24.0 → 0.25.0 — reverted that part,
since 0.24.0 is what's actually published and bumping it wasn't part of this
fix.

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all
      pass (ran via the pre-commit hook)
- [ ] Confirm `release-create.yml` (dry-run, then a real dispatch) publishes
      `0.2.2` cleanly — can't verify this in CI without actually dispatching
      the workflow, which I didn't do since it publishes to npm