### PR TITLE
fix(registry): give the update-available badge a warn color and capitalized label

### DIFF
--- a/packages/extensions-core/src/extensions/ExtensionsPage.css
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.css
@@ -160,6 +160,14 @@
   border-radius: var(--silo-radius-sm);
   padding: 0 5px;
 }
+.ext-badge-update {
+  font-size: calc(var(--settings-font) - 2px);
+  color: var(--silo-color-warn);
+  background: color-mix(in srgb, var(--silo-color-warn) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--silo-color-warn) 35%, transparent);
+  border-radius: var(--silo-radius-sm);
+  padding: 0 5px;
+}
 .ext-hint {
   font-size: calc(var(--settings-font) - 2px);
   color: var(--silo-color-text-lo);

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -427,8 +427,8 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                               </span>
                             )}
                             {state === "update-available" && (
-                              <span className="ext-badge">
-                                update available
+                              <span className="ext-badge-update">
+                                Update available
                               </span>
                             )}
                           </span>


### PR DESCRIPTION
## Summary
- The "update available" badge on the Extensions registry page used the same neutral gray styling as the "disabled" badge, making it easy to miss next to the accent-colored Update button.
- Style it like the existing status badges (`ok`-colored "Installed") using `--silo-color-warn`, and capitalize "Update" for consistency with other labels.

## Test plan
- [x] `pnpm test` passes (via pre-commit hook)
- [x] Lint passes (via pre-commit hook)
- [ ] Visually confirm the amber badge renders correctly in light and dark themes on the Extensions page

🤖 Generated with [Claude Code](https://claude.com/claude-code)