### PR TITLE
fix(release): scope npm publish steps to their own package

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -43,6 +43,14 @@ jobs:
         if: ${{ !inputs.publish }}
         run: pnpm publish --filter create-silo-extension --dry-run --no-git-checks
 
+      # Filtered to just create-silo-extension: `changeset publish` runs across
+      # every non-ignored workspace package, which previously made this
+      # workflow also re-attempt publishing @silo-code/sdk and could fail the
+      # whole job with "cannot publish over the previously published versions"
+      # if either package's local version already matched what's on npm.
+      # Versioning here is driven by release-please, not changesets (no
+      # pending changesets), so scoping the actual `npm publish` to this
+      # package loses nothing.
       - name: Publish to npm
         if: ${{ inputs.publish }}
-        run: pnpm changeset publish
+        run: pnpm publish --filter create-silo-extension --no-git-checks

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -47,10 +47,13 @@ jobs:
         run: pnpm publish --filter @silo-code/sdk --dry-run --no-git-checks
 
       # Gated path: real publish via OIDC trusted publishing (no token in env).
-      # `changeset publish` ships only non-private, ahead-of-registry packages
-      # (just @silo-code/sdk) and tags the release. If a scoped-package OIDC E404
-      # ever appears here, the fallback is `pnpm publish --filter @silo-code/sdk
-      # --no-git-checks` (npm/cli #8976).
+      # Filtered to just @silo-code/sdk: `changeset publish` runs across every
+      # non-ignored workspace package, which previously made this workflow also
+      # re-attempt publishing create-silo-extension (already on npm at the same
+      # version) and fail the whole job with "cannot publish over the previously
+      # published versions". Versioning here is driven by release-please, not
+      # changesets (no pending changesets), so scoping the actual `npm publish`
+      # to this package loses nothing.
       - name: Publish to npm
         if: ${{ inputs.publish }}
-        run: pnpm changeset publish
+        run: pnpm publish --filter @silo-code/sdk --no-git-checks

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "docs:preview": "pnpm --filter @silo-code/docs preview",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release:sdk": "pnpm --filter @silo-code/sdk build && changeset publish",
-    "release:create": "pnpm --filter create-silo-extension build && changeset publish",
+    "release:sdk": "pnpm --filter @silo-code/sdk build && pnpm publish --filter @silo-code/sdk --no-git-checks",
+    "release:create": "pnpm --filter create-silo-extension build && pnpm publish --filter create-silo-extension --no-git-checks",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "git config core.hooksPath .githooks"


### PR DESCRIPTION
## Problem

`release-sdk.yml` and `release-create.yml` both ran the workspace-wide `pnpm changeset publish`, which attempts to publish every non-ignored changesets package, not just the one the workflow builds. Since `create-silo-extension` isn't in `.changeset/config.json`'s ignore list, every SDK-only release also re-attempted publishing `create-silo-extension@0.2.2` (already live on npm), failing the whole job with "cannot publish over the previously published versions" — see [run 29440305932](https://github.com/silo-code/silo/actions/runs/29440305932/job/87437235274). `release-create.yml` had the same bug in reverse for `@silo-code/sdk`.

## Fix

Versioning here is driven by release-please (there are no pending changesets), so changesets' `publish` command was only providing the `npm publish` mechanics — and its git-tag side effect was never even pushed (workflow has `contents: read`, no push step), so nothing is lost by dropping it.

Scoped the real publish step in both workflows (and the matching root `package.json` scripts) to just their own package via `pnpm publish --filter <pkg> --no-git-checks`, mirroring the existing dry-run steps.

## Testing

- Verified both workflow YAML files parse correctly.
- The SDK release in the failing run *did* succeed (`@silo-code/sdk@0.27.0` published fine); only `create-silo-extension` failed — confirming the fix targets the actual bug without needing a re-release.
