### PR TITLE
fix(workspaces): desync busy status dots across workspaces

### DIFF
--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -405,6 +405,9 @@
 .ws-status-dot[data-status="busy"] {
   color: var(--silo-color-accent);
   animation: ws-status-pulse 1.4s ease-in-out infinite;
+  /* Per-row jitter (set inline from row.id) keeps multiple busy dots from
+     throbbing in lockstep — see busyJitterStyle in WorkspacesPanel.tsx. */
+  animation-delay: var(--ws-busy-jitter, 0s);
 }
 
 .ws-status-dot[data-status="busy"]::before,
@@ -415,11 +418,12 @@
   border-radius: 50%;
   border: 1px solid currentColor;
   animation: ws-status-wave 1.8s cubic-bezier(0.2, 0.6, 0.4, 1) infinite;
+  animation-delay: var(--ws-busy-jitter, 0s);
   pointer-events: none;
 }
 
 .ws-status-dot[data-status="busy"]::after {
-  animation-delay: 0.9s;
+  animation-delay: calc(var(--ws-busy-jitter, 0s) - 0.9s);
 }
 
 .ws-status-dot[data-status="none"] {

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -379,6 +379,27 @@
   min-width: 0;
 }
 
+/* Status-dot colors are fixed, not theme tokens: `--silo-color-ok/warn/err/
+   accent` vary a lot across presets (the "busy" dot in particular can land on
+   a teal or a neutral gray depending on the theme's accent, not the blue a
+   user expects "in progress" to mean). These four are meant to read as a
+   stable ok/warn/error/busy signal regardless of which theme is active, so
+   they're pinned to one semantic palette that only adapts to light vs. dark
+   (via `data-theme`, not the per-preset tokens). */
+:root {
+  --ws-status-ok: #16a34a;
+  --ws-status-warn: #d97706;
+  --ws-status-error: #dc2626;
+  --ws-status-busy: #2563eb;
+}
+
+[data-theme="dark"] {
+  --ws-status-ok: #4ade80;
+  --ws-status-warn: #fbbf24;
+  --ws-status-error: #f87171;
+  --ws-status-busy: #60a5fa;
+}
+
 .ws-status-dot {
   position: relative;
   flex-shrink: 0;
@@ -391,19 +412,19 @@
 }
 
 .ws-status-dot[data-status="ok"] {
-  color: var(--silo-color-ok);
+  color: var(--ws-status-ok);
 }
 
 .ws-status-dot[data-status="warn"] {
-  color: var(--silo-color-warn);
+  color: var(--ws-status-warn);
 }
 
 .ws-status-dot[data-status="error"] {
-  color: var(--silo-color-err);
+  color: var(--ws-status-error);
 }
 
 .ws-status-dot[data-status="busy"] {
-  color: var(--silo-color-accent);
+  color: var(--ws-status-busy);
   animation: ws-status-pulse 1.4s ease-in-out infinite;
   /* Per-row jitter (set inline from row.id) keeps multiple busy dots from
      throbbing in lockstep — see busyJitterStyle in WorkspacesPanel.tsx. */

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
@@ -79,7 +79,28 @@ function useHomeDir(): string {
   return useSyncExternalStore(subscribeHome, getHome);
 }
 
-function WorkspaceStatusRows({ rows }: { rows: WorkspaceStatusRow[] }) {
+// Deterministic per-row jitter so multiple "busy" status dots don't throb in
+// lockstep — hashed from the stable row id (not Math.random()) so the offset
+// doesn't jump around on re-render. Expressed as a negative delay so the
+// animation starts already in progress rather than pausing on mount.
+function busyJitterStyle(id: string): React.CSSProperties {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  }
+  const delaySeconds = -(((hash >>> 0) % 1000) / 1000) * 1.8;
+  return {
+    "--ws-busy-jitter": `${delaySeconds.toFixed(3)}s`,
+  } as React.CSSProperties;
+}
+
+function WorkspaceStatusRows({
+  workspaceId,
+  rows,
+}: {
+  workspaceId: string;
+  rows: WorkspaceStatusRow[];
+}) {
   if (rows.length === 0) return null;
   return (
     <>
@@ -89,6 +110,15 @@ function WorkspaceStatusRows({ rows }: { rows: WorkspaceStatusRow[] }) {
             className="ws-status-dot"
             data-status={row.status ?? "none"}
             aria-hidden="true"
+            style={
+              row.status === "busy"
+                ? // Providers commonly reuse the same row id across every
+                  // workspace (e.g. a fixed "build-task" id) — fold in the
+                  // workspace id too, or every workspace's dot would still
+                  // land on the same delay and throb in lockstep.
+                  busyJitterStyle(`${workspaceId}:${row.id}`)
+                : undefined
+            }
           />
           <span className="ws-status-label">{row.label}</span>
           {row.startedAt && (
@@ -369,7 +399,10 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
             </span>
           )}
         </div>
-        <WorkspaceStatusRows rows={service.getStatus(ws.id)} />
+        <WorkspaceStatusRows
+          workspaceId={ws.id}
+          rows={service.getStatus(ws.id)}
+        />
         <div className="ws-sections">
           {workspaceSectionRegistry.list().map((p) => {
             const Comp = p.component;


### PR DESCRIPTION
## Summary
- Follow-up to #202 (busy dot sonar-ping animation).
- **Desync busy dots across workspaces:** with multiple workspaces showing a "busy" status row, all the dots throbbed in perfect unison since every instance shared `animation-delay: 0`. Adds a deterministic per-row jitter — hashed from `workspaceId + row.id` (not `Math.random()`, so it's stable across re-renders) — expressed as a negative `animation-delay` via a `--ws-busy-jitter` CSS custom property, consumed by both the core throb and the wave-ring pseudo-elements. Keyed on `workspaceId + row.id`, not just `row.id`, since the real `workspace-modify-demo` example extension reuses the same row id (`"demo-busy"`) across every workspace — hashing on row id alone would still sync every dot.
- **Pin status-dot colors to a fixed light/dark palette:** the ok/warn/error/busy dots used `--silo-color-ok/warn/err/accent`, which vary a lot per theme preset — the "busy" dot in particular could land on gray (Dark), teal (Gruvbox Dark), or blue (Tokyo Night) depending on the theme's accent color, instead of reading as a consistent "in progress" signal. Pins the four status colors to a fixed semantic palette (new `--ws-status-*` custom properties, local to this file) that only adapts to light vs. dark via the `data-theme` attribute — independent of the active theme preset. Scoped entirely to `WorkspacesPanel.css`; no `--silo-color-*` design tokens or theme preset definitions were touched, so every other UI element still themes normally.

## Test plan
- [x] `pnpm test` / lint / typecheck ran via pre-commit hooks and passed.
- [x] Verified visually in the running dev app with the real `workspace-modify-demo` extension's busy rows across multiple open workspaces — confirmed the ring/throb phase differs between workspaces frame to frame (previously identical), and confirmed the busy dot renders the same blue across Dark, Gruvbox Dark, Tokyo Night, and Solarized Light themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)