### PR TITLE
fix(workspaces): tighten badge styling and stop over-truncating names

### DIFF
--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -115,6 +115,11 @@
   align-items: baseline;
   gap: 6px;
   min-width: 0;
+}
+
+/* Only reserve room for the close button while it's actually visible (on
+   hover) — otherwise it forces truncation even when nothing overlaps. */
+.ws-item:hover .ws-name-row {
   padding-right: 22px;
 }
 
@@ -129,14 +134,18 @@
 
 .ws-item .ws-badge {
   font-family: var(--silo-font-ui);
-  font-size: calc(1em - 2px);
+  font-size: calc(1em - 3px);
   color: var(--silo-color-text-lo);
   border: 1px solid var(--silo-color-text-lo);
   border-radius: 3px;
   padding: 0 4px;
   line-height: 1.1;
   flex-shrink: 0;
+  text-transform: lowercase;
   background: color-mix(in srgb, currentColor 12%, transparent);
+  /* Nudge up so the bordered box optically aligns with the baseline-aligned name text. */
+  position: relative;
+  top: -1px;
 }
 
 .ws-item .ws-folder {


### PR DESCRIPTION
## Summary
- Nudge workspace badges up 1px and shrink their font by 1px so they sit better against the name text
- Lowercase badge labels
- Only reserve room for the hover-only close (×) button while it's actually visible, instead of permanently — names were being truncated more aggressively than necessary

## Test plan
- [x] `pnpm lint` / pre-commit checks passed
- [x] `pnpm test` passed (via pre-commit hook)
- [ ] Visual check in the dev app: badges align to baseline, names truncate less, close button still doesn't overlap on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)