### PR TITLE
chore: add missing changeset for ctx.processes workspaceId/allWorkspaces

### DIFF
--- a/.changeset/processes-workspace-id.md
+++ b/.changeset/processes-workspace-id.md
@@ -1,0 +1,13 @@
+---
+"@silo-code/sdk": minor
+---
+
+`ctx.processes` now reports which workspace each session belongs to and can
+aggregate across every loaded workspace, not just the active one:
+
+- New `ProcessInfo.workspaceId` field, kept in sync as a session's owning
+  workspace changes (e.g. a terminal moves workspaces).
+- `getState({ allWorkspaces: true })` returns live sessions from every loaded
+  workspace instead of just the active one.
+- `subscribe(listener, { allWorkspaces: true })` fires on changes anywhere,
+  not just the active workspace.


### PR DESCRIPTION
## Summary
- PR #213 added `ProcessInfo.workspaceId` and the `allWorkspaces` option to `getState()`/`subscribe()` on `@silo-code/sdk`, but didn't stage a changeset — per this repo's convention ("Add a changeset whenever you change the public SDK surface"), that should have shipped alongside it so the `pnpm release:sdk` flow picks it up.
- No code changes; adds `.changeset/processes-workspace-id.md` describing the minor bump.
- This unblocks `../silo-extensions/system-monitor`, which needs this SDK feature published to depend on it for real (see companion PR in `silo-code/silo-extensions`).

## Test plan
- N/A — docs-only changeset addition, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)