### PR TITLE
feat(settings): align Extensions & Shortcuts chrome with the shared button/modal system

### DIFF
--- a/packages/extension-host/src/components/SettingsDialog.css
+++ b/packages/extension-host/src/components/SettingsDialog.css
@@ -96,8 +96,9 @@
   flex: 1 1 auto;
   overflow: auto;
   /* Extra right padding reserves the top-right gutter for the close button so
-     page content (e.g. a header action) never sits under it. */
-  padding: 20px 40px 20px var(--settings-pane-pad);
+     page content (e.g. a header action) never sits under it — sized to clear the
+     close button (right: 12px + 26px wide) with breathing room. */
+  padding: 20px 48px 20px var(--settings-pane-pad);
   color: var(--silo-color-text);
 }
 
@@ -119,24 +120,31 @@
   outline-offset: -1px;
 }
 
+/* Mirrors the shared modal close button (.silo-modal-close in theme.css) so the
+   bare Settings card's corner close reads identically to every ctx.ui / <Modal>
+   dialog — same 26px hit target, top-right inset, icon, and ghost hover. */
 .settings-close {
   position: absolute;
-  top: 8px;
-  right: 10px;
+  top: 12px;
+  right: 12px;
   width: 26px;
   height: 26px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  padding: 0;
   background: transparent;
   border: none;
   border-radius: var(--silo-radius-sm);
   color: var(--silo-color-text-lo);
-  font-size: 20px;
-  line-height: 1;
   cursor: pointer;
 }
-.settings-close:hover {
+/* Scoped under .settings-dialog (specificity 0,3,0) so it beats the global
+   `button:hover` rule (0,2,1) — otherwise the close would pick up the darker
+   filled-button hover mix instead of this subtle ghost highlight. This is the
+   same way the shared `.silo-modal .silo-modal-close:hover` outspecifies the
+   global, and matches the focus-ring rule above. */
+.settings-dialog .settings-close:hover {
   background: var(--silo-color-bg-hover);
   color: var(--silo-color-text-hi);
 }

--- a/packages/extension-host/src/components/SettingsDialog.tsx
+++ b/packages/extension-host/src/components/SettingsDialog.tsx
@@ -73,7 +73,14 @@ export function SettingsDialog() {
           title="Close (Esc)"
           aria-label="Close settings"
         >
-          ×
+          <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
         </button>
       </div>
     </Modal>

--- a/packages/extensions-core/src/extensions/ExtensionDetail.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionDetail.tsx
@@ -9,6 +9,8 @@ import {
   type RegistryExtension,
   type RegistryUpdate,
 } from "@silo-code/extension-host/internal";
+import { describeSource, localInstallSource } from "./extensions-list-model";
+import { SOURCE_ICON, sourceOriginLabel } from "./source-meta";
 
 const mgr = getExtensionManager();
 
@@ -79,6 +81,9 @@ export function ExtensionDetail({
     installed?.permissions ?? registryEntry?.latest?.permissions ?? [];
   const attested = registryEntry?.latest?.provenance === "attested";
   const repo = registryEntry?.repo;
+  // Installed from a folder/URL/npm rather than the registry — call the origin
+  // out explicitly (and drop the registry download count, which isn't this build).
+  const localSource = localInstallSource(installed);
 
   return (
     <div className="ext-detail">
@@ -155,7 +160,7 @@ export function ExtensionDetail({
         )}
         {registryEntry && (
           <span className="ext-hint">
-            {registryEntry.totalDownloads} downloads ·{" "}
+            {!localSource && `${registryEntry.totalDownloads} downloads · `}
             <a
               href="#"
               onClick={(e) => {
@@ -168,6 +173,27 @@ export function ExtensionDetail({
           </span>
         )}
       </div>
+
+      {localSource &&
+        (() => {
+          const SourceIcon = SOURCE_ICON[localSource.kind];
+          return (
+            <div
+              className="ext-source-callout"
+              title={describeSource(localSource)}
+            >
+              <SourceIcon size={16} weight="bold" />
+              <div className="ext-source-callout-text">
+                <span className="ext-source-callout-title">
+                  Installed from {sourceOriginLabel(localSource.kind)}
+                </span>
+                <span className="ext-source-callout-value">
+                  {localSource.value}
+                </span>
+              </div>
+            </div>
+          );
+        })()}
 
       <div className="ext-detail-readme">
         {readme === undefined ? (

--- a/packages/extensions-core/src/extensions/ExtensionsPage.css
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.css
@@ -176,26 +176,50 @@
 .ext-hint-warn {
   color: var(--silo-color-warn);
 }
-.ext-source {
+/* Browse row: the origin note that replaces the download count for a
+   folder/URL/npm install. Brighter than the surrounding dim meta line
+   (--silo-color-text-lo) so the "not from the registry" fact stands out. */
+.ext-source-note {
+  color: var(--silo-color-text-hi);
+}
+
+/* Detail view: an unmissable callout for a folder/URL/npm origin — the source
+   icon plus the full path/URL, which the Browse row deliberately omits. */
+.ext-source-callout {
   display: flex;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-  font-family: var(--silo-font-mono, monospace);
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--silo-color-bg-active);
+  border: 1px solid var(--silo-color-border-strong);
+  border-radius: var(--silo-radius-sm);
 }
-.ext-source svg {
+.ext-source-callout svg {
   flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--silo-color-accent);
 }
-.ext-source-value {
+.ext-source-callout-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.ext-source-callout-title {
+  color: var(--silo-color-text-hi);
+  font-size: calc(var(--settings-font) - 1px);
+}
+.ext-source-callout-value {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  /* Truncate from the left: the tail of a path/URL (the filename, the last
-     path segment) is the useful part, not the leading /Users/you/... or
-     https://... that's the same for every row. */
+  /* Left-truncate: the tail (filename / last path segment) is the useful part. */
   direction: rtl;
   text-align: left;
+  color: var(--silo-color-text-lo);
+  font-family: var(--silo-font-mono, monospace);
+  font-size: calc(var(--settings-font) - 2px);
 }
 
 .ext-actions {
@@ -204,20 +228,14 @@
   gap: 4px;
 }
 
-/* Buttons mirror .kb-edit-btn, sized down from that shared baseline so a row's
-   text (often a long path/URL) keeps most of the row's width. */
+/* Buttons ride the shared global button treatment (the `--silo-button-*` tokens
+   behind `button` / `.silo-button` in theme.css) — the same fill and hover the
+   git-explorer dialogs use — so this rule only trims them to the compact
+   settings-row size, keeping a row's text (often a long path/URL) most of the
+   width. */
 .ext-btn {
-  background: var(--silo-color-bg-active);
-  border: 1px solid var(--silo-color-border);
-  color: var(--silo-color-text-hi);
   padding: 4px 8px;
-  border-radius: var(--silo-radius-sm);
-  cursor: pointer;
-  font: inherit;
   font-size: calc(var(--settings-font) - 2px);
-}
-.ext-btn:hover {
-  background: var(--silo-color-bg-hover);
 }
 .ext-btn:disabled {
   opacity: 0.5;
@@ -230,9 +248,11 @@
   background: transparent;
   border-color: transparent;
 }
-.ext-row-btn:hover {
+/* Quiet ghost reveal on hover — same treatment as the modal close button. The
+   :not(:disabled) also lifts specificity past the global `button:hover` so this
+   wins rather than the darker filled-button hover. */
+.ext-row-btn:hover:not(:disabled) {
   background: var(--silo-color-bg-hover);
-  border-color: var(--silo-color-border);
 }
 .ext-btn-icon {
   padding: 4px 6px;
@@ -245,8 +265,10 @@
 .ext-tabs {
   display: flex;
   gap: 2px;
-  background: var(--silo-color-bg-active);
-  border: 1px solid var(--silo-color-border);
+  /* A recessed well (content surface, sunk below the card) with a defined edge,
+     so the active segment reads as a button raised out of it. */
+  background: var(--silo-color-content-bg);
+  border: 1px solid var(--silo-color-border-strong);
   border-radius: var(--silo-radius-sm);
   padding: 2px;
 }
@@ -264,7 +286,9 @@
   gap: 6px;
 }
 .ext-tab-active {
-  background: var(--silo-color-bg-hover);
+  /* The selected segment reads as a raised button — same fill as a resting
+     `.silo-button` — against the recessed track. */
+  background: var(--silo-button-bg);
   color: var(--silo-color-text-hi);
 }
 .ext-update-count {

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -2,18 +2,13 @@ import { useEffect, useState } from "react";
 import {
   ArrowsClockwise,
   DotsThreeVertical,
-  Folder,
-  LinkSimple,
-  Package,
   SealCheck,
-  Storefront,
 } from "@phosphor-icons/react";
 import type { ExtensionContext, MenuEntry } from "@silo-code/sdk";
 import { useServiceState } from "@silo-code/sdk";
 import {
   getExtensionManager,
   fetchRegistryIndex,
-  type InstallSource,
   type InstalledExtension,
   type ManifestPreview,
   type RegistryExtension,
@@ -21,9 +16,9 @@ import {
 } from "@silo-code/extension-host/internal";
 import { PermissionConsent } from "./PermissionConsent";
 import {
-  describeSource,
   filterExtensions,
   hasBuiltins,
+  localInstallSource,
   showsReloadHint,
   showsUpdateAction,
 } from "./extensions-list-model";
@@ -33,20 +28,11 @@ import {
   isInstallable,
   registryCategories,
 } from "./browse-model";
+import { sourceOriginLabel } from "./source-meta";
 import { ExtensionDetail } from "./ExtensionDetail";
 import "./ExtensionsPage.css";
 
 const mgr = getExtensionManager();
-
-// The label prefix ("Folder: ", "URL: ", …) is redundant once the kind is
-// legible at a glance — an icon says the same thing in less width, leaving
-// more room for the (often long) path/URL/id itself.
-const SOURCE_ICON: Record<InstallSource["kind"], typeof Folder> = {
-  folder: Folder,
-  url: LinkSimple,
-  npm: Package,
-  registry: Storefront,
-};
 
 /** Which pane the page is showing. Browse (the registry) is the landing view. */
 type View =
@@ -380,6 +366,9 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                   const installedExt = extensions.find(
                     (e) => e.id === entry.id,
                   );
+                  // A folder/URL/npm install of this id: note the origin in
+                  // place of the registry download count (it's not this build).
+                  const localSource = localInstallSource(installedExt);
                   const upd = updates.find((u) => u.id === entry.id);
                   return (
                     <div
@@ -440,7 +429,14 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                               ? `permissions: ${entry.latest.permissions.join(", ")}`
                               : "no permissions"}
                             {" · "}
-                            {entry.totalDownloads} downloads
+                            {localSource ? (
+                              <span className="ext-source-note">
+                                Installed from{" "}
+                                {sourceOriginLabel(localSource.kind)}
+                              </span>
+                            ) : (
+                              `${entry.totalDownloads} downloads`
+                            )}
                           </span>
                         </div>
                         <div className="ext-actions">
@@ -533,6 +529,9 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
               <div className="ext-list">
                 {visible.map((ext) => {
                   const upd = updates.find((u) => u.id === ext.id);
+                  // Folder/URL/npm origin, noted compactly; the full path lives
+                  // in the detail callout (registry installs need no note).
+                  const localSource = localInstallSource(ext);
                   return (
                     <div
                       key={ext.id}
@@ -560,8 +559,20 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                               <span className="ext-badge">disabled</span>
                             )}
                           </span>
+                          {ext.description && (
+                            <span className="ext-hint">{ext.description}</span>
+                          )}
                           <span className="ext-hint">
-                            {ext.description ?? ext.id}
+                            {ext.id}
+                            {localSource && (
+                              <>
+                                {" · "}
+                                <span className="ext-source-note">
+                                  Installed from{" "}
+                                  {sourceOriginLabel(localSource.kind)}
+                                </span>
+                              </>
+                            )}
                           </span>
                           {upd && (
                             <span className="ext-hint">
@@ -610,21 +621,6 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                           </button>
                         </div>
                       </div>
-                      {ext.source &&
-                        (() => {
-                          const SourceIcon = SOURCE_ICON[ext.source.kind];
-                          return (
-                            <span
-                              className="ext-hint ext-source"
-                              title={describeSource(ext.source)}
-                            >
-                              <SourceIcon size={12} />
-                              <span className="ext-source-value">
-                                {ext.source.value}
-                              </span>
-                            </span>
-                          );
-                        })()}
                     </div>
                   );
                 })}

--- a/packages/extensions-core/src/extensions/extensions-list-model.test.ts
+++ b/packages/extensions-core/src/extensions/extensions-list-model.test.ts
@@ -4,6 +4,7 @@ import {
   describeSource,
   filterExtensions,
   hasBuiltins,
+  localInstallSource,
   showsReloadHint,
   showsUpdateAction,
 } from "./extensions-list-model";
@@ -108,6 +109,31 @@ describe("describeSource", () => {
 
   it("is undefined when there's no recorded source", () => {
     expect(describeSource(undefined)).toBeUndefined();
+  });
+});
+
+describe("localInstallSource", () => {
+  it("returns the source only for non-registry installs", () => {
+    expect(
+      localInstallSource(ext({ source: { kind: "folder", value: "/e" } })),
+    ).toEqual({ kind: "folder", value: "/e" });
+    expect(
+      localInstallSource(ext({ source: { kind: "url", value: "https://x" } }))
+        ?.kind,
+    ).toBe("url");
+    expect(
+      localInstallSource(ext({ source: { kind: "npm", value: "acme-ext" } }))
+        ?.kind,
+    ).toBe("npm");
+    // Registry is the normal case — nothing to call out.
+    expect(
+      localInstallSource(ext({ source: { kind: "registry", value: "a.b" } })),
+    ).toBeNull();
+  });
+
+  it("is null for legacy source-less records and undefined", () => {
+    expect(localInstallSource(ext({}))).toBeNull();
+    expect(localInstallSource(undefined)).toBeNull();
   });
 });
 

--- a/packages/extensions-core/src/extensions/extensions-list-model.ts
+++ b/packages/extensions-core/src/extensions/extensions-list-model.ts
@@ -75,3 +75,17 @@ export function describeSource(
   }[source.kind];
   return `${label}: ${source.value}`;
 }
+
+/**
+ * The install source when an extension came from somewhere other than the
+ * registry (a folder, URL, or npm) — the case worth calling out explicitly,
+ * because the registry download count then describes a different artifact than
+ * the one installed. `null` for registry installs, built-ins, and legacy
+ * source-less records (nothing reliable to surface).
+ */
+export function localInstallSource(
+  ext: Pick<InstalledExtension, "source"> | undefined,
+): InstallSource | null {
+  const source = ext?.source;
+  return source && source.kind !== "registry" ? source : null;
+}

--- a/packages/extensions-core/src/extensions/source-meta.tsx
+++ b/packages/extensions-core/src/extensions/source-meta.tsx
@@ -1,0 +1,26 @@
+// Presentation lookups for an install source, shared by the Extensions list,
+// the Browse rows, and the detail callout so the icon and wording stay in sync.
+
+import { Folder, LinkSimple, Package, Storefront } from "@phosphor-icons/react";
+import type { InstallSource } from "@silo-code/extension-host/internal";
+
+// The label prefix ("Folder: ", "URL: ", …) is redundant once the kind is
+// legible at a glance — an icon says the same thing in less width, leaving
+// more room for the (often long) path/URL/id itself.
+export const SOURCE_ICON: Record<InstallSource["kind"], typeof Folder> = {
+  folder: Folder,
+  url: LinkSimple,
+  npm: Package,
+  registry: Storefront,
+};
+
+/** Short origin word for a source, e.g. "a folder", "a URL" — reads inline as
+ *  "Installed from {…}". */
+export function sourceOriginLabel(kind: InstallSource["kind"]): string {
+  return {
+    folder: "a folder",
+    url: "a URL",
+    npm: "npm",
+    registry: "the registry",
+  }[kind];
+}

--- a/packages/extensions-core/src/keybindings/KeybindingsPage.css
+++ b/packages/extensions-core/src/keybindings/KeybindingsPage.css
@@ -18,18 +18,12 @@
   color: var(--silo-color-text-hi);
 }
 
+/* Rides the shared global button treatment (the `--silo-button-*` tokens behind
+   `button` in theme.css); this rule only sets the compact size so it matches the
+   Extensions page's `.ext-btn` and buttons read the same across settings pages. */
 .kb-edit-btn {
-  background: var(--silo-color-bg-active);
-  border: 1px solid var(--silo-color-border);
-  color: var(--silo-color-text-hi);
-  padding: 5px 10px;
-  border-radius: var(--silo-radius-sm);
-  cursor: pointer;
-  font: inherit;
-  font-size: calc(var(--settings-font) - 1px);
-}
-.kb-edit-btn:hover {
-  background: var(--silo-color-bg-hover);
+  padding: 4px 8px;
+  font-size: calc(var(--settings-font) - 2px);
 }
 
 .kb-search {


### PR DESCRIPTION
## What & why

The Settings pages had drifted onto older generic surface tokens (`--silo-color-bg-active`, etc.), so their buttons, the Browse|Installed toggle, and the close button looked out of date next to the git-panel modals (which ride the shared `--silo-button-*` / `.silo-modal-*` system). This routes Settings back through the shared treatment and, along the way, surfaces where a non-registry extension was installed from.

## Chrome alignment

- **Buttons** — Keyboard Shortcuts "Edit keybindings.json" and the Extensions Install / Update / Retry / Update-all / detail-page actions / row kebab now ride the shared button fill + hover instead of overriding the resting background back to `--silo-color-bg-active`. (They were already `<button>` elements riding the global treatment; the class overrides were what held them back.)
- **Browse | Installed toggle** — recessed `--silo-color-content-bg` well with a raised `--silo-button-bg` active segment, replacing the lighter `--silo-color-bg-active` track (which resolved to a light blue in the light theme).
- **Close button** — matches the shared `.silo-modal-close`: same X icon, position, and subtle ghost hover. The hover rule is scoped under `.settings-dialog` so it outspecifies the global `button:hover` (which was painting the darker filled-button mix). The settings pane's right gutter was widened so page content clears the button.

## Install-source surfacing

- A **folder / URL / npm** install now shows an emphasized "Installed from a folder/URL" note in place of the registry **download count** on both the Browse and Installed rows — the count describes the published artifact, not the local build.
- The full path/URL moves to an obvious **callout** (source icon + origin + path) on the detail view.
- Installed rows now also show the **extension id**, matching Browse.
- New shared `source-meta` module (source icon + origin label) and a tested `localInstallSource` helper; unit tests cover folder/url/npm/registry and legacy source-less records.

## Testing

- `pnpm test` (extensions-core), `pnpm --filter silo exec tsc --noEmit`, and `pnpm lint` all green.
- All new/changed CSS uses only allowed design tokens (no component tokens, no hard-coded colors).

Note: styling verified via a token-accurate mockup in both themes; a full in-app visual pass still wants a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)