### PR TITLE
feat(extensions): nudge new users to the Extensions settings panel

### DIFF
--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -4,6 +4,7 @@ import {
   DotsThreeVertical,
   SealCheck,
 } from "@phosphor-icons/react";
+import { useSnapshot } from "valtio";
 import type { ExtensionContext, MenuEntry } from "@silo-code/sdk";
 import { useServiceState } from "@silo-code/sdk";
 import {
@@ -30,19 +31,24 @@ import {
 } from "./browse-model";
 import { sourceOriginLabel } from "./source-meta";
 import { ExtensionDetail } from "./ExtensionDetail";
+import { extensionsOnboarding, markVisited } from "./extensions-onboarding";
 import "./ExtensionsPage.css";
 
 const mgr = getExtensionManager();
 
 /**
  * The Settings-rail badge for the Extensions page (registered as
- * `SettingsPage.badge`): a count pill, mirroring the one on the Installed tab
- * (below), so an update is visible before the page is even opened. Reads the
- * manager's reactive state directly rather than the page's own `updates`
- * (which only exists once this page has mounted and fetched the registry).
+ * `SettingsPage.badge`): a "New" onboarding pill until the page is opened
+ * once, then the update-count pill (mirroring Installed). Reads the manager's
+ * reactive state directly rather than the page's own `updates` (which only
+ * exists once this page has mounted and fetched the registry).
  */
 export function ExtensionsRailBadge() {
+  const { visited } = useSnapshot(extensionsOnboarding);
   const { availableUpdates } = useServiceState(mgr);
+  if (!visited) {
+    return <span className="ext-update-count">New</span>;
+  }
   if (availableUpdates.length === 0) return null;
   return <span className="ext-update-count">{availableUpdates.length}</span>;
 }
@@ -77,6 +83,11 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       status: "loading",
     });
     const [updates, setUpdates] = useState<RegistryUpdate[]>([]);
+
+    // First mount clears the status-bar / rail onboarding indicators.
+    useEffect(() => {
+      markVisited(ctx.storage.global);
+    }, [ctx.storage.global]);
 
     // One index fetch feeds both the catalog and the update check; the fetch
     // is ETag-conditional so re-opening the page is a zero-body 304.

--- a/packages/extensions-core/src/extensions/extensions-onboarding.test.ts
+++ b/packages/extensions-core/src/extensions/extensions-onboarding.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Disposable, ExtensionStorage } from "@silo-code/sdk";
+import {
+  VISITED_KEY,
+  bindExtensionsOnboarding,
+  extensionsOnboarding,
+  markVisited,
+  readVisited,
+} from "./extensions-onboarding";
+
+function mockStorage(
+  initial: Record<string, unknown> = {},
+): ExtensionStorage & {
+  bag: Record<string, unknown>;
+  listeners: Set<() => void>;
+} {
+  const bag = { ...initial };
+  const listeners = new Set<() => void>();
+  return {
+    bag,
+    listeners,
+    get<T>(key: string, fallback?: T): T | undefined {
+      if (key in bag) return bag[key] as T;
+      return fallback;
+    },
+    set(key: string, value: unknown) {
+      if (value === undefined) delete bag[key];
+      else bag[key] = value;
+      for (const l of listeners) l();
+    },
+    keys() {
+      return Object.keys(bag);
+    },
+    subscribe(listener: () => void): Disposable {
+      listeners.add(listener);
+      return { dispose: () => listeners.delete(listener) };
+    },
+  };
+}
+
+beforeEach(() => {
+  extensionsOnboarding.visited = false;
+});
+
+describe("readVisited / markVisited", () => {
+  it("unset key means not visited", () => {
+    expect(readVisited(mockStorage())).toBe(false);
+  });
+
+  it("truthy non-true values do not count as visited", () => {
+    expect(readVisited(mockStorage({ [VISITED_KEY]: 1 }))).toBe(false);
+    expect(readVisited(mockStorage({ [VISITED_KEY]: "true" }))).toBe(false);
+  });
+
+  it("markVisited sets the flag and is idempotent", () => {
+    const storage = mockStorage();
+    const set = vi.spyOn(storage, "set");
+
+    markVisited(storage);
+    expect(readVisited(storage)).toBe(true);
+    expect(storage.bag[VISITED_KEY]).toBe(true);
+    expect(set).toHaveBeenCalledTimes(1);
+
+    markVisited(storage);
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("bindExtensionsOnboarding", () => {
+  it("syncs the proxy from storage and updates on subscribe", () => {
+    const storage = mockStorage({ [VISITED_KEY]: true });
+    const sub = bindExtensionsOnboarding(storage);
+    expect(extensionsOnboarding.visited).toBe(true);
+
+    storage.set(VISITED_KEY, undefined);
+    expect(extensionsOnboarding.visited).toBe(false);
+
+    markVisited(storage);
+    expect(extensionsOnboarding.visited).toBe(true);
+
+    sub.dispose();
+    storage.set(VISITED_KEY, undefined);
+    // Unbound — proxy no longer tracks storage.
+    expect(extensionsOnboarding.visited).toBe(true);
+  });
+});

--- a/packages/extensions-core/src/extensions/extensions-onboarding.ts
+++ b/packages/extensions-core/src/extensions/extensions-onboarding.ts
@@ -1,0 +1,38 @@
+import { proxy } from "valtio";
+import type { Disposable, ExtensionStorage } from "@silo-code/sdk";
+
+/** Persisted on `core.extensions` global storage once the user opens the panel. */
+export const VISITED_KEY = "hasVisitedExtensionsPage";
+
+/**
+ * Reactive mirror of the visited flag so surfaces outside `core.extensions`
+ * (the status-bar settings button) can observe it without sharing storage.
+ * Synced by {@link bindExtensionsOnboarding}.
+ */
+export const extensionsOnboarding = proxy({ visited: false });
+
+/** Unset or non-true ⇒ never visited (onboarding still active). */
+export function readVisited(storage: ExtensionStorage): boolean {
+  return storage.get(VISITED_KEY) === true;
+}
+
+/** Persist the first visit (idempotent). */
+export function markVisited(storage: ExtensionStorage): void {
+  if (!readVisited(storage)) {
+    storage.set(VISITED_KEY, true);
+  }
+}
+
+/**
+ * Keep {@link extensionsOnboarding} in sync with `storage` (initial read +
+ * hydrate / mutation subscriptions). Returns a disposable that unbinds.
+ */
+export function bindExtensionsOnboarding(
+  storage: ExtensionStorage,
+): Disposable {
+  const sync = () => {
+    extensionsOnboarding.visited = readVisited(storage);
+  };
+  sync();
+  return storage.subscribe(sync);
+}

--- a/packages/extensions-core/src/extensions/index.tsx
+++ b/packages/extensions-core/src/extensions/index.tsx
@@ -1,10 +1,12 @@
 import type { Extension } from "@silo-code/sdk";
 import { EXTENSIONS_SETTINGS_GROUP } from "@silo-code/extension-host/internal";
 import { makeExtensionsPage, ExtensionsRailBadge } from "./ExtensionsPage";
+import { bindExtensionsOnboarding } from "./extensions-onboarding";
 
 export const extension: Extension = {
   id: "core.extensions",
   activate(ctx) {
+    ctx.subscriptions.push(bindExtensionsOnboarding(ctx.storage.global));
     ctx.registerSettingsPage({
       id: "extensions",
       title: "Extensions",

--- a/packages/extensions-core/src/statusbar/settings-button/index.tsx
+++ b/packages/extensions-core/src/statusbar/settings-button/index.tsx
@@ -4,9 +4,11 @@
 // deps (React, @phosphor-icons/react), and acts on the app only through `ctx`
 // (the core-owned `settings.open` command).
 
+import { useSnapshot } from "valtio";
 import type { Extension } from "@silo-code/sdk";
 import { useServiceState } from "@silo-code/sdk";
 import { getExtensionManager } from "@silo-code/extension-host/internal";
+import { extensionsOnboarding } from "../../extensions/extensions-onboarding";
 import "./settings-button.css";
 
 // Gear/cog path on a 24×24 grid (from Twitter/X settings icon).
@@ -41,17 +43,22 @@ export const extension: Extension = {
     // The component closes over `ctx`; identity is stable (activate runs once).
     function SettingsButton() {
       const { availableUpdates } = useServiceState(getExtensionManager());
+      const { visited } = useSnapshot(extensionsOnboarding);
       const hasUpdates = availableUpdates.length > 0;
+      const showBadge = hasUpdates || !visited;
+      const ariaLabel = hasUpdates
+        ? "Settings (extension updates available)"
+        : !visited
+          ? "Settings (discover Extensions)"
+          : "Settings";
       return (
         <button
           className="settings-button"
-          aria-label={
-            hasUpdates ? "Settings (extension updates available)" : "Settings"
-          }
+          aria-label={ariaLabel}
           onClick={() => ctx.executeCommand("settings.open")}
         >
           <GearIcon />
-          {hasUpdates && (
+          {showBadge && (
             <span className="settings-button-badge" aria-hidden="true" />
           )}
         </button>

--- a/packages/extensions-core/src/statusbar/settings-button/settings-button.css
+++ b/packages/extensions-core/src/statusbar/settings-button/settings-button.css
@@ -18,8 +18,9 @@
   color: var(--silo-color-text-hi);
 }
 
-/* Subtle presence dot — extension updates are pending. No count: this is a
-   glance indicator, the count lives in the settings rail / Installed tab. */
+/* Subtle presence dot — extension updates pending, or the Extensions panel
+   has never been opened. No count: this is a glance indicator; the rail
+   badge carries the text / count. */
 .settings-button-badge {
   position: absolute;
   top: 1px;


### PR DESCRIPTION
## Summary
- Until the Extensions settings page is opened once, show the existing status-bar settings badge and a “New” pill on the Extensions rail tab.
- Persist the first visit in `core.extensions` global storage so both indicators clear afterward; update-count badges resume their normal behavior.
- Covered with unit tests for the visit flag read/mark/bind helpers.

## Test plan
- [ ] Fresh profile (or clear `hasVisitedExtensionsPage`): status bar gear shows the accent dot
- [ ] Open Settings without selecting Extensions: rail tab shows “New”; gear badge remains
- [ ] Select Extensions: “New” and gear onboarding badge clear; flag stays cleared after reopen
- [ ] With pending extension updates after visit: gear badge and rail count still appear as before


Made with [Cursor](https://cursor.com)