### PR TITLE
feat(git): worktree manager in the Git panel

### DIFF
--- a/apps/docs/guide/panels.md
+++ b/apps/docs/guide/panels.md
@@ -17,16 +17,42 @@ the columns are secondary, collapsible surfaces.
 
 **Right column**
 
-| Panel  | What it shows                                    |
-| ------ | ------------------------------------------------ |
-| Files  | File tree for the active workspace               |
-| Search | Cross-file content search                        |
-| Git    | Staged/unstaged changes, commit, branch switcher |
-| Themes | Live theme preview and picker                    |
+| Panel  | What it shows                                                |
+| ------ | ------------------------------------------------------------ |
+| Files  | File tree for the active workspace                           |
+| Search | Cross-file content search                                    |
+| Git    | Staged/unstaged changes, commit, branch + worktree switchers |
+| Themes | Live theme preview and picker                                |
 
 Extensions can add panels to either column — see [Extensions](/guide/extensions).
 
 <img src="/img/guide/git-panel.png" alt="Git panel open in the right column, showing staged changes and commit interface" width="400" />
+
+### Git worktrees
+
+The Git panel's **⋯ → Manage worktrees…** lists every
+[git worktree](https://git-scm.com/docs/git-worktree) of the repo — including
+ones created outside Silo (say, by a coding agent) — no matter where they live
+on disk. From there you can:
+
+- **Open a worktree alongside** the current folders (click its row). It appears
+  as an extra root in both the Files panel and the Git panel — the same
+  multi-root convention as [workspaces](/guide/workspaces) with several
+  folders — with its own branch, commit box, and changes. **Close view** later
+  removes just that root; the worktree on disk is untouched.
+- **Create a worktree** on a new or existing branch. The suggested location is
+  a sibling directory named `<repo>-<branch>`, which keeps the checkout out of
+  the main repo's file watcher and git status; the path is editable. (If you
+  place a worktree _inside_ the repo, add its directory to `.gitignore` so the
+  main view's status doesn't fill with its files.)
+- **Remove a worktree** — deletes its directory but keeps the branch. A
+  worktree with uncommitted changes asks for a force-remove first. **Prune
+  stale** clears bookkeeping for worktrees whose directories were deleted
+  manually.
+
+A Git view whose root is a linked worktree shows a small **worktree** pill next
+to its branch name, and its ⋯ menu gains **Close worktree view** and
+**Remove worktree…**.
 
 ## Organizing panels
 

--- a/packages/extensions-silo/src/file-explorer/FileExplorerPanel.css
+++ b/packages/extensions-silo/src/file-explorer/FileExplorerPanel.css
@@ -34,20 +34,36 @@
   padding-top: 0;
 }
 
+/* Overlaid on the row's right edge (not in the flex flow) so the root title
+   always fills the full width and nothing reflows when the icons appear — the
+   row keeps its height and the title doesn't jump. On hover they fade in over
+   the title's end, masked by the row's hover background. */
 .tree-root-actions {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   align-items: center;
   gap: 1px;
-  margin-left: auto;
-  padding-right: 4px;
+  /* Masks the title's end underneath. Defaults to the panel background (rows
+     are transparent over it) and switches to the hover color on the row that's
+     actually under the cursor, so the mask is seamless in both states. */
+  background: var(--silo-color-bg);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.1s;
 }
 
+/* Hovering anywhere in the panel reveals every root's actions — the prior
+   discoverability behavior, kept while avoiding the flow-reflow jump. */
 .file-explorer-panel:hover .tree-root-actions {
   opacity: 1;
   pointer-events: auto;
+}
+
+.tree-row.root:hover .tree-root-actions {
+  background: var(--silo-color-bg-hover);
 }
 
 .tree-hdr-btn {
@@ -127,6 +143,7 @@
   border-radius: 3px;
 }
 .tree-row.root {
+  position: relative;
   font-size: calc(1em - 2px);
   letter-spacing: 0.04em;
   color: var(--silo-color-text-hi);
@@ -153,10 +170,21 @@
   color: var(--silo-color-text);
 }
 
+/* The name is wrapped in an SDK Tooltip, whose host span is the real flex
+   child. Let it shrink so a long name (e.g. a deep root) truncates instead of
+   pushing the trailing root actions past the row's clipped right edge. */
+.tree-row > .silo-tooltip-host {
+  flex: 1;
+  min-width: 0;
+  display: block;
+  overflow: hidden;
+}
+
 .tree-row .name {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex: 1;
+  white-space: nowrap;
   margin-left: calc(0.4em - 4px);
 }
 

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -797,6 +797,140 @@
   animation: branch-push 0.7s ease-in-out infinite;
 }
 
+/* Worktree manager modal (shares the branch-modal shell classes) and the
+ * "worktree" header pill on linked-worktree GitViews. */
+.git-wt-pill {
+  flex-shrink: 0;
+  font-size: var(--silo-font-size-chrome);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--silo-color-text-lo);
+  background: color-mix(in srgb, var(--silo-color-text-lo) 14%, transparent);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+/* Worktree rows stack the directory name (with badges) over the checked-out
+ * branch on two lines, so long names truncate instead of scrolling the row's
+ * controls off-screen. The row aligns to the top so the actions sit against
+ * the title line rather than centering across both lines. */
+.git-wt-row {
+  align-items: flex-start;
+}
+
+.git-wt-row .git-branch-glyph {
+  /* Nudge the folder glyph down to sit on the title line's baseline. */
+  margin-top: 1px;
+}
+
+/* Center the hover action cluster across both lines instead of pinning it to
+ * the top-aligned title line. */
+.git-wt-row .git-branch-actions {
+  align-self: center;
+}
+
+.git-wt-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.git-wt-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* Let the tooltip host holding the directory name shrink so its ellipsis can
+ * engage; the badges keep their intrinsic width. */
+.git-wt-title .silo-tooltip-host {
+  min-width: 0;
+}
+
+.git-wt-dir {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Open worktrees (already a workspace folder) read as active: accent glyph and
+ * a bolder name. Clicking the row toggles the view, so this isn't a "current,
+ * non-clickable" marker — it's just the open state. */
+.git-wt-open .git-branch-glyph {
+  color: var(--silo-color-accent);
+}
+
+.git-wt-open .git-wt-dir {
+  font-weight: 600;
+  color: var(--silo-color-text-hi);
+}
+
+/* Rows with nothing to toggle (the primary folder) aren't interactive. */
+.git-wt-static {
+  cursor: default;
+}
+
+.git-wt-static:hover {
+  background: transparent;
+}
+
+/* The row action icons (prune/remove) sit a touch darker than the branch
+ * manager's resting `--silo-color-text-lo` so the single trash reads clearly
+ * in the two-line row. */
+.git-wt-row .git-branch-action {
+  color: var(--silo-color-text);
+}
+
+/* Explanatory copy: the lead under the modal title and the note above the
+ * footer. Muted and small so the worktree list stays the focus. */
+.git-wt-lead,
+.git-wt-note {
+  margin: 0;
+  color: var(--silo-color-text);
+  font-size: var(--silo-font-size-sm);
+  line-height: 1.45;
+}
+
+/* Second line: the checked-out branch, truncated. */
+.git-wt-branch {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+}
+
+/* Locked/stale badges read as warnings, not accent. */
+.git-branch-badge.git-wt-warn {
+  color: var(--silo-color-warn);
+  background: color-mix(in srgb, var(--silo-color-warn) 16%, transparent);
+}
+
+/* Create-worktree dialog: the new/existing branch choice. */
+.git-wt-mode {
+  display: flex;
+  gap: 16px;
+}
+
+.git-wt-mode-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.git-wt-error {
+  color: var(--silo-color-err);
+  font-size: var(--silo-font-size-chrome);
+}
+
 /* Force-delete confirmation (ctx.ui.showModal content) — lists the unmerged
  * commits as proper rows instead of one crunched line of confirm-body text. */
 .git-force-delete {

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -14,13 +14,15 @@ import {
   type MenuEntry,
   type NotifyOptions,
 } from "@silo-code/sdk";
-import type { GitFileStatus, GitStatus } from "../git/git-api";
+import type { GitFileStatus, GitStatus, GitWorktree } from "../git/git-api";
 import { getGitApi } from "./git-runtime";
 import { Section, FileRow } from "./git-rows";
 import { buildGitNavItems, navItemKey } from "./git-nav";
 import { ICON_CHECK, ICON_PLUS, ICON_MINUS, ICON_UNDO } from "./git-icons";
 import { summarizeGitError } from "./notify-error";
 import { BranchManager } from "./BranchManager";
+import { WorktreeManager } from "./WorktreeManager";
+import { findWorktreeFor } from "./worktree-model";
 
 const REFRESH_DEBOUNCE_MS = 400;
 // How often the panel fetches in the background so ↑ahead/↓behind stay roughly
@@ -28,6 +30,7 @@ const REFRESH_DEBOUNCE_MS = 400;
 const AUTOFETCH_INTERVAL_MS = 180_000;
 const statusCache = new Map<string, GitStatus>();
 const messageCache = new Map<string, string>();
+const worktreeCache = new Map<string, GitWorktree[]>();
 
 export function GitView({
   ctx,
@@ -53,6 +56,9 @@ export function GitView({
   const files = ctx.files;
   const [status, setStatus] = useState<GitStatus | null>(
     () => statusCache.get(cacheKey) ?? null,
+  );
+  const [worktrees, setWorktrees] = useState<GitWorktree[] | null>(
+    () => worktreeCache.get(cacheKey) ?? null,
   );
   const [message, setMessage] = useState(
     () => messageCache.get(cacheKey) ?? "",
@@ -124,6 +130,7 @@ export function GitView({
   useEffect(() => {
     setStatus(statusCache.get(cacheKey) ?? null);
     setMessage(messageCache.get(cacheKey) ?? "");
+    setWorktrees(worktreeCache.get(cacheKey) ?? null);
     if (!paused) refresh();
   }, [cacheKey, paused, refresh]);
 
@@ -156,6 +163,15 @@ export function GitView({
         })
         .catch((err) => notifyError("Git status failed", err, true))
         .finally(() => min.then(() => setBusy(false)));
+      // Also learn whether this folder is a linked worktree (drives the
+      // header pill). Cheap read; failures just leave the pill off.
+      api
+        .worktrees(folder)
+        .then((wts) => {
+          worktreeCache.set(cacheKey, wts);
+          setWorktrees(wts);
+        })
+        .catch(() => undefined);
     }, 50);
   }, [pendingRefresh, folder, workspaceId, cacheKey, notifyError]);
 
@@ -473,16 +489,35 @@ export function GitView({
   }
 
   // The "⋯" dropdown: the explicit Push/Pull (folded off the bar), plus Fetch
-  // and a way into the branch manager.
+  // and ways into the branch and worktree managers. A linked-worktree view
+  // additionally offers closing its root and removing the worktree itself.
   function gitMenuItems(): MenuEntry[] {
-    return [
+    const items: MenuEntry[] = [
       { label: pushTitle, disabled: !canPush || pushing, run: push },
       { label: "Pull", disabled: !canPull || pulling, run: pull },
       { type: "separator" },
       { label: "Fetch", run: fetchRemote },
       { type: "separator" },
       { label: "Manage branches…", run: openBranchManager },
+      { label: "Manage worktrees…", run: openWorktreeManager },
     ];
+    if (linkedWorktree) {
+      items.push({ type: "separator" });
+      if (isExtraFolder) {
+        items.push({
+          label: "Close worktree view",
+          run: () => ctx.workspaces.removeFolder(workspaceId, folder),
+        });
+      }
+      if (linkedWorktree.locked == null) {
+        items.push({
+          label: "Remove worktree…",
+          danger: true,
+          run: () => void removeThisWorktree(),
+        });
+      }
+    }
+    return items;
   }
 
   function openGitMenu(anchor: HTMLElement) {
@@ -504,6 +539,63 @@ export function GitView({
       ),
       { title: "Switch branches", size: "md", dismissible: true },
     );
+  }
+
+  // Open the worktree manager modal for this repo. Everything inside is
+  // parameterized by `folder`, so a multi-root workspace gets an independent
+  // manager per repo.
+  function openWorktreeManager() {
+    ctx.ui.showModal(
+      () => (
+        <WorktreeManager
+          ctx={ctx}
+          folder={folder}
+          workspaceId={workspaceId}
+          onChanged={refresh}
+          notifyError={notifyError}
+        />
+      ),
+      { title: "Worktrees", size: "md", dismissible: true },
+    );
+  }
+
+  // Remove the worktree this view is rooted in. Runs `git worktree remove`
+  // from the main worktree (git refuses to remove the worktree it's run in),
+  // then closes this view's root. Dirty trees get a force-remove confirm.
+  async function removeThisWorktree() {
+    const api = getGitApi();
+    if (!api) return;
+    const name = folder.split("/").filter(Boolean).pop() ?? folder;
+    const mainPath = worktrees?.find((w) => w.isMain)?.path ?? folder;
+    const ok = await ctx.ui.confirm({
+      title: `Remove worktree "${name}"?`,
+      body: `Deletes the directory at ${folder}. The branch itself is kept.`,
+      confirmLabel: "Remove",
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      try {
+        await api.removeWorktree(mainPath, folder);
+      } catch (err) {
+        if (
+          !/contains modified or untracked files|use --force/i.test(String(err))
+        ) {
+          throw err;
+        }
+        const force = await ctx.ui.confirm({
+          title: `"${name}" has uncommitted changes`,
+          body: "Force-remove the worktree and discard them? This can't be undone.",
+          confirmLabel: "Force Remove",
+          danger: true,
+        });
+        if (!force) return;
+        await api.removeWorktree(mainPath, folder, true);
+      }
+      ctx.workspaces.removeFolder(workspaceId, folder);
+    } catch (err) {
+      notifyError(`Remove "${name}" failed`, err);
+    }
   }
 
   async function commit() {
@@ -543,6 +635,18 @@ export function GitView({
   // Pull needs a tracking branch to pull from; the menu item is disabled
   // (not hidden) otherwise.
   const canPull = !!status?.upstream;
+  // This view's folder is a *linked* worktree of its repo (not the main one) —
+  // drives the header pill and the extra menu entries.
+  const linkedWorktree = (() => {
+    const wt = worktrees ? findWorktreeFor(folder, worktrees) : undefined;
+    return wt && !wt.isMain ? wt : undefined;
+  })();
+  // A linked worktree opened alongside is an extra folder; the host no-ops
+  // removeFolder on the primary, so only offer "close" for extras.
+  const isExtraFolder = (() => {
+    const ws = ctx.workspaces.getState().all.find((w) => w.id === workspaceId);
+    return ws ? ws.folder !== folder : false;
+  })();
 
   return (
     <div className="git-panel">
@@ -585,6 +689,11 @@ export function GitView({
                   </span>
                 </Tooltip>
               </span>
+              {linkedWorktree && (
+                <Tooltip content={`Linked worktree at ${folder}`}>
+                  <span className="git-wt-pill">worktree</span>
+                </Tooltip>
+              )}
               <span
                 className="git-root-remote"
                 onClick={(e) => e.stopPropagation()}
@@ -657,6 +766,11 @@ export function GitView({
               </span>
             )}
           </span>
+          {linkedWorktree && (
+            <Tooltip content={`Linked worktree at ${folder}`}>
+              <span className="git-wt-pill">worktree</span>
+            </Tooltip>
+          )}
           {/* Where the remote state lives: published → the ↑/↓ counts double as
               a Sync button; not yet published → a Publish-branch button. */}
           {status?.upstream ? (

--- a/packages/extensions-silo/src/git-explorer/WorktreeCreateDialog.tsx
+++ b/packages/extensions-silo/src/git-explorer/WorktreeCreateDialog.tsx
@@ -1,0 +1,187 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import type { ExtensionContext } from "@silo-code/sdk";
+import { suggestWorktreePath } from "./worktree-model";
+
+/** What the create dialog resolves with (see {@link WorktreeCreateDialog}). */
+export interface WorktreeCreateResult {
+  /** Absolute path for the new worktree. */
+  path: string;
+  /** Check out an existing branch, or create a new one from HEAD. */
+  branch: { existing: string } | { create: string };
+}
+
+export interface WorktreeCreateDialogProps {
+  ctx: ExtensionContext;
+  /** The repo the worktree is created from (drives the path suggestion). */
+  folder: string;
+  /** Local branches not already checked out in some worktree. */
+  availableBranches: string[];
+  /** Resolve the host modal with the form values, or `undefined` to cancel. */
+  close: (result?: WorktreeCreateResult) => void;
+}
+
+/**
+ * The `git worktree add` form, rendered as `ctx.ui.showModal` content. Check
+ * out a new branch (default) or an existing one, at a path prefilled with the
+ * sibling-directory convention (`<repo>-<branch>`) — the suggestion tracks the
+ * branch name until the path is edited by hand. Submits only after confirming
+ * the path doesn't already exist. The host owns the modal chrome and title.
+ */
+export function WorktreeCreateDialog({
+  ctx,
+  folder,
+  availableBranches,
+  close,
+}: WorktreeCreateDialogProps) {
+  const [mode, setMode] = useState<"new" | "existing">("new");
+  const [newName, setNewName] = useState("");
+  const [existing, setExisting] = useState(availableBranches[0] ?? "");
+  const [pathTouched, setPathTouched] = useState(false);
+  const [pathValue, setPathValue] = useState(() =>
+    suggestWorktreePath(folder, ""),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [checking, setChecking] = useState(false);
+  const nameRef = useRef<HTMLInputElement | null>(null);
+
+  useLayoutEffect(() => {
+    nameRef.current?.focus();
+  }, []);
+
+  const branchName = mode === "new" ? newName.trim() : existing;
+  const trimmedPath = pathValue.trim();
+  const canSubmit =
+    !checking &&
+    trimmedPath.length > 0 &&
+    (mode === "new" ? newName.trim().length > 0 : existing.length > 0);
+
+  // The path suggestion follows the branch name until the user edits the path.
+  function syncSuggestion(branch: string) {
+    if (!pathTouched) setPathValue(suggestWorktreePath(folder, branch));
+  }
+
+  async function submit() {
+    if (!canSubmit) return;
+    setChecking(true);
+    try {
+      // files.stat resolves null for absent paths — anything else is taken.
+      if ((await ctx.files.stat(trimmedPath)) !== null) {
+        setError("That path already exists — pick another.");
+        return;
+      }
+    } catch {
+      // Couldn't check (e.g. outside readable scope) — let git be the judge.
+    } finally {
+      setChecking(false);
+    }
+    close({
+      path: trimmedPath,
+      branch: mode === "new" ? { create: newName.trim() } : { existing },
+    });
+  }
+
+  return (
+    <form
+      className="silo-modal-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void submit();
+      }}
+    >
+      <div className="git-wt-mode" role="radiogroup" aria-label="Branch">
+        <label className="git-wt-mode-option">
+          <input
+            type="radio"
+            name="git-wt-mode"
+            checked={mode === "new"}
+            onChange={() => {
+              setMode("new");
+              syncSuggestion(newName.trim());
+            }}
+          />
+          New branch
+        </label>
+        <label className="git-wt-mode-option">
+          <input
+            type="radio"
+            name="git-wt-mode"
+            checked={mode === "existing"}
+            disabled={availableBranches.length === 0}
+            onChange={() => {
+              setMode("existing");
+              syncSuggestion(existing);
+            }}
+          />
+          Existing branch
+        </label>
+      </div>
+
+      {mode === "new" ? (
+        <>
+          <label className="silo-modal-label">New branch name</label>
+          <input
+            ref={nameRef}
+            className="silo-modal-input"
+            value={newName}
+            placeholder="feature/my-branch"
+            onChange={(e) => {
+              setNewName(e.target.value);
+              syncSuggestion(e.target.value.trim());
+            }}
+            autoCapitalize="off"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </>
+      ) : (
+        <>
+          <label className="silo-modal-label">Branch to check out</label>
+          <select
+            className="silo-modal-input"
+            value={existing}
+            onChange={(e) => {
+              setExisting(e.target.value);
+              syncSuggestion(e.target.value);
+            }}
+          >
+            {availableBranches.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+
+      <label className="silo-modal-label">Worktree path</label>
+      <input
+        className="silo-modal-input"
+        value={pathValue}
+        onChange={(e) => {
+          setPathTouched(true);
+          setPathValue(e.target.value);
+          setError(null);
+        }}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      {error && <div className="git-wt-error">{error}</div>}
+
+      <div className="silo-modal-actions">
+        <button type="button" className="silo-button" onClick={() => close()}>
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="silo-button-primary"
+          disabled={!canSubmit || branchName.length === 0}
+        >
+          Create
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
@@ -1,0 +1,437 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowsClockwise,
+  Broom,
+  FolderSimple,
+  Plus,
+  Trash,
+} from "@phosphor-icons/react";
+import {
+  Tooltip,
+  path,
+  useFocusGroup,
+  useServiceState,
+  type ExtensionContext,
+  type MenuEntry,
+} from "@silo-code/sdk";
+import type { GitWorktree } from "../git/git-api";
+import { getGitApi } from "./git-runtime";
+import {
+  branchesInUse,
+  buildWorktreeRows,
+  worktreeActions,
+  type WorktreeRow,
+} from "./worktree-model";
+import {
+  WorktreeCreateDialog,
+  type WorktreeCreateResult,
+} from "./WorktreeCreateDialog";
+
+export interface WorktreeManagerProps {
+  ctx: ExtensionContext;
+  /** The repo working directory whose worktrees are managed. */
+  folder: string;
+  workspaceId: string;
+  /** Called after a create/remove so the panel re-reads status. */
+  onChanged: () => void;
+  /** Surface a git failure as a toast (reuses the view's helper). */
+  notifyError: (title: string, err: unknown) => void;
+}
+
+/**
+ * Content of the worktree manager modal (`ctx.ui.showModal`). Lists every
+ * working tree of the repo (main first); click a row to open it **alongside**
+ * the current folders (`ctx.workspaces.addFolder` — File Explorer and the Git
+ * panel grow an extra root), hover for close-view / remove, and create or
+ * prune from the footer. The host owns the surrounding modal chrome.
+ */
+export function WorktreeManager({
+  ctx,
+  folder,
+  workspaceId,
+  onChanged,
+  notifyError,
+}: WorktreeManagerProps) {
+  const [worktrees, setWorktrees] = useState<GitWorktree[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Live workspace state so rows flip to "open" immediately after addFolder.
+  const wsState = useServiceState(ctx.workspaces);
+  const ws = wsState.all.find((w) => w.id === workspaceId) ?? null;
+  const wsFolder = ws?.folder ?? folder;
+  const allFolders = useMemo(
+    () => (ws ? [ws.folder, ...(ws.extraFolders ?? [])] : [folder]),
+    [ws, folder],
+  );
+
+  const reload = useCallback(async () => {
+    const api = getGitApi();
+    if (!api) {
+      notifyError("Worktrees", "Git provider (silo.git) unavailable.");
+      return;
+    }
+    try {
+      setWorktrees(await api.worktrees(folder));
+    } catch (err) {
+      notifyError("Listing worktrees failed", err);
+    }
+  }, [folder, notifyError]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const rows = useMemo(
+    () => buildWorktreeRows(worktrees ?? [], folder, wsFolder, allFolders),
+    [worktrees, folder, wsFolder, allFolders],
+  );
+  const anyPrunable = rows.some((r) => r.wt.prunable != null);
+
+  // Roving keyboard nav (same as the branch manager): one Tab stop, ↑/↓ move,
+  // Enter opens the row alongside when that's an available action.
+  const list = useFocusGroup({
+    count: rows.length,
+    orientation: "vertical",
+    onActivate: (i) => {
+      const row = rows[i];
+      if (row) toggleView(row);
+    },
+    onMenu: (i, anchor) => {
+      const row = rows[i];
+      if (row) openRowMenu(row, { anchor });
+    },
+  });
+
+  // The live provider, or a notify + null so handlers can bail gracefully.
+  function api() {
+    const a = getGitApi();
+    if (!a) notifyError("Worktrees", "Git provider (silo.git) unavailable.");
+    return a;
+  }
+
+  // Open alongside: the worktree becomes another workspace folder, so File
+  // Explorer and the Git panel grow an extra root. The scope roots follow the
+  // folder list, so files/terminals in the worktree work immediately.
+  async function open(row: WorktreeRow) {
+    if (busy) return;
+    ctx.workspaces.addFolder(workspaceId, row.wt.path);
+    ctx.ui.notify("info", `Opened ${path.basename(row.wt.path)} alongside`);
+  }
+
+  // Close the view only — the worktree itself is untouched.
+  function closeView(row: WorktreeRow) {
+    ctx.workspaces.removeFolder(workspaceId, row.wt.path);
+  }
+
+  // Clicking a row toggles its view: open it alongside if closed, close it if
+  // open. The primary folder and stale (prune-only) rows toggle nothing.
+  function toggleView(row: WorktreeRow) {
+    const acts = worktreeActions(row);
+    if (acts.includes("open")) void open(row);
+    else if (acts.includes("close")) closeView(row);
+  }
+
+  // Hover hint for a row, standing in for the removed open/close icons: what a
+  // click will do, or the path for a row that can't be toggled.
+  function toggleHint(row: WorktreeRow): string {
+    const acts = worktreeActions(row);
+    if (acts.includes("open")) return "Open alongside your current folders";
+    if (acts.includes("close"))
+      return "Close this view (the worktree stays on disk)";
+    return row.wt.path;
+  }
+
+  async function create() {
+    const a = api();
+    if (!a || busy) return;
+    const used = branchesInUse(worktrees ?? []);
+    let available: string[] = [];
+    try {
+      available = (await a.branches(folder))
+        .filter((b) => !b.remote && !used.has(b.name))
+        .map((b) => b.name);
+    } catch {
+      // No branch list (e.g. empty repo) — the dialog still allows a new branch.
+    }
+    const result = await ctx.ui.showModal<WorktreeCreateResult>(
+      (closeDialog) => (
+        <WorktreeCreateDialog
+          ctx={ctx}
+          folder={folder}
+          availableBranches={available}
+          close={closeDialog}
+        />
+      ),
+      { title: "Create worktree", dismissible: true, size: "sm" },
+    );
+    if (!result) return;
+    setBusy(true);
+    try {
+      await a.addWorktree(
+        folder,
+        result.path,
+        "existing" in result.branch
+          ? { branch: result.branch.existing }
+          : { newBranch: result.branch.create },
+      );
+      ctx.workspaces.addFolder(workspaceId, result.path);
+      ctx.ui.notify(
+        "info",
+        `Created worktree ${path.basename(result.path)} and opened it alongside`,
+      );
+      await reload();
+      onChanged();
+    } catch (err) {
+      notifyError("Create worktree failed", err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(row: WorktreeRow) {
+    const a = api();
+    if (!a || busy) return;
+    const name = path.basename(row.wt.path);
+    const ok = await ctx.ui.confirm({
+      title: `Remove worktree "${name}"?`,
+      body: `Deletes the directory at ${row.wt.path}. The branch itself is kept.`,
+      confirmLabel: "Remove",
+      danger: true,
+    });
+    if (!ok) return;
+    setBusy(true);
+    try {
+      try {
+        await a.removeWorktree(folder, row.wt.path);
+      } catch (err) {
+        // Dirty worktree: git refuses without --force. Confirm the discard.
+        if (
+          !/contains modified or untracked files|use --force/i.test(String(err))
+        ) {
+          throw err;
+        }
+        const force = await ctx.ui.confirm({
+          title: `"${name}" has uncommitted changes`,
+          body: "Force-remove the worktree and discard them? This can't be undone.",
+          confirmLabel: "Force Remove",
+          danger: true,
+        });
+        if (!force) return;
+        await a.removeWorktree(folder, row.wt.path, true);
+      }
+      if (row.isOpen) ctx.workspaces.removeFolder(workspaceId, row.wt.path);
+      await reload();
+      onChanged();
+    } catch (err) {
+      notifyError(`Remove "${name}" failed`, err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function prune() {
+    const a = api();
+    if (!a || busy) return;
+    setBusy(true);
+    try {
+      await a.pruneWorktrees(folder);
+      // Drop workspace folders that pointed at now-pruned directories.
+      for (const row of rows) {
+        if (row.wt.prunable != null && row.isOpen) {
+          ctx.workspaces.removeFolder(workspaceId, row.wt.path);
+        }
+      }
+      await reload();
+      onChanged();
+    } catch (err) {
+      notifyError("Prune failed", err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // The row context menu — the keyboard path to the row actions (ContextMenu
+  // key / Shift+F10 via the focus group, or right-click), mirroring the hover
+  // buttons.
+  function rowMenuItems(row: WorktreeRow): MenuEntry[] {
+    const acts = worktreeActions(row);
+    const items: MenuEntry[] = [];
+    if (acts.includes("open")) {
+      items.push({ label: "Open alongside", run: () => void open(row) });
+    }
+    if (acts.includes("close")) {
+      items.push({ label: "Close view", run: () => closeView(row) });
+    }
+    if (acts.includes("prune")) {
+      items.push({ label: "Prune stale worktrees", run: () => void prune() });
+    }
+    if (acts.includes("remove")) {
+      if (items.length > 0) items.push({ type: "separator" });
+      items.push({
+        label: "Remove worktree…",
+        danger: true,
+        run: () => void remove(row),
+      });
+    }
+    return items;
+  }
+
+  function openRowMenu(
+    row: WorktreeRow,
+    placement: { at?: { x: number; y: number }; anchor?: HTMLElement | null },
+  ) {
+    const items = rowMenuItems(row);
+    if (items.length === 0) return;
+    void ctx.ui.showMenu({ items, toggle: false, ...placement });
+  }
+
+  function rowBadges(row: WorktreeRow) {
+    const badges: { label: string; tooltip?: string; warn?: boolean }[] = [];
+    if (row.wt.isMain) badges.push({ label: "main" });
+    if (row.isCurrent) badges.push({ label: "this view" });
+    else if (row.isOpen) badges.push({ label: "open" });
+    if (row.wt.locked != null) {
+      badges.push({
+        label: "locked",
+        tooltip: row.wt.locked || undefined,
+        warn: true,
+      });
+    }
+    if (row.wt.prunable != null) {
+      badges.push({ label: "stale", tooltip: row.wt.prunable, warn: true });
+    }
+    return badges;
+  }
+
+  return (
+    <div className="git-branch-modal">
+      <p className="git-wt-lead">
+        Click a worktree to open it alongside your current folders; click an
+        open one again to close its view.
+      </p>
+      <div className="git-branch-list" {...list.containerProps}>
+        {worktrees === null && (
+          <div className="git-branch-loader">
+            <ArrowsClockwise size={22} className="git-branch-spin" />
+            <span>Loading worktrees…</span>
+          </div>
+        )}
+        {worktrees !== null && rows.length === 0 && (
+          <div className="git-branch-empty">No worktrees.</div>
+        )}
+        {rows.map((row, i) => {
+          const acts = worktreeActions(row);
+          const toggleable = acts.includes("open") || acts.includes("close");
+          return (
+            <div
+              key={row.wt.path}
+              className={`git-branch-row git-wt-row${row.isOpen ? " git-wt-open" : ""}${toggleable ? "" : " git-wt-static"}`}
+              role="button"
+              onClick={() => toggleView(row)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                if (e.button === 2) {
+                  openRowMenu(row, { at: { x: e.clientX, y: e.clientY } });
+                } else {
+                  openRowMenu(row, { anchor: e.currentTarget });
+                }
+              }}
+              {...list.getItemProps(i)}
+            >
+              <span className="git-branch-glyph">
+                <FolderSimple size={15} />
+              </span>
+              <span className="git-wt-text">
+                <span className="git-wt-title">
+                  <Tooltip content={toggleHint(row)}>
+                    <span className="git-wt-dir">
+                      {path.basename(row.wt.path)}
+                    </span>
+                  </Tooltip>
+                  {rowBadges(row).map((b) =>
+                    b.tooltip ? (
+                      <Tooltip key={b.label} content={b.tooltip}>
+                        <span
+                          className={`git-branch-badge${b.warn ? " git-wt-warn" : ""}`}
+                        >
+                          {b.label}
+                        </span>
+                      </Tooltip>
+                    ) : (
+                      <span
+                        key={b.label}
+                        className={`git-branch-badge${b.warn ? " git-wt-warn" : ""}`}
+                      >
+                        {b.label}
+                      </span>
+                    ),
+                  )}
+                </span>
+                <span className="git-wt-branch">
+                  {row.wt.branch ?? "(detached)"}
+                </span>
+              </span>
+              <span
+                className="git-branch-actions"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {acts.includes("prune") && (
+                  <Tooltip content="Prune stale worktrees">
+                    <button
+                      type="button"
+                      className="git-branch-action"
+                      tabIndex={-1}
+                      onClick={() => void prune()}
+                    >
+                      <Broom size={14} />
+                    </button>
+                  </Tooltip>
+                )}
+                {acts.includes("remove") && (
+                  <Tooltip content="Remove worktree">
+                    <button
+                      type="button"
+                      className="git-branch-action danger"
+                      tabIndex={-1}
+                      onClick={() => void remove(row)}
+                    >
+                      <Trash size={14} />
+                    </button>
+                  </Tooltip>
+                )}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="git-wt-note">
+        Opening a worktree adds it as another folder in this workspace — its
+        files, terminals, and Git panel appear alongside your current ones,
+        letting you work a second branch without switching. Closing a view
+        leaves the worktree and its branch untouched on disk.
+      </p>
+
+      <div className="git-branch-footer">
+        <button
+          type="button"
+          className="silo-button-primary"
+          onClick={() => void create()}
+          disabled={busy}
+        >
+          <Plus size={14} weight="bold" /> Create worktree
+        </button>
+        {anyPrunable && (
+          <button
+            type="button"
+            className="silo-button"
+            onClick={() => void prune()}
+            disabled={busy}
+          >
+            <Broom size={15} /> Prune stale
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import type { GitWorktree } from "../git/git-api";
+import {
+  normalizeFolderPath,
+  samePath,
+  buildWorktreeRows,
+  worktreeActions,
+  sanitizeBranchForPath,
+  suggestWorktreePath,
+  findWorktreeFor,
+  branchesInUse,
+} from "./worktree-model";
+
+function wt(overrides: Partial<GitWorktree>): GitWorktree {
+  return {
+    path: "/repo",
+    head: "abc",
+    branch: "main",
+    isMain: false,
+    detached: false,
+    bare: false,
+    locked: null,
+    prunable: null,
+    ...overrides,
+  };
+}
+
+describe("normalizeFolderPath / samePath", () => {
+  it("normalizes separators and trailing slashes", () => {
+    expect(normalizeFolderPath("/a/b/")).toBe("/a/b");
+    expect(normalizeFolderPath("C:\\repos\\proj")).toBe("C:/repos/proj");
+    expect(samePath("/a/b/", "/a/b")).toBe(true);
+  });
+
+  it("treats macOS /private realpaths as their symlinked form", () => {
+    expect(samePath("/private/tmp/x", "/tmp/x")).toBe(true);
+    expect(samePath("/private/var/folders/y", "/var/folders/y")).toBe(true);
+    // "/privateer" or unrelated /private children must not be rewritten.
+    expect(samePath("/privateer/tmp", "/tmp")).toBe(false);
+    expect(normalizeFolderPath("/private/stuff")).toBe("/private/stuff");
+  });
+
+  it("keeps distinct paths distinct", () => {
+    expect(samePath("/a/b", "/a/b2")).toBe(false);
+  });
+});
+
+describe("buildWorktreeRows", () => {
+  const main = wt({ path: "/w/repo", isMain: true, branch: "main" });
+  const feat = wt({ path: "/w/repo-feat", branch: "feat" });
+  const alpha = wt({ path: "/w/alpha", branch: "alpha" });
+
+  it("puts main first, then linked alphabetical by path", () => {
+    const rows = buildWorktreeRows([feat, alpha, main], "/w/repo", "/w/repo", [
+      "/w/repo",
+    ]);
+    expect(rows.map((r) => r.wt.path)).toEqual([
+      "/w/repo",
+      "/w/alpha",
+      "/w/repo-feat",
+    ]);
+  });
+
+  it("flags current, open, and primary rows", () => {
+    const rows = buildWorktreeRows([main, feat], "/w/repo-feat", "/w/repo", [
+      "/w/repo",
+      "/w/repo-feat/",
+    ]);
+    expect(rows[0]).toMatchObject({
+      isCurrent: false,
+      isOpen: true,
+      isPrimary: true,
+    });
+    expect(rows[1]).toMatchObject({
+      isCurrent: true,
+      isOpen: true,
+      isPrimary: false,
+    });
+  });
+
+  it("drops bare entries but keeps prunable ones", () => {
+    const bare = wt({ path: "/w/repo.git", bare: true });
+    const gone = wt({ path: "/w/gone", prunable: "directory missing" });
+    const rows = buildWorktreeRows([main, bare, gone], "/w/repo", "/w/repo", [
+      "/w/repo",
+    ]);
+    expect(rows.map((r) => r.wt.path)).toEqual(["/w/repo", "/w/gone"]);
+  });
+});
+
+describe("worktreeActions", () => {
+  const base = {
+    isCurrent: false,
+    isOpen: false,
+    isPrimary: false,
+  };
+
+  it("offers open for an unopened linked worktree, plus remove", () => {
+    expect(worktreeActions({ ...base, wt: wt({}) })).toEqual([
+      "open",
+      "remove",
+    ]);
+  });
+
+  it("offers close (not open) for an open non-primary row", () => {
+    expect(worktreeActions({ ...base, isOpen: true, wt: wt({}) })).toEqual([
+      "close",
+      "remove",
+    ]);
+  });
+
+  it("never offers remove or close for the main/primary worktree", () => {
+    expect(
+      worktreeActions({
+        ...base,
+        isOpen: true,
+        isPrimary: true,
+        isCurrent: true,
+        wt: wt({ isMain: true }),
+      }),
+    ).toEqual([]);
+  });
+
+  it("withholds remove from a locked worktree", () => {
+    expect(worktreeActions({ ...base, wt: wt({ locked: "" }) })).toEqual([
+      "open",
+    ]);
+    expect(
+      worktreeActions({ ...base, wt: wt({ locked: "pinned by CI" }) }),
+    ).toEqual(["open"]);
+  });
+
+  it("offers only prune for a prunable row", () => {
+    expect(
+      worktreeActions({ ...base, wt: wt({ prunable: "gitdir gone" }) }),
+    ).toEqual(["prune"]);
+  });
+
+  it("offers nothing but remove for the current (unopened-elsewhere) view", () => {
+    // isCurrent implies the folder is one of the workspace's folders in
+    // practice, but the gate itself: current rows never offer open.
+    expect(worktreeActions({ ...base, isCurrent: true, wt: wt({}) })).toEqual([
+      "remove",
+    ]);
+  });
+});
+
+describe("sanitizeBranchForPath / suggestWorktreePath", () => {
+  it("replaces separators and unsafe characters with dashes", () => {
+    expect(sanitizeBranchForPath("feat/x")).toBe("feat-x");
+    expect(sanitizeBranchForPath("fix\\win:path")).toBe("fix-win-path");
+    expect(sanitizeBranchForPath("wip branch name")).toBe("wip-branch-name");
+  });
+
+  it("trims leading/trailing dashes and dots", () => {
+    expect(sanitizeBranchForPath("-lead")).toBe("lead");
+    expect(sanitizeBranchForPath("trail.")).toBe("trail");
+    expect(sanitizeBranchForPath("release/v1..2")).toBe("release-v1.2");
+  });
+
+  it("suggests a sibling directory named <repo>-<branch>", () => {
+    expect(suggestWorktreePath("/w/proj", "feat/x")).toBe("/w/proj-feat-x");
+    expect(suggestWorktreePath("/w/proj/", "main")).toBe("/w/proj-main");
+  });
+
+  it("returns the dangling prefix for a blank branch", () => {
+    expect(suggestWorktreePath("/w/proj", "")).toBe("/w/proj-");
+  });
+});
+
+describe("findWorktreeFor / branchesInUse", () => {
+  it("matches a folder to its worktree through path normalization", () => {
+    const wts = [wt({ path: "/private/tmp/repo", isMain: true })];
+    expect(findWorktreeFor("/tmp/repo/", wts)).toBe(wts[0]);
+    expect(findWorktreeFor("/tmp/other", wts)).toBeUndefined();
+  });
+
+  it("collects checked-out branch names, skipping detached entries", () => {
+    const wts = [
+      wt({ branch: "main", isMain: true }),
+      wt({ path: "/w/x", branch: "feat" }),
+      wt({ path: "/w/d", branch: null, detached: true }),
+    ];
+    expect(branchesInUse(wts)).toEqual(new Set(["main", "feat"]));
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/worktree-model.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.ts
@@ -1,0 +1,129 @@
+import { path } from "@silo-code/sdk";
+import type { GitWorktree } from "../git/git-api";
+
+// Pure presentation logic for the worktree manager modal — path identity,
+// row derivation, action gating, and the suggested-path convention. Extracted
+// from WorktreeManager.tsx so the rules are unit-testable without rendering
+// React (per the repo's testing convention; see branch-model.ts).
+
+/**
+ * Normalize a folder path for identity comparison: forward slashes, no
+ * trailing slash, and macOS realpath'd temp prefixes folded back to their
+ * symlinked form (`/private/tmp/x` ⇔ `/tmp/x`) — git reports realpaths while
+ * workspace folders may hold the symlinked spelling.
+ */
+export function normalizeFolderPath(p: string): string {
+  let n = path.normalize(p);
+  if (n.length > 1 && n.endsWith("/")) n = n.slice(0, -1);
+  const priv = /^\/private(\/(?:tmp|var|etc)(?:\/|$).*)$/.exec(n);
+  if (priv) n = priv[1];
+  return n;
+}
+
+/** Whether two folder paths identify the same directory (see {@link normalizeFolderPath}). */
+export function samePath(a: string, b: string): boolean {
+  return normalizeFolderPath(a) === normalizeFolderPath(b);
+}
+
+/** One worktree row in the manager, with its relationship to the workspace. */
+export interface WorktreeRow {
+  wt: GitWorktree;
+  /** This entry is the folder the manager was opened from. */
+  isCurrent: boolean;
+  /** The worktree's path is already one of the workspace's folders. */
+  isOpen: boolean;
+  /** The worktree's path is the workspace's primary folder (can't be closed). */
+  isPrimary: boolean;
+}
+
+/**
+ * Derive display rows from a worktree list: main worktree first, then linked
+ * worktrees alphabetical by path. Bare entries are dropped (nothing to browse
+ * or open); prunable entries are kept — they drive the prune action.
+ */
+export function buildWorktreeRows(
+  worktrees: GitWorktree[],
+  currentFolder: string,
+  wsFolder: string,
+  allFolders: string[],
+): WorktreeRow[] {
+  return worktrees
+    .filter((wt) => !wt.bare)
+    .sort(
+      (a, b) =>
+        Number(b.isMain) - Number(a.isMain) || a.path.localeCompare(b.path),
+    )
+    .map((wt) => ({
+      wt,
+      isCurrent: samePath(wt.path, currentFolder),
+      isOpen: allFolders.some((f) => samePath(wt.path, f)),
+      isPrimary: samePath(wt.path, wsFolder),
+    }));
+}
+
+/** A row action offered for a worktree (drives the row context menu). */
+export type WorktreeAction = "open" | "close" | "remove" | "prune";
+
+/**
+ * The actions that apply to a worktree row, in display order. `open` adds the
+ * worktree as a workspace folder; `close` removes that folder (the worktree
+ * itself is untouched); `remove` deletes the worktree via git. A **prunable**
+ * row (directory already gone) only offers `prune`; the **main** worktree and
+ * the workspace's **primary** folder can't be removed, and a **locked**
+ * worktree can't be removed either.
+ */
+export function worktreeActions(row: WorktreeRow): WorktreeAction[] {
+  if (row.wt.prunable != null) return ["prune"];
+  const actions: WorktreeAction[] = [];
+  if (!row.isOpen && !row.isCurrent) actions.push("open");
+  if (row.isOpen && !row.isPrimary) actions.push("close");
+  if (!row.wt.isMain && !row.isPrimary && row.wt.locked == null) {
+    actions.push("remove");
+  }
+  return actions;
+}
+
+/** Sanitize a branch name into a filesystem-friendly directory suffix. */
+export function sanitizeBranchForPath(branch: string): string {
+  return branch
+    .replace(/[/\\:*?"<>|\s]+/g, "-")
+    .replace(/\.+/g, ".")
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
+/**
+ * The suggested location for a new worktree: a **sibling** of the repo named
+ * `<repo>-<branch>` (e.g. `/w/proj` + `feat/x` → `/w/proj-feat-x`). A sibling
+ * keeps the checkout out of the repo tree, so the main worktree's file watcher
+ * and git status never see it. Returns just the parent dir when `branch` is
+ * blank (the caller appends as the user types).
+ */
+export function suggestWorktreePath(repoPath: string, branch: string): string {
+  const parent = path.dirname(repoPath);
+  const repoName = path.basename(repoPath);
+  const suffix = sanitizeBranchForPath(branch);
+  return suffix
+    ? path.join(parent, `${repoName}-${suffix}`)
+    : path.join(parent, repoName ? `${repoName}-` : "");
+}
+
+/** The worktree whose root is `folder`, if any (see {@link samePath}). */
+export function findWorktreeFor(
+  folder: string,
+  worktrees: GitWorktree[],
+): GitWorktree | undefined {
+  return worktrees.find((wt) => samePath(wt.path, folder));
+}
+
+/**
+ * Branch names already checked out in some worktree — git refuses
+ * `worktree add` for these, so the create dialog filters them proactively.
+ * Detached and bare entries contribute nothing.
+ */
+export function branchesInUse(worktrees: GitWorktree[]): Set<string> {
+  const used = new Set<string>();
+  for (const wt of worktrees) {
+    if (wt.branch != null) used.add(wt.branch);
+  }
+  return used;
+}

--- a/packages/extensions-silo/src/git/git-api.ts
+++ b/packages/extensions-silo/src/git/git-api.ts
@@ -52,6 +52,26 @@ export interface GitBranch {
   upstream: string | null;
 }
 
+/** One working tree, as listed by {@link GitAPI.worktrees}. */
+export interface GitWorktree {
+  /** Absolute path of the worktree root (forward slashes). */
+  path: string;
+  /** Checked-out commit hash; `null` for a bare or prunable entry. */
+  head: string | null;
+  /** Short branch name (`refs/heads/x` → `x`); `null` when detached or bare. */
+  branch: string | null;
+  /** True for the main worktree — always the first entry git lists. */
+  isMain: boolean;
+  /** True when `HEAD` is detached (no branch checked out). */
+  detached: boolean;
+  /** True for a bare repository entry (nothing checked out to browse). */
+  bare: boolean;
+  /** Lock reason (`""` when locked without one); `null` when unlocked. */
+  locked: string | null;
+  /** Prune reason (e.g. a deleted directory); `null` when healthy. */
+  prunable: string | null;
+}
+
 /**
  * The typed API the `silo.git` provider publishes. All methods take the repo
  * working directory (`cwd`) as their first argument and run `git` off the UI
@@ -146,4 +166,32 @@ export interface GitAPI {
     branch: string,
     upstream?: string | null,
   ): Promise<GitLogEntry[]>;
+  /**
+   * All working trees of the repo containing `cwd` (`git worktree list
+   * --porcelain`), main worktree first — git lists the whole family from any
+   * of its worktrees. Resolves to an empty array outside a repo.
+   */
+  worktrees(cwd: string): Promise<GitWorktree[]>;
+  /**
+   * Create a worktree at `path` (`git worktree add`). Pass `branch` to check
+   * out an existing branch, or `newBranch` to create one (from `startPoint`,
+   * defaulting to `HEAD`) and check it out. Git refuses a branch that is
+   * already checked out in another worktree.
+   */
+  addWorktree(
+    cwd: string,
+    path: string,
+    options: { branch: string } | { newBranch: string; startPoint?: string },
+  ): Promise<void>;
+  /**
+   * Remove a worktree's directory and its bookkeeping (`git worktree remove`).
+   * The branch it had checked out is kept. Without `force`, git refuses to
+   * remove a worktree with modified or untracked files.
+   */
+  removeWorktree(cwd: string, path: string, force?: boolean): Promise<void>;
+  /**
+   * Drop bookkeeping for worktrees whose directories no longer exist
+   * (`git worktree prune`) — the entries {@link GitWorktree.prunable} flags.
+   */
+  pruneWorktrees(cwd: string): Promise<void>;
 }

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -6,7 +6,13 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFile } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  realpathSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createGitService, type ExecFn } from "./git-service";
@@ -33,346 +39,465 @@ const realExec: ExecFn = (command, args, options) =>
 
 const git = createGitService(realExec);
 
-describe("GitService (against a temp repo)", () => {
-  let repo: string;
+// Real-git tests spawn dozens of processes; under a loaded machine (the full
+// suite runs files in parallel) single tests can pass vitest's 5s default.
+const SUITE_TIMEOUT_MS = 20_000;
 
-  beforeEach(async () => {
-    repo = mkdtempSync(join(tmpdir(), "silo-gitsvc-"));
-    await realExec("git", ["init", "-q"], { cwd: repo });
-    await realExec("git", ["config", "user.email", "t@t"], { cwd: repo });
-    await realExec("git", ["config", "user.name", "t"], { cwd: repo });
-  });
+describe(
+  "GitService (against a temp repo)",
+  { timeout: SUITE_TIMEOUT_MS },
+  () => {
+    let repo: string;
 
-  afterEach(() => rmSync(repo, { recursive: true, force: true }));
-
-  it("reports inRepo:false outside a repository", async () => {
-    const outside = mkdtempSync(join(tmpdir(), "silo-norepo-"));
-    try {
-      const s = await git.status(outside);
-      expect(s.inRepo).toBe(false);
-      expect(s.files).toEqual([]);
-    } finally {
-      rmSync(outside, { recursive: true, force: true });
-    }
-  });
-
-  it("tracks a file through untracked → staged → committed", async () => {
-    writeFileSync(join(repo, "a.txt"), "hello\n");
-
-    let s = await git.status(repo);
-    expect(s.inRepo).toBe(true);
-    expect(s.files.find((f) => f.path === "a.txt")).toMatchObject({
-      isUntracked: true,
+    beforeEach(async () => {
+      repo = mkdtempSync(join(tmpdir(), "silo-gitsvc-"));
+      await realExec("git", ["init", "-q"], { cwd: repo });
+      await realExec("git", ["config", "user.email", "t@t"], { cwd: repo });
+      await realExec("git", ["config", "user.name", "t"], { cwd: repo });
     });
 
-    await git.stage(repo, ["a.txt"]);
-    s = await git.status(repo);
-    expect(s.files.find((f) => f.path === "a.txt")).toMatchObject({
-      isStaged: true,
-      isUntracked: false,
+    afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+    it("reports inRepo:false outside a repository", async () => {
+      const outside = mkdtempSync(join(tmpdir(), "silo-norepo-"));
+      try {
+        const s = await git.status(outside);
+        expect(s.inRepo).toBe(false);
+        expect(s.files).toEqual([]);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
     });
 
-    await git.commit(repo, "add a");
-    s = await git.status(repo);
-    expect(s.files).toEqual([]); // clean after commit
-  });
+    it("tracks a file through untracked → staged → committed", async () => {
+      writeFileSync(join(repo, "a.txt"), "hello\n");
 
-  it("unstages a staged file back to modified", async () => {
-    writeFileSync(join(repo, "a.txt"), "v1\n");
-    await git.stage(repo, ["a.txt"]);
-    await git.commit(repo, "init");
-    writeFileSync(join(repo, "a.txt"), "v2\n");
-    await git.stage(repo, ["a.txt"]);
-    expect(
-      (await git.status(repo)).files.find((f) => f.path === "a.txt"),
-    ).toMatchObject({ isStaged: true });
+      let s = await git.status(repo);
+      expect(s.inRepo).toBe(true);
+      expect(s.files.find((f) => f.path === "a.txt")).toMatchObject({
+        isUntracked: true,
+      });
 
-    await git.unstage(repo, ["a.txt"]);
-    expect(
-      (await git.status(repo)).files.find((f) => f.path === "a.txt"),
-    ).toMatchObject({ isStaged: false, isModified: true });
-  });
+      await git.stage(repo, ["a.txt"]);
+      s = await git.status(repo);
+      expect(s.files.find((f) => f.path === "a.txt")).toMatchObject({
+        isStaged: true,
+        isUntracked: false,
+      });
 
-  it("reads file content at a revision via show, empty for missing paths", async () => {
-    writeFileSync(join(repo, "a.txt"), "committed\n");
-    await git.stage(repo, ["a.txt"]);
-    await git.commit(repo, "init");
-
-    expect(await git.show(repo, "HEAD:a.txt")).toBe("committed\n");
-    expect(await git.show(repo, "HEAD:nope.txt")).toBe(""); // missing → empty
-  });
-
-  it("reverts a working-tree change", async () => {
-    writeFileSync(join(repo, "a.txt"), "orig\n");
-    await git.stage(repo, ["a.txt"]);
-    await git.commit(repo, "init");
-    writeFileSync(join(repo, "a.txt"), "scratch\n");
-
-    await git.revertFile(repo, ["a.txt"]);
-    expect((await git.status(repo)).files).toEqual([]); // change discarded
-  });
-
-  it("clean deletes an untracked file (discarding a new file)", async () => {
-    writeFileSync(join(repo, "a.txt"), "v1\n");
-    await git.stage(repo, ["a.txt"]);
-    await git.commit(repo, "init");
-    writeFileSync(join(repo, "junk.txt"), "scratch\n");
-    expect(
-      (await git.status(repo)).files.find((f) => f.path === "junk.txt"),
-    ).toMatchObject({ isUntracked: true });
-
-    await git.clean(repo, ["junk.txt"]);
-    expect(existsSync(join(repo, "junk.txt"))).toBe(false);
-    expect((await git.status(repo)).files).toEqual([]);
-  });
-
-  it("revertFile errors on an untracked path (use clean instead)", async () => {
-    writeFileSync(join(repo, "a.txt"), "v1\n");
-    await git.stage(repo, ["a.txt"]);
-    await git.commit(repo, "init");
-    writeFileSync(join(repo, "new.txt"), "untracked\n");
-    // git restore can't act on a path it doesn't know — the panel routes
-    // untracked discards to clean() for exactly this reason.
-    await expect(git.revertFile(repo, ["new.txt"])).rejects.toThrow(
-      /did not match any file/i,
-    );
-  });
-
-  // A repo needs one commit before branches exist / can be created.
-  async function seedCommit() {
-    writeFileSync(join(repo, "a.txt"), "v1\n");
-    await git.stage(repo, ["a.txt"]);
-    await git.commit(repo, "init");
-  }
-
-  it("creates, lists, switches between, and deletes branches", async () => {
-    await seedCommit();
-    const initial = await git.branches(repo);
-    expect(initial).toHaveLength(1);
-    const base = initial[0].name; // "main" or "master" depending on git config
-    expect(initial[0]).toMatchObject({ current: true, remote: false });
-
-    // createBranch checks out the new branch.
-    await git.createBranch(repo, "feature");
-    let branches = await git.branches(repo);
-    expect(branches.find((b) => b.name === "feature")).toMatchObject({
-      current: true,
-    });
-    expect(branches.find((b) => b.name === base)).toMatchObject({
-      current: false,
+      await git.commit(repo, "add a");
+      s = await git.status(repo);
+      expect(s.files).toEqual([]); // clean after commit
     });
 
-    // switchBranch moves HEAD back.
-    await git.switchBranch(repo, base);
-    branches = await git.branches(repo);
-    expect(branches.find((b) => b.name === base)).toMatchObject({
-      current: true,
-    });
-
-    // deleteBranch removes a (merged) branch.
-    await git.deleteBranch(repo, "feature");
-    expect((await git.branches(repo)).map((b) => b.name)).toEqual([base]);
-  });
-
-  it("renames a branch", async () => {
-    await seedCommit();
-    await git.createBranch(repo, "old-name");
-    await git.renameBranch(repo, "old-name", "new-name");
-    const names = (await git.branches(repo)).map((b) => b.name);
-    expect(names).toContain("new-name");
-    expect(names).not.toContain("old-name");
-  });
-
-  it("refuses to delete an unmerged branch without force", async () => {
-    await seedCommit();
-    const base = (await git.branches(repo)).find((b) => b.current)!.name;
-
-    // Commit something only on the side branch so it isn't merged into base.
-    await git.createBranch(repo, "wip");
-    writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
-    await git.stage(repo, ["b.txt"]);
-    await git.commit(repo, "wip work");
-    await git.switchBranch(repo, base);
-
-    await expect(git.deleteBranch(repo, "wip")).rejects.toThrow(
-      /not fully merged/i,
-    );
-    // Force succeeds.
-    await git.deleteBranch(repo, "wip", true);
-    expect((await git.branches(repo)).map((b) => b.name)).not.toContain("wip");
-  });
-
-  it("reports unmerged commits for a branch (empty when merged)", async () => {
-    await seedCommit();
-    const base = (await git.branches(repo)).find((b) => b.current)!.name;
-
-    // A branch with no extra commits is fully merged → nothing at risk.
-    await git.createBranch(repo, "merged");
-    await git.switchBranch(repo, base);
-    expect(await git.unmergedCommits(repo, "merged")).toEqual([]);
-
-    // A branch with a unique commit reports it as unmerged (vs HEAD/base).
-    await git.createBranch(repo, "wip");
-    writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
-    await git.stage(repo, ["b.txt"]);
-    await git.commit(repo, "wip work");
-    await git.switchBranch(repo, base);
-
-    const unmerged = await git.unmergedCommits(repo, "wip");
-    expect(unmerged).toHaveLength(1);
-    expect(unmerged[0].subject).toBe("wip work");
-  });
-
-  it("falls back to HEAD when the branch's upstream ref can't be resolved", async () => {
-    await seedCommit();
-    const base = (await git.branches(repo)).find((b) => b.current)!.name;
-    await git.createBranch(repo, "wip");
-    writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
-    await git.stage(repo, ["b.txt"]);
-    await git.commit(repo, "wip work");
-    await git.switchBranch(repo, base);
-
-    // A dangling upstream (e.g. a pruned remote-tracking branch) makes
-    // `<upstream>..wip` error; we must fall back to HEAD and still surface the
-    // unmerged commit rather than reporting the branch as safe to delete.
-    const unmerged = await git.unmergedCommits(repo, "wip", "origin/gone");
-    expect(unmerged).toHaveLength(1);
-    expect(unmerged[0].subject).toBe("wip work");
-  });
-
-  it("fetch --prune drops remote-tracking branches deleted upstream", async () => {
-    await seedCommit();
-    const base = (await git.branches(repo)).find((b) => b.current)!.name;
-    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
-    try {
-      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
-      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
-      await realExec("git", ["push", "-q", "origin", base], { cwd: repo });
-
-      // Push a branch, then fetch so its remote-tracking ref exists locally.
-      await git.createBranch(repo, "temp");
-      await realExec("git", ["push", "-q", "origin", "temp"], { cwd: repo });
-      await git.switchBranch(repo, base);
-      await git.fetch(repo, false);
-      expect((await git.branches(repo)).map((b) => b.name)).toContain(
-        "origin/temp",
-      );
-
-      // Delete it directly on the remote (as another clone would) so this
-      // clone's `origin/temp` tracking ref is now stale — still listed…
-      await realExec("git", ["branch", "-D", "temp"], { cwd: remote });
-      expect((await git.branches(repo)).map((b) => b.name)).toContain(
-        "origin/temp",
-      );
-
-      // …until fetch --prune reconciles and removes it.
-      await git.fetch(repo, true);
-      expect((await git.branches(repo)).map((b) => b.name)).not.toContain(
-        "origin/temp",
-      );
-    } finally {
-      rmSync(remote, { recursive: true, force: true });
-    }
-  });
-
-  it("pushes a branch and sets its upstream on first push", async () => {
-    await seedCommit();
-    const base = (await git.branches(repo)).find((b) => b.current)!.name;
-    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
-    try {
-      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
-      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
-
-      // First push of the current branch: publishes it and sets tracking.
-      await git.push(repo, { setUpstream: true });
+    it("unstages a staged file back to modified", async () => {
+      writeFileSync(join(repo, "a.txt"), "v1\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "init");
+      writeFileSync(join(repo, "a.txt"), "v2\n");
+      await git.stage(repo, ["a.txt"]);
       expect(
-        (await git.branches(repo)).find((b) => b.name === base)?.upstream,
-      ).toBe(`origin/${base}`);
+        (await git.status(repo)).files.find((f) => f.path === "a.txt"),
+      ).toMatchObject({ isStaged: true });
 
-      // Push a different local branch by name (without checking it out).
+      await git.unstage(repo, ["a.txt"]);
+      expect(
+        (await git.status(repo)).files.find((f) => f.path === "a.txt"),
+      ).toMatchObject({ isStaged: false, isModified: true });
+    });
+
+    it("reads file content at a revision via show, empty for missing paths", async () => {
+      writeFileSync(join(repo, "a.txt"), "committed\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "init");
+
+      expect(await git.show(repo, "HEAD:a.txt")).toBe("committed\n");
+      expect(await git.show(repo, "HEAD:nope.txt")).toBe(""); // missing → empty
+    });
+
+    it("reverts a working-tree change", async () => {
+      writeFileSync(join(repo, "a.txt"), "orig\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "init");
+      writeFileSync(join(repo, "a.txt"), "scratch\n");
+
+      await git.revertFile(repo, ["a.txt"]);
+      expect((await git.status(repo)).files).toEqual([]); // change discarded
+    });
+
+    it("clean deletes an untracked file (discarding a new file)", async () => {
+      writeFileSync(join(repo, "a.txt"), "v1\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "init");
+      writeFileSync(join(repo, "junk.txt"), "scratch\n");
+      expect(
+        (await git.status(repo)).files.find((f) => f.path === "junk.txt"),
+      ).toMatchObject({ isUntracked: true });
+
+      await git.clean(repo, ["junk.txt"]);
+      expect(existsSync(join(repo, "junk.txt"))).toBe(false);
+      expect((await git.status(repo)).files).toEqual([]);
+    });
+
+    it("revertFile errors on an untracked path (use clean instead)", async () => {
+      writeFileSync(join(repo, "a.txt"), "v1\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "init");
+      writeFileSync(join(repo, "new.txt"), "untracked\n");
+      // git restore can't act on a path it doesn't know — the panel routes
+      // untracked discards to clean() for exactly this reason.
+      await expect(git.revertFile(repo, ["new.txt"])).rejects.toThrow(
+        /did not match any file/i,
+      );
+    });
+
+    // A repo needs one commit before branches exist / can be created.
+    async function seedCommit() {
+      writeFileSync(join(repo, "a.txt"), "v1\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "init");
+    }
+
+    it("creates, lists, switches between, and deletes branches", async () => {
+      await seedCommit();
+      const initial = await git.branches(repo);
+      expect(initial).toHaveLength(1);
+      const base = initial[0].name; // "main" or "master" depending on git config
+      expect(initial[0]).toMatchObject({ current: true, remote: false });
+
+      // createBranch checks out the new branch.
       await git.createBranch(repo, "feature");
-      writeFileSync(join(repo, "f.txt"), "x\n");
-      await git.stage(repo, ["f.txt"]);
-      await git.commit(repo, "feature work");
+      let branches = await git.branches(repo);
+      expect(branches.find((b) => b.name === "feature")).toMatchObject({
+        current: true,
+      });
+      expect(branches.find((b) => b.name === base)).toMatchObject({
+        current: false,
+      });
+
+      // switchBranch moves HEAD back.
       await git.switchBranch(repo, base);
-      await git.push(repo, {
-        branch: "feature",
-        remote: "origin",
-        setUpstream: true,
+      branches = await git.branches(repo);
+      expect(branches.find((b) => b.name === base)).toMatchObject({
+        current: true,
       });
-      const { stdout } = await realExec("git", ["branch"], { cwd: remote });
-      expect(stdout).toContain("feature");
-    } finally {
-      rmSync(remote, { recursive: true, force: true });
-    }
-  });
 
-  it("pulls (fast-forward) commits added upstream", async () => {
-    await seedCommit();
-    const base = (await git.branches(repo)).find((b) => b.current)!.name;
-    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
-    const other = mkdtempSync(join(tmpdir(), "silo-gitclone-"));
-    try {
-      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
-      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
-      // Publish base and set tracking, so pull knows its upstream.
-      await git.push(repo, { setUpstream: true });
+      // deleteBranch removes a (merged) branch.
+      await git.deleteBranch(repo, "feature");
+      expect((await git.branches(repo)).map((b) => b.name)).toEqual([base]);
+    });
 
-      // A second clone advances the branch on the remote.
-      await realExec("git", ["clone", "-q", remote, other], {});
-      await realExec("git", ["config", "user.email", "t@t"], { cwd: other });
-      await realExec("git", ["config", "user.name", "t"], { cwd: other });
-      writeFileSync(join(other, "upstream.txt"), "from elsewhere\n");
-      await realExec("git", ["add", "."], { cwd: other });
-      await realExec("git", ["commit", "-q", "-m", "remote commit"], {
-        cwd: other,
-      });
-      await realExec("git", ["push", "-q", "origin", base], { cwd: other });
+    it("renames a branch", async () => {
+      await seedCommit();
+      await git.createBranch(repo, "old-name");
+      await git.renameBranch(repo, "old-name", "new-name");
+      const names = (await git.branches(repo)).map((b) => b.name);
+      expect(names).toContain("new-name");
+      expect(names).not.toContain("old-name");
+    });
 
-      // repo is now behind; a fast-forward pull brings the commit in.
-      await git.pull(repo);
-      expect(existsSync(join(repo, "upstream.txt"))).toBe(true);
-      const { stdout } = await realExec("git", ["log", "--oneline"], {
-        cwd: repo,
-      });
-      expect(stdout).toContain("remote commit");
-    } finally {
-      rmSync(remote, { recursive: true, force: true });
-      rmSync(other, { recursive: true, force: true });
-    }
-  });
+    it("refuses to delete an unmerged branch without force", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
 
-  it("rejects a fast-forward pull when the branch has diverged", async () => {
-    await seedCommit();
-    const base = (await git.branches(repo)).find((b) => b.current)!.name;
-    const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
-    const other = mkdtempSync(join(tmpdir(), "silo-gitclone-"));
-    try {
-      await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
-      await realExec("git", ["remote", "add", "origin", remote], { cwd: repo });
-      await git.push(repo, { setUpstream: true });
+      // Commit something only on the side branch so it isn't merged into base.
+      await git.createBranch(repo, "wip");
+      writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
+      await git.stage(repo, ["b.txt"]);
+      await git.commit(repo, "wip work");
+      await git.switchBranch(repo, base);
 
-      // The remote advances…
-      await realExec("git", ["clone", "-q", remote, other], {});
-      await realExec("git", ["config", "user.email", "t@t"], { cwd: other });
-      await realExec("git", ["config", "user.name", "t"], { cwd: other });
-      writeFileSync(join(other, "remote.txt"), "remote side\n");
-      await realExec("git", ["add", "."], { cwd: other });
-      await realExec("git", ["commit", "-q", "-m", "remote commit"], {
-        cwd: other,
-      });
-      await realExec("git", ["push", "-q", "origin", base], { cwd: other });
+      await expect(git.deleteBranch(repo, "wip")).rejects.toThrow(
+        /not fully merged/i,
+      );
+      // Force succeeds.
+      await git.deleteBranch(repo, "wip", true);
+      expect((await git.branches(repo)).map((b) => b.name)).not.toContain(
+        "wip",
+      );
+    });
 
-      // …while repo makes its own commit — now the histories have diverged.
-      writeFileSync(join(repo, "local.txt"), "local side\n");
-      await git.stage(repo, ["local.txt"]);
-      await git.commit(repo, "local commit");
+    it("reports unmerged commits for a branch (empty when merged)", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
 
-      // --ff-only can't reconcile a divergence, so it must reject (no merge).
-      await expect(git.pull(repo)).rejects.toThrow();
-    } finally {
-      rmSync(remote, { recursive: true, force: true });
-      rmSync(other, { recursive: true, force: true });
-    }
-  });
-});
+      // A branch with no extra commits is fully merged → nothing at risk.
+      await git.createBranch(repo, "merged");
+      await git.switchBranch(repo, base);
+      expect(await git.unmergedCommits(repo, "merged")).toEqual([]);
+
+      // A branch with a unique commit reports it as unmerged (vs HEAD/base).
+      await git.createBranch(repo, "wip");
+      writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
+      await git.stage(repo, ["b.txt"]);
+      await git.commit(repo, "wip work");
+      await git.switchBranch(repo, base);
+
+      const unmerged = await git.unmergedCommits(repo, "wip");
+      expect(unmerged).toHaveLength(1);
+      expect(unmerged[0].subject).toBe("wip work");
+    });
+
+    it("falls back to HEAD when the branch's upstream ref can't be resolved", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      await git.createBranch(repo, "wip");
+      writeFileSync(join(repo, "b.txt"), "only-on-wip\n");
+      await git.stage(repo, ["b.txt"]);
+      await git.commit(repo, "wip work");
+      await git.switchBranch(repo, base);
+
+      // A dangling upstream (e.g. a pruned remote-tracking branch) makes
+      // `<upstream>..wip` error; we must fall back to HEAD and still surface the
+      // unmerged commit rather than reporting the branch as safe to delete.
+      const unmerged = await git.unmergedCommits(repo, "wip", "origin/gone");
+      expect(unmerged).toHaveLength(1);
+      expect(unmerged[0].subject).toBe("wip work");
+    });
+
+    it("fetch --prune drops remote-tracking branches deleted upstream", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+      try {
+        await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+        await realExec("git", ["remote", "add", "origin", remote], {
+          cwd: repo,
+        });
+        await realExec("git", ["push", "-q", "origin", base], { cwd: repo });
+
+        // Push a branch, then fetch so its remote-tracking ref exists locally.
+        await git.createBranch(repo, "temp");
+        await realExec("git", ["push", "-q", "origin", "temp"], { cwd: repo });
+        await git.switchBranch(repo, base);
+        await git.fetch(repo, false);
+        expect((await git.branches(repo)).map((b) => b.name)).toContain(
+          "origin/temp",
+        );
+
+        // Delete it directly on the remote (as another clone would) so this
+        // clone's `origin/temp` tracking ref is now stale — still listed…
+        await realExec("git", ["branch", "-D", "temp"], { cwd: remote });
+        expect((await git.branches(repo)).map((b) => b.name)).toContain(
+          "origin/temp",
+        );
+
+        // …until fetch --prune reconciles and removes it.
+        await git.fetch(repo, true);
+        expect((await git.branches(repo)).map((b) => b.name)).not.toContain(
+          "origin/temp",
+        );
+      } finally {
+        rmSync(remote, { recursive: true, force: true });
+      }
+    });
+
+    it("pushes a branch and sets its upstream on first push", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+      try {
+        await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+        await realExec("git", ["remote", "add", "origin", remote], {
+          cwd: repo,
+        });
+
+        // First push of the current branch: publishes it and sets tracking.
+        await git.push(repo, { setUpstream: true });
+        expect(
+          (await git.branches(repo)).find((b) => b.name === base)?.upstream,
+        ).toBe(`origin/${base}`);
+
+        // Push a different local branch by name (without checking it out).
+        await git.createBranch(repo, "feature");
+        writeFileSync(join(repo, "f.txt"), "x\n");
+        await git.stage(repo, ["f.txt"]);
+        await git.commit(repo, "feature work");
+        await git.switchBranch(repo, base);
+        await git.push(repo, {
+          branch: "feature",
+          remote: "origin",
+          setUpstream: true,
+        });
+        const { stdout } = await realExec("git", ["branch"], { cwd: remote });
+        expect(stdout).toContain("feature");
+      } finally {
+        rmSync(remote, { recursive: true, force: true });
+      }
+    });
+
+    it("pulls (fast-forward) commits added upstream", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+      const other = mkdtempSync(join(tmpdir(), "silo-gitclone-"));
+      try {
+        await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+        await realExec("git", ["remote", "add", "origin", remote], {
+          cwd: repo,
+        });
+        // Publish base and set tracking, so pull knows its upstream.
+        await git.push(repo, { setUpstream: true });
+
+        // A second clone advances the branch on the remote.
+        await realExec("git", ["clone", "-q", remote, other], {});
+        await realExec("git", ["config", "user.email", "t@t"], { cwd: other });
+        await realExec("git", ["config", "user.name", "t"], { cwd: other });
+        writeFileSync(join(other, "upstream.txt"), "from elsewhere\n");
+        await realExec("git", ["add", "."], { cwd: other });
+        await realExec("git", ["commit", "-q", "-m", "remote commit"], {
+          cwd: other,
+        });
+        await realExec("git", ["push", "-q", "origin", base], { cwd: other });
+
+        // repo is now behind; a fast-forward pull brings the commit in.
+        await git.pull(repo);
+        expect(existsSync(join(repo, "upstream.txt"))).toBe(true);
+        const { stdout } = await realExec("git", ["log", "--oneline"], {
+          cwd: repo,
+        });
+        expect(stdout).toContain("remote commit");
+      } finally {
+        rmSync(remote, { recursive: true, force: true });
+        rmSync(other, { recursive: true, force: true });
+      }
+    });
+
+    // Git reports worktree paths realpath'd (on macOS, tmpdir() is a symlink into
+    // /private/...), so expectations resolve through realpathSync too — this pins
+    // the mismatch the panel's samePath() normalization exists for.
+    const real = (p: string) => realpathSync(p).replace(/\\/g, "/");
+
+    it("lists worktrees (main first) and creates one on a new branch", async () => {
+      await seedCommit();
+
+      let wts = await git.worktrees(repo);
+      expect(wts).toHaveLength(1);
+      expect(wts[0]).toMatchObject({ isMain: true, bare: false });
+      expect(wts[0].path).toBe(real(repo));
+
+      const wtPath = join(tmpdir(), `silo-gitwt-${Date.now()}`);
+      try {
+        await git.addWorktree(repo, wtPath, { newBranch: "feat/x" });
+        wts = await git.worktrees(repo);
+        expect(wts).toHaveLength(2);
+        expect(wts[0].isMain).toBe(true);
+        const linked = wts[1];
+        expect(linked.isMain).toBe(false);
+        expect(linked.branch).toBe("feat/x");
+        expect(linked.path).toBe(real(wtPath));
+
+        // The family is visible from the linked worktree too, same order.
+        const fromLinked = await git.worktrees(wtPath);
+        expect(fromLinked.map((w) => w.path)).toEqual(wts.map((w) => w.path));
+      } finally {
+        rmSync(wtPath, { recursive: true, force: true });
+      }
+    });
+
+    it("creates a worktree for an existing branch, refuses one already checked out", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      await git.createBranch(repo, "other");
+      await git.switchBranch(repo, base);
+
+      const wtPath = join(tmpdir(), `silo-gitwt-${Date.now()}`);
+      try {
+        await git.addWorktree(repo, wtPath, { branch: "other" });
+        const wts = await git.worktrees(repo);
+        expect(wts.find((w) => w.branch === "other")?.path).toBe(real(wtPath));
+
+        // `base` is checked out in the main worktree — git refuses a second one.
+        const wtPath2 = join(tmpdir(), `silo-gitwt2-${Date.now()}`);
+        await expect(
+          git.addWorktree(repo, wtPath2, { branch: base }),
+        ).rejects.toThrow(/already checked out|already used by worktree/i);
+      } finally {
+        rmSync(wtPath, { recursive: true, force: true });
+      }
+    });
+
+    it("removes a worktree: refuses dirty without force, keeps the branch", async () => {
+      await seedCommit();
+      const wtPath = join(tmpdir(), `silo-gitwt-${Date.now()}`);
+      try {
+        await git.addWorktree(repo, wtPath, { newBranch: "wt-branch" });
+        writeFileSync(join(wtPath, "scratch.txt"), "dirty\n");
+
+        await expect(git.removeWorktree(repo, wtPath)).rejects.toThrow(
+          /contains modified or untracked files|use --force/i,
+        );
+        expect(existsSync(wtPath)).toBe(true);
+
+        await git.removeWorktree(repo, wtPath, true);
+        expect(existsSync(wtPath)).toBe(false);
+        expect(await git.worktrees(repo)).toHaveLength(1);
+        // The branch survives the worktree's removal.
+        expect((await git.branches(repo)).map((b) => b.name)).toContain(
+          "wt-branch",
+        );
+      } finally {
+        rmSync(wtPath, { recursive: true, force: true });
+      }
+    });
+
+    it("flags a deleted worktree as prunable and prunes it", async () => {
+      await seedCommit();
+      const wtPath = join(tmpdir(), `silo-gitwt-${Date.now()}`);
+      await git.addWorktree(repo, wtPath, { newBranch: "gone" });
+      // Delete the directory out from under git (as `rm -rf` would).
+      rmSync(wtPath, { recursive: true, force: true });
+
+      const stale = (await git.worktrees(repo)).find((w) => !w.isMain);
+      expect(stale?.prunable).toBeTruthy();
+
+      await git.pruneWorktrees(repo);
+      expect(await git.worktrees(repo)).toHaveLength(1);
+    });
+
+    it("worktrees resolves to an empty list outside a repository", async () => {
+      const outside = mkdtempSync(join(tmpdir(), "silo-norepo-"));
+      try {
+        expect(await git.worktrees(outside)).toEqual([]);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects a fast-forward pull when the branch has diverged", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+      const other = mkdtempSync(join(tmpdir(), "silo-gitclone-"));
+      try {
+        await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+        await realExec("git", ["remote", "add", "origin", remote], {
+          cwd: repo,
+        });
+        await git.push(repo, { setUpstream: true });
+
+        // The remote advances…
+        await realExec("git", ["clone", "-q", remote, other], {});
+        await realExec("git", ["config", "user.email", "t@t"], { cwd: other });
+        await realExec("git", ["config", "user.name", "t"], { cwd: other });
+        writeFileSync(join(other, "remote.txt"), "remote side\n");
+        await realExec("git", ["add", "."], { cwd: other });
+        await realExec("git", ["commit", "-q", "-m", "remote commit"], {
+          cwd: other,
+        });
+        await realExec("git", ["push", "-q", "origin", base], { cwd: other });
+
+        // …while repo makes its own commit — now the histories have diverged.
+        writeFileSync(join(repo, "local.txt"), "local side\n");
+        await git.stage(repo, ["local.txt"]);
+        await git.commit(repo, "local commit");
+
+        // --ff-only can't reconcile a divergence, so it must reject (no merge).
+        await expect(git.pull(repo)).rejects.toThrow();
+      } finally {
+        rmSync(remote, { recursive: true, force: true });
+        rmSync(other, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -1,6 +1,7 @@
 import type { GitAPI, GitLogEntry } from "./git-api";
 import { parseGitStatus } from "./parse-status";
 import { parseBranches } from "./parse-branches";
+import { parseWorktrees } from "./parse-worktrees";
 
 // The GitAPI implementation, built on a generic one-shot `exec` (ctx.process.exec
 // in the app; a real-git wrapper in the contract test). This is the whole point
@@ -208,6 +209,50 @@ export function createGitService(exec: ExecFn): GitAPI {
         if (code === 0) return parseLog(stdout);
       }
       return [];
+    },
+
+    async worktrees(cwd) {
+      const { stdout, code } = await git(cwd, [
+        "worktree",
+        "list",
+        "--porcelain",
+      ]);
+      // Any error (e.g. not a git repository) → no worktrees.
+      if (code !== 0) return [];
+      return parseWorktrees(stdout);
+    },
+
+    addWorktree(cwd, path, options) {
+      // Existing branch: `worktree add <path> <branch>`; new branch:
+      // `worktree add -b <name> <path> [startPoint]`. Note the created path may
+      // lie outside the workspace's scope roots — fine for the bundled (unscoped)
+      // silo.git, but a scoped third-party git extension couldn't exec there.
+      return run(
+        cwd,
+        "branch" in options
+          ? ["worktree", "add", path, options.branch]
+          : [
+              "worktree",
+              "add",
+              "-b",
+              options.newBranch,
+              path,
+              ...(options.startPoint ? [options.startPoint] : []),
+            ],
+      );
+    },
+
+    removeWorktree(cwd, path, force) {
+      return run(cwd, [
+        "worktree",
+        "remove",
+        ...(force ? ["--force"] : []),
+        path,
+      ]);
+    },
+
+    pruneWorktrees(cwd) {
+      return run(cwd, ["worktree", "prune"]);
     },
   };
 }

--- a/packages/extensions-silo/src/git/index.ts
+++ b/packages/extensions-silo/src/git/index.ts
@@ -35,7 +35,11 @@ export const extension: Extension<GitAPI> = {
       // Strip --no-optional-locks from the display — it's an internal safeguard.
       const displayArgs = args.filter((a) => a !== "--no-optional-locks");
       const subcommand = displayArgs[0] ?? "";
-      const isReadOnly = READ_ONLY.has(subcommand);
+      // `worktree list` is a read the panel polls; other worktree subcommands
+      // (add/remove/prune) mutate and stay at info.
+      const isReadOnly =
+        READ_ONLY.has(subcommand) ||
+        (subcommand === "worktree" && displayArgs[1] === "list");
       ctx.log[isReadOnly ? "debug" : "info"](
         `> ${[command, ...displayArgs].join(" ")}`,
         options?.cwd ? { cwd: options.cwd } : undefined,

--- a/packages/extensions-silo/src/git/parse-worktrees.test.ts
+++ b/packages/extensions-silo/src/git/parse-worktrees.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { parseWorktrees } from "./parse-worktrees";
+
+// Fixtures mimic `git worktree list --porcelain`: blank-line-separated stanzas,
+// each starting with `worktree <abs-path>`.
+
+describe("parseWorktrees", () => {
+  it("parses a main-only repo", () => {
+    const raw = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+    ].join("\n");
+    expect(parseWorktrees(raw)).toEqual([
+      {
+        path: "/repo",
+        head: "abc123",
+        branch: "main",
+        isMain: true,
+        detached: false,
+        bare: false,
+        locked: null,
+        prunable: null,
+      },
+    ]);
+  });
+
+  it("marks only the first stanza as the main worktree", () => {
+    const raw = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo-feat",
+      "HEAD def456",
+      "branch refs/heads/feat/x",
+      "",
+    ].join("\n");
+    const [main, linked] = parseWorktrees(raw);
+    expect(main.isMain).toBe(true);
+    expect(linked.isMain).toBe(false);
+    expect(linked.path).toBe("/repo-feat");
+    expect(linked.branch).toBe("feat/x");
+  });
+
+  it("strips the refs/heads/ prefix but keeps slashes in branch names", () => {
+    const raw = [
+      "worktree /w",
+      "HEAD a",
+      "branch refs/heads/feat/core-updates",
+    ].join("\n");
+    expect(parseWorktrees(raw)[0].branch).toBe("feat/core-updates");
+  });
+
+  it("parses a detached worktree with no branch", () => {
+    const raw = ["worktree /w", "HEAD abc123", "detached"].join("\n");
+    expect(parseWorktrees(raw)[0]).toMatchObject({
+      branch: null,
+      detached: true,
+      head: "abc123",
+    });
+  });
+
+  it("parses a bare entry", () => {
+    const raw = ["worktree /repo.git", "bare"].join("\n");
+    expect(parseWorktrees(raw)[0]).toMatchObject({
+      bare: true,
+      head: null,
+      branch: null,
+    });
+  });
+
+  it("parses locked with and without a reason", () => {
+    const raw = [
+      "worktree /a",
+      "HEAD x",
+      "branch refs/heads/a",
+      "locked",
+      "",
+      "worktree /b",
+      "HEAD y",
+      "branch refs/heads/b",
+      "locked reason with spaces",
+      "",
+    ].join("\n");
+    const [a, b] = parseWorktrees(raw);
+    expect(a.locked).toBe("");
+    expect(b.locked).toBe("reason with spaces");
+  });
+
+  it("parses a prunable entry with a reason", () => {
+    const raw = [
+      "worktree /gone",
+      "HEAD abc",
+      "branch refs/heads/gone",
+      "prunable gitdir file points to non-existent location",
+    ].join("\n");
+    expect(parseWorktrees(raw)[0].prunable).toBe(
+      "gitdir file points to non-existent location",
+    );
+  });
+
+  it("normalizes backslashes in paths to forward slashes", () => {
+    const raw = [
+      "worktree C:\\repos\\proj",
+      "HEAD a",
+      "branch refs/heads/main",
+    ].join("\n");
+    expect(parseWorktrees(raw)[0].path).toBe("C:/repos/proj");
+  });
+
+  it("tolerates trailing blank lines and returns empty for empty input", () => {
+    expect(parseWorktrees("")).toEqual([]);
+    expect(parseWorktrees("\n\n")).toEqual([]);
+    const raw = [
+      "worktree /repo",
+      "HEAD a",
+      "branch refs/heads/main",
+      "",
+      "",
+    ].join("\n");
+    expect(parseWorktrees(raw)).toHaveLength(1);
+  });
+});

--- a/packages/extensions-silo/src/git/parse-worktrees.ts
+++ b/packages/extensions-silo/src/git/parse-worktrees.ts
@@ -1,0 +1,57 @@
+import type { GitWorktree } from "./git-api";
+
+// Pure parser for `git worktree list --porcelain`. Kept a pure
+// string→GitWorktree[] function (no exec) so it's unit-testable against
+// captured fixtures, the same way parse-status.ts and parse-branches.ts are.
+
+/**
+ * Parse `git worktree list --porcelain` output into {@link GitWorktree}
+ * entries. Stanzas are separated by blank lines and each starts with
+ * `worktree <abs-path>`, followed by attribute lines: `HEAD <sha>`,
+ * `branch refs/heads/<name>`, bare labels `bare` / `detached`, and
+ * label-with-optional-value lines `locked [reason]` / `prunable [reason]`.
+ * Git always lists the main worktree first.
+ */
+export function parseWorktrees(raw: string): GitWorktree[] {
+  const worktrees: GitWorktree[] = [];
+  let current: GitWorktree | null = null;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) {
+      current = null;
+      continue;
+    }
+    if (line.startsWith("worktree ")) {
+      current = {
+        // Forward slashes, matching the repo-wide path convention.
+        path: line.slice("worktree ".length).replace(/\\/g, "/"),
+        head: null,
+        branch: null,
+        isMain: worktrees.length === 0,
+        detached: false,
+        bare: false,
+        locked: null,
+        prunable: null,
+      };
+      worktrees.push(current);
+      continue;
+    }
+    if (!current) continue;
+    if (line.startsWith("HEAD ")) {
+      current.head = line.slice("HEAD ".length);
+    } else if (line.startsWith("branch ")) {
+      const ref = line.slice("branch ".length);
+      current.branch = ref.startsWith("refs/heads/")
+        ? ref.slice("refs/heads/".length)
+        : ref;
+    } else if (line === "bare") {
+      current.bare = true;
+    } else if (line === "detached") {
+      current.detached = true;
+    } else if (line === "locked" || line.startsWith("locked ")) {
+      current.locked = line.slice("locked".length).trim();
+    } else if (line === "prunable" || line.startsWith("prunable ")) {
+      current.prunable = line.slice("prunable".length).trim();
+    }
+  }
+  return worktrees;
+}


### PR DESCRIPTION
## Summary

Adds a **Worktrees** manager to the Git panel (`silo.*`), so you can list, open, create, and remove git worktrees without leaving Silo. Opening a worktree adds it as another folder in the workspace — File Explorer, the Git panel, and terminals grow an extra root — letting you work a second branch alongside the current one.

### Git service surface
A new worktree API on `silo.git`, backed by a porcelain parser (`parse-worktrees.ts`):
- `worktrees(cwd)` — list all working trees (main first)
- `addWorktree(cwd, path, { branch } | { newBranch, startPoint? })`
- `removeWorktree(cwd, path, force?)`
- `pruneWorktrees(cwd)`

`GitWorktree` carries `path`, `head`, `branch`, `isMain`, `detached`, `bare`, `locked`, and `prunable`. `worktree list` is treated as a pollable read.

### Modal UX (`WorktreeManager`)
- **Two-line rows** — directory name over the checked-out branch, both truncated with `…`, so long worktree names no longer scroll the row controls off-screen.
- **Click to toggle** — clicking a row opens it alongside, or closes the view if already open (the worktree stays on disk). The redundant open/close icons are gone; the hover tooltip on the name states what a click will do.
- **Guidance copy** — a lead under the title explains the toggle, and a note above the footer explains what an open worktree gives you.
- **Create / prune** from the footer; **remove** (with a dirty-tree force confirm) from the row.

### Related fix — File Explorer roots
Long root names were clipping their trailing action icons (new file/folder, refresh, collapse). The root name now truncates, and the root actions are an absolute overlay that appears on panel hover (discoverability preserved) instead of reflowing the row — so the row height and title position don't jump when the icons appear.

## Testing
- `pnpm test` (git + worktree suites): 84 passing, including the porcelain parser and the worktree row/action model.
- `pnpm lint` and typecheck green.
- Runtime verification of the modal is still pending a dev-app restart on my end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)