### PR TITLE
feat(editor): per-tab word wrap / minimap toggle in context menu

### DIFF
--- a/packages/extension-host/src/extension-host/editor-core.ts
+++ b/packages/extension-host/src/extension-host/editor-core.ts
@@ -7,6 +7,7 @@ import {
   getEditorScrollPosition,
   setEditorViewState,
   getEditorViewState,
+  getEditorSettingOverride,
 } from "../state/workspaces";
 import {
   setEditorBackup,
@@ -14,9 +15,15 @@ import {
   readEditorBackup,
   resolveRestoredBuffer,
 } from "../state/editor-backups";
-import { getEditorSettings, setEditorSetting } from "../state/editor-settings";
+import {
+  getEditorSettings,
+  setEditorSetting,
+  mergeEditorSettings,
+  toggleEditorViewOption,
+} from "../state/editor-settings";
 import type {
   EditorSettings,
+  EditorSettingsOverride,
   RenderWhitespace,
   RenderLineHighlight,
 } from "../state/types";
@@ -68,6 +75,12 @@ export {
   resolveRestoredBuffer,
   getEditorSettings,
   setEditorSetting,
+  // Per-tab word-wrap/minimap override: read, merge with the global tier, and
+  // toggle — backs the editor's own context-menu entries (not part of the
+  // global Settings page).
+  getEditorSettingOverride,
+  mergeEditorSettings,
+  toggleEditorViewOption,
   getDndService,
   monacoThemeName,
   getThemeBase,
@@ -76,7 +89,12 @@ export {
   // views reach it via @silo-code/extension-host/internal rather than a raw docked/ path.
   ensureMonaco,
 };
-export type { EditorSettings, RenderWhitespace, RenderLineHighlight };
+export type {
+  EditorSettings,
+  EditorSettingsOverride,
+  RenderWhitespace,
+  RenderLineHighlight,
+};
 
 /**
  * Shared Monaco onMount setup for both modes: register the app themes, apply the

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -150,6 +150,9 @@ export {
   resolveRestoredBuffer,
   getEditorSettings,
   setEditorSetting,
+  getEditorSettingOverride,
+  mergeEditorSettings,
+  toggleEditorViewOption,
   monacoThemeName,
   getDiffContentProvider,
   languageFromPath,
@@ -160,6 +163,7 @@ export {
 } from "./editor-core";
 export type {
   EditorSettings,
+  EditorSettingsOverride,
   RenderWhitespace,
   RenderLineHighlight,
 } from "./editor-core";

--- a/packages/extension-host/src/state/editor-settings.test.ts
+++ b/packages/extension-host/src/state/editor-settings.test.ts
@@ -9,9 +9,19 @@
 // Assert at the surviving contract (the settings → options function), not the
 // component internals that are about to move.
 
-import { describe, it, expect } from "vitest";
-import { toMonacoOptions } from "./editor-settings";
-import { DEFAULT_EDITOR_SETTINGS, type EditorSettings } from "./types";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  toMonacoOptions,
+  mergeEditorSettings,
+  toggleEditorViewOption,
+} from "./editor-settings";
+import { getEditorSettingOverride } from "./workspaces";
+import { store } from "./store";
+import {
+  DEFAULT_EDITOR_SETTINGS,
+  type EditorSettings,
+  type WorkspaceInternal,
+} from "./types";
 
 describe("toMonacoOptions", () => {
   it("maps the shipped defaults to the expected Monaco options", () => {
@@ -75,5 +85,78 @@ describe("toMonacoOptions", () => {
       formatOnSave: true,
     });
     expect(opts).not.toHaveProperty("formatOnSave");
+  });
+});
+
+describe("mergeEditorSettings", () => {
+  it("falls through to the base when no override is given", () => {
+    expect(mergeEditorSettings(DEFAULT_EDITOR_SETTINGS, undefined)).toEqual(
+      DEFAULT_EDITOR_SETTINGS,
+    );
+  });
+
+  it("overlays only the overridden keys, leaving the rest of the base untouched", () => {
+    const merged = mergeEditorSettings(DEFAULT_EDITOR_SETTINGS, {
+      wordWrap: true,
+    });
+    expect(merged.wordWrap).toBe(true);
+    expect(merged.minimap).toBe(DEFAULT_EDITOR_SETTINGS.minimap);
+    expect(merged.tabSize).toBe(DEFAULT_EDITOR_SETTINGS.tabSize);
+  });
+
+  it("overlays both overridden keys at once", () => {
+    const merged = mergeEditorSettings(DEFAULT_EDITOR_SETTINGS, {
+      wordWrap: true,
+      minimap: true,
+    });
+    expect(merged.wordWrap).toBe(true);
+    expect(merged.minimap).toBe(true);
+  });
+});
+
+describe("toggleEditorViewOption", () => {
+  function makeWorkspace(id: string): WorkspaceInternal {
+    return {
+      id,
+      name: id,
+      folder: `/ws/${id}`,
+      createdAt: "",
+      lastOpenedAt: "",
+      terminals: [],
+      editors: [],
+      dockLayout: null,
+      previewEditorId: null,
+    };
+  }
+
+  beforeEach(() => {
+    store.workspaces = { w: makeWorkspace("w") };
+    store.editorSettings = { ...DEFAULT_EDITOR_SETTINGS };
+  });
+
+  it("flips the effective (global) value into an explicit override", () => {
+    expect(store.editorSettings.wordWrap).toBe(false);
+    toggleEditorViewOption("w", "ed1", "wordWrap");
+    expect(getEditorSettingOverride("w", "ed1")).toEqual({ wordWrap: true });
+  });
+
+  it("flips relative to an existing override, not the global default", () => {
+    toggleEditorViewOption("w", "ed1", "wordWrap"); // false -> true
+    toggleEditorViewOption("w", "ed1", "wordWrap"); // true -> false
+    expect(getEditorSettingOverride("w", "ed1")).toEqual({ wordWrap: false });
+  });
+
+  it("keeps overrides independent per key", () => {
+    toggleEditorViewOption("w", "ed1", "wordWrap");
+    toggleEditorViewOption("w", "ed1", "minimap");
+    expect(getEditorSettingOverride("w", "ed1")).toEqual({
+      wordWrap: true,
+      minimap: true,
+    });
+  });
+
+  it("keeps overrides independent per editor id", () => {
+    toggleEditorViewOption("w", "ed1", "wordWrap");
+    expect(getEditorSettingOverride("w", "ed2")).toEqual({});
   });
 });

--- a/packages/extension-host/src/state/editor-settings.ts
+++ b/packages/extension-host/src/state/editor-settings.ts
@@ -1,6 +1,10 @@
 import type { editor as MonacoEditor } from "monaco-editor";
 import { store } from "./store";
-import type { EditorSettings } from "./types";
+import {
+  getEditorSettingOverride,
+  setEditorSettingOverride,
+} from "./workspaces";
+import type { EditorSettings, EditorSettingsOverride } from "./types";
 
 /**
  * Resolve the effective editor settings.
@@ -20,6 +24,35 @@ export function setEditorSetting<K extends keyof EditorSettings>(
   value: EditorSettings[K],
 ): void {
   store.editorSettings[key] = value;
+}
+
+/**
+ * Overlay a tab's local override (if any) onto the global settings — pure, so
+ * it's unit-testable without touching the store. Absent override keys fall
+ * through to `base`.
+ */
+export function mergeEditorSettings(
+  base: EditorSettings,
+  override: EditorSettingsOverride | undefined,
+): EditorSettings {
+  return { ...base, ...override };
+}
+
+/**
+ * Flip one tab's word-wrap/minimap override relative to its *effective*
+ * current value (global setting overlaid by any existing override) — not the
+ * global value — so toggling always does what the menu label just showed.
+ */
+export function toggleEditorViewOption(
+  workspaceId: string,
+  editorId: string,
+  key: keyof EditorSettingsOverride,
+): void {
+  const effective = mergeEditorSettings(
+    getEditorSettings(),
+    getEditorSettingOverride(workspaceId, editorId),
+  );
+  setEditorSettingOverride(workspaceId, editorId, key, !effective[key]);
 }
 
 /**

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -35,6 +35,8 @@ export interface WorkspaceInternal extends Workspace {
   dockLayout: unknown | null;
   editorScrollPositions?: Record<string, { top: number; left: number }>;
   editorViewStates?: Record<string, unknown>;
+  /** Per-tab word-wrap/minimap overrides, toggled from the editor's context menu. */
+  editorSettingsOverrides?: Record<string, EditorSettingsOverride>;
   sidePanelLocations?: Record<string, SidePanelSlot>;
   sidePanelOrder?: Record<string, number>;
   activeSidePanelTabs?: Record<string, string>;
@@ -216,6 +218,16 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   smoothScrolling: true,
   breadcrumbs: true,
 };
+
+/**
+ * A single tab's overrides of the global {@link EditorSettings} — only the
+ * fields a per-instance context-menu toggle can flip. Absent keys fall
+ * through to the global setting; see mergeEditorSettings() in
+ * editor-settings.ts.
+ */
+export type EditorSettingsOverride = Partial<
+  Pick<EditorSettings, "wordWrap" | "minimap">
+>;
 
 export type TerminalCursorStyle = "block" | "bar" | "underline";
 

--- a/packages/extension-host/src/state/workspaces.test.ts
+++ b/packages/extension-host/src/state/workspaces.test.ts
@@ -14,6 +14,8 @@ import {
   savePanelStateToWorkspace,
   loadPanelStateFromWorkspace,
   activateWorkspace,
+  setEditorSettingOverride,
+  getEditorSettingOverride,
 } from "./workspaces";
 import { clearEditorBackup } from "./editor-backups";
 
@@ -95,5 +97,35 @@ describe("side-panel visibility is per-workspace", () => {
     // And w2 kept its own.
     activateWorkspace("w2");
     expect(store.sidePanelVisibility).toEqual({ git: false });
+  });
+});
+
+describe("editor settings override (per-tab word wrap / minimap)", () => {
+  it("returns {} when no override has been set", () => {
+    expect(getEditorSettingOverride("w", "ed1")).toEqual({});
+  });
+
+  it("stores and reads back a single key", () => {
+    setEditorSettingOverride("w", "ed1", "wordWrap", true);
+    expect(getEditorSettingOverride("w", "ed1")).toEqual({ wordWrap: true });
+  });
+
+  it("merges a second key into the same editor's override", () => {
+    setEditorSettingOverride("w", "ed1", "wordWrap", true);
+    setEditorSettingOverride("w", "ed1", "minimap", true);
+    expect(getEditorSettingOverride("w", "ed1")).toEqual({
+      wordWrap: true,
+      minimap: true,
+    });
+  });
+
+  it("keeps overrides independent per editor id", () => {
+    setEditorSettingOverride("w", "ed1", "wordWrap", true);
+    expect(getEditorSettingOverride("w", "ed2")).toEqual({});
+  });
+
+  it("is a no-op for a workspace id that doesn't exist", () => {
+    setEditorSettingOverride("missing", "ed1", "wordWrap", true);
+    expect(getEditorSettingOverride("missing", "ed1")).toEqual({});
   });
 });

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -4,6 +4,7 @@ import { store } from "./store";
 import { clearEditorBackup } from "./editor-backups";
 import type {
   EditorRecord,
+  EditorSettingsOverride,
   TerminalKind,
   TerminalRecord,
   WorkspaceInternal,
@@ -172,6 +173,31 @@ export function getEditorViewState(
   editorId: string,
 ): unknown {
   return store.workspaces[workspaceId]?.editorViewStates?.[editorId] ?? null;
+}
+
+export function setEditorSettingOverride<
+  K extends keyof EditorSettingsOverride,
+>(
+  workspaceId: string,
+  editorId: string,
+  key: K,
+  value: EditorSettingsOverride[K],
+): void {
+  const ws = store.workspaces[workspaceId];
+  if (!ws) return;
+  if (!ws.editorSettingsOverrides) ws.editorSettingsOverrides = {};
+  if (!ws.editorSettingsOverrides[editorId])
+    ws.editorSettingsOverrides[editorId] = {};
+  ws.editorSettingsOverrides[editorId][key] = value;
+}
+
+export function getEditorSettingOverride(
+  workspaceId: string,
+  editorId: string,
+): EditorSettingsOverride {
+  return (
+    store.workspaces[workspaceId]?.editorSettingsOverrides?.[editorId] ?? {}
+  );
 }
 
 /**

--- a/packages/extensions-core/src/editor/TextViewer.tsx
+++ b/packages/extensions-core/src/editor/TextViewer.tsx
@@ -22,6 +22,8 @@ import {
   readEditorBackup,
   resolveRestoredBuffer,
   getEditorSettings,
+  mergeEditorSettings,
+  toggleEditorViewOption,
   monacoThemeName,
   languageFromPath,
   toTextEditorOptions,
@@ -74,6 +76,17 @@ export function TextViewer({
   const filePath = record?.filePath ?? null;
   const isUntitled = record !== null && filePath === null;
 
+  // This tab's own word-wrap/minimap overrides (if any), read through `snap`
+  // so valtio re-renders this component when they change — merged over the
+  // global settings without mutating them.
+  const settingsOverride = wsId
+    ? snap.workspaces[wsId]?.editorSettingsOverrides?.[editorId]
+    : undefined;
+  const effectiveSettings = mergeEditorSettings(
+    snap.editorSettings,
+    settingsOverride,
+  );
+
   // Both saved files and untitled buffers start with `null` content so we
   // render the placeholder for one paint before Monaco mounts. This lets
   // dockview finish its own focus shuffle around a freshly-added panel — if
@@ -99,6 +112,10 @@ export function TextViewer({
   // re-reading from disk when an untitled buffer is "save-as"d — we just
   // wrote the file ourselves so disk == in-memory.
   const loadedPathRef = useRef<string | null>(null);
+  // The two per-tab view-toggle context-menu actions currently registered on
+  // this editor, so a re-registration (label needs to flip) disposes the
+  // previous pair first.
+  const viewActionsRef = useRef<Array<{ dispose(): void }>>([]);
   // Active disposer for this editor's selection source (registered while focused).
   const selSourceRef = useRef<Disposable | null>(null);
 
@@ -395,12 +412,56 @@ export function TextViewer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content]);
 
+  // Keep the context-menu labels in sync after the initial mount (registered
+  // once by onMount above) — re-registers whenever the effective value
+  // changes, whether from this tab's own toggle or a change to the global
+  // default while this tab has no override.
+  useEffect(() => {
+    const ed = editorRef.current;
+    if (!ed) return;
+    registerViewToggleActions(ed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [effectiveSettings.wordWrap, effectiveSettings.minimap]);
+
+  // Register this tab's "Word Wrap" / "Minimap" entries in Monaco's own
+  // native context menu, just below its built-in groups. Monaco actions have
+  // no checkbox rendering, so on/off is encoded in the label text — which
+  // means the pair has to be disposed and re-added whenever the effective
+  // value flips, to keep the label in sync. Text editor only; diff mode has
+  // no per-tab override.
+  function registerViewToggleActions(ed: MonacoEditor.IStandaloneCodeEditor) {
+    for (const d of viewActionsRef.current) d.dispose();
+    viewActionsRef.current = [
+      ed.addAction({
+        id: "silo.editor.toggleWordWrapForTab",
+        label: effectiveSettings.wordWrap ? "Word Wrap ✓" : "Word Wrap",
+        contextMenuGroupId: "9_silo-view",
+        contextMenuOrder: 1,
+        run: () => {
+          const ws = wsIdRef.current;
+          if (ws) toggleEditorViewOption(ws, editorId, "wordWrap");
+        },
+      }),
+      ed.addAction({
+        id: "silo.editor.toggleMinimapForTab",
+        label: effectiveSettings.minimap ? "Minimap ✓" : "Minimap",
+        contextMenuGroupId: "9_silo-view",
+        contextMenuOrder: 2,
+        run: () => {
+          const ws = wsIdRef.current;
+          if (ws) toggleEditorViewOption(ws, editorId, "minimap");
+        },
+      }),
+    ];
+  }
+
   const onMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
     // Shared core setup: app themes + active theme + strip the broken
     // semantic-navigation context-menu actions. Same call the diff mode makes,
     // so both stay in lockstep.
     setupMonacoEditor(monaco, editor);
+    registerViewToggleActions(editor);
 
     // A pending reveal (opened via `ctx.editors.open(path, { selection })` — e.g.
     // a clicked search result) wins over scroll restore: jump to and select the
@@ -564,11 +625,12 @@ export function TextViewer({
         }}
         onMount={onMount}
         // The shared core's text-mode options: global editor settings (minimap,
-        // indentation, wrap, whitespace, formatOnType/Paste, …) + font + drop
-        // handling. Diff mode derives from the same settings via the sibling
-        // builder, so the two can't drift. Updates flow through because
+        // indentation, wrap, whitespace, formatOnType/Paste, …), this tab's own
+        // word-wrap/minimap override (if any), + font + drop handling. Diff
+        // mode derives from the global settings alone via the sibling builder
+        // (no per-tab override there). Updates flow through because
         // @monaco-editor/react re-applies the options prop.
-        options={toTextEditorOptions(snap.editorSettings, snap.uiFontSize)}
+        options={toTextEditorOptions(effectiveSettings, snap.uiFontSize)}
       />
     );
   }


### PR DESCRIPTION
## Summary
- Adds "Word Wrap" and "Minimap" entries to Monaco's native right-click context menu, letting a single editor tab override the global word-wrap/minimap setting without changing it for other tabs.
- The override is stored per-workspace, keyed by `editorId` (mirroring the existing `editorScrollPositions`/`editorViewStates` pattern), so it persists across app restarts and stays scoped to that tab.
- Text editor only — diff view (`DiffPanel.tsx`) is unaffected by design.

## Test plan
- [x] `pnpm test` — full suite green (635 tests), including new unit tests for `mergeEditorSettings`, `toggleEditorViewOption`, and the workspace override get/set helpers.
- [x] `pnpm --filter silo exec tsc --noEmit` — clean.
- [x] `pnpm lint` — clean.
- [x] Manually verified in the running dev app via the automation bridge: right-clicked in the editor, confirmed "Word Wrap"/"Minimap" render at the bottom of the native menu, toggling flips Monaco's live options and the checkmark label, a second tab in the same workspace stayed on the global default (proving isolation), and the override round-tripped to the workspace's on-disk JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)