### PR TITLE
feat(dock): show a tooltip with the full tab name when the label is truncated

### DIFF
--- a/apps/docs/api/other/tooltip.md
+++ b/apps/docs/api/other/tooltip.md
@@ -42,6 +42,17 @@ function PanelActions({ onNewFile, onNewFolder, onRefresh }) {
 trigger. Drop the native `title` attribute when you add `Tooltip`; they serve
 the same purpose and the native one produces a second popup.
 
+Pass `disabled` to suppress the popup while keeping the wrapper mounted (so
+layout doesn't shift). This is the way to make a tooltip conditional without
+toggling the element in and out of the tree — for example, showing a tab's full
+name only once its label is truncated:
+
+```tsx
+<Tooltip content={title} disabled={!isTruncated}>
+  <span className="tab-label">{title}</span>
+</Tooltip>
+```
+
 ## Behaviour
 
 - **600 ms hover delay** — avoids visual noise while the cursor moves across
@@ -54,6 +65,8 @@ the same purpose and the native one produces a second popup.
   enough room above, it flips below.
 - **Display-only** — `pointer-events: none` on the popup; it never
   interferes with the element beneath it.
+- **Disablable** — when `disabled` is `true` the wrapper still renders (layout
+  is unchanged) but the popup never appears.
 
 ## Styling
 
@@ -66,7 +79,8 @@ host loads the CSS.
 ## Types
 
 - [`Tooltip`](/api/types/functions/Tooltip) — the component's generated type
-  reference (props: `content: string`, `children: ReactNode`).
+  reference (props: `content: string`, `children: ReactNode`,
+  `disabled?: boolean`).
 
 ## See also
 

--- a/apps/docs/api/types/functions/Tooltip.md
+++ b/apps/docs/api/types/functions/Tooltip.md
@@ -4,7 +4,7 @@
 function Tooltip(__namedParameters): Element;
 ```
 
-Defined in: [packages/sdk/src/Tooltip.tsx:31](https://github.com/silo-code/silo/blob/main/packages/sdk/src/Tooltip.tsx#L31)
+Defined in: [packages/sdk/src/Tooltip.tsx:35](https://github.com/silo-code/silo/blob/main/packages/sdk/src/Tooltip.tsx#L35)
 
 Lightweight tooltip — wraps any trigger element and shows a styled popup
 above it after a 600 ms hover delay. Renders via a portal so `overflow:
@@ -16,6 +16,10 @@ style exactly. Display-only: `pointer-events: none`.
 The CSS classes (`.silo-tooltip`, `.silo-tooltip-host`) are provided by the
 host — no stylesheet import is needed in the extension.
 
+Pass `disabled` to keep the trigger wrapper mounted (so layout stays stable)
+while suppressing the popup — handy when the tooltip is only useful
+conditionally, e.g. showing the full label of a tab only once it's truncated.
+
 ## Parameters
 
 ### \_\_namedParameters
@@ -24,9 +28,20 @@ host — no stylesheet import is needed in the extension.
 
 `string`
 
+Text shown in the popup.
+
 #### children
 
 `ReactNode`
+
+The trigger element the tooltip is anchored to.
+
+#### disabled?
+
+`boolean` = `false`
+
+When `true`, the wrapper still renders (layout is unchanged) but the popup
+never appears. Defaults to `false`.
 
 ## Returns
 

--- a/packages/extension-host/src/panels/CenterDock.css
+++ b/packages/extension-host/src/panels/CenterDock.css
@@ -229,6 +229,15 @@
 .editor-dock .dv-tabs-container .dv-tab .dv-default-tab-action {
   flex-shrink: 0;
 }
+/* The label is wrapped in a `<Tooltip>` (`.silo-tooltip-host`) so the full name
+ * shows on hover once the label is truncated — the host span is now the flex
+ * child, so it carries the shrink + `min-width: 0` and the inner content span
+ * keeps the ellipsis. */
+.editor-dock .dv-tabs-container .dv-tab .silo-tooltip-host {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
 .editor-dock .dv-tabs-container .dv-tab .dv-default-tab-content {
   min-width: 0;
   overflow: hidden;

--- a/packages/extension-host/src/panels/DockTab.tsx
+++ b/packages/extension-host/src/panels/DockTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSnapshot } from "valtio";
 import type { IDockviewPanelHeaderProps } from "dockview";
 import type { TerminalTabDecoration } from "@silo-code/sdk";
@@ -10,6 +10,7 @@ import {
 } from "../state/workspaces";
 import { prompt } from "../extension-host/modal-service";
 import { terminalTabDecorationRegistry } from "../extension-host/terminal-tab-decoration-registry";
+import { Tooltip } from "../components/Tooltip";
 
 // Custom tab: mirrors dockview's default tab DOM, but renders the dirty marker
 // as its own styled span so we can size/color it independently. (DockviewDefaultTab
@@ -32,6 +33,12 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
   const [isDeleted, setIsDeleted] = useState(
     () => !!api.getParameters<{ deleted?: boolean }>().deleted,
   );
+  // Only surface the hover tooltip when the label is actually clipped by the
+  // shrink-to-fit tab strip (see CenterDock.css) — otherwise it just gets in
+  // the way. `scrollWidth > clientWidth` on the label span detects the ellipsis;
+  // a ResizeObserver re-checks whenever the strip resizes or tabs open/close.
+  const contentRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
   const snap = useSnapshot(store);
   const [tabDecoration, setTabDecoration] =
     useState<TerminalTabDecoration | null>(() =>
@@ -56,6 +63,16 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
     setTitle(api.title ?? "");
     return () => sub.dispose();
   }, [api]);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const check = () => setIsTruncated(el.scrollWidth > el.clientWidth);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [title, isDirty]);
 
   // Re-read getParameters() on each change rather than trusting the event
   // payload, which only carries the keys that changed in that update.
@@ -177,12 +194,15 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
       onDoubleClick={onTabDoubleClick}
       onContextMenu={onTabContextMenu}
     >
-      <span
-        className={`dv-default-tab-content${isPreview ? " preview-title" : ""}${isDeleted ? " deleted-title" : ""}`}
-      >
-        {isDirty && <span className="dvi-dirty-indicator">●</span>}
-        {title}
-      </span>
+      <Tooltip content={title} disabled={!isTruncated}>
+        <span
+          ref={contentRef}
+          className={`dv-default-tab-content${isPreview ? " preview-title" : ""}${isDeleted ? " deleted-title" : ""}`}
+        >
+          {isDirty && <span className="dvi-dirty-indicator">●</span>}
+          {title}
+        </span>
+      </Tooltip>
       {tabDecoration && (
         <span
           className="dvi-tab-decoration"

--- a/packages/sdk/src/Tooltip.tsx
+++ b/packages/sdk/src/Tooltip.tsx
@@ -16,6 +16,10 @@ const MARGIN_PX = 8;
  * The CSS classes (`.silo-tooltip`, `.silo-tooltip-host`) are provided by the
  * host — no stylesheet import is needed in the extension.
  *
+ * Pass `disabled` to keep the trigger wrapper mounted (so layout stays stable)
+ * while suppressing the popup — handy when the tooltip is only useful
+ * conditionally, e.g. showing the full label of a tab only once it's truncated.
+ *
  * @example
  * ```tsx
  * <Tooltip content="New File">
@@ -31,9 +35,17 @@ const MARGIN_PX = 8;
 export function Tooltip({
   content,
   children,
+  disabled = false,
 }: {
+  /** Text shown in the popup. */
   content: string;
+  /** The trigger element the tooltip is anchored to. */
   children: ReactNode;
+  /**
+   * When `true`, the wrapper still renders (layout is unchanged) but the popup
+   * never appears. Defaults to `false`.
+   */
+  disabled?: boolean;
 }) {
   const ref = useRef<HTMLSpanElement>(null);
   const [anchor, setAnchor] = useState<{ cx: number; top: number } | null>(
@@ -42,6 +54,7 @@ export function Tooltip({
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const show = () => {
+    if (disabled) return;
     timer.current = setTimeout(() => {
       const r = ref.current?.getBoundingClientRect();
       if (r) setAnchor({ cx: r.left + r.width / 2, top: r.top - GAP_PX });


### PR DESCRIPTION
## Summary

Since #205 shrank editor/terminal tabs to fit the strip, a crowded strip truncates labels to an unreadable ellipsis. This surfaces the full tab name in a hover tooltip — but **only when the label is actually clipped**, so it stays out of the way on readable tabs.

Uses the SDK `<Tooltip>` (the same styled popup the status bar and file explorer use), not a native `title`.

## Changes

- **`packages/sdk/src/Tooltip.tsx`** — add an optional `disabled` prop. It keeps the trigger wrapper mounted (layout stays stable) while suppressing the popup. This is what makes a conditional tooltip work without remounting the trigger — remounting would detach the observer below.
- **`packages/extension-host/src/panels/DockTab.tsx`** — measure truncation (`scrollWidth > clientWidth`) on the label span via a `ResizeObserver` and pass `disabled={!isTruncated}`, so it re-checks as the strip resizes or tabs open/close.
- **`packages/extension-host/src/panels/CenterDock.css`** — the label now nests in `.silo-tooltip-host`, so that wrapper carries the flex shrink + `min-width: 0` and the inner span keeps its ellipsis.
- **Docs** — document `disabled` on the Tooltip API page and regenerate the type reference (per the self-documentation rule for public SDK changes).

## Testing

- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm docs:api`, and `pnpm test` (via the pre-commit hook) all pass.
- No unit test added: the truncation check is a DOM measurement, not extractable pure logic, and this suite deliberately avoids rendered-React tests. Worth a manual check in the running app — open enough tabs to truncate some and confirm the tooltip fires only on the clipped ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)