### PR TITLE
fix(workspaces): make busy status indicator more noticeable

### DIFF
--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -380,6 +380,7 @@
 }
 
 .ws-status-dot {
+  position: relative;
   flex-shrink: 0;
   width: 6px;
   height: 6px;
@@ -406,6 +407,21 @@
   animation: ws-status-pulse 1.4s ease-in-out infinite;
 }
 
+.ws-status-dot[data-status="busy"]::before,
+.ws-status-dot[data-status="busy"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  animation: ws-status-wave 1.8s cubic-bezier(0.2, 0.6, 0.4, 1) infinite;
+  pointer-events: none;
+}
+
+.ws-status-dot[data-status="busy"]::after {
+  animation-delay: 0.9s;
+}
+
 .ws-status-dot[data-status="none"] {
   color: var(--silo-color-text);
 }
@@ -414,10 +430,24 @@
   0%,
   100% {
     opacity: 1;
+    transform: scale(1);
   }
 
   50% {
-    opacity: 0.4;
+    opacity: 0.55;
+    transform: scale(1.2);
+  }
+}
+
+@keyframes ws-status-wave {
+  0% {
+    opacity: 0.7;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(3.4);
   }
 }
 


### PR DESCRIPTION
## Summary
- The "busy" workspace status dot only faded opacity (1 → 0.4), which was easy to miss in the sidebar.
- Adds two `::before`/`::after` pseudo-element rings that expand outward and fade (a "sonar ping"), staggered 0.9s apart on a 1.8s loop, plus a slight scale added to the existing core throb.
- CSS-only change (`WorkspacesPanel.css`); no JSX/markup changes needed since the dot is a bare `<span>`.

## Test plan
- [x] Verified visually in the running dev app: switched to a theme with a blue accent (Tokyo Night), injected a synthetic `data-status="busy"` status row via the automation bridge in a sandbox workspace, and captured a sequence of screenshots confirming the ring visibly expands and fades across frames while the core dot throbs.
- [x] `pnpm test` / lint ran via pre-commit hooks and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)