### PR TITLE
feat(registry): app-side extension registry — browse, install, update (RFC 0014 P1)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4602,6 +4602,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tar",
  "tauri",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,8 @@ notify = "8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tar = "0.4"
 flate2 = "1"
+# sha256 pin verification for registry installs (RFC 0014)
+sha2 = "0.10"
 # Content search backend for `ctx.search` — ripgrep's engine (matcher + searcher)
 # and its `.gitignore`-aware directory walker.
 grep = "0.3"

--- a/apps/desktop/src-tauri/src/commands/cli.rs
+++ b/apps/desktop/src-tauri/src/commands/cli.rs
@@ -49,7 +49,18 @@ pub fn resolve_cli_request(argv: &[String], cwd: &str) -> Option<CliRequest> {
     match first.as_str() {
         "install" => {
             let raw = pos.next()?;
+            // A registry id (`publisher.name`, no separators) installs from the
+            // Silo Extension Registry — unless a matching path actually exists,
+            // in which case the folder wins (paths are the older contract).
             let resolved = resolve_path(raw, cwd);
+            if looks_like_extension_id(raw) && !resolved.exists() {
+                return Some(CliRequest {
+                    action: "install".to_string(),
+                    path: None,
+                    kind: None,
+                    id: Some(raw.clone()),
+                });
+            }
             Some(CliRequest {
                 action: "install".to_string(),
                 path: Some(super::fs::normalize_path(&resolved)),
@@ -81,6 +92,28 @@ pub fn resolve_cli_request(argv: &[String], cwd: &str) -> Option<CliRequest> {
             })
         }
     }
+}
+
+/// Whether an install argument reads as a registry extension id
+/// (`<publisher>.<name>`, lowercase, no path separators) rather than a path.
+fn looks_like_extension_id(raw: &str) -> bool {
+    if raw.contains('/') || raw.contains('\\') {
+        return false;
+    }
+    let Some((publisher, name)) = raw.split_once('.') else {
+        return false;
+    };
+    let ok_publisher = !publisher.is_empty()
+        && publisher.starts_with(|c: char| c.is_ascii_lowercase() || c.is_ascii_digit())
+        && publisher
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+    let ok_name = !name.is_empty()
+        && name.starts_with(|c: char| c.is_ascii_lowercase() || c.is_ascii_digit())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-' || c == '_');
+    ok_publisher && ok_name
 }
 
 /// Resolve a raw CLI path token to an absolute, canonicalized path.
@@ -239,5 +272,44 @@ mod tests {
     #[test]
     fn uninstall_no_id_returns_none() {
         assert!(resolve_cli_request(&argv(&["uninstall"]), "/").is_none());
+    }
+
+    #[test]
+    fn install_registry_id_when_no_such_path() {
+        // "silo.system-monitor" reads as an id and nothing exists at that
+        // relative path → registry install.
+        let req =
+            resolve_cli_request(&argv(&["install", "silo.system-monitor"]), "/no/such/cwd")
+                .unwrap();
+        assert_eq!(req.action, "install");
+        assert_eq!(req.id.unwrap(), "silo.system-monitor");
+        assert!(req.path.is_none());
+    }
+
+    #[test]
+    fn install_existing_path_beats_registry_id() {
+        // A real directory whose name also parses as an id installs as a folder.
+        let dir = std::env::temp_dir().join("acme.clock");
+        std::fs::create_dir_all(&dir).unwrap();
+        let req = resolve_cli_request(
+            &argv(&["install", "acme.clock"]),
+            &std::env::temp_dir().to_string_lossy(),
+        )
+        .unwrap();
+        assert!(req.id.is_none());
+        assert!(req.path.unwrap().ends_with("acme.clock"));
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn looks_like_extension_id_rules() {
+        assert!(looks_like_extension_id("acme.weather"));
+        assert!(looks_like_extension_id("silo.system-monitor"));
+        assert!(looks_like_extension_id("a1.b_c.d"));
+        assert!(!looks_like_extension_id("no-dot"));
+        assert!(!looks_like_extension_id("Acme.weather")); // ids are lowercase
+        assert!(!looks_like_extension_id("./relative.path"));
+        assert!(!looks_like_extension_id("dir/file.ext"));
+        assert!(!looks_like_extension_id(".hidden"));
     }
 }

--- a/apps/desktop/src-tauri/src/commands/install.rs
+++ b/apps/desktop/src-tauri/src/commands/install.rs
@@ -1,16 +1,26 @@
+use sha2::{Digest, Sha256};
 use std::io::Cursor;
 
 /// Download a `.tgz` tarball from `url` and extract its contents into `dest_dir`.
 ///
-/// Used by the extension manager to stage npm and URL installs: the TypeScript
-/// side calls this after resolving the tarball URL, then walks `dest_dir` to
-/// find the extracted `package.json` manifest.
+/// Used by the extension manager to stage npm, URL, and registry installs: the
+/// TypeScript side calls this after resolving the tarball URL, then walks
+/// `dest_dir` to find the extracted `package.json` manifest.
+///
+/// When `expected_sha256` is set (registry installs — the index pins a digest
+/// at ingest, RFC 0014), the downloaded bytes are hashed and a mismatch fails
+/// the install *before* anything is extracted, so a tampered or swapped asset
+/// never reaches disk.
 ///
 /// npm tarballs prefix every path with `package/`, so extraction yields
 /// `dest_dir/package/<files>`. GitHub release tarballs vary by publisher.
 /// The TypeScript install pipeline probes both roots.
 #[tauri::command]
-pub async fn download_extract(url: String, dest_dir: String) -> Result<(), String> {
+pub async fn download_extract(
+    url: String,
+    dest_dir: String,
+    expected_sha256: Option<String>,
+) -> Result<(), String> {
     let response = reqwest::get(&url)
         .await
         .map_err(|e| format!("download failed: {e}"))?;
@@ -27,10 +37,39 @@ pub async fn download_extract(url: String, dest_dir: String) -> Result<(), Strin
         .await
         .map_err(|e| format!("reading response body failed: {e}"))?;
 
+    if let Some(expected) = expected_sha256 {
+        let actual = hex_sha256(&bytes);
+        if !actual.eq_ignore_ascii_case(expected.trim()) {
+            return Err(format!(
+                "integrity check failed: tarball sha256 {actual} does not match the registry's pinned digest {expected} — refusing to install"
+            ));
+        }
+    }
+
     let cursor = Cursor::new(bytes);
     let gz = flate2::read::GzDecoder::new(cursor);
     let mut archive = tar::Archive::new(gz);
     archive
         .unpack(&dest_dir)
         .map_err(|e| format!("extraction failed: {e}"))
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_sha256_matches_known_vector() {
+        // `echo -n silo | shasum -a 256`
+        assert_eq!(
+            hex_sha256(b"silo"),
+            "30ec2f855071fb404f5ced96a5b0743d61a6adeeaacd7c6445240c5d52e18b57"
+        );
+    }
 }

--- a/apps/desktop/src/cli/index.ts
+++ b/apps/desktop/src/cli/index.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import {
   applyCliOpen,
   applyCliInstall,
+  applyCliInstallFromRegistry,
   applyCliUninstall,
   type CliOpenRequest,
 } from "./open-handler";
@@ -11,21 +12,23 @@ import {
  * A resolved CLI request from `src-tauri/src/commands/cli.rs`.
  *
  * - `open` — open a path (dir, file, or missing)
- * - `install` — install an extension from a local folder
+ * - `install` — install an extension: `path` for a local folder, `id` for a
+ *   registry id (`silo install acme.weather`)
  * - `uninstall` — uninstall an extension by id
  */
 type CliRequest =
   | ({ action: "open" } & CliOpenRequest)
-  | { action: "install"; path: string }
+  | { action: "install"; path?: string; id?: string }
   | { action: "uninstall"; id: string };
 
 function dispatch(req: CliRequest): void {
   if (req.action === "open") {
     applyCliOpen(req);
   } else if (req.action === "install") {
-    applyCliInstall(req.path).catch((err) =>
-      console.error("[silo cli] install failed:", err),
-    );
+    const run = req.id
+      ? applyCliInstallFromRegistry(req.id)
+      : applyCliInstall(req.path ?? "");
+    run.catch((err) => console.error("[silo cli] install failed:", err));
   } else if (req.action === "uninstall") {
     applyCliUninstall(req.id).catch((err) =>
       console.error("[silo cli] uninstall failed:", err),

--- a/apps/desktop/src/cli/open-handler.ts
+++ b/apps/desktop/src/cli/open-handler.ts
@@ -102,6 +102,17 @@ export async function applyCliInstall(path: string): Promise<void> {
   await getExtensionManager().installFromFolder(path);
 }
 
+/**
+ * Install an extension by registry id (`silo install acme.weather`). The
+ * tarball is digest-verified against the registry's pinned sha256. Like the
+ * folder path above, an explicit CLI install implies consent — the manifest's
+ * permissions are granted without the UI modal (same contract since the CLI
+ * shipped); they're visible afterward on the Extensions page.
+ */
+export async function applyCliInstallFromRegistry(id: string): Promise<void> {
+  await getExtensionManager().installFromRegistry(id, async () => true);
+}
+
 /** Uninstall an extension by its id (e.g. `"dave.clock"`). */
 export async function applyCliUninstall(id: string): Promise<void> {
   await getExtensionManager().uninstall(id);

--- a/packages/extension-host/src/extension-host/extension-manager.test.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.test.ts
@@ -824,3 +824,134 @@ describe("update", () => {
     );
   });
 });
+
+// ---- registry install + update (RFC 0014) --------------------------------
+
+import { clearRegistryCache } from "./registry-client";
+
+describe("installFromRegistry", () => {
+  /** A registry index whose only entry is acme.x at `version`. */
+  function registryFetch(version: string, sha256: string) {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => ({
+        schemaVersion: 1,
+        name: "test",
+        generatedAt: "",
+        extensions: [
+          {
+            id: "acme.x",
+            description: "x",
+            categories: ["productivity"],
+            repo: "acme/x",
+            status: "active",
+            latest: {
+              version,
+              tarballUrl: `https://github.com/acme/x/releases/download/v${version}/x.tgz`,
+              mirrorUrl: null,
+              sha256,
+              size: 1,
+              engine: null,
+              permissions: ["fs:read"],
+              provenance: "none",
+              publishedAt: "",
+            },
+            totalDownloads: 0,
+            readme: "/readme/acme.x.md",
+            detail: "/ext/acme.x.json",
+          },
+        ],
+      }),
+    });
+  }
+
+  function stageOnDownload() {
+    invokeMock.mockImplementation(
+      async (_cmd: string, args: { destDir?: string }) => {
+        if (args.destDir) {
+          fsMap.set(
+            `${args.destDir}/package/package.json`,
+            manifest(["fs:read"]),
+          );
+          fsMap.set(
+            "/cfg/extensions/acme.x/package.json",
+            manifest(["fs:read"]),
+          );
+        }
+      },
+    );
+  }
+
+  beforeEach(() => {
+    clearRegistryCache();
+  });
+
+  it("passes the pinned digest to download_extract and records the registry source", async () => {
+    global.fetch = registryFetch("1.0.0", "digest-1");
+    stageOnDownload();
+
+    await mgr.installFromRegistry("acme.x", async () => true);
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      "download_extract",
+      expect.objectContaining({
+        url: "https://github.com/acme/x/releases/download/v1.0.0/x.tgz",
+        expectedSha256: "digest-1",
+      }),
+    );
+    expect(installedRecord()).toMatchObject({
+      source: { kind: "registry", value: "acme.x" },
+    });
+  });
+
+  it("rejects ids the registry does not list", async () => {
+    global.fetch = registryFetch("1.0.0", "digest-1");
+    await expect(
+      mgr.installFromRegistry("acme.nope", async () => true),
+    ).rejects.toThrow(/not in the registry/);
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "download_extract",
+      expect.anything(),
+    );
+  });
+
+  it("update() re-resolves a registry source through the index with the new digest", async () => {
+    global.fetch = registryFetch("1.0.0", "digest-1");
+    stageOnDownload();
+    await mgr.installFromRegistry("acme.x", async () => true);
+
+    // A new version lands in the registry.
+    clearRegistryCache();
+    global.fetch = registryFetch("1.1.0", "digest-2");
+
+    await mgr.update("acme.x", async () => true);
+
+    expect(invokeMock).toHaveBeenLastCalledWith(
+      "download_extract",
+      expect.objectContaining({
+        url: "https://github.com/acme/x/releases/download/v1.1.0/x.tgz",
+        expectedSha256: "digest-2",
+      }),
+    );
+  });
+
+  it("checkUpdates surfaces newer registry versions for installed rows", async () => {
+    global.fetch = registryFetch("1.0.0", "digest-1");
+    stageOnDownload();
+    await mgr.installFromRegistry("acme.x", async () => true);
+
+    clearRegistryCache();
+    global.fetch = registryFetch("1.1.0", "digest-2");
+
+    const updates = await mgr.checkUpdates();
+    expect(updates).toEqual([
+      expect.objectContaining({
+        id: "acme.x",
+        installedVersion: "1.0.0",
+        latestVersion: "1.1.0",
+      }),
+    ]);
+  });
+});

--- a/packages/extension-host/src/extension-host/extension-manager.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.ts
@@ -37,6 +37,12 @@ import {
 } from "./builtins-registry";
 import { appVersion } from "../services/tauri-app";
 import { isEngineCompatible } from "./engine-compat";
+import {
+  fetchRegistryIndex,
+  findUpdates,
+  resolveRegistryInstall,
+  type RegistryUpdate,
+} from "./registry-client";
 import type { Disposable, Permission } from "@silo-code/sdk";
 import type { ReactiveService } from "@silo-code/sdk";
 
@@ -83,11 +89,13 @@ export function validateManifestPermissions(
  * re-fetch the same package later without an uninstall/reinstall round-trip.
  */
 export interface InstallSource {
-  kind: "folder" | "url" | "npm";
+  kind: "folder" | "url" | "npm" | "registry";
   /**
    * `folder`: absolute path to the source folder; `url`: the tarball URL;
    * `npm`: the original spec as typed (`"pkg"` or `"@scope/pkg@1.2.0"`), so an
-   * unpinned spec re-resolves to latest on update while a pinned one stays pinned.
+   * unpinned spec re-resolves to latest on update while a pinned one stays
+   * pinned; `registry`: the extension id, re-resolved against the registry
+   * index (with its pinned digest) on update.
    */
   value: string;
 }
@@ -204,7 +212,31 @@ export interface ExtensionManager extends ReactiveService<ExtensionManagerState>
     url: string,
     requestConsent: (preview: ManifestPreview) => Promise<boolean>,
     source?: InstallSource,
+    expectedSha256?: string,
   ): Promise<void>;
+  /**
+   * Install an extension by id from the Silo Extension Registry (RFC 0014):
+   * resolve the id against the registry index, download the pinned tarball,
+   * **verify its sha256 against the digest the registry recorded at ingest**
+   * (a swapped or tampered asset fails before extraction), then run the
+   * standard consent + install pipeline. Records `{ kind: "registry" }` as the
+   * install source so updates re-resolve (and re-verify) through the index.
+   */
+  installFromRegistry(
+    id: string,
+    requestConsent: (preview: ManifestPreview) => Promise<boolean>,
+  ): Promise<void>;
+  /**
+   * Diff installed registry-sourced extensions against the registry index and
+   * return the available updates. Cheap to poll: the index fetch is
+   * ETag-conditional, so the steady state is a zero-body 304.
+   */
+  checkUpdates(): Promise<RegistryUpdate[]>;
+  /**
+   * The README.md shipped inside an installed extension's package (npm pack
+   * always includes it), for the detail view. `null` when absent.
+   */
+  readInstalledReadme(id: string): Promise<string | null>;
   /**
    * Update an installed extension in place from its recorded
    * {@link InstallSource}: re-fetch the package (folder: re-copy; url/npm:
@@ -530,12 +562,23 @@ export async function resolveNpmTarball(packageName: string): Promise<string> {
   return versionData.dist.tarball;
 }
 
-/** Extract the tarball from `url` into a unique temp dir, return the staging dir path. */
-async function stageFromUrl(url: string): Promise<string> {
+/**
+ * Extract the tarball from `url` into a unique temp dir, return the staging dir
+ * path. With `expectedSha256` (registry installs), the host verifies the
+ * downloaded bytes against the pinned digest before extracting anything.
+ */
+async function stageFromUrl(
+  url: string,
+  expectedSha256?: string,
+): Promise<string> {
   const tmp = await tempDir();
   const stagingDir = `${tmp}silo-install-${Date.now()}`;
   await fsCreateDir(stagingDir);
-  await invoke("download_extract", { url, destDir: stagingDir });
+  await invoke("download_extract", {
+    url,
+    destDir: stagingDir,
+    expectedSha256,
+  });
   return stagingDir;
 }
 
@@ -738,8 +781,8 @@ export function getExtensionManager(): ExtensionManager {
       });
     },
 
-    async installFromUrl(url, requestConsent, source) {
-      const stagingDir = await stageFromUrl(url);
+    async installFromUrl(url, requestConsent, source, expectedSha256) {
+      const stagingDir = await stageFromUrl(url, expectedSha256);
       try {
         const pkgRoot = await findPackageRoot(stagingDir);
         const preview = await service!.previewInstall(pkgRoot);
@@ -752,6 +795,31 @@ export function getExtensionManager(): ExtensionManager {
       } finally {
         await fsDelete(stagingDir).catch(() => {});
       }
+    },
+
+    async installFromRegistry(id, requestConsent) {
+      const index = await fetchRegistryIndex();
+      const release = resolveRegistryInstall(index, id);
+      await service!.installFromUrl(
+        release.url,
+        requestConsent,
+        { kind: "registry", value: id },
+        release.sha256,
+      );
+    },
+
+    async checkUpdates() {
+      const index = await fetchRegistryIndex();
+      return findUpdates(cached.extensions, index);
+    },
+
+    async readInstalledReadme(id) {
+      const rec = (await readInstalledFile()).extensions.find(
+        (e) => e.id === id,
+      );
+      if (!rec) return null;
+      const root = await extensionsRoot();
+      return fsReadText(`${root}/${rec.dir}/README.md`).catch(() => null);
     },
 
     async update(id, requestConsent) {
@@ -776,6 +844,15 @@ export function getExtensionManager(): ExtensionManager {
         if (!(await fsPathExists(`${pkgRoot}/package.json`))) {
           throw new Error(`Source folder no longer exists: ${pkgRoot}`);
         }
+      } else if (rec.source.kind === "registry") {
+        // Re-resolve through the index so the update gets the current pinned
+        // digest and is verified the same way the original install was.
+        const release = resolveRegistryInstall(
+          await fetchRegistryIndex(),
+          rec.source.value,
+        );
+        stagingDir = await stageFromUrl(release.url, release.sha256);
+        pkgRoot = await findPackageRoot(stagingDir);
       } else {
         const url =
           rec.source.kind === "npm"

--- a/packages/extension-host/src/extension-host/registry-client.test.ts
+++ b/packages/extension-host/src/extension-host/registry-client.test.ts
@@ -1,0 +1,228 @@
+// Covers the registry client: index parsing (defensive against malformed
+// entries), ETag caching, install resolution (mirror fallback, removed/
+// unreleased errors), semver compare, and the update diff.
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  clearRegistryCache,
+  compareVersions,
+  fetchRegistryIndex,
+  findUpdates,
+  parseRegistryIndex,
+  registryReadmeUrl,
+  resolveRegistryInstall,
+  type RegistryIndex,
+} from "./registry-client";
+import type { InstalledExtension } from "./extension-manager";
+
+const latest = (version: string, extra: Record<string, unknown> = {}) => ({
+  version,
+  tarballUrl: `https://github.com/acme/x/releases/download/v${version}/x.tgz`,
+  mirrorUrl: null,
+  sha256: "abc123",
+  size: 10,
+  engine: "^0.17.0",
+  permissions: ["network"],
+  provenance: "none",
+  publishedAt: "2026-07-13T00:00:00Z",
+  ...extra,
+});
+
+const entry = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  description: `${id} does things`,
+  categories: ["productivity"],
+  repo: `acme/${id.split(".")[1]}`,
+  status: "active",
+  latest: latest("1.2.0"),
+  totalDownloads: 5,
+  readme: `/readme/${id}.md`,
+  detail: `/ext/${id}.json`,
+  ...extra,
+});
+
+function index(extensions: unknown[]): RegistryIndex {
+  return parseRegistryIndex({
+    schemaVersion: 1,
+    name: "test",
+    generatedAt: "2026-07-13T00:00:00Z",
+    extensions,
+  });
+}
+
+const row = (over: Partial<InstalledExtension>): InstalledExtension => ({
+  id: "acme.weather",
+  name: "Weather",
+  version: "1.0.0",
+  publisher: "acme",
+  enabled: true,
+  loaded: true,
+  builtin: false,
+  permissions: ["network"],
+  hostVersion: "1.0.0",
+  engineCompatible: true,
+  source: { kind: "registry", value: "acme.weather" },
+  ...over,
+});
+
+describe("parseRegistryIndex", () => {
+  it("parses valid entries and defaults optional fields", () => {
+    const idx = index([entry("acme.weather")]);
+    expect(idx.extensions).toHaveLength(1);
+    expect(idx.extensions[0].latest?.version).toBe("1.2.0");
+    expect(idx.extensions[0].status).toBe("active");
+  });
+
+  it("drops malformed entries instead of failing the catalog", () => {
+    const idx = index([
+      entry("acme.weather"),
+      { id: 42 },
+      "garbage",
+      entry("acme.clock", { latest: { version: "1.0.0" } }), // missing tarball/sha → latest null
+    ]);
+    expect(idx.extensions.map((e) => e.id)).toEqual([
+      "acme.weather",
+      "acme.clock",
+    ]);
+    expect(idx.extensions[1].latest).toBeNull();
+  });
+
+  it("throws when there is no extensions array at all", () => {
+    expect(() => parseRegistryIndex({})).toThrow(/malformed/);
+    expect(() => parseRegistryIndex(null)).toThrow(/malformed/);
+  });
+});
+
+describe("fetchRegistryIndex (ETag cache)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    clearRegistryCache();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("caches by ETag and serves the cached index on 304", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ etag: '"v1"' }),
+      json: async () => ({ extensions: [entry("acme.weather")] }),
+    });
+    const first = await fetchRegistryIndex("https://r.example");
+    expect(first.extensions).toHaveLength(1);
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 304,
+      headers: new Headers(),
+    });
+    const second = await fetchRegistryIndex("https://r.example");
+    expect(second).toBe(first);
+    expect(fetchMock.mock.calls[1][1].headers["if-none-match"]).toBe('"v1"');
+  });
+
+  it("throws a readable error on HTTP failure", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+    });
+    await expect(fetchRegistryIndex("https://r.example")).rejects.toThrow(
+      /HTTP 500/,
+    );
+  });
+});
+
+describe("resolveRegistryInstall", () => {
+  it("resolves the pinned tarball for an active extension", () => {
+    const r = resolveRegistryInstall(
+      index([entry("acme.weather")]),
+      "acme.weather",
+    );
+    expect(r).toEqual({
+      url: "https://github.com/acme/x/releases/download/v1.2.0/x.tgz",
+      sha256: "abc123",
+      version: "1.2.0",
+    });
+  });
+
+  it("falls back to the mirror when the upstream is unavailable", () => {
+    const idx = index([
+      entry("acme.weather", {
+        status: "unavailable",
+        latest: latest("1.2.0", { mirrorUrl: "https://mirror.example/x.tgz" }),
+      }),
+    ]);
+    expect(resolveRegistryInstall(idx, "acme.weather").url).toBe(
+      "https://mirror.example/x.tgz",
+    );
+  });
+
+  it("errors for unknown, removed, and unreleased extensions", () => {
+    const idx = index([
+      entry("acme.removed", { status: "removed" }),
+      entry("acme.unreleased", { latest: null }),
+    ]);
+    expect(() => resolveRegistryInstall(idx, "acme.nope")).toThrow(
+      /not in the registry/,
+    );
+    expect(() => resolveRegistryInstall(idx, "acme.removed")).toThrow(
+      /removed/,
+    );
+    expect(() => resolveRegistryInstall(idx, "acme.unreleased")).toThrow(
+      /no published release/,
+    );
+  });
+});
+
+describe("compareVersions", () => {
+  it("orders semver correctly, prereleases before releases", () => {
+    expect(compareVersions("0.10.0", "0.9.9")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0-beta", "1.0.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+  });
+});
+
+describe("findUpdates", () => {
+  it("reports a newer registry version, with permission-widening flagged", () => {
+    const idx = index([
+      entry("acme.weather", {
+        latest: latest("1.1.0", { permissions: ["network", "fs:write"] }),
+      }),
+    ]);
+    const updates = findUpdates([row({})], idx);
+    expect(updates).toEqual([
+      {
+        id: "acme.weather",
+        name: "Weather",
+        installedVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        widensPermissions: true,
+      },
+    ]);
+  });
+
+  it("is quiet when up to date, and ignores non-registry sources", () => {
+    const idx = index([entry("acme.weather", { latest: latest("1.0.0") })]);
+    expect(findUpdates([row({})], idx)).toEqual([]);
+    // Newer version exists, but the row came from a folder → no upstream.
+    const newer = index([entry("acme.weather", { latest: latest("2.0.0") })]);
+    expect(
+      findUpdates([row({ source: { kind: "folder", value: "/src" } })], newer),
+    ).toEqual([]);
+    // Registry row that the index no longer lists → nothing to offer.
+    expect(findUpdates([row({})], index([]))).toEqual([]);
+  });
+});
+
+describe("registryReadmeUrl", () => {
+  it("joins the registry base with the entry's readme path", () => {
+    expect(
+      registryReadmeUrl({ readme: "/readme/a.b.md" }, "https://r.example"),
+    ).toBe("https://r.example/readme/a.b.md");
+  });
+});

--- a/packages/extension-host/src/extension-host/registry-client.ts
+++ b/packages/extension-host/src/extension-host/registry-client.ts
@@ -1,0 +1,261 @@
+/**
+ * Client for the Silo Extension Registry (RFC 0014) — the static JSON index
+ * at `registry.getsilo.dev`. The registry is data, not a service: this module
+ * fetches `index.json` (ETag-cached, so steady-state polls are 304s), resolves
+ * ids to digest-pinned tarballs for {@link ExtensionManager.installFromRegistry},
+ * and diffs installed versions against the index for update checking.
+ *
+ * Exposed only via `@silo-code/extension-host/internal` (core-tier).
+ *
+ * @internal
+ */
+import type { Permission } from "@silo-code/sdk";
+import type { InstalledExtension } from "./extension-manager";
+
+/** The official registry. Federated/private registries (P3) are other base URLs. */
+export const DEFAULT_REGISTRY_URL = "https://registry.getsilo.dev";
+
+/**
+ * The registry base URL in effect: the `silo.registryUrl` localStorage key
+ * overrides the default (a dev/testing hatch — point the app at a local
+ * `build-index` output; multi-registry settings are the real mechanism, P3).
+ */
+export function registryBaseUrl(): string {
+  try {
+    return localStorage.getItem("silo.registryUrl") ?? DEFAULT_REGISTRY_URL;
+  } catch {
+    return DEFAULT_REGISTRY_URL;
+  }
+}
+
+/** The pinned, installable release of an extension, as recorded at ingest. */
+export interface RegistryVersionInfo {
+  version: string;
+  tarballUrl: string;
+  /** Availability fallback copy (P2 mirror); null until mirrored. */
+  mirrorUrl: string | null;
+  /** The digest pinned at ingest — verified before install. */
+  sha256: string;
+  size: number;
+  engine: string | null;
+  permissions: Permission[];
+  provenance: "attested" | "none";
+  publishedAt: string;
+}
+
+/** One extension in the registry index. */
+export interface RegistryExtension {
+  id: string;
+  description: string;
+  categories: string[];
+  /** The bound GitHub repo (`owner/name`) — identity, per the namespace rule. */
+  repo: string;
+  /** `unavailable`/`removed` = the upstream repo or assets have gone away. */
+  status: "active" | "unavailable" | "removed";
+  /** Newest non-yanked version; null when nothing has been released yet. */
+  latest: RegistryVersionInfo | null;
+  totalDownloads: number;
+  /** Registry-relative path of the version-pinned README (markdown). */
+  readme: string;
+  /** Registry-relative path of the full version-history record. */
+  detail: string;
+}
+
+export interface RegistryIndex {
+  schemaVersion: number;
+  name: string;
+  generatedAt: string;
+  extensions: RegistryExtension[];
+}
+
+/** An available update for an installed registry-sourced extension. */
+export interface RegistryUpdate {
+  id: string;
+  name: string;
+  installedVersion: string;
+  latestVersion: string;
+  /**
+   * The new version requests permissions beyond the granted set — the update
+   * will re-prompt for consent (see `updateNeedsConsent`).
+   */
+  widensPermissions: boolean;
+}
+
+/**
+ * Parse and defensively validate a fetched index. Malformed entries are
+ * dropped rather than failing the whole catalog — one bad record must not
+ * take Browse down.
+ */
+export function parseRegistryIndex(raw: unknown): RegistryIndex {
+  const obj = raw as Partial<RegistryIndex> | null;
+  if (!obj || typeof obj !== "object" || !Array.isArray(obj.extensions)) {
+    throw new Error("registry index is malformed (no extensions array)");
+  }
+  const extensions: RegistryExtension[] = [];
+  for (const e of obj.extensions as Partial<RegistryExtension>[]) {
+    if (
+      typeof e?.id !== "string" ||
+      typeof e.description !== "string" ||
+      typeof e.repo !== "string" ||
+      !Array.isArray(e.categories)
+    ) {
+      continue;
+    }
+    const l = e.latest as Partial<RegistryVersionInfo> | null | undefined;
+    const latest =
+      l &&
+      typeof l.version === "string" &&
+      typeof l.tarballUrl === "string" &&
+      typeof l.sha256 === "string"
+        ? ({
+            version: l.version,
+            tarballUrl: l.tarballUrl,
+            mirrorUrl: typeof l.mirrorUrl === "string" ? l.mirrorUrl : null,
+            sha256: l.sha256,
+            size: typeof l.size === "number" ? l.size : 0,
+            engine: typeof l.engine === "string" ? l.engine : null,
+            permissions: Array.isArray(l.permissions)
+              ? (l.permissions as Permission[])
+              : [],
+            provenance: l.provenance === "attested" ? "attested" : "none",
+            publishedAt: typeof l.publishedAt === "string" ? l.publishedAt : "",
+          } satisfies RegistryVersionInfo)
+        : null;
+    extensions.push({
+      id: e.id,
+      description: e.description,
+      categories: e.categories.filter(
+        (c): c is string => typeof c === "string",
+      ),
+      repo: e.repo,
+      status:
+        e.status === "unavailable" || e.status === "removed"
+          ? e.status
+          : "active",
+      latest,
+      totalDownloads:
+        typeof e.totalDownloads === "number" ? e.totalDownloads : 0,
+      readme: typeof e.readme === "string" ? e.readme : `/readme/${e.id}.md`,
+      detail: typeof e.detail === "string" ? e.detail : `/ext/${e.id}.json`,
+    });
+  }
+  return {
+    schemaVersion:
+      typeof obj.schemaVersion === "number" ? obj.schemaVersion : 1,
+    name: typeof obj.name === "string" ? obj.name : "registry",
+    generatedAt: typeof obj.generatedAt === "string" ? obj.generatedAt : "",
+    extensions,
+  };
+}
+
+// ETag cache per base URL: steady-state re-fetches are zero-body 304s.
+const cache = new Map<string, { etag: string | null; index: RegistryIndex }>();
+
+/** Fetch (or revalidate) the registry index. */
+export async function fetchRegistryIndex(
+  baseUrl: string = registryBaseUrl(),
+): Promise<RegistryIndex> {
+  const cached = cache.get(baseUrl);
+  const headers: Record<string, string> = {};
+  if (cached?.etag) headers["if-none-match"] = cached.etag;
+
+  const resp = await fetch(`${baseUrl}/index.json`, { headers });
+  if (resp.status === 304 && cached) return cached.index;
+  if (!resp.ok) {
+    throw new Error(`registry ${baseUrl} → HTTP ${resp.status}`);
+  }
+  const index = parseRegistryIndex(await resp.json());
+  cache.set(baseUrl, { etag: resp.headers.get("etag"), index });
+  return index;
+}
+
+/** Test hook: drop the ETag cache. @internal */
+export function clearRegistryCache(): void {
+  cache.clear();
+}
+
+/** Absolute URL of an extension's README on the registry. */
+export function registryReadmeUrl(
+  ext: Pick<RegistryExtension, "readme">,
+  baseUrl: string = registryBaseUrl(),
+): string {
+  return `${baseUrl}${ext.readme}`;
+}
+
+/**
+ * Resolve an id to its installable release: the pinned tarball URL + digest.
+ * Throws with a user-facing message when the extension is unknown, has no
+ * release, or has been removed from the registry.
+ */
+export function resolveRegistryInstall(
+  index: RegistryIndex,
+  id: string,
+): { url: string; sha256: string; version: string } {
+  const ext = index.extensions.find((e) => e.id === id);
+  if (!ext) {
+    throw new Error(`"${id}" is not in the registry.`);
+  }
+  if (ext.status === "removed") {
+    throw new Error(`"${id}" has been removed from the registry.`);
+  }
+  if (!ext.latest) {
+    throw new Error(`"${id}" has no published release yet.`);
+  }
+  // Prefer the publisher's asset; fall back to the registry mirror when the
+  // upstream has gone away (both carry the same pinned digest).
+  const url =
+    ext.status === "unavailable" && ext.latest.mirrorUrl
+      ? ext.latest.mirrorUrl
+      : ext.latest.tarballUrl;
+  return { url, sha256: ext.latest.sha256, version: ext.latest.version };
+}
+
+/**
+ * Compare exact semver strings (`x.y.z` with optional prerelease); prereleases
+ * sort before their release. Non-semver input falls back to string compare.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) =>
+    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(v);
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return a.localeCompare(b);
+  for (let i = 1; i <= 3; i++) {
+    const d = Number(pa[i]) - Number(pb[i]);
+    if (d !== 0) return d;
+  }
+  const [preA, preB] = [pa[4], pb[4]];
+  if (preA === preB) return 0;
+  if (preA === undefined) return 1;
+  if (preB === undefined) return -1;
+  return preA.localeCompare(preB);
+}
+
+/**
+ * Diff installed registry-sourced extensions against the index. Only rows
+ * installed from the registry are considered (folder/URL installs have no
+ * upstream; npm installs re-resolve through npm in `update()`).
+ */
+export function findUpdates(
+  extensions: readonly InstalledExtension[],
+  index: RegistryIndex,
+): RegistryUpdate[] {
+  const updates: RegistryUpdate[] = [];
+  for (const ext of extensions) {
+    if (ext.source?.kind !== "registry") continue;
+    const entry = index.extensions.find((e) => e.id === ext.id);
+    const latest = entry?.latest;
+    if (!latest) continue;
+    if (compareVersions(latest.version, ext.version) <= 0) continue;
+    updates.push({
+      id: ext.id,
+      name: ext.name,
+      installedVersion: ext.version,
+      latestVersion: latest.version,
+      widensPermissions: latest.permissions.some(
+        (p) => !ext.permissions.includes(p),
+      ),
+    });
+  }
+  return updates;
+}

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -72,6 +72,19 @@ export type {
   ManifestPreview,
 } from "./extension-manager";
 export { getExtensionManager } from "./extension-manager";
+// The registry client — browse/search data for the manager page and id → pinned
+// tarball resolution. Same core-only rationale as the manager it feeds.
+export type {
+  RegistryExtension,
+  RegistryIndex,
+  RegistryUpdate,
+  RegistryVersionInfo,
+} from "./registry-client";
+export {
+  DEFAULT_REGISTRY_URL,
+  fetchRegistryIndex,
+  registryReadmeUrl,
+} from "./registry-client";
 // The rail group the manager page shares with all non-core settings pages, so
 // the manager declares the same key the host forces non-core pages into.
 export { EXTENSIONS_SETTINGS_GROUP } from "./settings-pages";

--- a/packages/extensions-core/package.json
+++ b/packages/extensions-core/package.json
@@ -24,6 +24,7 @@
     "monaco-editor": "^0.55.1",
     "react": "^19.1.0",
     "react-colorful": "^5.7.0",
+    "react-markdown": "^10.1.0",
     "react-dom": "^19.1.0",
     "valtio": "^2.3.2"
   },

--- a/packages/extensions-core/src/extensions/ExtensionDetail.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionDetail.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from "react";
+import Markdown from "react-markdown";
+import { ArrowLeft, SealCheck } from "@phosphor-icons/react";
+import type { ExtensionContext } from "@silo-code/sdk";
+import {
+  getExtensionManager,
+  registryReadmeUrl,
+  type InstalledExtension,
+  type RegistryExtension,
+  type RegistryUpdate,
+} from "@silo-code/extension-host/internal";
+
+const mgr = getExtensionManager();
+
+export interface ExtensionDetailProps {
+  ctx: ExtensionContext;
+  /** The id being shown; at least one of the two records below exists. */
+  id: string;
+  registryEntry?: RegistryExtension;
+  installed?: InstalledExtension;
+  update?: RegistryUpdate;
+  busy: boolean;
+  onBack: () => void;
+  onInstall: () => void;
+  onUpdate: () => void;
+  onToggle: () => void;
+  onUninstall: () => void;
+}
+
+/**
+ * Drill-in detail for one extension — works for both worlds: a registry entry
+ * (Browse), an installed extension, or both at once. Shows the header facts,
+ * the action that makes sense for the current state, and the README (the
+ * local copy for installed extensions, the registry's version-pinned copy
+ * otherwise).
+ */
+export function ExtensionDetail({
+  ctx,
+  id,
+  registryEntry,
+  installed,
+  update,
+  busy,
+  onBack,
+  onInstall,
+  onUpdate,
+  onToggle,
+  onUninstall,
+}: ExtensionDetailProps) {
+  const [readme, setReadme] = useState<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    setReadme(undefined);
+    const load = async (): Promise<string | null> => {
+      if (installed) return mgr.readInstalledReadme(id);
+      if (registryEntry) {
+        const resp = await fetch(registryReadmeUrl(registryEntry));
+        return resp.ok ? resp.text() : null;
+      }
+      return null;
+    };
+    load()
+      .then((text) => {
+        if (!cancelled) setReadme(text);
+      })
+      .catch(() => {
+        if (!cancelled) setReadme(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, installed !== undefined, registryEntry !== undefined]);
+
+  const name = installed?.name ?? id;
+  const description = installed?.description ?? registryEntry?.description;
+  const version = installed?.version ?? registryEntry?.latest?.version;
+  const permissions =
+    installed?.permissions ?? registryEntry?.latest?.permissions ?? [];
+  const attested = registryEntry?.latest?.provenance === "attested";
+  const repo = registryEntry?.repo;
+
+  return (
+    <div className="ext-detail">
+      <button className="ext-btn ext-detail-back" onClick={onBack}>
+        <ArrowLeft size={13} /> Extensions
+      </button>
+
+      <div className="ext-detail-head">
+        <div className="ext-detail-title">
+          <span className="ext-label">
+            {name}
+            <span className="ext-brand">
+              {installed?.publisher ?? id.split(".")[0]}
+            </span>
+            {version && <span className="ext-version">v{version}</span>}
+            {installed?.builtin && (
+              <span className="ext-badge-builtin">Built-in</span>
+            )}
+            {installed && !installed.enabled && (
+              <span className="ext-badge">disabled</span>
+            )}
+            {attested && (
+              <span
+                className="ext-badge-verified"
+                title="Build provenance verified: this package was built from its repo by CI"
+              >
+                <SealCheck size={12} weight="fill" /> verified build
+              </span>
+            )}
+          </span>
+          {description && <span className="ext-hint">{description}</span>}
+          {registryEntry?.status === "unavailable" && (
+            <span className="ext-hint ext-hint-warn">
+              The source repository is no longer reachable — installed copies
+              keep working, but updates may fail.
+            </span>
+          )}
+        </div>
+
+        <div className="ext-actions">
+          {!installed && registryEntry?.latest && (
+            <button className="ext-btn" onClick={onInstall} disabled={busy}>
+              Install
+            </button>
+          )}
+          {installed && update && (
+            <button className="ext-btn" onClick={onUpdate} disabled={busy}>
+              Update to v{update.latestVersion}
+            </button>
+          )}
+          {installed && (
+            <button className="ext-btn" onClick={onToggle} disabled={busy}>
+              {installed.enabled ? "Disable" : "Enable"}
+            </button>
+          )}
+          {installed && !installed.builtin && (
+            <button className="ext-btn" onClick={onUninstall} disabled={busy}>
+              Uninstall
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="ext-detail-meta">
+        <span className="ext-hint">
+          Permissions:{" "}
+          {permissions.length > 0 ? permissions.join(", ") : "none"}
+        </span>
+        {update?.widensPermissions && (
+          <span className="ext-hint ext-hint-warn">
+            The update requests new permissions — you&rsquo;ll be asked to
+            approve them.
+          </span>
+        )}
+        {registryEntry && (
+          <span className="ext-hint">
+            {registryEntry.totalDownloads} downloads ·{" "}
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                void ctx.ui.openExternal(`https://github.com/${repo}`);
+              }}
+            >
+              {repo}
+            </a>
+          </span>
+        )}
+      </div>
+
+      <div className="ext-detail-readme">
+        {readme === undefined ? (
+          <span className="ext-hint">Loading README…</span>
+        ) : readme === null ? (
+          <span className="ext-hint">No README available.</span>
+        ) : (
+          <Markdown
+            components={{
+              // READMEs are untrusted: raw HTML is already not rendered by
+              // react-markdown; links route through the host's opener rather
+              // than navigating the webview.
+              a: ({ href, children }) => (
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    if (href) void ctx.ui.openExternal(href);
+                  }}
+                >
+                  {children}
+                </a>
+              ),
+              img: ({ src, alt }) =>
+                typeof src === "string" && /^https?:\/\//.test(src) ? (
+                  <img src={src} alt={alt ?? ""} />
+                ) : null,
+            }}
+          >
+            {readme}
+          </Markdown>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-core/src/extensions/ExtensionsPage.css
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.css
@@ -231,3 +231,201 @@
   display: flex;
   align-items: center;
 }
+
+/* ---- Browse / Installed tabs (registry is the primary surface) ---------- */
+
+.ext-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--silo-color-bg-active);
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm);
+  padding: 2px;
+}
+.ext-tab {
+  background: transparent;
+  border: none;
+  color: var(--silo-color-text-lo);
+  padding: 3px 10px;
+  border-radius: var(--silo-radius-sm);
+  cursor: pointer;
+  font: inherit;
+  font-size: calc(var(--settings-font) - 1px);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ext-tab-active {
+  background: var(--silo-color-bg-hover);
+  color: var(--silo-color-text-hi);
+}
+.ext-update-count {
+  font-size: calc(var(--settings-font) - 3px);
+  color: var(--silo-color-accent);
+  background: color-mix(in srgb, var(--silo-color-accent) 14%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--silo-color-accent) 35%, transparent);
+  border-radius: 999px;
+  padding: 0 5px;
+  line-height: 1.4;
+}
+
+/* Category facet chips on the Browse view. */
+.ext-cats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.ext-cat {
+  background: transparent;
+  border: 1px solid var(--silo-color-border);
+  color: var(--silo-color-text-lo);
+  padding: 1px 8px;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  font-size: calc(var(--settings-font) - 2px);
+  font-family: var(--silo-font-mono, monospace);
+}
+.ext-cat:hover {
+  color: var(--silo-color-text-hi);
+}
+.ext-cat-active {
+  color: var(--silo-color-accent);
+  border-color: var(--silo-color-accent);
+}
+
+/* Rows double as drill-in targets on both views. */
+.ext-row-click {
+  cursor: pointer;
+}
+.ext-row-click:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+.ext-badge-verified {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: calc(var(--settings-font) - 2px);
+  color: var(--silo-color-ok);
+  background: color-mix(in srgb, var(--silo-color-ok) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--silo-color-ok) 35%, transparent);
+  border-radius: var(--silo-radius-sm);
+  padding: 0 5px;
+}
+
+/* Search + built-in toggle + Update all, on one line above the installed list. */
+.ext-installed-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.ext-installed-bar .ext-search {
+  flex: 1 1 auto;
+  width: auto;
+}
+
+/* ---- Detail drill-in ----------------------------------------------------- */
+
+.ext-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+.ext-detail-back {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.ext-detail-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.ext-detail-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.ext-detail-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--silo-color-border);
+}
+.ext-detail-meta a {
+  color: var(--silo-color-accent);
+  text-decoration: none;
+}
+.ext-detail-meta a:hover {
+  text-decoration: underline;
+}
+
+/* The README scrolls on its own; keep it readable but clearly subordinate. */
+.ext-detail-readme {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
+  color: var(--silo-color-text-hi);
+  font-size: calc(var(--settings-font) - 1px);
+  line-height: 1.55;
+}
+.ext-detail-readme h1,
+.ext-detail-readme h2,
+.ext-detail-readme h3 {
+  color: var(--silo-color-text-hi);
+  margin: 0.9em 0 0.35em;
+}
+.ext-detail-readme h1 {
+  font-size: 1.25em;
+}
+.ext-detail-readme h2 {
+  font-size: 1.1em;
+}
+.ext-detail-readme h3 {
+  font-size: 1em;
+}
+.ext-detail-readme p,
+.ext-detail-readme ul,
+.ext-detail-readme ol {
+  margin: 0.4em 0;
+}
+.ext-detail-readme code {
+  font-family: var(--silo-font-mono, monospace);
+  font-size: 0.92em;
+  background: var(--silo-color-bg-active);
+  border-radius: var(--silo-radius-sm);
+  padding: 0.1em 0.35em;
+}
+.ext-detail-readme pre {
+  background: var(--silo-color-bg-active);
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm);
+  padding: 8px 10px;
+  overflow-x: auto;
+}
+.ext-detail-readme pre code {
+  background: none;
+  padding: 0;
+}
+.ext-detail-readme img {
+  max-width: 100%;
+}
+.ext-detail-readme a {
+  color: var(--silo-color-accent);
+}
+.ext-detail-readme table {
+  border-collapse: collapse;
+}
+.ext-detail-readme th,
+.ext-detail-readme td {
+  border: 1px solid var(--silo-color-border);
+  padding: 3px 8px;
+}

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -1,18 +1,23 @@
-import { useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import {
   ArrowsClockwise,
   DotsThreeVertical,
   Folder,
   LinkSimple,
   Package,
+  SealCheck,
+  Storefront,
 } from "@phosphor-icons/react";
 import type { ExtensionContext, MenuEntry } from "@silo-code/sdk";
 import { useServiceState } from "@silo-code/sdk";
 import {
   getExtensionManager,
+  fetchRegistryIndex,
   type InstallSource,
   type InstalledExtension,
   type ManifestPreview,
+  type RegistryExtension,
+  type RegistryUpdate,
 } from "@silo-code/extension-host/internal";
 import { PermissionConsent } from "./PermissionConsent";
 import {
@@ -22,35 +27,83 @@ import {
   showsReloadHint,
   showsUpdateAction,
 } from "./extensions-list-model";
+import {
+  browseInstallState,
+  filterRegistry,
+  isInstallable,
+  registryCategories,
+} from "./browse-model";
+import { ExtensionDetail } from "./ExtensionDetail";
 import "./ExtensionsPage.css";
 
 const mgr = getExtensionManager();
 
-// The label prefix ("Folder: ", "URL: ", "npm: ") is redundant once the kind
-// is legible at a glance — an icon says the same thing in less width, leaving
-// more room for the (often long) path/URL itself.
+// The label prefix ("Folder: ", "URL: ", …) is redundant once the kind is
+// legible at a glance — an icon says the same thing in less width, leaving
+// more room for the (often long) path/URL/id itself.
 const SOURCE_ICON: Record<InstallSource["kind"], typeof Folder> = {
   folder: Folder,
   url: LinkSimple,
   npm: Package,
+  registry: Storefront,
 };
+
+/** Which pane the page is showing. Browse (the registry) is the landing view. */
+type View =
+  | { kind: "browse" }
+  | { kind: "installed" }
+  | { kind: "detail"; id: string; from: "browse" | "installed" };
+
+type RegistryState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; entries: RegistryExtension[] };
 
 /**
  * Factory: the Extensions settings page closes over `ctx` so it can drive the
- * native folder picker, confirm dialogs, and toasts. Structure mirrors the
- * Editor / Keyboard Shortcuts pages (header + flat list).
+ * native folder picker, confirm dialogs, and toasts. The registry Browse view
+ * is the primary surface (RFC 0014); folder/URL/npm installs live behind the
+ * page-level overflow menu.
  */
 export function makeExtensionsPage(ctx: ExtensionContext) {
   return function ExtensionsPage() {
     const { extensions } = useServiceState(mgr);
     const [busy, setBusy] = useState<string | null>(null);
+    const [view, setView] = useState<View>({ kind: "browse" });
     const [query, setQuery] = useState("");
+    const [browseQuery, setBrowseQuery] = useState("");
+    const [category, setCategory] = useState("");
     const [showBuiltins, setShowBuiltins] = useState(false);
+    const [registry, setRegistry] = useState<RegistryState>({
+      status: "loading",
+    });
+    const [updates, setUpdates] = useState<RegistryUpdate[]>([]);
+
+    // One index fetch feeds both the catalog and the update check; the fetch
+    // is ETag-conditional so re-opening the page is a zero-body 304.
+    async function loadRegistry() {
+      setRegistry({ status: "loading" });
+      try {
+        const index = await fetchRegistryIndex();
+        setRegistry({ status: "ready", entries: index.extensions });
+        setUpdates(await mgr.checkUpdates());
+      } catch (err) {
+        setRegistry({
+          status: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    useEffect(() => {
+      void loadRegistry();
+    }, []);
 
     const visible = filterExtensions(extensions, { query, showBuiltins });
     const builtinsPresent = hasBuiltins(extensions);
-    const [installInput, setInstallInput] = useState("");
-    const installInputRef = useRef<HTMLInputElement>(null);
+    const catalog =
+      registry.status === "ready"
+        ? filterRegistry(registry.entries, { query: browseQuery, category })
+        : [];
 
     async function run(key: string, fn: () => Promise<void>) {
       setBusy(key);
@@ -91,10 +144,22 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       );
     }
 
+    function installFromRegistry(id: string) {
+      void run(id, async () => {
+        await mgr.installFromRegistry(id, requestConsent);
+        setUpdates(await mgr.checkUpdates().catch(() => []));
+        ctx.ui.notify("info", `Installed ${id}`);
+      });
+    }
+
     async function installFromRemote() {
-      const value = installInput.trim();
+      const value = (
+        await ctx.ui.prompt({
+          title: "Install from URL or npm",
+          placeholder: "npm package name or tarball URL…",
+        })
+      )?.trim();
       if (!value) return;
-      setInstallInput("");
       const isUrl = value.startsWith("http://") || value.startsWith("https://");
       await run("install", async () => {
         if (isUrl) {
@@ -106,7 +171,7 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       });
     }
 
-    async function install() {
+    async function installFromFolder() {
       const folder = await ctx.ui.pickFolder();
       if (!folder) return;
       const preview = await mgr.previewInstall(folder).catch((err) => {
@@ -130,10 +195,23 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       );
     }
 
-    function update(ext: InstalledExtension) {
+    function update(ext: Pick<InstalledExtension, "id" | "name">) {
       void run(ext.id, async () => {
         await mgr.update(ext.id, requestConsent);
+        setUpdates(await mgr.checkUpdates().catch(() => []));
         ctx.ui.notify("info", `Updated ${ext.name}`);
+      });
+    }
+
+    function updateAll() {
+      void run("update-all", async () => {
+        // Sequential on purpose: each update may pop a consent modal, and two
+        // in-flight file swaps racing each other helps nobody.
+        for (const u of updates) {
+          await mgr.update(u.id, requestConsent);
+        }
+        setUpdates(await mgr.checkUpdates().catch(() => []));
+        ctx.ui.notify("info", "Extensions updated");
       });
     }
 
@@ -151,9 +229,22 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       });
     }
 
-    // Every row action lives behind one overflow menu rather than a row of
-    // buttons — Reload only applies to rows with a recorded install source,
-    // Uninstall only to non-built-ins, Disable/Enable always applies.
+    // Folder/URL/npm installs are the secondary path (RFC 0014): still fully
+    // supported, but tucked behind the page-level overflow instead of owning
+    // header real estate.
+    function openPageMenu(anchor: HTMLElement) {
+      const items: MenuEntry[] = [
+        { label: "Install from folder…", run: () => void installFromFolder() },
+        {
+          label: "Install from URL or npm…",
+          run: () => void installFromRemote(),
+        },
+        { type: "separator" },
+        { label: "Check for updates", run: () => void loadRegistry() },
+      ];
+      void ctx.ui.showMenu({ items, anchor, align: "end" });
+    }
+
     function openRowMenu(ext: InstalledExtension, anchor: HTMLElement) {
       const items: MenuEntry[] = [];
       if (showsUpdateAction(ext)) {
@@ -178,130 +269,326 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       void ctx.ui.showMenu({ items, anchor, align: "end" });
     }
 
+    // ---- detail drill-in ----------------------------------------------------
+
+    if (view.kind === "detail") {
+      const installedExt = extensions.find((e) => e.id === view.id);
+      const registryEntry =
+        registry.status === "ready"
+          ? registry.entries.find((e) => e.id === view.id)
+          : undefined;
+      return (
+        <div className="ext-page">
+          <ExtensionDetail
+            ctx={ctx}
+            id={view.id}
+            installed={installedExt}
+            registryEntry={registryEntry}
+            update={updates.find((u) => u.id === view.id)}
+            busy={busy !== null}
+            onBack={() => setView({ kind: view.from })}
+            onInstall={() => installFromRegistry(view.id)}
+            onUpdate={() => installedExt && update(installedExt)}
+            onToggle={() => installedExt && toggle(installedExt)}
+            onUninstall={() => installedExt && void uninstall(installedExt)}
+          />
+        </div>
+      );
+    }
+
+    // ---- list views ---------------------------------------------------------
+
     return (
       <div className="ext-page">
         <div className="ext-header">
           <h2>Extensions</h2>
           <div className="ext-header-actions">
-            {builtinsPresent && (
-              <label className="ext-toggle">
-                <input
-                  type="checkbox"
-                  checked={showBuiltins}
-                  onChange={(e) => setShowBuiltins(e.target.checked)}
-                />
-                Show built-in extensions
-              </label>
-            )}
+            <div className="ext-tabs" role="tablist">
+              <button
+                role="tab"
+                aria-selected={view.kind === "browse"}
+                className={`ext-tab${view.kind === "browse" ? " ext-tab-active" : ""}`}
+                onClick={() => setView({ kind: "browse" })}
+              >
+                Browse
+              </button>
+              <button
+                role="tab"
+                aria-selected={view.kind === "installed"}
+                className={`ext-tab${view.kind === "installed" ? " ext-tab-active" : ""}`}
+                onClick={() => setView({ kind: "installed" })}
+              >
+                Installed
+                {updates.length > 0 && (
+                  <span className="ext-update-count">{updates.length}</span>
+                )}
+              </button>
+            </div>
             <button
-              className="ext-btn"
-              onClick={install}
-              disabled={busy === "install"}
+              className="ext-btn ext-btn-icon"
+              onClick={(e) => openPageMenu(e.currentTarget)}
+              title="More install options"
             >
-              Install from folder…
+              <DotsThreeVertical size={16} weight="bold" />
             </button>
           </div>
         </div>
 
-        <div className="ext-install-remote">
-          <input
-            ref={installInputRef}
-            className="ext-install-input"
-            type="text"
-            placeholder="npm package name or tarball URL…"
-            value={installInput}
-            onChange={(e) => setInstallInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") void installFromRemote();
-            }}
-            disabled={busy === "install"}
-          />
-          <button
-            className="ext-btn"
-            onClick={() => void installFromRemote()}
-            disabled={busy === "install" || !installInput.trim()}
-          >
-            Install
-          </button>
-        </div>
-
-        {extensions.length > 0 && (
-          <input
-            className="ext-search"
-            type="text"
-            placeholder="Search extensions…"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-          />
-        )}
-
-        {extensions.length === 0 ? (
-          <div className="ext-empty">
-            No extensions installed. Use <b>Install from folder…</b> to add one.
-          </div>
-        ) : visible.length === 0 ? (
-          <div className="ext-empty">No extensions match “{query}”.</div>
-        ) : (
-          <div className="ext-list">
-            {visible.map((ext) => (
-              <div key={ext.id} className="ext-row">
-                <div className="ext-row-top">
-                  <div className="ext-row-text">
-                    <span className="ext-label">
-                      {ext.name}
-                      <span className="ext-brand">{ext.publisher}</span>
-                      {ext.builtin && (
-                        <span className="ext-badge-builtin">Built-in</span>
-                      )}
-                      <span className="ext-version">v{ext.version}</span>
-                      {!ext.enabled && (
-                        <span className="ext-badge">disabled</span>
-                      )}
-                    </span>
-                    <span className="ext-hint">
-                      {ext.description ?? ext.id}
-                    </span>
-                    {showsReloadHint(ext) && (
-                      <span className="ext-hint ext-hint-warn">
-                        Reload the window to finish disabling this extension.
-                      </span>
-                    )}
-                    {!ext.engineCompatible && (
-                      <span className="ext-hint ext-hint-warn">
-                        Needs Silo {ext.engine} — you&rsquo;re on{" "}
-                        {ext.hostVersion}. Update Silo to use this extension.
-                      </span>
-                    )}
-                  </div>
-                  <div className="ext-actions">
-                    <button
-                      className="ext-btn ext-row-btn ext-btn-icon"
-                      onClick={(e) => openRowMenu(ext, e.currentTarget)}
-                      disabled={busy === ext.id}
-                      title="Extension actions"
-                    >
-                      <DotsThreeVertical size={16} weight="bold" />
-                    </button>
-                  </div>
-                </div>
-                {ext.source &&
-                  (() => {
-                    const SourceIcon = SOURCE_ICON[ext.source.kind];
-                    return (
-                      <span
-                        className="ext-hint ext-source"
-                        title={describeSource(ext.source)}
-                      >
-                        <SourceIcon size={12} />
-                        <span className="ext-source-value">
-                          {ext.source.value}
-                        </span>
-                      </span>
-                    );
-                  })()}
+        {view.kind === "browse" ? (
+          <>
+            <input
+              className="ext-search"
+              type="text"
+              placeholder="Search the extension registry…"
+              value={browseQuery}
+              onChange={(e) => setBrowseQuery(e.target.value)}
+            />
+            {registry.status === "ready" && (
+              <div className="ext-cats">
+                <button
+                  className={`ext-cat${category === "" ? " ext-cat-active" : ""}`}
+                  onClick={() => setCategory("")}
+                >
+                  all
+                </button>
+                {registryCategories(registry.entries).map((c) => (
+                  <button
+                    key={c}
+                    className={`ext-cat${category === c ? " ext-cat-active" : ""}`}
+                    onClick={() => setCategory(category === c ? "" : c)}
+                  >
+                    {c}
+                  </button>
+                ))}
               </div>
-            ))}
-          </div>
+            )}
+            {registry.status === "loading" ? (
+              <div className="ext-empty">Loading the extension registry…</div>
+            ) : registry.status === "error" ? (
+              <div className="ext-empty">
+                Couldn&rsquo;t reach the extension registry: {registry.message}{" "}
+                <button className="ext-btn" onClick={() => void loadRegistry()}>
+                  Retry
+                </button>
+              </div>
+            ) : catalog.length === 0 ? (
+              <div className="ext-empty">No extensions match.</div>
+            ) : (
+              <div className="ext-list">
+                {catalog.map((entry) => {
+                  const state = browseInstallState(entry, extensions, updates);
+                  return (
+                    <div
+                      key={entry.id}
+                      className="ext-row ext-row-click"
+                      onClick={() =>
+                        setView({
+                          kind: "detail",
+                          id: entry.id,
+                          from: "browse",
+                        })
+                      }
+                    >
+                      <div className="ext-row-top">
+                        <div className="ext-row-text">
+                          <span className="ext-label">
+                            {entry.id}
+                            {entry.latest && (
+                              <span className="ext-version">
+                                v{entry.latest.version}
+                              </span>
+                            )}
+                            {entry.latest?.provenance === "attested" && (
+                              <span
+                                className="ext-badge-verified"
+                                title="Build provenance verified"
+                              >
+                                <SealCheck size={12} weight="fill" /> verified
+                              </span>
+                            )}
+                            {state === "installed" && (
+                              <span className="ext-badge-builtin">
+                                Installed
+                              </span>
+                            )}
+                            {state === "update-available" && (
+                              <span className="ext-badge">
+                                update available
+                              </span>
+                            )}
+                          </span>
+                          <span className="ext-hint">{entry.description}</span>
+                          <span className="ext-hint">
+                            {entry.latest?.permissions.length
+                              ? `permissions: ${entry.latest.permissions.join(", ")}`
+                              : "no permissions"}
+                            {" · "}
+                            {entry.totalDownloads} downloads
+                          </span>
+                        </div>
+                        <div className="ext-actions">
+                          {state === "not-installed" &&
+                            isInstallable(entry) && (
+                              <button
+                                className="ext-btn"
+                                disabled={busy === entry.id}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  installFromRegistry(entry.id);
+                                }}
+                              >
+                                Install
+                              </button>
+                            )}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="ext-installed-bar">
+              {extensions.length > 0 && (
+                <input
+                  className="ext-search"
+                  type="text"
+                  placeholder="Search installed extensions…"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                />
+              )}
+              {builtinsPresent && (
+                <label className="ext-toggle">
+                  <input
+                    type="checkbox"
+                    checked={showBuiltins}
+                    onChange={(e) => setShowBuiltins(e.target.checked)}
+                  />
+                  Show built-in
+                </label>
+              )}
+              {updates.length > 0 && (
+                <button
+                  className="ext-btn"
+                  onClick={updateAll}
+                  disabled={busy !== null}
+                >
+                  Update all ({updates.length})
+                </button>
+              )}
+            </div>
+
+            {extensions.length === 0 ? (
+              <div className="ext-empty">
+                No extensions installed yet — find one in <b>Browse</b>.
+              </div>
+            ) : visible.length === 0 ? (
+              <div className="ext-empty">No extensions match “{query}”.</div>
+            ) : (
+              <div className="ext-list">
+                {visible.map((ext) => {
+                  const upd = updates.find((u) => u.id === ext.id);
+                  return (
+                    <div
+                      key={ext.id}
+                      className="ext-row ext-row-click"
+                      onClick={() =>
+                        setView({
+                          kind: "detail",
+                          id: ext.id,
+                          from: "installed",
+                        })
+                      }
+                    >
+                      <div className="ext-row-top">
+                        <div className="ext-row-text">
+                          <span className="ext-label">
+                            {ext.name}
+                            <span className="ext-brand">{ext.publisher}</span>
+                            {ext.builtin && (
+                              <span className="ext-badge-builtin">
+                                Built-in
+                              </span>
+                            )}
+                            <span className="ext-version">v{ext.version}</span>
+                            {!ext.enabled && (
+                              <span className="ext-badge">disabled</span>
+                            )}
+                          </span>
+                          <span className="ext-hint">
+                            {ext.description ?? ext.id}
+                          </span>
+                          {upd && (
+                            <span className="ext-hint">
+                              Update available: v{upd.latestVersion}
+                              {upd.widensPermissions &&
+                                " (requests new permissions)"}
+                            </span>
+                          )}
+                          {showsReloadHint(ext) && (
+                            <span className="ext-hint ext-hint-warn">
+                              Reload the window to finish disabling this
+                              extension.
+                            </span>
+                          )}
+                          {!ext.engineCompatible && (
+                            <span className="ext-hint ext-hint-warn">
+                              Needs Silo {ext.engine} — you&rsquo;re on{" "}
+                              {ext.hostVersion}. Update Silo to use this
+                              extension.
+                            </span>
+                          )}
+                        </div>
+                        <div className="ext-actions">
+                          {upd && (
+                            <button
+                              className="ext-btn"
+                              disabled={busy === ext.id}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                update(ext);
+                              }}
+                            >
+                              Update
+                            </button>
+                          )}
+                          <button
+                            className="ext-btn ext-row-btn ext-btn-icon"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openRowMenu(ext, e.currentTarget);
+                            }}
+                            disabled={busy === ext.id}
+                            title="Extension actions"
+                          >
+                            <DotsThreeVertical size={16} weight="bold" />
+                          </button>
+                        </div>
+                      </div>
+                      {ext.source &&
+                        (() => {
+                          const SourceIcon = SOURCE_ICON[ext.source.kind];
+                          return (
+                            <span
+                              className="ext-hint ext-source"
+                              title={describeSource(ext.source)}
+                            >
+                              <SourceIcon size={12} />
+                              <span className="ext-source-value">
+                                {ext.source.value}
+                              </span>
+                            </span>
+                          );
+                        })()}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
         )}
       </div>
     );

--- a/packages/extensions-core/src/extensions/browse-model.test.ts
+++ b/packages/extensions-core/src/extensions/browse-model.test.ts
@@ -1,0 +1,127 @@
+// Browse-view rules: search/category filtering, removed entries hidden,
+// installed/update state, and installability.
+
+import { describe, it, expect } from "vitest";
+import type {
+  InstalledExtension,
+  RegistryExtension,
+  RegistryUpdate,
+} from "@silo-code/extension-host/internal";
+import {
+  browseInstallState,
+  filterRegistry,
+  isInstallable,
+  registryCategories,
+} from "./browse-model";
+
+const entry = (
+  id: string,
+  over: Partial<RegistryExtension> = {},
+): RegistryExtension => ({
+  id,
+  description: `${id} description`,
+  categories: ["monitoring"],
+  repo: `acme/${id}`,
+  status: "active",
+  latest: {
+    version: "1.0.0",
+    tarballUrl: "https://example.com/x.tgz",
+    mirrorUrl: null,
+    sha256: "abc",
+    size: 1,
+    engine: null,
+    permissions: [],
+    provenance: "none",
+    publishedAt: "",
+  },
+  totalDownloads: 0,
+  readme: `/readme/${id}.md`,
+  detail: `/ext/${id}.json`,
+  ...over,
+});
+
+const installedRow = (id: string): InstalledExtension => ({
+  id,
+  name: id,
+  version: "1.0.0",
+  publisher: "acme",
+  enabled: true,
+  loaded: true,
+  builtin: false,
+  permissions: [],
+  hostVersion: "1.0.0",
+  engineCompatible: true,
+  source: { kind: "registry", value: id },
+});
+
+describe("filterRegistry", () => {
+  const entries = [
+    entry("acme.weather", { categories: ["status-bar"] }),
+    entry("acme.clock", { description: "A clock panel" }),
+    entry("acme.gone", { status: "removed" }),
+  ];
+
+  it("matches id, description, and category; hides removed", () => {
+    expect(
+      filterRegistry(entries, { query: "", category: "" }).map((e) => e.id),
+    ).toEqual(["acme.weather", "acme.clock"]);
+    expect(
+      filterRegistry(entries, { query: "clock panel", category: "" }),
+    ).toHaveLength(1);
+    expect(
+      filterRegistry(entries, { query: "status-b", category: "" })[0].id,
+    ).toBe("acme.weather");
+    expect(
+      filterRegistry(entries, { query: "", category: "status-bar" }),
+    ).toHaveLength(1);
+    expect(
+      filterRegistry(entries, { query: "weather", category: "monitoring" }),
+    ).toHaveLength(0);
+  });
+});
+
+describe("registryCategories", () => {
+  it("is the sorted unique set", () => {
+    expect(
+      registryCategories([
+        entry("a.a", { categories: ["z", "monitoring"] }),
+        entry("a.b", { categories: ["monitoring"] }),
+      ]),
+    ).toEqual(["monitoring", "z"]);
+  });
+});
+
+describe("browseInstallState", () => {
+  const updates: RegistryUpdate[] = [
+    {
+      id: "acme.weather",
+      name: "acme.weather",
+      installedVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      widensPermissions: false,
+    },
+  ];
+
+  it("prefers update-available over installed, else not-installed", () => {
+    const installed = [
+      installedRow("acme.weather"),
+      installedRow("acme.clock"),
+    ];
+    expect(browseInstallState(entry("acme.weather"), installed, updates)).toBe(
+      "update-available",
+    );
+    expect(browseInstallState(entry("acme.clock"), installed, updates)).toBe(
+      "installed",
+    );
+    expect(browseInstallState(entry("acme.new"), installed, updates)).toBe(
+      "not-installed",
+    );
+  });
+});
+
+describe("isInstallable", () => {
+  it("requires a published release", () => {
+    expect(isInstallable(entry("a.a"))).toBe(true);
+    expect(isInstallable(entry("a.a", { latest: null }))).toBe(false);
+  });
+});

--- a/packages/extensions-core/src/extensions/browse-model.ts
+++ b/packages/extensions-core/src/extensions/browse-model.ts
@@ -1,0 +1,70 @@
+// Pure logic for the registry Browse view — search/category filtering and the
+// installed/update state of a registry entry — factored out of the component
+// so the rules are unit-testable (see extensions-list-model.ts for the same
+// pattern on the Installed view).
+
+import type {
+  InstalledExtension,
+  RegistryExtension,
+  RegistryUpdate,
+} from "@silo-code/extension-host/internal";
+
+export interface BrowseFilter {
+  /** Free-text search; matched against id, description, and categories. */
+  query: string;
+  /** Category facet; empty string = all. */
+  category: string;
+}
+
+/** Filter registry entries by search text and category facet. */
+export function filterRegistry(
+  entries: readonly RegistryExtension[],
+  { query, category }: BrowseFilter,
+): RegistryExtension[] {
+  const q = query.trim().toLowerCase();
+  return entries.filter((e) => {
+    if (e.status === "removed") return false;
+    if (category && !e.categories.includes(category)) return false;
+    if (!q) return true;
+    return (
+      e.id.toLowerCase().includes(q) ||
+      e.description.toLowerCase().includes(q) ||
+      e.categories.some((c) => c.includes(q))
+    );
+  });
+}
+
+/** Sorted unique categories present in the catalog (drives the facet chips). */
+export function registryCategories(
+  entries: readonly RegistryExtension[],
+): string[] {
+  return [...new Set(entries.flatMap((e) => e.categories))].sort();
+}
+
+/** How a registry entry relates to this install of Silo. */
+export type BrowseInstallState =
+  | "not-installed"
+  | "installed"
+  | "update-available";
+
+export function browseInstallState(
+  entry: Pick<RegistryExtension, "id">,
+  installed: readonly InstalledExtension[],
+  updates: readonly RegistryUpdate[],
+): BrowseInstallState {
+  if (updates.some((u) => u.id === entry.id)) return "update-available";
+  if (installed.some((e) => e.id === entry.id)) return "installed";
+  return "not-installed";
+}
+
+/**
+ * Whether the Install action is offered: there must be a published release,
+ * and a `removed` entry is filtered out before this is asked. `unavailable`
+ * stays installable — the tarball may still resolve (or a mirror exists), and
+ * the manager surfaces a clear error if not.
+ */
+export function isInstallable(
+  entry: Pick<RegistryExtension, "latest">,
+): boolean {
+  return entry.latest !== null;
+}

--- a/packages/extensions-core/src/extensions/extensions-list-model.ts
+++ b/packages/extensions-core/src/extensions/extensions-list-model.ts
@@ -59,14 +59,19 @@ export function showsUpdateAction(ext: InstalledExtension): boolean {
 
 /**
  * Human-readable "where this came from" line for a row, e.g. `Folder:
- * /path/to/ext` or `URL: https://example.com/ext.tgz`. `undefined` for
- * built-ins and legacy records with no recorded source — the row hides the
- * line entirely rather than showing a label with nothing after it.
+ * /path/to/ext` or `Registry: acme.weather`. `undefined` for built-ins and
+ * legacy records with no recorded source — the row hides the line entirely
+ * rather than showing a label with nothing after it.
  */
 export function describeSource(
   source: InstallSource | undefined,
 ): string | undefined {
   if (!source) return undefined;
-  const label = { folder: "Folder", url: "URL", npm: "npm" }[source.kind];
+  const label = {
+    folder: "Folder",
+    url: "URL",
+    npm: "npm",
+    registry: "Registry",
+  }[source.kind];
   return `${label}: ${source.value}`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.7(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.16)(react@19.2.7)
       valtio:
         specifier: ^2.3.2
         version: 2.3.2(@types/react@19.2.16)(react@19.2.7)


### PR DESCRIPTION
## Summary

The app half of RFC 0014 Phase 1 (pairs with the `extensions-registry` data repo):

- **Registry client** (`registry-client.ts`, host-internal): ETag-cached fetch of the static `index.json` (steady state = zero-body 304), defensive index parsing, id → digest-pinned tarball resolution with mirror fallback, semver update diffing. `silo.registryUrl` localStorage key as a dev override for the base URL.
- **Digest verification**: `download_extract` (Rust) takes an optional `expected_sha256` and fails a mismatched tarball **before extraction** (sha2). Registry installs and registry-sourced updates always pass the pin.
- **`installFromRegistry` / `checkUpdates` / `readInstalledReadme`** on `ExtensionManager`; new `"registry"` install source that re-resolves (and re-verifies) through the index on update.
- **`silo install <id>`**: the Rust CLI detects a registry id vs a path (existing paths win) and routes accordingly.
- **Extensions page restructured per RFC 0014** — registry **Browse is the landing view** (search, category facets, verified-build badges, one-click install through the existing consent modal), **Installed** second with per-row Update + "Update all", folder/URL/npm installs demoted to the page overflow menu, and a list → detail drill-in with rendered READMEs (local copy for installed extensions, the registry's version-pinned copy for browse). `react-markdown` (already used by markdown-preview) renders untrusted READMEs with links routed through `ctx.ui.openExternal`.

## Tests

- `registry-client.test.ts` (parsing, ETag cache, resolution, update diff), new `extension-manager.test.ts` cases (digest pass-through, registry source recording, registry update re-resolve, checkUpdates), `browse-model.test.ts` (search/facets/install state), Rust tests for id-vs-path CLI routing and the sha256 helper.
- Full suite green (`pnpm test`, `cargo test`), `pnpm lint`, `tsc --noEmit`.

## Runtime verification

Drove the real dev app against a locally served build of the actual registry index (5 real extensions ingested from silo-extensions' GitHub releases): Browse rendered with badges/facets, installed `silo.agent-monitor` end-to-end from its GitHub release, drilled into detail with full README render, uninstalled cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msn4U5z8LX4WNDGoA6hixR