### PR TITLE
feat(extensions): Surface pending extension updates in status bar, settings rail, and app menu

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -33,7 +33,15 @@ mgr
     void mgr
       .loadInstalled()
       .catch((err) => console.error("loadInstalled failed", err))
-      .finally(() => setExtensionsReady());
+      .finally(() => {
+        setExtensionsReady();
+        // Kick off one background update check so the status bar / settings
+        // rail can show a badge without anyone having opened the Extensions
+        // page first (which does its own check on mount).
+        void mgr.checkUpdates().catch((err) => {
+          console.error("checkUpdates failed", err);
+        });
+      });
   });
 
 userConfigDir()

--- a/apps/docs/api/registration/register-settings-page.md
+++ b/apps/docs/api/registration/register-settings-page.md
@@ -16,6 +16,19 @@ ctx.registerSettingsPage({
 });
 ```
 
+Pass `badge` to render a small indicator after the title in the rail (e.g. an
+update count) — its own component, so it can subscribe to reactive state and
+update independently of the page's own render:
+
+```tsx
+ctx.registerSettingsPage({
+  id: "acme",
+  title: "Acme",
+  component: AcmeSettings,
+  badge: AcmeUpdateBadge, // e.g. renders a pill when updates are pending
+});
+```
+
 ## Types
 
 Pass [`SettingsPage`](/api/types/interfaces/SettingsPage).

--- a/apps/docs/api/types/interfaces/Extension.md
+++ b/apps/docs/api/types/interfaces/Extension.md
@@ -1,6 +1,6 @@
 # Interface: Extension\<API\>
 
-Defined in: [packages/sdk/src/types.ts:747](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L747)
+Defined in: [packages/sdk/src/types.ts:754](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L754)
 
 The shape of a Silo extension: a stable id plus an
 [activate](#activate) function the host calls once, passing
@@ -25,7 +25,7 @@ extensions that publish nothing.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:753](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L753)
+Defined in: [packages/sdk/src/types.ts:760](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L760)
 
 Unique extension id, conventionally namespaced: `core.*` for Silo's core
 feature set, `silo.*` for its optional bundled features, `<vendor>.*` for
@@ -39,7 +39,7 @@ third parties (e.g. `"core.editor"`, `"silo.git"`, `"acme.foo"`).
 optional manifest?: ExtensionManifest;
 ```
 
-Defined in: [packages/sdk/src/types.ts:760](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L760)
+Defined in: [packages/sdk/src/types.ts:767](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L767)
 
 Optional display metadata for the **Extensions** settings page. Built-in
 extensions declare it here so they can be listed (and disabled) with a name
@@ -54,7 +54,7 @@ package manifest instead. See [ExtensionManifest](ExtensionManifest.md).
 activate(ctx): void | API;
 ```
 
-Defined in: [packages/sdk/src/types.ts:767](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L767)
+Defined in: [packages/sdk/src/types.ts:774](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L774)
 
 Called once by the host; register contributions against `ctx` here.
 **Optionally return an API object** to publish it for other extensions to
@@ -79,7 +79,7 @@ extension publishes no API.
 optional deactivate(): void;
 ```
 
-Defined in: [packages/sdk/src/types.ts:769](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L769)
+Defined in: [packages/sdk/src/types.ts:776](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L776)
 
 Optional cleanup hook (reserved for dynamic load/unload).
 

--- a/apps/docs/api/types/interfaces/ExtensionContext.md
+++ b/apps/docs/api/types/interfaces/ExtensionContext.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionContext
 
-Defined in: [packages/sdk/src/types.ts:495](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L495)
+Defined in: [packages/sdk/src/types.ts:502](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L502)
 
 The object handed to [Extension.activate](Extension.md#activate). It is the *only* sanctioned
 way an extension touches the running app: register contributions, invoke
@@ -16,7 +16,7 @@ commands, and read/drive state through the typed consumer services. Every
 readonly extensionId: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:497](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L497)
+Defined in: [packages/sdk/src/types.ts:504](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L504)
 
 The activating extension's id (its [Extension.id](Extension.md#id)).
 
@@ -28,7 +28,7 @@ The activating extension's id (its [Extension.id](Extension.md#id)).
 readonly subscriptions: Disposable[];
 ```
 
-Defined in: [packages/sdk/src/types.ts:499](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L499)
+Defined in: [packages/sdk/src/types.ts:506](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L506)
 
 Disposables tracked for this extension; the host disposes them on teardown.
 
@@ -40,7 +40,7 @@ Disposables tracked for this extension; the host disposes them on teardown.
 readonly storage: ExtensionStorageScopes;
 ```
 
-Defined in: [packages/sdk/src/types.ts:515](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L515)
+Defined in: [packages/sdk/src/types.ts:522](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L522)
 
 Persisted, per-extension key/value storage, in two scopes
 ([ExtensionStorageScopes](ExtensionStorageScopes.md)): `global` (shared across all workspaces —
@@ -64,7 +64,7 @@ scope keyed by panel id, for panel-local UI state.)
 readonly workspaces: WorkspaceService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:566](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L566)
+Defined in: [packages/sdk/src/types.ts:573](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L573)
 
 Consumer API for driving workspace state — create, rename, reorder,
 activate, soft close/reopen, and hard delete. Subscribe to a frozen
@@ -78,7 +78,7 @@ state for read access without depending on Valtio.
 readonly editors: EditorService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:572](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L572)
+Defined in: [packages/sdk/src/types.ts:579](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L579)
 
 The editor & document domain — open files into editor tabs, drive the
 active editor (save / close), and register editor save handlers. Opening
@@ -92,7 +92,7 @@ editors lives here, not on [ExtensionContext.workspaces](#workspaces).
 readonly layout: LayoutService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:578](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L578)
+Defined in: [packages/sdk/src/types.ts:585](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L585)
 
 Consumer API for app layout — side-panel collapse state. Read via
 getState/useServiceState/subscribe; drive via toggleSidePanel /
@@ -106,7 +106,7 @@ setSidePanelCollapsed.
 readonly process: ProcessService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:584](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L584)
+Defined in: [packages/sdk/src/types.ts:591](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L591)
 
 Persistent process / PTY sessions that **survive app restarts** — the core
 primitive under the terminal (and future task runners, REPLs). Spawn or
@@ -120,7 +120,7 @@ re-attach a session and drive it via the returned `ProcessSession`.
 readonly processes: ProcessesService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:592](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L592)
+Defined in: [packages/sdk/src/types.ts:599](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L599)
 
 Workspace process observability — a live view of what is running in each
 terminal, with optional CPU/memory stats and a surgical kill that leaves the
@@ -136,7 +136,7 @@ See [ProcessesService](ProcessesService.md) for the full API.
 readonly terminals: TerminalService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:600](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L600)
+Defined in: [packages/sdk/src/types.ts:607](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L607)
 
 Consumer API for the terminal domain — open a terminal tab in a workspace
 (`create`) or reap a workspace's terminals (`closeWorkspace`). The terminal
@@ -152,7 +152,7 @@ from the workspace's records, and PTY sessions live on
 readonly files: FileService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:606](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L606)
+Defined in: [packages/sdk/src/types.ts:613](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L613)
 
 Host-mediated filesystem access — read / write / list / watch, all routed
 through the host rather than raw Tauri. The single privileged chokepoint
@@ -166,7 +166,7 @@ for the filesystem; watcher lifecycle is host-owned (see [FileService](FileServi
 readonly search: SearchService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:613](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L613)
+Defined in: [packages/sdk/src/types.ts:620](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L620)
 
 Cross-file content search over the workspace — the core primitive under the
 Search panel (and future quick-open / find-references). Runs a native search
@@ -181,7 +181,7 @@ with matches grouped by file. See [SearchService](SearchService.md).
 readonly theme: ThemeService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:620](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L620)
+Defined in: [packages/sdk/src/types.ts:627](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L627)
 
 Consumer API for the theme domain — read the merged preset set + active
 theme, switch themes, and manage custom themes. Read via getState /
@@ -196,7 +196,7 @@ subscribe; contribute a new preset via
 readonly dnd: DndService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:627](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L627)
+Defined in: [packages/sdk/src/types.ts:634](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L634)
 
 Drag-and-drop — be a drag source ([DndService.beginDrag](DndService.md#begindrag)) and a drop
 target ([DndService.registerDropTarget](DndService.md#registerdroptarget)), with typed payloads
@@ -211,7 +211,7 @@ drag affordance and the modifier-mode resolution.
 readonly ui: UiService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:634](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L634)
+Defined in: [packages/sdk/src/types.ts:641](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L641)
 
 User-interaction — the only sanctioned way to talk to the user (the host
 renders the chrome). Native file/folder pickers ([UiService.pickFolder](UiService.md#pickfolder),
@@ -226,7 +226,7 @@ notifications ([UiService.notify](UiService.md#notify)). Mirrors VS Code's `wind
 readonly net: NetworkService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:642](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L642)
+Defined in: [packages/sdk/src/types.ts:649](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L649)
 
 Server-side HTTP client — makes requests from the Rust backend, bypassing
 the browser's CORS policy. Use when browser `fetch` is insufficient:
@@ -242,7 +242,7 @@ loading a URL. See [NetworkService](NetworkService.md) for the full API.
 readonly webview: WebviewService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:649](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L649)
+Defined in: [packages/sdk/src/types.ts:656](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L656)
 
 Real DOM access, navigation control, and native pixel capture inside an
 `<iframe>` you own — including cross-origin content the browser's
@@ -257,7 +257,7 @@ same-origin policy would otherwise fully sandbox. Requires the
 readonly system: SystemService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:657](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L657)
+Defined in: [packages/sdk/src/types.ts:664](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L664)
 
 Static host-platform metadata — the OS, CPU architecture, and running Silo
 version. Values are baked into the binary at build time and never change
@@ -273,7 +273,7 @@ See [SystemService](SystemService.md) for the full API.
 readonly log: LogService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:670](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L670)
+Defined in: [packages/sdk/src/types.ts:677](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L677)
 
 Write-only structured logger scoped to this extension. Entries appear in
 the **Output** panel under the extension's display name. A channel is
@@ -294,7 +294,7 @@ ctx.log.show(); // open the Output panel, select this extension's channel
 registerEditor(editor): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:517](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L517)
+Defined in: [packages/sdk/src/types.ts:524](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L524)
 
 Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 
@@ -316,7 +316,7 @@ Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 registerFileType(type): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:519](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L519)
+Defined in: [packages/sdk/src/types.ts:526](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L526)
 
 Register a [FileType](FileType.md) (declarative file metadata).
 
@@ -338,7 +338,7 @@ Register a [FileType](FileType.md) (declarative file metadata).
 registerCommand(cmd): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:521](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L521)
+Defined in: [packages/sdk/src/types.ts:528](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L528)
 
 Register a [Command](Command.md) (a named, invokable action).
 
@@ -360,7 +360,7 @@ Register a [Command](Command.md) (a named, invokable action).
 registerMenuItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:523](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L523)
+Defined in: [packages/sdk/src/types.ts:530](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L530)
 
 Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a menu).
 
@@ -382,7 +382,7 @@ Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a
 registerKeybinding(binding): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:525](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L525)
+Defined in: [packages/sdk/src/types.ts:532](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L532)
 
 Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 
@@ -404,7 +404,7 @@ Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 registerSidePanel(panel): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:527](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L527)
+Defined in: [packages/sdk/src/types.ts:534](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L534)
 
 Register a [SidePanel](SidePanel.md) (a left/right column panel).
 
@@ -426,7 +426,7 @@ Register a [SidePanel](SidePanel.md) (a left/right column panel).
 registerDockPanelKind<T>(kind): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:533](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L533)
+Defined in: [packages/sdk/src/types.ts:540](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L540)
 
 Register a [DockPanelKind](DockPanelKind.md) (a center-dock tab kind). The params
 generic `T` is inferred from the component's [DockPanelProps](DockPanelProps.md)
@@ -456,7 +456,7 @@ annotation, so kinds with typed params register without casts.
 registerStatusItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:537](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L537)
+Defined in: [packages/sdk/src/types.ts:544](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L544)
 
 Register a [StatusItem](StatusItem.md) (a status-bar widget).
 
@@ -478,7 +478,7 @@ Register a [StatusItem](StatusItem.md) (a status-bar widget).
 registerSettingsPage(page): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:539](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L539)
+Defined in: [packages/sdk/src/types.ts:546](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L546)
 
 Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 
@@ -500,7 +500,7 @@ Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 registerThemePreset(preset): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:545](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L545)
+Defined in: [packages/sdk/src/types.ts:552](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L552)
 
 Register a [ThemePreset](ThemePreset.md) (a selectable theme in the picker).
 
@@ -527,7 +527,7 @@ Use [ctx.theme.registerPreset()](ThemeService.md#registerpreset) instead.
 executeCommand<T>(id, ...args): Promise<T>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:560](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L560)
+Defined in: [packages/sdk/src/types.ts:567](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L567)
 
 Invoke a registered command by id — including commands contributed by
 other extensions. The minimal "operate" primitive; pairs with the typed
@@ -570,7 +570,7 @@ Expected return type of the command (defaults to `unknown`).
 getExtension<API>(id): ExtensionHandle<API> | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:684](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L684)
+Defined in: [packages/sdk/src/types.ts:691](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L691)
 
 Resolve a handle to another extension in order to consume the API it
 published (the value its [Extension.activate](Extension.md#activate) returned). This is how

--- a/apps/docs/api/types/interfaces/ExtensionHandle.md
+++ b/apps/docs/api/types/interfaces/ExtensionHandle.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionHandle\<API\>
 
-Defined in: [packages/sdk/src/types.ts:695](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L695)
+Defined in: [packages/sdk/src/types.ts:702](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L702)
 
 A handle to another extension, obtained via
 [ExtensionContext.getExtension](ExtensionContext.md#getextension). Lets one extension consume another's
@@ -20,7 +20,7 @@ published API while tolerating its absence.
 readonly id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:697](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L697)
+Defined in: [packages/sdk/src/types.ts:704](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L704)
 
 The resolved extension's id.
 
@@ -32,7 +32,7 @@ The resolved extension's id.
 readonly active: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:699](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L699)
+Defined in: [packages/sdk/src/types.ts:706](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L706)
 
 True once that extension has activated.
 
@@ -44,7 +44,7 @@ True once that extension has activated.
 readonly api: API | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:702](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L702)
+Defined in: [packages/sdk/src/types.ts:709](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L709)
 
 Its published API (what its `activate` returned), or `undefined` if it
 hasn't activated or published nothing.

--- a/apps/docs/api/types/interfaces/ExtensionManifest.md
+++ b/apps/docs/api/types/interfaces/ExtensionManifest.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionManifest
 
-Defined in: [packages/sdk/src/types.ts:718](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L718)
+Defined in: [packages/sdk/src/types.ts:725](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L725)
 
 Display metadata for an extension, surfaced in the **Extensions** settings
 page (name, one-line description, version, and [\* \| publisher](#publisher) brand). For built-in extensions this is declared in-code on the
@@ -18,7 +18,7 @@ namespace for the publisher) when one is absent.
 readonly optional name?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:720](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L720)
+Defined in: [packages/sdk/src/types.ts:727](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L727)
 
 Human-friendly name shown in the Extensions list (falls back to the id).
 
@@ -30,7 +30,7 @@ Human-friendly name shown in the Extensions list (falls back to the id).
 readonly optional description?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:722](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L722)
+Defined in: [packages/sdk/src/types.ts:729](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L729)
 
 One-line description shown beneath the name.
 
@@ -42,7 +42,7 @@ One-line description shown beneath the name.
 readonly optional version?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:724](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L724)
+Defined in: [packages/sdk/src/types.ts:731](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L731)
 
 Version string shown next to the name.
 
@@ -54,7 +54,7 @@ Version string shown next to the name.
 readonly optional publisher?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:731](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L731)
+Defined in: [packages/sdk/src/types.ts:738](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L738)
 
 The publisher/brand shown beside the name (e.g. `"Silo"`). Built-in
 extensions are always branded `"Silo"` by the host regardless of this field;

--- a/apps/docs/api/types/interfaces/SettingsPage.md
+++ b/apps/docs/api/types/interfaces/SettingsPage.md
@@ -66,3 +66,19 @@ component: ComponentType;
 Defined in: [packages/sdk/src/types.ts:482](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L482)
 
 Renders the right-hand pane when this page is selected.
+
+***
+
+### badge?
+
+```ts
+optional badge?: ComponentType<{
+}>;
+```
+
+Defined in: [packages/sdk/src/types.ts:489](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L489)
+
+Optional small indicator rendered after the title in the left rail (e.g.
+an update-available count). Rendered as its own component — separate from
+[SettingsPage.component](#component) — so it can subscribe to reactive state and
+update independently of whether the page itself is the active one.

--- a/packages/extension-host/src/components/SettingsDialog.css
+++ b/packages/extension-host/src/components/SettingsDialog.css
@@ -53,6 +53,10 @@
 }
 
 .settings-rail-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   text-align: left;
   background: transparent;
   border: none;
@@ -61,6 +65,11 @@
   border-radius: var(--silo-radius-sm);
   cursor: pointer;
   font: inherit;
+}
+.settings-rail-item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .settings-rail-item:hover {
   background: var(--silo-color-bg-hover);

--- a/packages/extension-host/src/components/SettingsDialog.tsx
+++ b/packages/extension-host/src/components/SettingsDialog.tsx
@@ -45,6 +45,7 @@ export function SettingsDialog() {
           {pages.map((p) => {
             const newGroup = p.group !== lastGroup;
             lastGroup = p.group;
+            const Badge = p.badge;
             return (
               <button
                 key={p.id}
@@ -55,7 +56,8 @@ export function SettingsDialog() {
                   ui.pageId = p.id;
                 }}
               >
-                {p.title}
+                <span className="settings-rail-item-label">{p.title}</span>
+                {Badge && <Badge />}
               </button>
             );
           })}

--- a/packages/extension-host/src/extension-host/extension-manager.test.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.test.ts
@@ -954,4 +954,25 @@ describe("installFromRegistry", () => {
       }),
     ]);
   });
+
+  it("checkUpdates publishes the result onto reactive state for other UI to read", async () => {
+    global.fetch = registryFetch("1.0.0", "digest-1");
+    stageOnDownload();
+    await mgr.installFromRegistry("acme.x", async () => true);
+
+    clearRegistryCache();
+    global.fetch = registryFetch("1.1.0", "digest-2");
+
+    await mgr.checkUpdates();
+    expect(mgr.getState().availableUpdates).toEqual([
+      expect.objectContaining({ id: "acme.x" }),
+    ]);
+
+    // A subsequent refresh (install/uninstall/enable/disable) must not wipe
+    // the last known update check.
+    await mgr.disable("acme.x");
+    expect(mgr.getState().availableUpdates).toEqual([
+      expect.objectContaining({ id: "acme.x" }),
+    ]);
+  });
 });

--- a/packages/extension-host/src/extension-host/extension-manager.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.ts
@@ -153,6 +153,14 @@ export interface InstalledExtension {
 
 export interface ExtensionManagerState {
   extensions: readonly InstalledExtension[];
+  /**
+   * Registry updates available for installed extensions, as of the last
+   * {@link ExtensionManager.checkUpdates} call. Empty until the first check
+   * (startup kicks one off; see `main.tsx`) — surfaces the same data the
+   * Extensions page shows, reactively, so other UI (status bar, settings
+   * rail) can indicate updates without polling the registry themselves.
+   */
+  availableUpdates: readonly RegistryUpdate[];
 }
 
 export interface ExtensionManager extends ReactiveService<ExtensionManagerState> {
@@ -412,7 +420,10 @@ async function writeInstalledFile(file: InstalledFile): Promise<void> {
 
 // ---- reactive state ----------------------------------------------------------
 
-let cached: ExtensionManagerState = Object.freeze({ extensions: [] });
+let cached: ExtensionManagerState = Object.freeze({
+  extensions: [],
+  availableUpdates: [],
+});
 const listeners = new Set<(s: ExtensionManagerState) => void>();
 
 function emit(): void {
@@ -487,7 +498,12 @@ async function refresh(): Promise<void> {
     });
   }
   rows.sort((a, b) => a.name.localeCompare(b.name));
-  cached = Object.freeze({ extensions: rows });
+  // Preserve the last update check — a refresh (install/uninstall/enable/
+  // disable) doesn't itself change what's available upstream.
+  cached = Object.freeze({
+    extensions: rows,
+    availableUpdates: cached.availableUpdates,
+  });
   emit();
 }
 
@@ -810,7 +826,10 @@ export function getExtensionManager(): ExtensionManager {
 
     async checkUpdates() {
       const index = await fetchRegistryIndex();
-      return findUpdates(cached.extensions, index);
+      const availableUpdates = findUpdates(cached.extensions, index);
+      cached = Object.freeze({ ...cached, availableUpdates });
+      emit();
+      return availableUpdates;
     },
 
     async readInstalledReadme(id) {

--- a/packages/extension-host/src/extension-host/menu-items.ts
+++ b/packages/extension-host/src/extension-host/menu-items.ts
@@ -17,6 +17,7 @@ import {
 import type { Disposable, MenuId, MenuItemContribution } from "@silo-code/sdk";
 import { checkForUpdatesInteractive } from "./update-service";
 import { openSettings } from "./settings-dialog";
+import { getExtensionManager } from "./extension-manager";
 
 export const menuItemRegistry = new Registry<MenuItemContribution>();
 
@@ -25,6 +26,21 @@ export const menuItemRegistry = new Registry<MenuItemContribution>();
 onKeymapChange(() => {
   void syncMenu();
 });
+
+// Same idea for the extension-updates entry in Help (below): the native menu
+// has no reactive text, so a changed update count means a full rebuild —
+// cheap and already the established pattern here (see onKeymapChange above).
+// Deferred to first `syncMenu()` call (rather than module-eval time) so this
+// stays inert if extension-manager.ts is mid-circular-import when this module
+// first loads (as it is in extension-manager.test.ts's dependency graph).
+let subscribedToExtensionManager = false;
+function ensureExtensionManagerSubscription(): void {
+  if (subscribedToExtensionManager) return;
+  subscribedToExtensionManager = true;
+  getExtensionManager().subscribe(() => {
+    void syncMenu();
+  });
+}
 
 const isMac =
   typeof navigator !== "undefined" &&
@@ -145,6 +161,23 @@ async function windowPredefinedGroups(): Promise<PredefinedMenuItem[][]> {
   return [[await PredefinedMenuItem.new({ item: "Minimize" })]];
 }
 
+// The count is read fresh at each `syncMenu()` rebuild (triggered by the
+// manager subscription above) — the native menu has no live-text mechanism,
+// so "reactive" here means "rebuilt", same as the accelerator/keymap case.
+async function buildExtensionUpdatesMenuItem(): Promise<MenuItem> {
+  const count = getExtensionManager().getState().availableUpdates.length;
+  return MenuItem.new({
+    id: "help:extension-updates",
+    text:
+      count > 0
+        ? `Extension Updates Available (${count})…`
+        : "Check for Extension Updates…",
+    action: () => {
+      openSettings("extensions");
+    },
+  });
+}
+
 async function buildHelpSubmenu(
   extras: MenuItemContribution[],
 ): Promise<Submenu> {
@@ -169,6 +202,8 @@ async function buildHelpSubmenu(
     );
   }
 
+  items.push(await buildExtensionUpdatesMenuItem());
+
   const groups = groupAndSort(extras);
   for (const group of groups) {
     if (items.length > 0)
@@ -191,6 +226,7 @@ async function applyWhenClauses(): Promise<void> {
 }
 
 export async function syncMenu(): Promise<void> {
+  ensureExtensionManagerSubscription();
   // Drop any previous tracking from a prior sync.
   liveItems = [];
   contextSub?.dispose();

--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -57,6 +57,12 @@
   --silo-button-primary-text: #fff;
   --silo-button-danger-bg: var(--silo-color-err);
   --silo-button-danger-text: #fff;
+  /* Normal-button hover/active fill. Dark themes push toward black (the
+     button surface already sits lighter than the panel, so darkening reads
+     as a subtle recess); light themes override this to push toward white
+     instead — see the light block below. */
+  --silo-button-hover-bg: color-mix(in srgb, var(--silo-button-bg) 85%, #000);
+  --silo-button-active-bg: color-mix(in srgb, var(--silo-button-bg) 75%, #000);
 
   /* ── Component tokens · colors (theming-contract.md › The component-token
    * surface). Host-chrome treatments — `ThemeVars` keys (theme-overridable) but
@@ -211,6 +217,11 @@
      --silo-color-bg-hover default). Hover darkens further via the color-mix in the button
      rules. */
   --silo-button-bg: #d4d4d4;
+  /* Direction flip from the dark default above: the button surface here sits
+     darker than the panel, so darkening it further on hover reads as harsh,
+     near-black. Push toward white instead — lighter and still visible. */
+  --silo-button-hover-bg: color-mix(in srgb, var(--silo-button-bg) 85%, #fff);
+  --silo-button-active-bg: color-mix(in srgb, var(--silo-button-bg) 75%, #fff);
 
   --silo-content-text: var(--silo-color-content-text);
   --silo-content-editor-text-dim: #6b6b6b;
@@ -281,9 +292,12 @@ body,
  * Class names are `silo-`-prefixed for the same collision-firewall reason the
  * custom properties are (theming-contract.md › Decision 1) — these globals ride
  * on every button in extension DOM too.
- * Every variant hovers the same way: a slightly darker shade of its own fill
- * (color-mix toward black), with no border change. The variant :hover/:active
- * selectors carry a class, so they outspecify the generic ones below. */
+ * Every variant hovers/actives the same way structurally: a color-mix shade
+ * of its own fill, no border change. The normal variant's shade direction is
+ * theme-driven (`--silo-button-hover-bg`/`--silo-button-active-bg`, flipped
+ * light vs. dark above); primary/danger always mix toward black since their
+ * saturated fills read fine either way. The variant :hover/:active selectors
+ * carry a class, so they outspecify the generic ones below. */
 button {
   background: var(--silo-button-bg);
   color: var(--silo-button-text);
@@ -295,11 +309,11 @@ button {
 }
 
 button:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--silo-button-bg) 85%, #000);
+  background: var(--silo-button-hover-bg);
 }
 
 button:active:not(:disabled) {
-  background: color-mix(in srgb, var(--silo-button-bg) 75%, #000);
+  background: var(--silo-button-active-bg);
 }
 
 button:disabled {
@@ -315,11 +329,11 @@ button.silo-button {
 }
 
 button.silo-button:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--silo-button-bg) 85%, #000);
+  background: var(--silo-button-hover-bg);
 }
 
 button.silo-button:active:not(:disabled) {
-  background: color-mix(in srgb, var(--silo-button-bg) 75%, #000);
+  background: var(--silo-button-active-bg);
 }
 
 /* primary — primary action. */

--- a/packages/extensions-core/src/extensions/ExtensionsPage.css
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.css
@@ -265,10 +265,9 @@
 .ext-tabs {
   display: flex;
   gap: 2px;
-  /* A recessed well (content surface, sunk below the card) with a defined edge,
-     so the active segment reads as a button raised out of it. */
+  /* A recessed well (content surface, sunk below the card) so the active
+     segment reads as a button raised out of it. */
   background: var(--silo-color-content-bg);
-  border: 1px solid var(--silo-color-border-strong);
   border-radius: var(--silo-radius-sm);
   padding: 2px;
 }

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -34,6 +34,19 @@ import "./ExtensionsPage.css";
 
 const mgr = getExtensionManager();
 
+/**
+ * The Settings-rail badge for the Extensions page (registered as
+ * `SettingsPage.badge`): a count pill, mirroring the one on the Installed tab
+ * (below), so an update is visible before the page is even opened. Reads the
+ * manager's reactive state directly rather than the page's own `updates`
+ * (which only exists once this page has mounted and fetched the registry).
+ */
+export function ExtensionsRailBadge() {
+  const { availableUpdates } = useServiceState(mgr);
+  if (availableUpdates.length === 0) return null;
+  return <span className="ext-update-count">{availableUpdates.length}</span>;
+}
+
 /** Which pane the page is showing. Browse (the registry) is the landing view. */
 type View =
   | { kind: "browse" }
@@ -455,7 +468,7 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                             )}
                           {upd && installedExt && (
                             <button
-                              className="ext-btn"
+                              className="ext-btn silo-button-primary"
                               disabled={busy === entry.id}
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -510,7 +523,7 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
               )}
               {updates.length > 0 && (
                 <button
-                  className="ext-btn"
+                  className="ext-btn silo-button-primary"
                   onClick={updateAll}
                   disabled={busy !== null}
                 >
@@ -598,7 +611,7 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
                         <div className="ext-actions">
                           {upd && (
                             <button
-                              className="ext-btn"
+                              className="ext-btn silo-button-primary"
                               disabled={busy === ext.id}
                               onClick={(e) => {
                                 e.stopPropagation();

--- a/packages/extensions-core/src/extensions/index.tsx
+++ b/packages/extensions-core/src/extensions/index.tsx
@@ -1,6 +1,6 @@
 import type { Extension } from "@silo-code/sdk";
 import { EXTENSIONS_SETTINGS_GROUP } from "@silo-code/extension-host/internal";
-import { makeExtensionsPage } from "./ExtensionsPage";
+import { makeExtensionsPage, ExtensionsRailBadge } from "./ExtensionsPage";
 
 export const extension: Extension = {
   id: "core.extensions",
@@ -13,6 +13,7 @@ export const extension: Extension = {
       group: EXTENSIONS_SETTINGS_GROUP,
       order: -1,
       component: makeExtensionsPage(ctx),
+      badge: ExtensionsRailBadge,
     });
   },
 };

--- a/packages/extensions-core/src/statusbar/settings-button/index.tsx
+++ b/packages/extensions-core/src/statusbar/settings-button/index.tsx
@@ -5,6 +5,8 @@
 // (the core-owned `settings.open` command).
 
 import type { Extension } from "@silo-code/sdk";
+import { useServiceState } from "@silo-code/sdk";
+import { getExtensionManager } from "@silo-code/extension-host/internal";
 import "./settings-button.css";
 
 // Gear/cog path on a 24×24 grid (from Twitter/X settings icon).
@@ -38,13 +40,20 @@ export const extension: Extension = {
   activate(ctx) {
     // The component closes over `ctx`; identity is stable (activate runs once).
     function SettingsButton() {
+      const { availableUpdates } = useServiceState(getExtensionManager());
+      const hasUpdates = availableUpdates.length > 0;
       return (
         <button
           className="settings-button"
-          aria-label="Settings"
+          aria-label={
+            hasUpdates ? "Settings (extension updates available)" : "Settings"
+          }
           onClick={() => ctx.executeCommand("settings.open")}
         >
           <GearIcon />
+          {hasUpdates && (
+            <span className="settings-button-badge" aria-hidden="true" />
+          )}
         </button>
       );
     }

--- a/packages/extensions-core/src/statusbar/settings-button/settings-button.css
+++ b/packages/extensions-core/src/statusbar/settings-button/settings-button.css
@@ -1,4 +1,5 @@
 .settings-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -15,4 +16,16 @@
 
 .settings-button:hover {
   color: var(--silo-color-text-hi);
+}
+
+/* Subtle presence dot — extension updates are pending. No count: this is a
+   glance indicator, the count lives in the settings rail / Installed tab. */
+.settings-button-badge {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--silo-color-accent);
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -480,6 +480,13 @@ export interface SettingsPage {
   order?: number;
   /** Renders the right-hand pane when this page is selected. */
   component: React.ComponentType;
+  /**
+   * Optional small indicator rendered after the title in the left rail (e.g.
+   * an update-available count). Rendered as its own component — separate from
+   * {@link SettingsPage.component} — so it can subscribe to reactive state and
+   * update independently of whether the page itself is the active one.
+   */
+  badge?: React.ComponentType;
 }
 
 /**


### PR DESCRIPTION
## Summary
- The Extensions settings page was the only place an available update was visible, and only after opening it. `checkUpdates()` now also publishes into the extension manager's reactive state (`availableUpdates`), driving three glance indicators: a subtle dot on the status bar gear, a count badge on the "Extensions" entry in the settings rail (new `SettingsPage.badge` on the SDK), and a Help-menu entry that reflects the current count.
- Browse/Installed "Update" buttons now use the accent-colored `silo-button-primary` treatment so they're obviously actionable next to the neutral Install/menu buttons.
- Small polish fixes surfaced along the way: removed the redundant border around the Browse/Installed segmented control, and fixed the global normal-button hover/active fill so light themes lighten on hover instead of darkening (which was reading as harsh/near-black).

## Test plan
- [x] `pnpm test` — full suite green (added coverage for `checkUpdates` publishing to reactive state and surviving unrelated refreshes)
- [x] `pnpm lint` (eslint boundary + stylelint design-tokens-only)
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm docs:api` regenerated (`SettingsPage.badge` type + hand-authored `register-settings-page.md` example)
- [x] Manually verified in the running dev app by temporarily forcing 2 fake registry updates: status bar dot, rail badge, Installed/Browse tab counts, and accent Update buttons all rendered correctly, then confirmed a clean state with no simulated updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)