### PR TITLE
docs: surface the live extension registry catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,15 @@ Orientation docs (read when relevant):
 - `docs/silo-extensions-repo.md` — the **external** `silo-code/silo-extensions`
   repo (cloned at `../silo-extensions`): how its third-party extensions relate to
   this repo — published-SDK lag, npm (not pnpm) build commands, runtime trust /
-  `silo.permissions`, and how to install a branch without merging.
+  `silo.permissions`, and how to install a branch without merging. They
+  **publish into** the registry; discovery is Browse /
+  [extensions.getsilo.dev](https://extensions.getsilo.dev), not cloning that repo.
+- `docs/extensions-registry-repo.md` — the **external**
+  `silo-code/extensions-registry` repo (cloned at `../extensions-registry`):
+  git-backed catalog behind
+  [extensions.getsilo.dev](https://extensions.getsilo.dev) (humans) and
+  [registry.getsilo.dev](https://registry.getsilo.dev) (app/CLI index). How it
+  relates to in-app Browse / install / update in this monorepo.
 - `apps/docs/guide/extension-checklist.md` — pre-flight checklist for any
   extension (bundled or third-party): boundaries, permissions, styling,
   lifecycle, packaging, stability.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Keep every project you're juggling running simultaneously — terminals, agents, and layout intact — switch between them instantly. 100% open source, free forever.
 
-[**Download for macOS →**](https://github.com/silo-code/silo/releases/latest) &nbsp;·&nbsp; [**Download for Linux →**](https://github.com/silo-code/silo/releases/latest) &nbsp;·&nbsp; [Docs](https://getsilo.dev) &nbsp;·&nbsp; [Roadmap](https://getsilo.dev/roadmap) &nbsp;·&nbsp; [Follow on X](https://x.com/silo_code)
+[**Download for macOS →**](https://github.com/silo-code/silo/releases/latest) &nbsp;·&nbsp; [**Download for Linux →**](https://github.com/silo-code/silo/releases/latest) &nbsp;·&nbsp; [Docs](https://getsilo.dev) &nbsp;·&nbsp; [Extensions](https://extensions.getsilo.dev) &nbsp;·&nbsp; [Roadmap](https://getsilo.dev/roadmap) &nbsp;·&nbsp; [Follow on X](https://x.com/silo_code)
 
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue) ![Platform: macOS](https://img.shields.io/badge/platform-macOS-lightgrey) ![Platform: Linux](https://img.shields.io/badge/platform-Linux-lightgrey) ![Platform: Windows (experimental)](<https://img.shields.io/badge/platform-Windows%20(experimental)-yellow>) ![Status: Early](https://img.shields.io/badge/status-early%20access-orange)
 
@@ -30,7 +30,7 @@ Open as many project workspaces as you need and tab between them instantly. Each
 - **Local-first** — everything runs on your machine; no cloud sync, no telemetry, no account required
 - **Layout that sticks** — each workspace remembers its exact terminal tab arrangement; name tabs for specific jobs and they're waiting exactly where you left them
 - **Terminals and editors as equals** — a terminal tab and an editor tab are the same thing; arrange them side by side, stack them, name them; span a workspace across multiple folders for monorepos or paired projects
-- **Extension SDK** — every built-in feature ships as an extension against the same public API you get; no ceiling on what you can add
+- **Extension SDK** — every built-in feature ships as an extension against the same public API you get; browse and install from [extensions.getsilo.dev](https://extensions.getsilo.dev) or **Settings → Extensions**
 
 ## Extend Silo with Claude Code
 
@@ -63,11 +63,12 @@ Claude scaffolds the project, writes the TypeScript, compiles it, and installs i
 Extensions install and uninstall live — no restart needed:
 
 ```bash
-silo install ~/my-extensions/dave.git-branch
+silo install silo.local-web-viewer              # from the registry by id
+silo install ~/my-extensions/dave.git-branch    # or from a local folder
 silo uninstall dave.git-branch
 ```
 
-→ [Full guide](https://getsilo.dev/guide/claude-skill) · [Extension API](https://getsilo.dev/api/)
+→ [Extension catalog](https://extensions.getsilo.dev) · [Full guide](https://getsilo.dev/guide/claude-skill) · [Extension API](https://getsilo.dev/api/)
 
 ## Who it's for
 

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -118,6 +118,10 @@ export default withMermaid(
         },
         { text: "Guides", link: "/guide/" },
         { text: "API Reference", link: "/api/" },
+        {
+          text: "Extensions",
+          link: "https://extensions.getsilo.dev",
+        },
         { text: "Roadmap", link: "/roadmap" },
       ],
 

--- a/apps/docs/guide/claude-skill.md
+++ b/apps/docs/guide/claude-skill.md
@@ -65,8 +65,11 @@ disable or uninstall them from the UI.
 
 ## Publish your extension
 
-When the extension is ready to share, publish it to npm and others can install
-it by package name from Silo's Extensions settings page.
+When the extension is ready to share, publish it to the Silo registry so it
+appears on Browse and
+[extensions.getsilo.dev](https://extensions.getsilo.dev) — see
+[Sharing extensions](/guide/sharing-extensions#publish-to-the-silo-registry).
+Folder / URL / npm sideloads still work for private shares.
 
-See [Publishing an extension](/guide/publishing-an-extension) for the full
-workflow.
+See [Publishing an extension](/guide/publishing-an-extension) for the package
+contract.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -54,14 +54,21 @@ pass the path — use the binary path or the installed shim.
 ## Extension commands
 
 ```sh
-silo install /path/to/my-extension   # install an extension from a local folder
+silo install silo.local-web-viewer   # install from the Silo registry by id
+silo install /path/to/my-extension   # install from a local folder
+silo install <url-or-npm>            # install from a tarball URL or npm name
 silo uninstall acme.clock            # uninstall an extension by id
 ```
 
-`silo install <path>` is the CLI equivalent of **Settings → Extensions →
-Install from folder…**: Silo copies the package into
-`~/.config/silo/extensions/<id>/` and loads it immediately. The path resolves
-against your shell's working directory, so relative paths work.
+`silo install` picks the source from the argument:
+
+- A registry id (`publisher.name`, and no such path on disk) installs from
+  [registry.getsilo.dev](https://registry.getsilo.dev) — same catalog as
+  **Settings → Extensions → Browse**.
+- A filesystem path is the CLI equivalent of **Install from folder…**: Silo
+  copies the package into `~/.config/silo/extensions/<id>/` and loads it
+  immediately. Relative paths resolve against your shell's working directory.
+- A URL or npm package name downloads that tarball (sideload).
 
 `silo uninstall <id>` removes the extension's copied files from disk and
 unloads it from the running app. The `id` is the `silo.id` value from the
@@ -70,3 +77,6 @@ extension's `package.json`.
 Both commands follow the same warm/cold model as `silo <path>`: if Silo is
 already running the command is forwarded to the live instance; if not, it is
 applied on the next launch.
+
+See [Extensions](/guide/extensions) for Browse, updates, and the public catalog
+at [extensions.getsilo.dev](https://extensions.getsilo.dev).

--- a/apps/docs/guide/extensions.md
+++ b/apps/docs/guide/extensions.md
@@ -4,27 +4,72 @@ Silo's features are built as extensions — self-contained packages that add
 panels, editors, commands, themes, workspace badges, and more. You can disable
 any built-in extension or install new ones without restarting the app.
 
-## Managing extensions
+## Find and install
 
-Open **Settings → Extensions** (or press <kbd>⌘,</kbd> and choose Extensions)
-to see every loaded extension with its id, version, and enable/disable toggle.
+The primary way to discover extensions is the **registry**:
+
+1. In Silo, open **Settings → Extensions**. The **Browse** tab is the default
+   view — search, filter by category, and install with one click (you'll get a
+   permissions consent prompt when an extension declares any).
+2. Or browse the public catalog at
+   [extensions.getsilo.dev](https://extensions.getsilo.dev), then install from
+   Settings → Extensions (or the CLI below).
 
 ```sh
-silo install <path>   # install from a local folder
-silo install <url>    # install from a URL or npm tarball
-silo uninstall <id>   # remove by id
+silo install silo.local-web-viewer   # install by registry id
+silo uninstall silo.local-web-viewer
+```
+
+The catalog is backed by a static index at
+[registry.getsilo.dev](https://registry.getsilo.dev) — the same data the app
+polls for Browse and updates.
+
+## Managing extensions <a id="updates"></a>
+
+Open **Settings → Extensions** (or press <kbd>⌘,</kbd> and choose Extensions)
+for two tabs:
+
+- **Browse** — the registry catalog
+- **Installed** — everything currently on disk, with enable/disable, detail,
+  and uninstall
+
+When a newer version is on the registry, Silo shows an update badge (also on
+the settings gear and in the app menu). From Installed you can **Update** one
+extension or **Update all**. If the new version declares different
+[permissions](/guide/permissions), you'll re-consent before it applies.
+
+```sh
+silo install <path>          # sideload from a local folder
+silo install <url-or-npm>    # sideload from a tarball URL or npm name
+silo uninstall <id>          # remove by id
 ```
 
 Extensions are stored in `~/.config/silo/extensions/` and reload automatically
 on the next launch. Use **Disable / Enable** in Settings to unload or reload one
 without restarting.
 
+## Sideloading (folder, URL, npm)
+
+Folder, tarball URL, and npm installs remain supported forever as secondary
+paths — useful for private packages, work-in-progress builds, or extensions
+that aren't on the registry yet.
+
+| Path         | How                                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------------------- |
+| Local folder | **Settings → Extensions → Install from folder…**, or `silo install /path/to/ext`                          |
+| Tarball URL  | Paste a GitHub Release (or other) `.tgz` URL into Install from npm or URL…, or `silo install <url>`       |
+| npm package  | Type the package name (e.g. `silo-my-extension`) into the same field, or `silo install silo-my-extension` |
+
+See [Sharing extensions](/guide/sharing-extensions) for packing and distributing
+outside the registry.
+
 ## Built-in extensions
 
 Silo ships with a set of first-party extensions that cover the core workflow.
-They are listed in **Settings → Extensions** under the Silo publisher. Each can
-be disabled individually; none can be uninstalled (they ship inside the app, so
-there's nothing on disk to remove).
+They are listed in **Settings → Extensions** under the Silo publisher (flip
+**Show built-in extensions** if they're hidden). Each can be disabled
+individually; none can be uninstalled (they ship inside the app, so there's
+nothing on disk to remove).
 
 | Extension        | What it adds                                                                           |
 | ---------------- | -------------------------------------------------------------------------------------- |
@@ -37,43 +82,14 @@ there's nothing on disk to remove).
 | Image Viewer     | Read-only viewer for common image formats                                              |
 | Themes           | Themes side panel and the bundled presets (Tokyo Night, Solarized Light, Gruvbox Dark) |
 
-## The silo-extensions repository
+## Official community extensions
 
-[`silo-code/silo-extensions`](https://github.com/silo-code/silo-extensions)
-is the community extension catalog — a curated collection of extensions built
-against the public SDK.
-
-Browse the repo for an extension you want, then install it in one step:
-
-```sh
-# clone the repo and install from a folder
-git clone https://github.com/silo-code/silo-extensions
-cd silo-extensions/local-web-viewer
-npm install && npm run build
-silo install .
-```
-
-Or install a packed release directly by URL without cloning:
-
-```sh
-silo install https://github.com/silo-code/silo-extensions/releases/download/...
-```
-
-Check each extension's `README.md` for its specific install command and any
-[permissions](/guide/permissions) it declares.
-
-## Installing from npm
-
-Extensions published to npm install by package name from Settings:
-
-1. Open **Settings → Extensions → Install from npm or URL…**
-2. Type the npm package name (e.g. `silo-my-extension`) and press Enter.
-
-Or use the CLI:
-
-```sh
-silo install silo-my-extension
-```
+[`silo-code/silo-extensions`](https://github.com/silo-code/silo-extensions) is
+the GitHub repo behind several first-party-adjacent extensions (Documents Side
+Panel, Local Web Viewer, System Monitor, and others). They publish through the
+same registry as everyone else — install them from **Browse** or
+[extensions.getsilo.dev](https://extensions.getsilo.dev), not by cloning the
+repo (unless you're developing them).
 
 ## Building your own
 
@@ -84,9 +100,11 @@ guides covers everything from the mental model to publishing:
 - **[What is an extension?](/guide/what-is-an-extension)** — the `activate(ctx)` model
 - **[Your first extension](/guide/getting-started)** — step-by-step tutorial
 - **[Build with Claude Code](/guide/claude-skill)** — describe what you want; get a working extension
+- **[Sharing extensions](/guide/sharing-extensions)** — publish to the registry (or sideload)
 
 ## See also
 
 - [Side panels](/guide/panels) — the panel UI extensions can contribute to
 - [Permissions & access](/guide/permissions) — what to watch for when installing third-party extensions
 - [Publishing an extension](/guide/publishing-an-extension) — the packaging reference
+- [extensions.getsilo.dev](https://extensions.getsilo.dev) — public catalog

--- a/apps/docs/guide/publishing-an-extension.md
+++ b/apps/docs/guide/publishing-an-extension.md
@@ -5,11 +5,12 @@ folder — no rebuild of the app required. If you've followed [Your first
 extension](/guide/getting-started) you've already written one; this page is the
 full packaging contract: the manifest, the build, and how the host loads it.
 
-::: tip Status
-Installing from a **local folder** (via UI or `silo install <path>`) is
-available now. Scaffolding via `npx create-silo-extension` is available now.
-Installing from a **URL / git / npm registry** and **update checking** are on the
-[roadmap](/roadmap#extension-distribution).
+::: tip Distribution
+Install from a **local folder**, **URL / npm**, or the **Silo registry**
+(`silo install <id>`, Settings → Extensions → Browse). Updates poll the
+registry automatically. To list an extension on Browse and
+[extensions.getsilo.dev](https://extensions.getsilo.dev), see
+[Sharing extensions](/guide/sharing-extensions#publish-to-the-silo-registry).
 :::
 
 ## Scaffold a new extension
@@ -218,3 +219,9 @@ kind is open when you disable it. Prefer a side panel for now.
 Run through the [extension checklist](/guide/extension-checklist) —
 boundaries, permissions, styling, lifecycle, packaging, and stability, in one
 scannable pass.
+
+To put the package on the public catalog (Browse +
+[extensions.getsilo.dev](https://extensions.getsilo.dev)), follow
+[Publish to the Silo registry](/guide/sharing-extensions#publish-to-the-silo-registry)
+— register once via the website form, then cut GitHub Releases with the
+[publish-extension-action](https://github.com/silo-code/publish-extension-action).

--- a/apps/docs/guide/sharing-extensions.md
+++ b/apps/docs/guide/sharing-extensions.md
@@ -1,8 +1,36 @@
 # Sharing extensions
 
-Once you've built an extension you want others to use, there are several ways to
-share it — from a quick one-liner for a colleague to a fully published npm
-package. Pick the approach that matches your audience.
+Once you've built an extension you want others to use, pick the path that
+matches your audience. For anything meant for the wider Silo community, publish
+to the **extension registry** — that's what Browse and
+[extensions.getsilo.dev](https://extensions.getsilo.dev) read. Folder, Git,
+tarball, and npm remain useful sideloads for private or one-off shares.
+
+## Publish to the Silo registry
+
+Publishing is release-driven: register once, then every GitHub Release you cut
+is ingested automatically. No registry accounts or tokens — your id is
+`<github-owner>.<name>`, bound to the repo you control.
+
+1. **Set up releases (once per repo).** New extension?
+   `npx create-silo-extension` scaffolds the
+   [publish-extension-action](https://github.com/silo-code/publish-extension-action)
+   workflow. Existing extension: add that action, then publish with
+   `npm version patch && git push --follow-tags`.
+2. **Register (once per extension).** Use the form at
+   [extensions.getsilo.dev/publish](https://extensions.getsilo.dev/publish) —
+   it opens a pre-filled PR against `silo-code/extensions-registry`. A bot
+   validates and merges.
+3. **Done.** After ingest, the listing appears at
+   `extensions.getsilo.dev/<id>` and in **Settings → Extensions → Browse**.
+   Users install with one click or `silo install <id>`. Later releases update
+   the listing; installed users see an Update badge.
+
+See [Publishing an extension](/guide/publishing-an-extension) for the package
+shape and [Permissions & access](/guide/permissions) for what you declare in
+`silo.permissions`.
+
+**When to use this:** public extensions for the Silo community.
 
 ## Install from a local folder
 
@@ -48,7 +76,8 @@ cd my-extensions/clock && npm install && npm run build && silo install .
 
 **When to use this:** pro users who want to inspect the source, make local
 tweaks, or stay on the latest commit. Requires Node/npm on the recipient's
-machine.
+machine. To put the same package on Browse for everyone else, [publish to the
+registry](#publish-to-the-silo-registry) as well.
 
 ## Share a packed tarball
 
@@ -62,8 +91,8 @@ npm pack                      # → silo-my-clock-0.1.0.tgz
 
 Options for distributing the `.tgz`:
 
-- **Attach to a GitHub release** — upload the `.tgz` as a release asset; the
-  install URL is the asset's download link.
+- **Attach to a GitHub release** — required for registry publishing, and also
+  usable as a direct install URL (asset download link).
 - **Commit to a repo** — for a collection repo, commit each `.tgz` alongside
   its source; the raw GitHub URL becomes the install link.
 - **Send the file directly** — paste the path or URL into
@@ -85,7 +114,8 @@ npm run pack                  # build + npm pack → silo-my-ext-0.1.0.tgz
 
 ## Publish to npm
 
-Publishing makes your extension installable by package name from anywhere:
+Publishing makes your extension installable by package name from anywhere
+(sideload path — separate from the Silo registry):
 
 ```sh
 npm publish --access public
@@ -104,16 +134,16 @@ Or they can use the npm tarball URL directly:
 https://registry.npmjs.org/silo-my-clock/-/silo-my-clock-0.1.0.tgz
 ```
 
-See [Publishing an extension](/guide/publishing-an-extension) for the full
-package shape, manifest requirements, and recommended CI setup.
-
-**When to use this:** public extensions meant for the wider Silo community.
+**When to use this:** npm distribution alongside (or instead of) the Silo
+registry. npm alone does not list the extension on Browse or
+[extensions.getsilo.dev](https://extensions.getsilo.dev).
 
 ## Comparison
 
-| Method            | Requires Node/npm | Pinned version     | Public URL |
-| ----------------- | ----------------- | ------------------ | ---------- |
-| Local folder      | To build          | —                  | No         |
-| Git clone + build | Yes               | No (tracks branch) | No         |
-| Packed tarball    | No                | Yes                | Optional   |
-| npm publish       | No                | Yes                | Yes        |
+| Method            | On Browse / catalog | Requires Node/npm | Pinned version     | Public URL |
+| ----------------- | ------------------- | ----------------- | ------------------ | ---------- |
+| Silo registry     | Yes                 | No (to install)   | Yes (per release)  | Yes        |
+| Local folder      | No                  | To build          | —                  | No         |
+| Git clone + build | No                  | Yes               | No (tracks branch) | No         |
+| Packed tarball    | No                  | No                | Yes                | Optional   |
+| npm publish       | No                  | No                | Yes                | Yes        |

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -13,6 +13,9 @@ hero:
       text: Get started
       link: /guide/
     - theme: alt
+      text: Extensions
+      link: https://extensions.getsilo.dev
+    - theme: alt
       text: View on GitHub
       link: https://github.com/silo-code/silo
     - theme: alt
@@ -37,7 +40,7 @@ features:
     details: A terminal tab and an editor tab are the same thing — arrange them side by side, stack them, name them. Span a workspace across multiple folders for monorepos or paired projects, and the file tree, git panel, and search cover all roots automatically.
   - icon: 🧩
     title: Open extension SDK
-    details: Every built-in feature — terminal, files, git, themes — ships as an extension against the same public API you get. No ceiling on what you can add.
+    details: Every built-in feature — terminal, files, git, themes — ships as an extension against the same public API you get. Browse and install from the catalog (extensions.getsilo.dev) or Settings → Extensions.
 ---
 
 ## Built for developers juggling coding agents
@@ -95,8 +98,11 @@ The result is a first-class extension — installs and uninstalls live, no resta
 
 Silo has a public extension SDK (`@silo-code/sdk`), modeled on VS Code and Obsidian. Every first-party feature — terminal, file explorer, git, themes — is built as an extension against the same API you get. If a built-in can do it, so can you.
 
+Browse what's already available at **[extensions.getsilo.dev](https://extensions.getsilo.dev)**, or install from **Settings → Extensions → Browse** in the app.
+
 - **[What is an extension?](/guide/what-is-an-extension)** — start here
 - **[Your first extension](/guide/getting-started)** — 5-minute walkthrough
 - **[Build with Claude Code](/guide/claude-skill)** — scaffold and install via AI
+- **[Sharing & publishing](/guide/sharing-extensions)** — list on the catalog
 - **[API Reference](/api/)** — the full `ctx` surface
 - **[Roadmap](/roadmap)** — what's stable, what's planned

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -82,6 +82,7 @@ primitives above — so a third party could build the same.
 ## Extension distribution <a id="extension-distribution"></a>
 
 How a third-party extension gets from a package into the running app. See
+[Extensions](/guide/extensions) (install / Browse / updates) and
 [Publishing an extension](/guide/publishing-an-extension).
 
 | Capability                                           | Status                               |                                                                                                 |
@@ -95,11 +96,17 @@ How a third-party extension gets from a package into the running app. See
 | `npx create-silo-extension` scaffold                 | <Badge type="tip" text="stable" />   | [docs](/guide/publishing-an-extension#scaffold-a-new-extension)                                 |
 | Install from URL (tarball / GitHub release)          | <Badge type="tip" text="stable" />   | [docs](/guide/sharing-extensions#share-a-packed-tarball)                                        |
 | Install from npm registry                            | <Badge type="tip" text="stable" />   | [docs](/guide/sharing-extensions#publish-to-npm)                                                |
-| Update checking + apply                              | <Badge type="info" text="planned" /> | [design](https://github.com/silo-code/silo/blob/main/docs/proposals/0014-extension-registry.md) |
-| Extension registry — browse / search / install       | <Badge type="info" text="planned" /> | [design](https://github.com/silo-code/silo/blob/main/docs/proposals/0014-extension-registry.md) |
-| Registry website (`extensions.getsilo.dev`)          | <Badge type="info" text="planned" /> | [design](https://github.com/silo-code/silo/blob/main/docs/proposals/0014-extension-registry.md) |
+| Update checking + apply                              | <Badge type="tip" text="stable" />   | [docs](/guide/extensions#updates)                                                               |
+| Extension registry — browse / search / install       | <Badge type="tip" text="stable" />   | [docs](/guide/extensions) · [catalog](https://extensions.getsilo.dev)                           |
+| Registry website (`extensions.getsilo.dev`)          | <Badge type="tip" text="stable" />   | [extensions.getsilo.dev](https://extensions.getsilo.dev)                                        |
 | Private / team registries (federated index)          | <Badge type="info" text="planned" /> | [design](https://github.com/silo-code/silo/blob/main/docs/proposals/0014-extension-registry.md) |
 | Permissions / capability model                       | <Badge type="tip" text="stable" />   | [docs](/guide/permissions)                                                                      |
+
+> **Updates:** "Update checking + apply" is the P1 registry feature — the app
+> polls [registry.getsilo.dev](https://registry.getsilo.dev), shows a badge, and
+> applies Update / Update all from Settings → Extensions. That is not the same
+> as **Safe update** below (stage → validate → swap + rollback on a bad
+> install), which is still planned.
 
 ## Extension model & safety
 

--- a/docs/extensions-registry-repo.md
+++ b/docs/extensions-registry-repo.md
@@ -1,0 +1,61 @@
+# The external `extensions-registry` repo
+
+The git-backed extension catalog lives in
+[`silo-code/extensions-registry`](https://github.com/silo-code/extensions-registry)
+— **not** in this monorepo. Locally it's a sibling clone:
+`../extensions-registry` (i.e. `projects/extensions-registry`). Design:
+[RFC 0014](./proposals/0014-extension-registry.md).
+
+## Two URLs, one repo
+
+| URL                                                      | Audience           | What                                                                                                                      |
+| -------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| [extensions.getsilo.dev](https://extensions.getsilo.dev) | Humans             | Catalog website (Astro site under `site/`) — browse, detail pages, [publish form](https://extensions.getsilo.dev/publish) |
+| [registry.getsilo.dev](https://registry.getsilo.dev)     | App / CLI / agents | Static JSON index (GitHub Pages from `dist/`) — `index.json`, `/ext/<id>.json`, readmes, advisories, `llms.txt`           |
+
+**The registry is data, not a service.** CI is the only writer; every write is a
+commit (`git log` = audit log). The Silo app reads the data URL via
+`DEFAULT_REGISTRY_URL` in
+`packages/extension-host/src/extension-host/registry-client.ts`. Point humans at
+the website; don't treat `registry.getsilo.dev` as a product landing page.
+
+## How it relates to this monorepo
+
+| Piece                        | Where                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Browse / install / update UI | This repo — Settings → Extensions (`ExtensionsPage`, `ExtensionManager.installFromRegistry` / `checkUpdates`) |
+| Index schema + ingest + site | `extensions-registry`                                                                                         |
+| Official community packages  | [`silo-extensions`](./silo-extensions-repo.md) — a **publisher**, not the catalog                             |
+| Release packing action       | [`silo-code/publish-extension-action`](https://github.com/silo-code/publish-extension-action)                 |
+
+Discovery for users and docs: **Browse in-app** or
+[extensions.getsilo.dev](https://extensions.getsilo.dev). Do not send people to
+clone `silo-extensions` just to install something that's already published.
+
+## Publishing (steady state)
+
+1. Register once — `extensions/<id>.json` via PR (website form pre-fills it). Id
+   must be `<github-owner>.<name>`.
+2. Cut a GitHub Release on the publisher repo with the `npm pack` `.tgz`
+   (tags `vX.Y.Z` or `<name>@vX.Y.Z` for multi-extension repos). Ingest pins
+   sha256 and rebuilds the index.
+
+User-facing walkthrough:
+[Sharing extensions](../apps/docs/guide/sharing-extensions.md#publish-to-the-silo-registry).
+
+## Local work in that repo
+
+Not part of this pnpm workspace. From `../extensions-registry`:
+
+```sh
+npm test
+GITHUB_TOKEN=$(gh auth token) npm run ingest
+npm run build          # → dist/ (what GitHub Pages serves)
+cd site && npm run dev # Astro catalog against a freshly built index
+```
+
+## Still planned (don't document as shipped)
+
+Private / team (federated) registries are RFC 0014 P3 — still `planned` on the
+[roadmap](../apps/docs/roadmap.md#extension-distribution). P1 (public index +
+site + in-app Browse / install / update) is stable.

--- a/docs/silo-extensions-repo.md
+++ b/docs/silo-extensions-repo.md
@@ -7,10 +7,22 @@ Locally it's cloned as a sibling of this repo — from the Silo repo root that's
 that repo relates to this one, so working across the boundary doesn't require
 rediscovering it each time.
 
+## Discovery vs. this repo
+
+`silo-extensions` is a **publisher** of packages, not the catalog. Released
+extensions appear on [extensions.getsilo.dev](https://extensions.getsilo.dev)
+and in **Settings → Extensions → Browse** via the
+[`extensions-registry`](./extensions-registry-repo.md) index. To install one as
+a user: Browse, `silo install <id>`, or the website — **do not** clone this repo
+just to try a published release.
+
+Clone / build / folder-install here when **developing** an extension (or testing
+a branch that isn't on the registry yet).
+
 ## What lives there
 
 Independently-installable extensions, one per top-level folder
-(`docs-panel`, `local-web-viewer`, `system-monitor`). Each is its own npm
+(`docs-panel`, `local-web-viewer`, `system-monitor`, …). Each is its own npm
 package. These are the model for **third-party** extensions — unlike the bundled
 `core.*` / `silo.*` extensions in `packages/extensions-*`, they consume Silo only
 through the public SDK and are installed at runtime, not compiled into the app.
@@ -67,7 +79,12 @@ To reach beyond that scope they must declare capabilities in `package.json` unde
 
 ## Installing one without merging to `main`
 
-The host `ExtensionManager` offers three install paths:
+For a **released** id that's already ingested, prefer the registry path:
+`silo install <id>` or Settings → Extensions → Browse
+(see [`extensions-registry-repo.md`](./extensions-registry-repo.md)).
+
+For a **branch** that isn't on the registry yet, the host
+`ExtensionManager` offers:
 
 - **Install from folder** (`previewInstall`) — point at a built extension dir.
   Easiest for a branch: clone, `npm install && npm run build`, install the folder.
@@ -76,7 +93,10 @@ The host `ExtensionManager` offers three install paths:
   npm-standard `package/` layout, a `package.json` with the `silo.*` manifest,
   and the built `dist/` (pulled in via the `files` field). A raw git-branch
   codeload tarball does **not** qualify — no built `dist/`, wrong layout.
-- **Install from npm** (`installFromNpm`) — by package name from the registry.
+- **Install from npm** (`installFromNpm`) — by package name from npm (sideload;
+  not the Silo registry).
+- **Install from registry** (`installFromRegistry`) — by `<publisher>.<name>`
+  from [registry.getsilo.dev](https://registry.getsilo.dev).
 
 So to test a branch on another machine: either clone + build + install-folder, or
 `npm pack` the built extension and attach the `.tgz` to a GitHub **pre-release**


### PR DESCRIPTION
## Summary
- Flip RFC 0014 P1 roadmap rows (Browse / install, update checking, `extensions.getsilo.dev`) to **stable**, with a callout distinguishing them from planned Safe update
- Rewrite user guides (extensions, sharing, publishing, CLI, Claude skill), README, docs home, and nav so discovery leads with Browse + [extensions.getsilo.dev](https://extensions.getsilo.dev) rather than cloning `silo-extensions`
- Add `docs/extensions-registry-repo.md` and orient `CLAUDE.md` / `silo-extensions-repo.md` around the registry sibling (human site vs machine index)

## Test plan
- [ ] Spot-check [extensions guide](https://getsilo.dev/guide/extensions) / local `pnpm docs:dev` links for Browse, catalog, and `#updates`
- [ ] Confirm roadmap Extension distribution badges and catalog links
- [ ] Confirm docs nav **Extensions** → `https://extensions.getsilo.dev`
- [ ] Skim `docs/extensions-registry-repo.md` against the live sites


Made with [Cursor](https://cursor.com)