### PR TITLE
docs(proposals): mark RFC 0011 implemented, fix stale index/roadmap entries

### DIFF
--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -136,7 +136,6 @@ The shape of each planned surface is now designed in an **RFC** under
 | Extension authoring toolchain                                                       | [RFC 0007](https://github.com/silo-code/silo/blob/main/docs/proposals/0007-extension-authoring-toolchain.md)           |
 | Package format + remote install (GitHub / npm)                                      | [RFC 0008](https://github.com/silo-code/silo/blob/main/docs/proposals/0008-extension-package-format-remote-install.md) |
 | Language intelligence (TS/JS via `tsserver`)                                        | [RFC 0009](https://github.com/silo-code/silo/blob/main/docs/proposals/0009-language-intelligence-lsp.md)               |
-| Self-owned PTY host daemon                                                          | [RFC 0010](https://github.com/silo-code/silo/blob/main/docs/proposals/0010-pty-host-daemon.md)                         |
 | <a id="context-menus"></a>Context-menu contributions (explorer / editor / terminal) | [RFC 0013](https://github.com/silo-code/silo/blob/main/docs/proposals/0013-context-menu-contributions.md)              |
 
 ---

--- a/docs/proposals/0011-iframe-navigation-events.md
+++ b/docs/proposals/0011-iframe-navigation-events.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: implemented
 created: 2026-06-21
 ---
 
@@ -189,7 +189,7 @@ frames; polling cannot distinguish "same URL" from "new URL" without reading it.
 
 ## Decision
 
-_To be filled in when the RFC is accepted._
-
-Once implemented, flip `ctx.webview` on the [Roadmap](/roadmap) from `planned`
-to `stable` and add its hand-authored page at `apps/docs/api/state/webview.md`.
+**Implemented.** Shipped as `ctx.webview` — `WebFrame.onNavigate` /
+`onBlocked` — via the three-layer design above (Tauri init script → host
+message listener → SDK surface). `ctx.webview` is `stable` on the
+[Roadmap](/roadmap) and documented at [`/api/webview/`](/api/webview/).

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -53,6 +53,8 @@ never deleted** — "we considered X and rejected it" stops the debate recurring
 | [0008](./0008-extension-package-format-remote-install.md) | Extension package format + remote install (GitHub / npm)          | 2026-06-04 | draft       |
 | [0009](./0009-language-intelligence-lsp.md)               | Language intelligence — TS/JS via `tsserver`                      | 2026-05-29 | draft       |
 | [0010](./0010-pty-host-daemon.md)                         | Self-owned PTY host daemon (replace abduco)                       | 2026-06-04 | implemented |
+| [0011](./0011-iframe-navigation-events.md)                | Iframe navigation events via webview init script                  | 2026-06-21 | implemented |
+| [0012](./0012-keyboard-navigation-architecture.md)        | Keyboard navigation architecture                                  | 2026-06-06 | implemented |
 | [0013](./0013-context-menu-contributions.md)              | Context-menu contributions for built-in surfaces                  | 2026-07-02 | draft       |
 | [0014](./0014-extension-registry.md)                      | Extension registry — publishing, discovery, install               | 2026-07-12 | draft       |
 | [0015](./0015-workspace-extension-contributions.md)       | Workspace extension contributions — property pages + context menu | 2026-07-15 | draft       |


### PR DESCRIPTION
## What & why

Follow-up from reviewing `docs/proposals/` against the codebase and roadmap:

- **RFC 0011** (iframe navigation events): `ctx.webview.onNavigate`/`onBlocked` is fully shipped in the SDK — flip status to `implemented` and fill in the Decision section.
- **`docs/proposals/README.md`**: add missing index rows for RFC 0011 and RFC 0012 (keyboard navigation) — the latter was already `implemented` in its frontmatter but never listed in the index table.
- **`apps/docs/roadmap.md`**: remove RFC 0010 (PTY host daemon) from the "Designed surfaces (planned)" table — it's already implemented and shown as `stable` elsewhere on the roadmap.

RFC 0002 (typed ctx events) and RFC 0004 (ctx.storage) were also reviewed but intentionally left as-is: both are partially implemented (0002's SDK-exported `EventEmitter<T>` for extension-authored events isn't shipped; 0004's `secrets` store isn't shipped), so they stay in their current non-implemented states.

## How to test

- Read RFC 0011 and confirm the Decision section matches `packages/sdk/src/webview-service.ts`
- `docs/proposals/README.md` index now lists 0011 and 0012
- `apps/docs/roadmap.md` no longer lists RFC 0010 as a planned surface

## Checklist

- [x] PR title is a valid Conventional Commit
- [x] Docs-only change