### PR TITLE
fix(dock): shrink editor/terminal tabs to fit instead of scrolling

### DIFF
--- a/packages/extension-host/src/panels/CenterDock.css
+++ b/packages/extension-host/src/panels/CenterDock.css
@@ -212,6 +212,28 @@
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
+
+/* Shrink tabs to fit the strip instead of relying on horizontal scroll once
+ * many are open. Dockview's default is `flex-shrink: 0`, which keeps every
+ * tab at its full label width and pushes the strip into native scroll —
+ * clunky with a lot of terminals/editors open. Letting tabs shrink down to
+ * `min-width` (ellipsis handles the truncated label) covers the common case;
+ * beyond that floor, dockview's native scroll/overflow dropdown still kicks
+ * in as before. `max-width` keeps a couple of open tabs from stretching
+ * across the whole strip. */
+.editor-dock .dv-tabs-container .dv-tab {
+  flex-shrink: 1;
+  min-width: 84px;
+  max-width: 200px;
+}
+.editor-dock .dv-tabs-container .dv-tab .dv-default-tab-action {
+  flex-shrink: 0;
+}
+.editor-dock .dv-tabs-container .dv-tab .dv-default-tab-content {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .editor-dock .dv-tab.dv-inactive-tab {
   border-color: transparent;
   color: var(--silo-content-tab-text-inactive);


### PR DESCRIPTION
## Summary
- Dockview's default tab strip keeps every tab at its full label width (`flex-shrink: 0`), so once enough terminals/editors are open the strip falls back to horizontal scroll — clunky with many terminals running.
- Let `.dv-tab` shrink down to an 84px floor (ellipsis truncates the label) before falling back to dockview's native scroll/overflow dropdown; capped at 200px so one or two open tabs don't stretch across the whole strip.

## Test plan
- [x] `pnpm test` (ran automatically via pre-commit hook — 617 tests passed)
- [x] Verified in the running dev app via the automation bridge: opened 10+ terminals in one dock group and confirmed tabs shrink to fit without scrolling; pushed to 21 tabs and confirmed the floor is respected with dockview's native overflow dropdown taking over beyond that; confirmed the close button stays full size and clicking/closing a shrunk tab still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)