### PR TITLE
fix(terminals): keep PTYs on soft-close; reap them on workspace delete

### DIFF
--- a/apps/desktop/src-tauri/src/commands/session_host.rs
+++ b/apps/desktop/src-tauri/src/commands/session_host.rs
@@ -28,6 +28,10 @@ use pty_host::{discovery, foreground, paths};
 
 const NAME_PREFIX: &str = "silo";
 const CONNECT_TIMEOUT: Duration = Duration::from_millis(3000);
+// The daemon's own kill sequence (SIGTERM, sleep 150ms, SIGKILL — see
+// pty-host's `kill_group`) plus buffer for the OS to actually reap it and the
+// master reader thread to remove the socket file.
+const KILL_TIMEOUT: Duration = Duration::from_millis(1000);
 // Sentinel the frontend normalizes to a 404 ("session no longer exists" +
 // Recreate), via tauri-terminal-client.ts. An incompatible leftover daemon is,
 // from this build's view, unreachable — i.e. effectively gone.
@@ -86,7 +90,10 @@ impl SessionHostBackend {
             Ok((T_HELLO, p)) => {
                 log_event(
                     "host_incompatible",
-                    &format!("handle={handle} daemon_proto={:?} app_proto={PROTO_VERSION}", parse_hello(&p)),
+                    &format!(
+                        "handle={handle} daemon_proto={:?} app_proto={PROTO_VERSION}",
+                        parse_hello(&p)
+                    ),
                 );
                 Err(SESSION_GONE.into())
             }
@@ -168,8 +175,27 @@ impl SessionBackend for SessionHostBackend {
     fn kill(&self, handle: &str) -> Result<(), String> {
         // Best-effort: if we can connect, ask the daemon to terminate; a failed
         // connect means it's already gone, which is success for our purposes.
-        if let Ok(mut s) = UnixStream::connect(paths::sock_path(handle)) {
-            let _ = write_frame(&mut s, T_KILL, &[]);
+        match UnixStream::connect(paths::sock_path(handle)) {
+            Ok(mut s) => {
+                let _ = write_frame(&mut s, T_KILL, &[]);
+            }
+            Err(_) => return Ok(()),
+        }
+
+        // Block until the socket actually stops accepting connections, so a
+        // caller that awaits kill() can trust the session is truly gone. Without
+        // this, a liveness probe or reattach racing right after kill() returns
+        // could reconnect to the still-dying daemon and resurrect the session in
+        // `terminal_attach` before the daemon's SIGTERM/sleep(150ms)/SIGKILL
+        // sequence finishes tearing it down. Best-effort: if it doesn't converge
+        // within the timeout, return anyway rather than hang a delete/close.
+        let sock = paths::sock_path(handle);
+        let deadline = Instant::now() + KILL_TIMEOUT;
+        while Instant::now() < deadline {
+            if !discovery::is_live(&sock) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
         }
         Ok(())
     }
@@ -203,7 +229,7 @@ impl ForegroundSub for SocketForegroundSub {
                     }
                     // malformed — keep waiting rather than ending the stream
                 }
-                Ok(_) => {} // ignore the HELLO / any stray ring data
+                Ok(_) => {}            // ignore the HELLO / any stray ring data
                 Err(_) => return None, // connection closed → session gone
             }
         }
@@ -276,7 +302,8 @@ struct SocketMaster(UnixStream);
 impl SessionMaster for SocketMaster {
     fn resize(&self, size: PtySize) -> Result<(), String> {
         let mut s = &self.0;
-        write_frame(&mut s, T_RESIZE, &resize_payload(size.cols, size.rows)).map_err(|e| e.to_string())
+        write_frame(&mut s, T_RESIZE, &resize_payload(size.cols, size.rows))
+            .map_err(|e| e.to_string())
     }
 }
 

--- a/apps/desktop/src-tauri/src/commands/session_registry.rs
+++ b/apps/desktop/src-tauri/src/commands/session_registry.rs
@@ -83,12 +83,24 @@ pub fn all() -> HashMap<String, String> {
     read_map()
 }
 
+/// Serializes any test in this crate that redirects `SILO_SESSION_REGISTRY` —
+/// it's a process-global env var, and cargo runs unit tests in parallel
+/// threads within one binary, so two tests touching it concurrently (this
+/// module's own test, plus `terminal.rs`'s `resolve_attach` tests) would race
+/// without a shared lock.
+#[cfg(test)]
+pub(crate) fn test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn save_load_remove_roundtrip() {
+        let _guard = test_lock().lock().unwrap();
         // Redirect the registry to a temp file for the duration of the test.
         let mut file = std::env::temp_dir();
         file.push(format!("silo-session-test-{}.json", std::process::id()));

--- a/apps/desktop/src-tauri/src/commands/terminal.rs
+++ b/apps/desktop/src-tauri/src/commands/terminal.rs
@@ -8,7 +8,8 @@ use std::thread;
 use uuid::Uuid;
 
 use super::session_backend::{
-    active_backend, log_event, Connection, ForegroundInfo, SessionChild, SessionMaster,
+    active_backend, log_event, Connection, ForegroundInfo, SessionBackend, SessionChild,
+    SessionMaster,
 };
 use super::session_registry;
 use super::terminal_io::{run_foreground_loop, run_reader_loop};
@@ -110,8 +111,9 @@ pub fn terminal_create(
         let handle_clone = handle.clone();
         let session_id_clone = session_id.clone();
         let app_clone = app.clone();
+        let on_gone = evict_on_gone(&state, &session_id, &session);
         thread::spawn(move || {
-            run_reader_loop(reader, handle_clone, app_clone, session_id_clone);
+            run_reader_loop(reader, handle_clone, app_clone, session_id_clone, on_gone);
         });
     }
 
@@ -126,6 +128,24 @@ pub fn terminal_create(
     Ok(session_id)
 }
 
+/// Build the reader loop's `on_gone` callback: evict `session_id` from
+/// `state.sessions`, but only if it still points at this exact session — a
+/// kill+reattach (or a fresh recreate under the same id) may have already
+/// replaced the entry by the time this stream's reader loop notices EOF, and
+/// blindly removing by key would evict that newer, live session instead.
+fn evict_on_gone(
+    state: &TerminalState,
+    session_id: &str,
+    session: &Arc<PtySession>,
+) -> impl FnOnce() + Send + 'static {
+    let sessions = state.sessions.clone();
+    let session_id = session_id.to_string();
+    let session = session.clone();
+    move || {
+        sessions.remove_if(&session_id, |_, v| Arc::ptr_eq(v, &session));
+    }
+}
+
 #[tauri::command]
 pub fn terminal_write(
     state: tauri::State<TerminalState>,
@@ -138,7 +158,9 @@ pub fn terminal_write(
     writer
         .write_all(&data)
         .map_err(|e| format!("Failed to write: {}", e))?;
-    writer.flush().map_err(|e| format!("Failed to flush: {}", e))?;
+    writer
+        .flush()
+        .map_err(|e| format!("Failed to flush: {}", e))?;
 
     Ok(())
 }
@@ -168,10 +190,7 @@ pub fn terminal_resize(
 }
 
 #[tauri::command]
-pub fn terminal_kill(
-    state: tauri::State<TerminalState>,
-    sessionId: String,
-) -> Result<(), String> {
+pub fn terminal_kill(state: tauri::State<TerminalState>, sessionId: String) -> Result<(), String> {
     let backend = active_backend();
     // Resolve the handle: prefer the persisted mapping, then the live session's
     // recorded handle, finally derivation (legacy sessions).
@@ -205,6 +224,53 @@ pub fn terminal_kill(
     result
 }
 
+/// Outcome of resolving a session id to an attachable handle: either it's
+/// already tracked in memory and live (nothing left to do), or it needs a
+/// fresh `backend.attach()` at the returned handle.
+#[cfg_attr(test, derive(Debug))]
+enum AttachPlan {
+    AlreadyLive,
+    NeedsAttach(String),
+}
+
+/// The handle/liveness resolution at the top of `terminal_attach`, pulled out
+/// as a pure function of `backend` + `state` so it's unit-testable without a
+/// `tauri::AppHandle`. Detects a dead/missing session up front — attaching to
+/// a session that no longer exists must fail with a typed marker (not a fake
+/// "Process exited"), so the frontend can show a clear "session no longer
+/// exists" state instead — and evicts a stale in-memory entry left after kill
+/// / daemon crash. An early-return "already live" here used to skip this
+/// check entirely, which made post-kill probes report alive forever.
+fn resolve_attach(
+    backend: &dyn SessionBackend,
+    state: &TerminalState,
+    session_id: &str,
+) -> Result<AttachPlan, String> {
+    // Use the persisted handle; only fall back to derivation for legacy
+    // sessions created before the registry existed.
+    let handle = session_registry::load(session_id)
+        .or_else(|| state.sessions.get(session_id).map(|s| s.handle.clone()))
+        .unwrap_or_else(|| backend.handle_for(session_id));
+
+    if !backend.exists(&handle) {
+        state.sessions.remove(session_id);
+        session_registry::remove(session_id);
+        log_event(
+            "attach_gone",
+            &format!("session={} handle={}", session_id, handle),
+        );
+        return Err("SESSION_GONE".to_string());
+    }
+
+    // Already live in memory (e.g. the app reloaded but the process didn't die)
+    // and the daemon still owns the session.
+    if state.sessions.contains_key(session_id) {
+        return Ok(AttachPlan::AlreadyLive);
+    }
+
+    Ok(AttachPlan::NeedsAttach(handle))
+}
+
 #[tauri::command]
 pub fn terminal_attach(
     app: tauri::AppHandle,
@@ -213,26 +279,11 @@ pub fn terminal_attach(
     cols: u16,
     rows: u16,
 ) -> Result<(), String> {
-    // Already live in memory (e.g. the app reloaded but the process didn't die).
-    if state.sessions.contains_key(&sessionId) {
-        return Ok(());
-    }
-
     let backend = active_backend();
-    // Use the persisted handle; only fall back to derivation for legacy sessions
-    // created before the registry existed.
-    let handle = session_registry::load(&sessionId).unwrap_or_else(|| backend.handle_for(&sessionId));
-
-    // Detect a dead/missing session up front. Attaching to a session that no
-    // longer exists must fail with a typed marker (not a fake "Process exited"),
-    // so the frontend can show a clear "session no longer exists" state instead.
-    if !backend.exists(&handle) {
-        log_event(
-            "attach_gone",
-            &format!("session={} handle={}", sessionId, handle),
-        );
-        return Err("SESSION_GONE".to_string());
-    }
+    let handle = match resolve_attach(backend.as_ref(), &state, &sessionId)? {
+        AttachPlan::AlreadyLive => return Ok(()),
+        AttachPlan::NeedsAttach(handle) => handle,
+    };
 
     let size = PtySize {
         rows,
@@ -256,8 +307,9 @@ pub fn terminal_attach(
         let handle_clone = handle.clone();
         let session_id_clone = sessionId.clone();
         let app_clone = app.clone();
+        let on_gone = evict_on_gone(&state, &sessionId, &session);
         thread::spawn(move || {
-            run_reader_loop(reader, handle_clone, app_clone, session_id_clone);
+            run_reader_loop(reader, handle_clone, app_clone, session_id_clone, on_gone);
         });
     }
 
@@ -300,8 +352,9 @@ pub fn terminal_start_stream(
         }
         let reader = session.reader.clone();
         let handle = session.handle.clone();
+        let on_gone = evict_on_gone(&state, &sessionId, session.value());
         thread::spawn(move || {
-            run_reader_loop(reader, handle, app, sessionId);
+            run_reader_loop(reader, handle, app, sessionId, on_gone);
         });
         Ok(())
     }
@@ -332,4 +385,146 @@ pub fn terminal_foreground_snapshot(
     sessionId: String,
 ) -> Option<ForegroundInfo> {
     state.fg_cache.get(&sessionId).map(|r| r.value().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::session_backend::ForegroundSub;
+    use super::*;
+
+    /// A `SessionBackend` whose `exists()` answer is fixed for the test —
+    /// the only thing `resolve_attach` needs to make its decision.
+    struct FakeBackend {
+        exists: bool,
+    }
+
+    impl SessionBackend for FakeBackend {
+        fn handle_for(&self, session_id: &str) -> String {
+            format!("fake-{session_id}")
+        }
+        fn create(
+            &self,
+            _handle: &str,
+            _cwd: &str,
+            _size: PtySize,
+            _command: Option<Vec<String>>,
+        ) -> Result<Connection, String> {
+            unimplemented!("not exercised by resolve_attach")
+        }
+        fn attach(&self, _handle: &str, _size: PtySize) -> Result<Connection, String> {
+            unimplemented!("not exercised by resolve_attach")
+        }
+        fn exists(&self, _handle: &str) -> bool {
+            self.exists
+        }
+        fn list(&self) -> Vec<String> {
+            vec![]
+        }
+        fn kill(&self, _handle: &str) -> Result<(), String> {
+            Ok(())
+        }
+        fn subscribe_foreground(&self, _handle: &str) -> Option<Box<dyn ForegroundSub>> {
+            None
+        }
+    }
+
+    struct NoopMaster;
+    impl SessionMaster for NoopMaster {
+        fn resize(&self, _size: PtySize) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    /// A tracked-in-memory session with no real backend behind it — enough to
+    /// populate `state.sessions` for a test.
+    fn fake_session(handle: &str) -> Arc<PtySession> {
+        Arc::new(PtySession {
+            handle: handle.to_string(),
+            master: Arc::new(Mutex::new(Box::new(NoopMaster) as Box<dyn SessionMaster>)),
+            reader: Arc::new(Mutex::new(
+                Box::new(std::io::empty()) as Box<dyn Read + Send>
+            )),
+            writer: Arc::new(Mutex::new(
+                Box::new(std::io::sink()) as Box<dyn Write + Send>
+            )),
+            child: None,
+            #[cfg(windows)]
+            streaming: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    /// Redirects `session_registry` to a scratch file for the duration of
+    /// `f`, under the crate-wide test lock (see `session_registry::test_lock`).
+    fn with_registry(f: impl FnOnce()) {
+        let _guard = session_registry::test_lock().lock().unwrap();
+        let mut file = std::env::temp_dir();
+        file.push(format!(
+            "silo-terminal-attach-test-{}.json",
+            std::process::id()
+        ));
+        std::env::set_var("SILO_SESSION_REGISTRY", &file);
+        let _ = std::fs::remove_file(&file);
+        f();
+        let _ = std::fs::remove_file(&file);
+        std::env::remove_var("SILO_SESSION_REGISTRY");
+    }
+
+    #[test]
+    fn dead_backend_evicts_stale_in_memory_entry_and_returns_session_gone() {
+        with_registry(|| {
+            let state = TerminalState::new();
+            session_registry::save("s1", "fake-s1");
+            // Simulate exactly the bug this fixes: a session still tracked in
+            // memory (e.g. after a daemon crash) whose backend no longer has it.
+            state
+                .sessions
+                .insert("s1".to_string(), fake_session("fake-s1"));
+
+            let backend = FakeBackend { exists: false };
+            let result = resolve_attach(&backend, &state, "s1");
+
+            assert_eq!(result.unwrap_err(), "SESSION_GONE");
+            assert!(
+                !state.sessions.contains_key("s1"),
+                "stale entry must be evicted, not left to report alive forever"
+            );
+            assert_eq!(session_registry::load("s1"), None);
+        });
+    }
+
+    #[test]
+    fn live_backend_with_tracked_session_short_circuits_as_already_live() {
+        with_registry(|| {
+            let state = TerminalState::new();
+            session_registry::save("s2", "fake-s2");
+            state
+                .sessions
+                .insert("s2".to_string(), fake_session("fake-s2"));
+
+            let backend = FakeBackend { exists: true };
+            let plan = resolve_attach(&backend, &state, "s2").unwrap();
+
+            assert!(matches!(plan, AttachPlan::AlreadyLive));
+            assert!(
+                state.sessions.contains_key("s2"),
+                "must not evict a live session"
+            );
+        });
+    }
+
+    #[test]
+    fn live_backend_without_tracked_session_resolves_to_needs_attach() {
+        with_registry(|| {
+            let state = TerminalState::new();
+            session_registry::save("s3", "fake-s3");
+
+            let backend = FakeBackend { exists: true };
+            let plan = resolve_attach(&backend, &state, "s3").unwrap();
+
+            match plan {
+                AttachPlan::NeedsAttach(handle) => assert_eq!(handle, "fake-s3"),
+                AttachPlan::AlreadyLive => panic!("expected NeedsAttach, not AlreadyLive"),
+            }
+        });
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/terminal_io.rs
+++ b/apps/desktop/src-tauri/src/commands/terminal_io.rs
@@ -41,11 +41,19 @@ pub fn decode_utf8_stream(bytes: &[u8]) -> (String, Vec<u8>) {
 /// to the frontend. Scrollback persistence is handled on the frontend via the
 /// xterm.js SerializeAddon (see terminal_save_buffer) — the backend no longer
 /// captures or interprets the byte stream.
+///
+/// `on_gone` is called once the stream ends (EOF or a read error), so the
+/// caller can evict its own tracked session entry — this is the one place that
+/// reliably observes "this session just died", so it's also the one place that
+/// should own pruning stale bookkeeping, rather than leaving every other
+/// session-touching command (`terminal_write`, `terminal_resize`, a future
+/// reattach) to trust a possibly-stale entry until something else notices.
 pub fn run_reader_loop(
     reader: Arc<Mutex<Box<dyn Read + Send>>>,
     handle: String,
     app: tauri::AppHandle,
     session_id: String,
+    on_gone: impl FnOnce() + Send + 'static,
 ) {
     let mut buf = vec![0u8; 8192];
     // Holds an incomplete multi-byte UTF-8 sequence split across reads.
@@ -87,6 +95,7 @@ pub fn run_reader_loop(
             }
         }
     }
+    on_gone();
 }
 
 /// Forward a session's foreground-process updates (RFC 0010 N1) to the frontend

--- a/apps/desktop/src/automation/bridge.ts
+++ b/apps/desktop/src/automation/bridge.ts
@@ -5,13 +5,13 @@ import {
   getThemeService,
   getProcessService,
   getTerminalService,
+  getWorkspaceService,
   executeCommand,
   contextKeys,
   store,
   sidePanelRegistry,
   createWorkspace,
   activateWorkspace,
-  deleteWorkspace,
   openEditor,
   openDiff,
   openPreviewDiff,
@@ -313,7 +313,12 @@ async function handleOp(
         active: store.activeWorkspaceId,
         workspaces: store.workspaceOrder.map((id) => {
           const w = store.workspaces[id];
-          return { id, name: w?.name, folder: w?.folder };
+          return {
+            id,
+            name: w?.name,
+            folder: w?.folder,
+            closedAt: w?.closedAt ?? null,
+          };
         }),
       };
 
@@ -330,19 +335,51 @@ async function handleOp(
       return { active: store.activeWorkspaceId };
     }
 
-    // Asserted teardown: fully remove a workspace entry. deleteWorkspace()
-    // switches the active workspace away first (pickNextOpen), so a test can
-    // then safely delete the sandbox folder it pointed at. Returns the verified
-    // end state — `deleted` is true only if the id is truly gone from the store.
+    // Soft-close — keeps the workspace entry (and its terminal records / PTYs).
+    // Counterpart to deleteWorkspace; drives ctx.workspaces.close.
+    case "closeWorkspace": {
+      const id = String(args.id ?? "");
+      getWorkspaceService().close(id);
+      const ws = store.workspaces[id];
+      return {
+        closed: Boolean(ws?.closedAt),
+        active: store.activeWorkspaceId,
+      };
+    }
+
+    // Asserted teardown: fully remove a workspace entry (and reap its PTYs).
+    // Routes through the same WorkspaceService.delete the UI uses, awaiting
+    // its returned promise so the reply waits until PTYs are actually killed
+    // — the entry itself is already gone by the time delete() returns, since
+    // it removes it synchronously before awaiting the reap. Returns the
+    // verified end state — `deleted` is true only if the id is truly gone.
     case "deleteWorkspace": {
       const id = String(args.id ?? "");
-      // Mirror the real UI delete path (WorkspacesPanel.confirmDelete): reap the
-      // workspace's terminal sessions before removing it, so no PTYs leak.
-      getTerminalService().closeWorkspace(id);
-      deleteWorkspace(id);
+      await getWorkspaceService().delete(id);
       const deleted =
         !store.workspaces[id] && !store.workspaceOrder.includes(id);
       return { deleted, active: store.activeWorkspaceId };
+    }
+
+    // Probe whether a PTY session is still alive in the pty-host daemon.
+    // Uses process.attach (404/"no longer exists" → alive:false). Does not
+    // kill the session — kill() itself (terminal.rs) now blocks until the
+    // daemon actually tears down, so there's no post-kill race window left to
+    // guard against here; a single probe is enough.
+    case "processAlive": {
+      const sessionId = String(args.sessionId ?? "");
+      if (!sessionId) return { alive: false };
+      try {
+        await getProcessService().attach(sessionId, { cols: 80, rows: 24 });
+        return { alive: true };
+      } catch (err) {
+        const status = (err as { status?: number } | null)?.status;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (status === 404 || msg.includes("no longer exists")) {
+          return { alive: false };
+        }
+        return { alive: false, error: msg };
+      }
     }
 
     case "openFile": {
@@ -359,6 +396,15 @@ async function handleOp(
       });
       if (!rec) throw new Error("openTerminal: no active workspace");
       return { terminalId: rec.id, panelId: `terminal:${rec.id}` };
+    }
+
+    // Write to a terminal PTY (force-spawns if the tab has never mounted).
+    case "sendText": {
+      const terminalId = String(args.terminalId ?? "");
+      const text = String(args.text ?? "");
+      const addNewline = args.addNewline !== false;
+      getTerminalService().sendText(terminalId, text, addNewline);
+      return { sent: true };
     }
 
     case "listTerminals": {

--- a/apps/desktop/src/automation/client.ts
+++ b/apps/desktop/src/automation/client.ts
@@ -23,7 +23,13 @@ export interface EditorDetail {
 
 export interface WorkspaceList {
   active: string | null;
-  workspaces: { id: string; name?: string; folder?: string }[];
+  workspaces: {
+    id: string;
+    name?: string;
+    folder?: string;
+    /** ISO timestamp when soft-closed, or null when open. */
+    closedAt?: string | null;
+  }[];
 }
 
 /** Resolved Monaco editor configuration, from the `editorOptions` op. */
@@ -156,11 +162,41 @@ export class SiloAutomation {
     return this.call("activateWorkspace", { id });
   }
 
-  /** Fully remove a workspace entry (switches active away first). For teardown. */
+  /**
+   * Soft-close a workspace — keeps the entry (and its terminals / PTYs) so it
+   * can be reopened. Counterpart to {@link SiloAutomation.deleteWorkspace}.
+   */
+  closeWorkspace(
+    id: string,
+  ): Promise<{ closed: boolean; active: string | null }> {
+    return this.call("closeWorkspace", { id });
+  }
+
+  /** Fully remove a workspace entry (and reap its PTYs). For teardown. */
   deleteWorkspace(
     id: string,
   ): Promise<{ deleted: boolean; active: string | null }> {
     return this.call("deleteWorkspace", { id });
+  }
+
+  /**
+   * Whether a PTY session is still alive in the pty-host daemon. Uses
+   * `ctx.process.attach` as a probe — does not kill the session.
+   */
+  processAlive(sessionId: string): Promise<{ alive: boolean; error?: string }> {
+    return this.call("processAlive", { sessionId });
+  }
+
+  /** Terminal tab records for a workspace (defaults to the active one). */
+  listTerminals(workspaceId?: string): Promise<{
+    terminals: {
+      id: string;
+      title: string;
+      sessionId: string;
+      kind: string;
+    }[];
+  }> {
+    return this.call("listTerminals", { workspaceId });
   }
 
   openFile(path: string): Promise<{ editorId: string; panelId: string }> {
@@ -206,6 +242,19 @@ export class SiloAutomation {
 
   openTerminal(cwd?: string): Promise<{ terminalId: string; panelId: string }> {
     return this.call("openTerminal", { cwd });
+  }
+
+  /**
+   * Write to a terminal's PTY as if typed. Force-spawns the session when the
+   * tab has never mounted — useful for tests that need a live `sessionId`
+   * without waiting on dock mount/focus.
+   */
+  sendText(
+    terminalId: string,
+    text: string,
+    addNewline = true,
+  ): Promise<{ sent: boolean }> {
+    return this.call("sendText", { terminalId, text, addNewline });
   }
 
   /** Run a registered command id — the same dispatch menus/keybindings use. */

--- a/apps/desktop/src/automation/workspace-pty-lifecycle.it.test.ts
+++ b/apps/desktop/src/automation/workspace-pty-lifecycle.it.test.ts
@@ -1,0 +1,190 @@
+// Integration test (Layer 2): soft-close vs hard-delete PTY lifecycle.
+//
+// Regression guards for:
+//   1. Soft-close must keep terminal records and live PTY sessions (including
+//      when CenterDock unmounts into the empty state — previously killed PTYs
+//      via a bad TerminalPanel unmount lookup).
+//   2. Hard-delete (ctx.workspaces.delete) must reap every PTY in the workspace.
+//
+// Requires the dev app running (`pnpm dev`); skips otherwise.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[workspace-pty-lifecycle.it] no dev app reachable on :7878 — skipping. " +
+      "Run `pnpm dev` to exercise this suite.",
+  );
+}
+
+/**
+ * Open a shell tab and wait until its PTY has spawned. Mounts the panel, then
+ * force-spawns via sendText (same on-demand path as unmounted `ctx.terminals`
+ * writes) so we don't depend on dock focus timing.
+ */
+async function spawnTerminal(
+  workspaceId: string,
+  cwd: string,
+): Promise<{ terminalId: string; sessionId: string }> {
+  const { terminalId, panelId } = await silo.openTerminal(cwd);
+  try {
+    await silo.activatePanel(panelId);
+  } catch {
+    // Panel may not be in the dock yet — sendText force-spawns regardless.
+  }
+  // Nudge the PTY awake without running a command (no trailing CR).
+  await silo.sendText(terminalId, "", false);
+  let sessionId = "";
+  await expect
+    .poll(
+      async () => {
+        const list = await silo.listTerminals(workspaceId);
+        const rec = list.terminals.find((t) => t.id === terminalId);
+        sessionId = rec?.sessionId ?? "";
+        return sessionId;
+      },
+      { timeout: 15000, interval: 100 },
+    )
+    .not.toBe("");
+  return { terminalId, sessionId };
+}
+
+describe.skipIf(!available)("workspace close vs delete PTY lifecycle", () => {
+  let folderA: string;
+  let folderB: string;
+  let priorActive: string | null;
+  let wsA: string;
+  let wsB: string;
+
+  beforeAll(async () => {
+    priorActive = (await silo.listWorkspaces()).active;
+    folderA = await mkdtemp(join(tmpdir(), "silo-it-pty-a-"));
+    folderB = await mkdtemp(join(tmpdir(), "silo-it-pty-b-"));
+    await writeFile(join(folderA, "readme.txt"), "a\n");
+    await writeFile(join(folderB, "readme.txt"), "b\n");
+    wsA = (await silo.openWorkspace(folderA, "it-pty-a")).id;
+    wsB = (await silo.openWorkspace(folderB, "it-pty-b")).id;
+  });
+
+  afterAll(async () => {
+    // Best-effort teardown — tests may have already deleted one or both.
+    for (const id of [wsA, wsB]) {
+      if (!id) continue;
+      try {
+        await silo.deleteWorkspace(id);
+      } catch {
+        /* already gone */
+      }
+    }
+    if (priorActive) {
+      try {
+        await silo.activateWorkspace(priorActive);
+      } catch {
+        /* unknown */
+      }
+    }
+    await rm(folderA, { recursive: true, force: true });
+    await rm(folderB, { recursive: true, force: true });
+  });
+
+  it(
+    "soft-close keeps the PTY alive and the terminal record intact",
+    { timeout: 30000 },
+    async () => {
+      await silo.activateWorkspace(wsA);
+      const { terminalId, sessionId } = await spawnTerminal(wsA, folderA);
+
+      // Keeper workspace stays open so this is a warm soft-close (dock stays
+      // mounted). The empty-state path is covered by the next test when it can
+      // reach active === null.
+      const closed = await silo.closeWorkspace(wsA);
+      expect(closed.closed).toBe(true);
+      expect(closed.active).not.toBe(wsA);
+
+      const list = await silo.listWorkspaces();
+      const entry = list.workspaces.find((w) => w.id === wsA);
+      expect(entry?.closedAt).toBeTruthy();
+
+      const terminals = await silo.listTerminals(wsA);
+      expect(
+        terminals.terminals.find((t) => t.id === terminalId)?.sessionId,
+      ).toBe(sessionId);
+
+      expect((await silo.processAlive(sessionId)).alive).toBe(true);
+
+      // Reopen and confirm the same session is still attachable.
+      await silo.activateWorkspace(wsA);
+      expect((await silo.processAlive(sessionId)).alive).toBe(true);
+    },
+  );
+
+  it(
+    "soft-close of the last open sandbox keeps the PTY when the app hits empty state",
+    { timeout: 30000 },
+    async () => {
+      // Soft-close every sandbox we control, then ask: if that left the app with
+      // no open workspace (active === null), CenterDock unmounts warmed docks —
+      // the regression path that previously killed PTYs. When the user's session
+      // has other open workspaces we can't force empty state; skip in that case.
+      await silo.activateWorkspace(wsA);
+      const { sessionId } = await spawnTerminal(wsA, folderA);
+
+      await silo.closeWorkspace(wsA);
+      await silo.closeWorkspace(wsB);
+
+      const after = await silo.listWorkspaces();
+      if (after.active !== null) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[workspace-pty-lifecycle.it] other workspaces still open " +
+            `(active=${after.active}) — skipping empty-state PTY assertion.`,
+        );
+        // Still assert soft-close itself didn't kill this sandbox's PTY.
+        expect((await silo.processAlive(sessionId)).alive).toBe(true);
+        await silo.activateWorkspace(wsA);
+        await silo.activateWorkspace(wsB);
+        return;
+      }
+
+      // Empty state: panels unmounted, but records + daemon session must live.
+      expect((await silo.processAlive(sessionId)).alive).toBe(true);
+      const terminals = await silo.listTerminals(wsA);
+      expect(terminals.terminals.some((t) => t.sessionId === sessionId)).toBe(
+        true,
+      );
+
+      await silo.activateWorkspace(wsA);
+      await silo.activateWorkspace(wsB);
+      expect((await silo.processAlive(sessionId)).alive).toBe(true);
+    },
+  );
+
+  it("hard-delete reaps the workspace's PTY", { timeout: 30000 }, async () => {
+    await silo.activateWorkspace(wsB);
+    const { sessionId } = await spawnTerminal(wsB, folderB);
+    expect((await silo.processAlive(sessionId)).alive).toBe(true);
+
+    const deleted = await silo.deleteWorkspace(wsB);
+    expect(deleted.deleted).toBe(true);
+    wsB = ""; // afterAll shouldn't try again
+
+    // closeWorkspace fires terminal_kill without awaiting — poll until the
+    // pty-host reaps the session rather than racing the async invoke.
+    await expect
+      .poll(async () => (await silo.processAlive(sessionId)).alive, {
+        timeout: 5000,
+        interval: 50,
+      })
+      .toBe(false);
+    const list = await silo.listWorkspaces();
+    expect(list.workspaces.some((w) => w.folder === folderB)).toBe(false);
+  });
+});

--- a/apps/docs/api/state/workspaces.md
+++ b/apps/docs/api/state/workspaces.md
@@ -42,7 +42,7 @@ to the full signature.
 | [`activate(id)`](/api/types/interfaces/WorkspaceService#activate)                           | Activate (and reopen if closed).                                             |
 | [`close(id)`](/api/types/interfaces/WorkspaceService#close)                                 | Soft close — hidden but still saved.                                         |
 | [`reopen(id)`](/api/types/interfaces/WorkspaceService#reopen)                               | Reverse of `close`.                                                          |
-| [`delete(id)`](/api/types/interfaces/WorkspaceService#delete)                               | Hard delete — permanent removal.                                             |
+| [`delete(id)`](/api/types/interfaces/WorkspaceService#delete)                               | Hard delete — permanent removal (also reaps the workspace's terminals).      |
 | [`addFolder(id, folder)`](/api/types/interfaces/WorkspaceService#addfolder)                 | Add an extra folder to a workspace.                                          |
 | [`removeFolder(id, folder)`](/api/types/interfaces/WorkspaceService#removefolder)           | Remove an extra folder.                                                      |
 

--- a/apps/docs/api/types/interfaces/TerminalService.md
+++ b/apps/docs/api/types/interfaces/TerminalService.md
@@ -1,13 +1,15 @@
 # Interface: TerminalService
 
-Defined in: [packages/sdk/src/terminal-service.ts:96](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L96)
+Defined in: [packages/sdk/src/terminal-service.ts:98](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L98)
 
 Consumer API for the terminal domain, exposed as
 [ExtensionContext.terminals](ExtensionContext.md#terminals). The terminal is a core feature — a
 built-in DockKind like the editor — so this mirrors [EditorService](EditorService.md):
 `create` opens a terminal tab in a workspace, and `closeWorkspace` reaps a
-workspace's terminals (used when a workspace is deleted). The tab itself is
-rendered by the core dock from the workspace's terminal records.
+workspace's terminals. [WorkspaceService.delete](WorkspaceService.md#delete) calls `closeWorkspace`
+for you; the primitive remains available for surgical reaping without
+deleting the workspace. The tab itself is rendered by the core dock from the
+workspace's terminal records.
 
 ## Methods
 
@@ -17,7 +19,7 @@ rendered by the core dock from the workspace's terminal records.
 create(input?): TerminalRecord | undefined;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:106](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L106)
+Defined in: [packages/sdk/src/terminal-service.ts:108](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L108)
 
 Open a new terminal in a workspace (defaults to the active one). Returns the
 created [TerminalRecord](TerminalRecord.md); the PTY session spawns lazily when its tab
@@ -45,9 +47,11 @@ happen because activating any workspace happens before extensions run.
 closeWorkspace(workspaceId): void;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:108](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L108)
+Defined in: [packages/sdk/src/terminal-service.ts:114](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L114)
 
-Close and kill every terminal in a workspace (e.g. on workspace delete).
+Close and kill every terminal in a workspace. [WorkspaceService.delete](WorkspaceService.md#delete)
+reaps terminals the same way automatically, so this is for reaping a
+workspace's terminals surgically, without deleting the workspace itself.
 
 #### Parameters
 
@@ -70,7 +74,7 @@ sendText(
    addNewline?): void;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:129](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L129)
+Defined in: [packages/sdk/src/terminal-service.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L135)
 
 Write text to a terminal's PTY as if the user typed it. By default a
 carriage return is appended so the line executes; pass `addNewline: false`
@@ -119,7 +123,7 @@ if (term) ctx.terminals.sendText(term.id, "npm run build");
 close(terminalId): void;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:136](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L136)
+Defined in: [packages/sdk/src/terminal-service.ts:142](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L142)
 
 Close one terminal tab and kill its PTY session. No-op if the id is unknown.
 To reap every terminal in a workspace at once use
@@ -143,7 +147,7 @@ To reap every terminal in a workspace at once use
 rename(terminalId, name): void;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:144](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L144)
+Defined in: [packages/sdk/src/terminal-service.ts:150](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L150)
 
 Set a terminal's user-facing name ([TerminalRecord.customName](TerminalRecord.md#customname)),
 shown on its tab and persisted across restarts. Passing an empty string
@@ -172,7 +176,7 @@ No-op for an unknown `terminalId`.
 focus(terminalId): void;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:150](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L150)
+Defined in: [packages/sdk/src/terminal-service.ts:156](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L156)
 
 Switch to the workspace containing this terminal and activate its tab in
 the center dock. No-ops if the terminal id is unknown.
@@ -195,7 +199,7 @@ the center dock. No-ops if the terminal id is unknown.
 registerTabDecoration(provider): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:158](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L158)
+Defined in: [packages/sdk/src/terminal-service.ts:164](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L164)
 
 Register a decoration provider for terminal tabs. The first registered
 provider that returns a non-null decoration for a terminal wins; subsequent
@@ -220,7 +224,7 @@ the provider.
 getTabDecoration(terminalId): TerminalTabDecoration | null;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:164](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L164)
+Defined in: [packages/sdk/src/terminal-service.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L170)
 
 Get the current decoration for a terminal tab. Returns the first non-null
 result from registered providers, or `null` if none apply.
@@ -243,7 +247,7 @@ result from registered providers, or `null` if none apply.
 invalidateTabDecorations(): void;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L171)
+Defined in: [packages/sdk/src/terminal-service.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L177)
 
 Signal that tab decoration data has changed. Fires all listeners registered
 via [TerminalService.subscribeTabDecorations](#subscribetabdecorations), causing terminal tabs
@@ -261,7 +265,7 @@ to re-query providers and re-render their decoration.
 subscribeTabDecorations(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L177)
+Defined in: [packages/sdk/src/terminal-service.ts:183](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L183)
 
 Subscribe to tab decoration invalidations. Returns a [Disposable](Disposable.md)
 that cancels the subscription.
@@ -284,7 +288,7 @@ that cancels the subscription.
 subscribeOsc(terminalId, handler): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:207](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L207)
+Defined in: [packages/sdk/src/terminal-service.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L213)
 
 Subscribe to raw OSC (Operating System Command) escape sequences emitted
 by the terminal identified by `terminalId`. The handler is called once per
@@ -336,7 +340,7 @@ ctx.subscriptions.push(sub);
 subscribeOutput(terminalId, handler): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:240](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L240)
+Defined in: [packages/sdk/src/terminal-service.ts:246](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L246)
 
 Subscribe to the raw PTY output stream of the terminal identified by
 `terminalId`. The `handler` is called with every chunk of bytes the PTY
@@ -388,7 +392,7 @@ ctx.subscriptions.push(sub);
 getActive(): string | null;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:252](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L252)
+Defined in: [packages/sdk/src/terminal-service.ts:258](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L258)
 
 The record id of the terminal tab that is currently active in the active
 workspace's center dock, or `null` when an editor tab (or nothing) is
@@ -408,7 +412,7 @@ split does not count.
 subscribeActive(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:274](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L274)
+Defined in: [packages/sdk/src/terminal-service.ts:280](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L280)
 
 Subscribe to active-terminal changes. The listener receives the terminal
 record id whenever a terminal tab becomes the active center-dock panel,

--- a/apps/docs/api/types/interfaces/WorkspaceService.md
+++ b/apps/docs/api/types/interfaces/WorkspaceService.md
@@ -289,12 +289,17 @@ Remove an extra folder from a workspace.
 ### delete()
 
 ```ts
-delete(id): void;
+delete(id): Promise<void>;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L191)
+Defined in: [packages/sdk/src/workspace-service.ts:198](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L198)
 
-Hard delete — permanent removal.
+Hard delete — permanent removal. Also reaps every terminal in the
+workspace (removes records and kills live PTY sessions); callers do not
+need a separate [TerminalService.closeWorkspace](TerminalService.md#closeworkspace) step. The entry is
+removed from state synchronously (before this returns); the returned
+promise resolves once the reaped PTYs have actually been killed, for
+callers (e.g. tests) that need that guarantee. Most callers can ignore it.
 
 #### Parameters
 
@@ -304,7 +309,7 @@ Hard delete — permanent removal.
 
 #### Returns
 
-`void`
+`Promise`\<`void`\>
 
 ***
 
@@ -314,7 +319,7 @@ Hard delete — permanent removal.
 registerStatus(provider): Disposable;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L213)
+Defined in: [packages/sdk/src/workspace-service.ts:220](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L220)
 
 Register a status provider that contributes status rows to workspace
 rows in the Workspaces side panel. Multiple providers may be registered;
@@ -354,7 +359,7 @@ ctx.subscriptions.push(
 getStatus(workspaceId): WorkspaceStatusRow[];
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:220](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L220)
+Defined in: [packages/sdk/src/workspace-service.ts:227](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L227)
 
 Concatenate all registered providers' rows for one workspace (in
 registration order). Called synchronously during panel render — providers
@@ -378,7 +383,7 @@ must be fast and side-effect-free.
 invalidateStatus(): void;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:229](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L229)
+Defined in: [packages/sdk/src/workspace-service.ts:236](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L236)
 
 Signal that status data has changed. Fires all listeners registered
 via [WorkspaceService.subscribeStatus](#subscribestatus), causing the Workspaces
@@ -398,7 +403,7 @@ Call this after any mutation to the state your `provide` function reads.
 subscribeStatus(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:239](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L239)
+Defined in: [packages/sdk/src/workspace-service.ts:246](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L246)
 
 Subscribe to status invalidations. The listener is called whenever
 [WorkspaceService.invalidateStatus](#invalidatestatus) is invoked. Returns a
@@ -425,7 +430,7 @@ to observe invalidations.
 registerSection(provider): Disposable;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:263](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L263)
+Defined in: [packages/sdk/src/workspace-service.ts:270](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L270)
 
 Register a section provider that mounts a React component inside workspace
 rows in the Workspaces side panel. Returns a [Disposable](Disposable.md) that
@@ -467,7 +472,7 @@ ctx.subscriptions.push(
 subscribeSection(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:280](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L280)
+Defined in: [packages/sdk/src/workspace-service.ts:287](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L287)
 
 Subscribe to section registration changes. The listener is called whenever
 a [WorkspaceSectionProvider](WorkspaceSectionProvider.md) is registered or unregistered. Returns a
@@ -501,7 +506,7 @@ update its own state directly.
 registerBadge(provider): Disposable;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:302](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L302)
+Defined in: [packages/sdk/src/workspace-service.ts:309](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L309)
 
 Register a badge provider that contributes [WorkspaceBadge](WorkspaceBadge.md)s next to
 the workspace name in the Workspaces side panel. Multiple providers may be
@@ -541,7 +546,7 @@ ctx.subscriptions.push(
 getBadges(workspaceId): WorkspaceBadge[];
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:309](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L309)
+Defined in: [packages/sdk/src/workspace-service.ts:316](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L316)
 
 Concatenate all registered providers' badges for one workspace (in
 registration order). Called synchronously during panel render — providers
@@ -565,7 +570,7 @@ must be fast and side-effect-free.
 invalidateBadges(): void;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:318](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L318)
+Defined in: [packages/sdk/src/workspace-service.ts:325](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L325)
 
 Signal that badge data has changed. Fires all listeners registered via
 [WorkspaceService.subscribeBadges](#subscribebadges), causing the Workspaces panel to
@@ -585,7 +590,7 @@ Call this after any mutation to the state your `provide` function reads.
 subscribeBadges(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/workspace-service.ts:325](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L325)
+Defined in: [packages/sdk/src/workspace-service.ts:332](https://github.com/silo-code/silo/blob/main/packages/sdk/src/workspace-service.ts#L332)
 
 Subscribe to badge invalidations. The listener is called whenever
 [WorkspaceService.invalidateBadges](#invalidatebadges) is invoked. Returns a

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -192,26 +192,39 @@ automation can't operate). They call the **same `state/workspaces` APIs the UI
 does**, so the behavior under test — focus, activation, panel routing — is
 faithful. **Intended for a sandbox workspace; never point them at real files.**
 
-| op                  | args                                                 | result                                                                                |
-| ------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `listWorkspaces`    | —                                                    | `{ active, workspaces: [{id,name,folder}] }`                                          |
-| `openWorkspace`     | `{ folder: string, name?: string }`                  | `{ id }` — creates **and activates** it                                               |
-| `activateWorkspace` | `{ id: string }`                                     | `{ active }` — the active workspace id                                                |
-| `deleteWorkspace`   | `{ id: string }`                                     | `{ deleted, active }` — asserted teardown; removes the entry and switches active away |
-| `openFile`          | `{ path: string }`                                   | `{ editorId, panelId: "editor:<id>" }`                                                |
-| `openTerminal`      | `{ cwd?: string }`                                   | `{ terminalId, panelId: "terminal:<id>" }`                                            |
-| `openDiff`          | `{ path: string, mode?: "workingTree" \| "staged" }` | `{ diffId, panelId: "diff:<id>" }`                                                    |
-| `activatePanel`     | `{ panelId: string }`                                | `{ activated }`                                                                       |
-| `showSidePanel`     | `{ id: string }`                                     | `{ shown, slot?, error? }` — expands the panel's slot and clicks its tab              |
+| op                  | args                                                 | result                                                                                 |
+| ------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `listWorkspaces`    | —                                                    | `{ active, workspaces: [{id,name,folder}] }`                                           |
+| `openWorkspace`     | `{ folder: string, name?: string }`                  | `{ id }` — creates **and activates** it                                                |
+| `activateWorkspace` | `{ id: string }`                                     | `{ active }` — the active workspace id                                                 |
+| `closeWorkspace`    | `{ id: string }`                                     | `{ closed, active }` — soft-close; keeps entry + PTYs (reopen via `activateWorkspace`) |
+| `deleteWorkspace`   | `{ id: string }`                                     | `{ deleted, active }` — hard-delete; reaps terminals/PTYs and removes the entry        |
+| `processAlive`      | `{ sessionId: string }`                              | `{ alive, error? }` — probe whether a PTY session still exists in the daemon           |
+| `listTerminals`     | `{ workspaceId?: string }`                           | `{ terminals: [{id,title,sessionId,kind}] }` — defaults to the active workspace        |
+| `openFile`          | `{ path: string }`                                   | `{ editorId, panelId: "editor:<id>" }`                                                 |
+| `openTerminal`      | `{ cwd?: string }`                                   | `{ terminalId, panelId: "terminal:<id>" }`                                             |
+| `sendText`          | `{ terminalId, text, addNewline? }`                  | `{ sent }` — write to a PTY; force-spawns if the tab never mounted                     |
+| `openDiff`          | `{ path: string, mode?: "workingTree" \| "staged" }` | `{ diffId, panelId: "diff:<id>" }`                                                     |
+| `activatePanel`     | `{ panelId: string }`                                | `{ activated }`                                                                        |
+| `showSidePanel`     | `{ id: string }`                                     | `{ shown, slot?, error? }` — expands the panel's slot and clicks its tab               |
 
 Notes:
 
 - `openWorkspace` derives `name` from the last path segment of `folder` if
   omitted, and activates the new workspace.
+- `closeWorkspace` is the soft-close counterpart: sets `closedAt`, keeps the
+  workspace entry and its terminal records / PTY sessions, and switches active
+  away when needed. Reopen with `activateWorkspace` (or `workspaces.reopen`).
 - `deleteWorkspace` is the teardown counterpart: it removes the workspace entry
   and (if it was active) switches to the next open one, so a test can then
-  delete the sandbox folder it pointed at without racing the dock. `deleted` is
-  `true` only once the id is gone from the store.
+  delete the sandbox folder it pointed at without racing the dock. It also
+  awaits the reap of the workspace's terminals — the reply only returns once
+  every live PTY is confirmed killed at the daemon (not just once the kill
+  request was sent), so a `processAlive` check right after is not racy.
+  `deleted` is `true` only once the id is gone from the store.
+- `processAlive` probes a session via `ctx.process.attach` — `{ alive: true }`
+  if the pty-host still has it, `{ alive: false }` on a 404 ("session no
+  longer exists"). It does not terminate the session.
 - `openFile`/`openTerminal`/`openDiff` operate on the **active workspace**; if
   there is none they error with `no active workspace`.
 - `showSidePanel` wakes a **lazy-mounted** side panel (file explorer, git,
@@ -473,8 +486,6 @@ Conventions that keep them reliable:
 
 This is the minimal-plus surface. Natural extensions, roughly in order:
 
-- **`closeWorkspace` op:** the soft-close counterpart to `deleteWorkspace`
-  (keeps the entry, reopenable) — add if a test needs to exercise close/reopen.
 - **More input ops:** `type` (synthetic input into the focused editor),
   `dispatchKey`, `waitFor` (poll an `expr`/op until truthy), `screenshot`
   (webview capture).

--- a/packages/extension-host/src/extension-host/terminal-service.test.ts
+++ b/packages/extension-host/src/extension-host/terminal-service.test.ts
@@ -118,6 +118,21 @@ describe("TerminalService.close (B7)", () => {
   });
 });
 
+describe("TerminalService.closeWorkspace", () => {
+  it("kills every live session and clears the workspace's terminal list", () => {
+    svc.closeWorkspace("w");
+    expect(store.workspaces.w.terminals).toEqual([]);
+    expect(deleteTerminal).toHaveBeenCalledWith("sess-1");
+    expect(deleteTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op for an unknown workspace id", () => {
+    svc.closeWorkspace("nope");
+    expect(store.workspaces.w.terminals).toHaveLength(2);
+    expect(deleteTerminal).not.toHaveBeenCalled();
+  });
+});
+
 describe("TerminalService.rename (B7)", () => {
   it("sets a custom name and mirrors it into the title", () => {
     svc.rename("t1", "  deploy  ");

--- a/packages/extension-host/src/extension-host/terminal-service.ts
+++ b/packages/extension-host/src/extension-host/terminal-service.ts
@@ -75,6 +75,34 @@ function ensureSession(terminalId: string): Promise<string | null> {
 
 let service: TerminalService | null = null;
 
+/**
+ * Remove every terminal record in a workspace and await force-kill of each live
+ * PTY. Used by {@link TerminalService.closeWorkspace} (fire-and-forget) and by
+ * the automation bridge (awaited so delete replies after reaps finish).
+ *
+ * @internal
+ */
+export async function reapWorkspaceTerminals(
+  workspaceId: string,
+): Promise<void> {
+  const ws = store.workspaces[workspaceId];
+  if (!ws) return;
+  // Snapshot ids first — removeTerminal mutates the array.
+  const ids = ws.terminals.map((t) => t.id);
+  const kills: Promise<void>[] = [];
+  for (const id of ids) {
+    const rec = removeTerminal(workspaceId, id);
+    if (rec?.sessionId) {
+      kills.push(
+        tauriTerminalClient
+          .deleteTerminal(rec.sessionId)
+          .catch((err) => console.warn("delete terminal failed", err)),
+      );
+    }
+  }
+  await Promise.all(kills);
+}
+
 /** @internal — host factory; extensions receive this as `ctx.terminals`. */
 export function getTerminalService(): TerminalService {
   if (service) return service;
@@ -105,18 +133,7 @@ export function getTerminalService(): TerminalService {
       }
     },
     closeWorkspace(workspaceId) {
-      const ws = store.workspaces[workspaceId];
-      if (!ws) return;
-      // Snapshot ids first — removeTerminal mutates the array.
-      const ids = ws.terminals.map((t) => t.id);
-      for (const id of ids) {
-        const rec = removeTerminal(workspaceId, id);
-        if (rec?.sessionId) {
-          tauriTerminalClient
-            .deleteTerminal(rec.sessionId)
-            .catch((err) => console.warn("delete terminal failed", err));
-        }
-      }
+      void reapWorkspaceTerminals(workspaceId);
     },
     sendText(terminalId, text, addNewline = true) {
       // A PTY treats Enter as a carriage return, so append "\r" (not "\n") to

--- a/packages/extension-host/src/extension-host/workspace-service.test.ts
+++ b/packages/extension-host/src/extension-host/workspace-service.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { deleteTerminal } = vi.hoisted(() => ({
+  deleteTerminal: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("../services/tauri-terminal-client", () => ({
+  tauriTerminalClient: { deleteTerminal },
+}));
+
+import { store } from "../state/store";
+import type { WorkspaceInternal } from "../state/types";
+import { getWorkspaceService } from "./workspace-service";
+
+const svc = getWorkspaceService();
+
+function makeWorkspace(id: string): WorkspaceInternal {
+  return {
+    id,
+    name: id,
+    folder: `/ws/${id}`,
+    createdAt: "",
+    lastOpenedAt: "",
+    terminals: [],
+    editors: [],
+    dockLayout: null,
+    previewEditorId: null,
+  };
+}
+
+beforeEach(() => {
+  deleteTerminal.mockReset().mockResolvedValue(undefined);
+  const a = makeWorkspace("a");
+  a.terminals = [
+    { id: "t1", sessionId: "sess-1", kind: "shell", title: "Terminal" },
+    { id: "t2", sessionId: "", kind: "shell", title: "Terminal" },
+  ];
+  const b = makeWorkspace("b");
+  store.workspaces = { a, b };
+  store.workspaceOrder = ["a", "b"];
+  store.panelOrder = ["a", "b"];
+  store.activeWorkspaceId = "a";
+  store.groups = {};
+});
+
+describe("WorkspaceService.delete", () => {
+  it("reaps live PTY sessions before removing the workspace", () => {
+    svc.delete("a");
+    expect(deleteTerminal).toHaveBeenCalledWith("sess-1");
+    expect(deleteTerminal).toHaveBeenCalledTimes(1);
+    expect(store.workspaces.a).toBeUndefined();
+    expect(store.workspaceOrder).toEqual(["b"]);
+    expect(store.activeWorkspaceId).toBe("b");
+  });
+
+  it("does not touch terminals belonging to other workspaces", () => {
+    store.workspaces.b!.terminals = [
+      { id: "tb", sessionId: "sess-b", kind: "shell", title: "Terminal" },
+    ];
+    svc.delete("a");
+    expect(deleteTerminal).toHaveBeenCalledWith("sess-1");
+    expect(deleteTerminal).not.toHaveBeenCalledWith("sess-b");
+    expect(store.workspaces.b!.terminals).toHaveLength(1);
+  });
+
+  it("removes a workspace with only unspawned terminals without a kill call", () => {
+    store.workspaces.a!.terminals = [
+      { id: "t-unspawned", sessionId: "", kind: "shell", title: "Terminal" },
+    ];
+    svc.delete("a");
+    expect(deleteTerminal).not.toHaveBeenCalled();
+    expect(store.workspaces.a).toBeUndefined();
+  });
+
+  it("is a no-op for an unknown workspace id", () => {
+    svc.delete("nope");
+    expect(deleteTerminal).not.toHaveBeenCalled();
+    expect(Object.keys(store.workspaces)).toEqual(["a", "b"]);
+  });
+});

--- a/packages/extension-host/src/extension-host/workspace-service.ts
+++ b/packages/extension-host/src/extension-host/workspace-service.ts
@@ -23,6 +23,7 @@ import type {
 import { workspaceStatusRegistry } from "./workspace-status-registry";
 import { workspaceSectionRegistry } from "./workspace-section-registry";
 import { workspaceBadgeRegistry } from "./workspace-badge-registry";
+import { reapWorkspaceTerminals } from "./terminal-service";
 
 // `ctx.workspaces` — the public contract lives in @silo-code/sdk
 // (workspace-service.ts); this is the host implementation.
@@ -94,7 +95,18 @@ export function getWorkspaceService(): WorkspaceService {
     reopen: reopenWorkspace,
     addFolder: addExtraFolder,
     removeFolder: removeExtraFolder,
-    delete: deleteWorkspace,
+    delete(id) {
+      // Start the reap before removing the workspace entry — callers must not
+      // have to remember a separate terminals.closeWorkspace step (orphaned
+      // sessions otherwise live on in the pty-host daemon). reapWorkspaceTerminals
+      // removes the terminal records synchronously (before its first await), so
+      // deleteWorkspace below still runs against an already-emptied list; the
+      // returned promise only resolves once the PTYs are actually killed, for
+      // callers that need that guarantee (e.g. the automation bridge).
+      const reaped = reapWorkspaceTerminals(id);
+      deleteWorkspace(id);
+      return reaped;
+    },
     registerStatus(provider: WorkspaceStatusProvider) {
       return workspaceStatusRegistry.register(provider);
     },

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -41,6 +41,7 @@ export { initGlobalErrorCapture } from "./extension-host/global-error-capture";
 export { getThemeService } from "./extension-host/theme-service";
 export { getProcessService } from "./extension-host/process-service";
 export { getTerminalService } from "./extension-host/terminal-service";
+export { getWorkspaceService } from "./extension-host/workspace-service";
 export { executeCommand } from "./extension-host/commands";
 export { contextKeys } from "./extension-host/context-keys";
 export { sidePanelRegistry } from "./extension-host/side-panels";

--- a/packages/extension-host/src/panels/open-workspace-menu.test.tsx
+++ b/packages/extension-host/src/panels/open-workspace-menu.test.tsx
@@ -14,12 +14,6 @@ vi.mock("../extension-host/ui-service", () => ({
   }),
 }));
 
-vi.mock("../extension-host/terminal-service", () => ({
-  getTerminalService: () => ({
-    closeWorkspace: vi.fn(),
-  }),
-}));
-
 vi.mock("../extension-host/file-service", () => ({
   getFileService: () => ({
     pathExists: vi.fn(),

--- a/packages/extension-host/src/panels/open-workspace-menu.tsx
+++ b/packages/extension-host/src/panels/open-workspace-menu.tsx
@@ -9,7 +9,6 @@ import {
 import type { MenuEntry, Workspace } from "@silo-code/sdk";
 import { getWorkspaceService } from "../extension-host/workspace-service";
 import { getUiService } from "../extension-host/ui-service";
-import { getTerminalService } from "../extension-host/terminal-service";
 import { getFileService } from "../extension-host/file-service";
 import { deleteGroup, restoreGroup } from "../state/workspaces";
 import type { ClosedGroupEntry } from "../state/partition-saved-entries";
@@ -58,7 +57,7 @@ export function useFolderExistence(
   return results;
 }
 
-/** Confirm, then hard-delete a workspace and tear down its terminals. */
+/** Confirm, then hard-delete a workspace (terminals are reaped by delete). */
 async function confirmAndDeleteWorkspace(
   id: string,
   name: string,
@@ -70,7 +69,6 @@ async function confirmAndDeleteWorkspace(
     danger: true,
   });
   if (!ok) return;
-  getTerminalService().closeWorkspace(id);
   getWorkspaceService().delete(id);
 }
 

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -33,6 +33,7 @@ import { xtermThemeFor } from "./xterm-theme";
 import { effectiveFontFamily } from "./terminal-font";
 import { buildTerminalPaste } from "./terminal-path-paste";
 import { findFileLinks, getHomeDir } from "./terminal-links";
+import { findTerminalOwnerId } from "./terminal-lifecycle";
 import { TerminalSearch } from "./TerminalSearch";
 import { Breadcrumb } from "../editor/Breadcrumb";
 import "@xterm/xterm/css/xterm.css";
@@ -78,9 +79,7 @@ async function openFileFromTerminal(
   editors: EditorService,
 ): Promise<void> {
   // Find the workspace that owns this terminal (don't assume the active one).
-  const wsId = Object.keys(store.workspaces).find((id) =>
-    store.workspaces[id].terminals.some((t) => t.id === terminalId),
-  );
+  const wsId = findTerminalOwnerId(Object.values(store.workspaces), terminalId);
   if (!wsId) return;
   const ws = store.workspaces[wsId];
 
@@ -612,12 +611,17 @@ export function TerminalPanel(
       disposers.forEach((d) => d());
       term.dispose();
 
-      // Clean up session only if the terminal record was deleted
-      const wsId = store.activeWorkspaceId;
-      const recordStillExists =
-        wsId &&
-        store.workspaces[wsId]?.terminals.some((t) => t.id === terminalId);
-      if (!recordStillExists && sessionId && session) {
+      // Kill only when the record was removed (tab close / workspace delete).
+      // Soft-close and empty-state unmount leave records in place — including
+      // on non-active workspaces — so look across every workspace, not just
+      // store.activeWorkspaceId (which is null when the last open workspace
+      // soft-closes and CenterDock swaps to the empty state).
+      if (
+        findTerminalOwnerId(Object.values(store.workspaces), terminalId) ===
+          null &&
+        sessionId &&
+        session
+      ) {
         session.kill().catch(() => {});
       }
     };

--- a/packages/extensions-core/src/terminal/terminal-lifecycle.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-lifecycle.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { findTerminalOwnerId } from "./terminal-lifecycle";
+
+describe("findTerminalOwnerId", () => {
+  const workspaces = [
+    {
+      id: "ws_a",
+      terminals: [{ id: "term_a" }, { id: "term_b" }],
+    },
+    {
+      id: "ws_c",
+      terminals: [{ id: "term_c" }],
+    },
+  ];
+
+  it("finds a terminal on the active workspace", () => {
+    expect(findTerminalOwnerId(workspaces, "term_a")).toBe("ws_a");
+  });
+
+  it("finds a terminal on a non-active (e.g. soft-closed) workspace", () => {
+    // Regression: unmount used to look up only store.activeWorkspaceId, so
+    // closing the last open workspace (activeId → null) falsely treated every
+    // still-persisted terminal as deleted and killed its PTY.
+    expect(findTerminalOwnerId(workspaces, "term_c")).toBe("ws_c");
+  });
+
+  it("returns null when the record was removed (tab close / hard delete)", () => {
+    expect(findTerminalOwnerId(workspaces, "term_gone")).toBeNull();
+  });
+
+  it("returns null for an empty workspace map (empty-state unmount)", () => {
+    expect(findTerminalOwnerId([], "term_a")).toBeNull();
+  });
+
+  it("skips null/undefined workspace entries", () => {
+    expect(
+      findTerminalOwnerId([null, undefined, workspaces[0]], "term_b"),
+    ).toBe("ws_a");
+    expect(findTerminalOwnerId([null, undefined], "term_b")).toBeNull();
+  });
+});

--- a/packages/extensions-core/src/terminal/terminal-lifecycle.ts
+++ b/packages/extensions-core/src/terminal/terminal-lifecycle.ts
@@ -1,0 +1,20 @@
+/**
+ * Which workspace (if any) currently owns a terminal record, scanning every
+ * workspace rather than assuming the active one. Backs two call sites in
+ * {@link TerminalPanel}: the unmount-kill guard (kill the PTY only when the
+ * record was actually removed — tab close / workspace delete — never when the
+ * panel merely unmounts because the dock is hidden or the last open workspace
+ * soft-closed, since records and sessions must survive that) and resolving a
+ * terminal-matched file path against its owning workspace's folder.
+ */
+export function findTerminalOwnerId(
+  workspaces: Iterable<
+    { id: string; terminals: readonly { id: string }[] } | null | undefined
+  >,
+  terminalId: string,
+): string | null {
+  for (const ws of workspaces) {
+    if (ws?.terminals.some((t) => t.id === terminalId)) return ws.id;
+  }
+  return null;
+}

--- a/packages/extensions-core/src/workspaces/workspace-add-menu.tsx
+++ b/packages/extensions-core/src/workspaces/workspace-add-menu.tsx
@@ -21,7 +21,7 @@ import type { Workspace } from "./workspace-helpers";
 
 const WorkspaceIcon = SquaresFour;
 
-/** Confirm, then hard-delete a workspace and tear down its terminals. */
+/** Confirm, then hard-delete a workspace (terminals are reaped by delete). */
 export async function confirmAndDeleteWorkspace(
   ctx: ExtensionContext,
   id: string,
@@ -34,7 +34,6 @@ export async function confirmAndDeleteWorkspace(
     danger: true,
   });
   if (!ok) return;
-  ctx.terminals.closeWorkspace(id);
   ctx.workspaces.delete(id);
 }
 

--- a/packages/sdk/src/terminal-service.ts
+++ b/packages/sdk/src/terminal-service.ts
@@ -87,8 +87,10 @@ export interface CreateTerminalInput {
  * {@link ExtensionContext.terminals}. The terminal is a core feature — a
  * built-in DockKind like the editor — so this mirrors {@link EditorService}:
  * `create` opens a terminal tab in a workspace, and `closeWorkspace` reaps a
- * workspace's terminals (used when a workspace is deleted). The tab itself is
- * rendered by the core dock from the workspace's terminal records.
+ * workspace's terminals. {@link WorkspaceService.delete} calls `closeWorkspace`
+ * for you; the primitive remains available for surgical reaping without
+ * deleting the workspace. The tab itself is rendered by the core dock from the
+ * workspace's terminal records.
  *
  * @category Consumer Services
  * @public
@@ -104,7 +106,11 @@ export interface TerminalService {
    * happen because activating any workspace happens before extensions run.
    */
   create(input?: CreateTerminalInput): TerminalRecord | undefined;
-  /** Close and kill every terminal in a workspace (e.g. on workspace delete). */
+  /**
+   * Close and kill every terminal in a workspace. {@link WorkspaceService.delete}
+   * reaps terminals the same way automatically, so this is for reaping a
+   * workspace's terminals surgically, without deleting the workspace itself.
+   */
   closeWorkspace(workspaceId: string): void;
 
   /**

--- a/packages/sdk/src/workspace-service.ts
+++ b/packages/sdk/src/workspace-service.ts
@@ -187,8 +187,15 @@ export interface WorkspaceService {
   addFolder(id: string, folder: string): void;
   /** Remove an extra folder from a workspace. */
   removeFolder(id: string, folder: string): void;
-  /** Hard delete — permanent removal. */
-  delete(id: string): void;
+  /**
+   * Hard delete — permanent removal. Also reaps every terminal in the
+   * workspace (removes records and kills live PTY sessions); callers do not
+   * need a separate {@link TerminalService.closeWorkspace} step. The entry is
+   * removed from state synchronously (before this returns); the returned
+   * promise resolves once the reaped PTYs have actually been killed, for
+   * callers (e.g. tests) that need that guarantee. Most callers can ignore it.
+   */
+  delete(id: string): Promise<void>;
 
   /**
    * Register a status provider that contributes status rows to workspace


### PR DESCRIPTION
## Summary
- Soft-close (including into empty state) no longer kills live PTY sessions — `TerminalPanel` unmount looks across all workspaces instead of only `activeWorkspaceId`.
- Hard-delete reaps terminals via `WorkspaceService.delete` / `reapWorkspaceTerminals`; callers no longer need a separate `terminals.closeWorkspace` step.
- Tighten attach/kill races so a post-kill probe cannot resurrect a dying session (await kill until the socket is gone; drop stale in-memory attachments when the daemon is gone).

## Test plan
- [x] Unit: `terminal-lifecycle`, `workspace-service.delete`, `terminal-service.closeWorkspace`
- [x] Integration against Silo Dev: `workspace-pty-lifecycle.it.test.ts` (soft-close keeps PTY, empty-state keeps PTY, hard-delete reaps) — 3/3 green
- [ ] Manual: soft-close last open workspace with a running terminal, reopen, confirm same session; delete workspace and confirm shell is gone


Made with [Cursor](https://cursor.com)