### PR TITLE
feat(workspaces): educational close/delete popups with a "don't show again" checkbox

### DIFF
--- a/packages/extension-host/src/extension-host/confirm-with-dont-show-again.test.ts
+++ b/packages/extension-host/src/extension-host/confirm-with-dont-show-again.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import type { ExtensionStorage, UiService } from "@silo-code/sdk";
+import {
+  confirmWithDontShowAgain,
+  resolveDialogOutcome,
+} from "./confirm-with-dont-show-again";
+
+// `resolveDialogOutcome` is the pure decision behind the dialog's buttons
+// (cancel never persists, proceed persists iff checked) — covered directly,
+// no rendering needed. `confirmWithDontShowAgain`'s own logic (the
+// suppression short-circuit, and threading `ui.showModal`'s result through)
+// is covered against a fake `UiService`/`ExtensionStorage`; the checkbox UI
+// itself lives in the component and is exercised via the `verify` skill.
+
+function fakeStorage(initial: Record<string, unknown> = {}): ExtensionStorage {
+  const bag = { ...initial };
+  return {
+    get: <T>(key: string, fallback?: T) =>
+      (key in bag ? (bag[key] as T) : fallback) as T | undefined,
+    set: (key, value) => {
+      if (value === undefined) delete bag[key];
+      else bag[key] = value;
+    },
+    keys: () => Object.keys(bag),
+    subscribe: () => ({ dispose: () => {} }),
+  };
+}
+
+describe("resolveDialogOutcome", () => {
+  it("cancel never proceeds and never persists, even if checked", () => {
+    expect(resolveDialogOutcome("cancel", true)).toEqual({
+      proceed: false,
+      persist: false,
+    });
+    expect(resolveDialogOutcome("cancel", false)).toEqual({
+      proceed: false,
+      persist: false,
+    });
+  });
+
+  it("proceeding persists iff the checkbox was checked", () => {
+    expect(resolveDialogOutcome("proceed", true)).toEqual({
+      proceed: true,
+      persist: true,
+    });
+    expect(resolveDialogOutcome("proceed", false)).toEqual({
+      proceed: true,
+      persist: false,
+    });
+  });
+});
+
+describe("confirmWithDontShowAgain", () => {
+  const opts = {
+    storageKey: "test.dontShowAgain",
+    title: "Close workspace",
+    body: "It keeps running in the background.",
+    confirmLabel: "Close",
+    mode: { kind: "info" as const },
+  };
+
+  it("short-circuits to true without opening a dialog once suppressed", async () => {
+    const storage = fakeStorage({ [opts.storageKey]: true });
+    const ui = {
+      showModal: () => {
+        throw new Error("should not be called once suppressed");
+      },
+    } as unknown as UiService;
+
+    await expect(confirmWithDontShowAgain(ui, storage, opts)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("opens the dialog and resolves with the user's choice when not suppressed", async () => {
+    const storage = fakeStorage();
+    const ui = {
+      showModal: () => Promise.resolve(true),
+    } as unknown as UiService;
+
+    await expect(confirmWithDontShowAgain(ui, storage, opts)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("treats a dismissed (undefined) result as not proceeding", async () => {
+    const storage = fakeStorage();
+    const ui = {
+      showModal: () => Promise.resolve(undefined),
+    } as unknown as UiService;
+
+    await expect(confirmWithDontShowAgain(ui, storage, opts)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("passes dismissible: true for confirm mode and false for info mode", async () => {
+    const storage = fakeStorage();
+    const seen: boolean[] = [];
+    const ui = {
+      showModal: (_render: unknown, options?: { dismissible?: boolean }) => {
+        seen.push(Boolean(options?.dismissible));
+        return Promise.resolve(true);
+      },
+    } as unknown as UiService;
+
+    await confirmWithDontShowAgain(ui, storage, {
+      ...opts,
+      mode: { kind: "info" },
+    });
+    await confirmWithDontShowAgain(ui, storage, {
+      ...opts,
+      storageKey: "test.other",
+      mode: { kind: "confirm", danger: true },
+    });
+
+    expect(seen).toEqual([false, true]);
+  });
+});

--- a/packages/extension-host/src/extension-host/confirm-with-dont-show-again.tsx
+++ b/packages/extension-host/src/extension-host/confirm-with-dont-show-again.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import type { ExtensionStorage, UiService } from "@silo-code/sdk";
+import { ModalActions } from "./Modal";
+
+// A `ctx.ui.showModal`-based confirm/info dialog with a persisted "don't show
+// this again" checkbox — the one capability `ctx.ui.confirm` has no room for
+// (ConfirmOptions is a plain title/body/two-buttons shape). Built as host
+// content rather than a public SDK addition: extending `ConfirmOptions` would
+// drag every consumer (and the docs-generation pipeline) into a contract
+// change for what today is a single feature's need.
+
+/**
+ * `confirm`: Cancel + a primary/danger button, dismissible (Escape/backdrop
+ * resolve like Cancel) — mirrors `ctx.ui.confirm`.
+ * `info`: a single acknowledgement button, not dismissible — there's nothing
+ * to cancel, so forcing the explicit click keeps the checkbox's fate
+ * unambiguous.
+ *
+ * @internal
+ */
+export type DontShowAgainDialogMode =
+  | { kind: "confirm"; danger?: boolean }
+  | { kind: "info" };
+
+/** @internal */
+export interface DontShowAgainDialogOptions {
+  /** Key in `storage` that remembers the user opted out of this dialog. */
+  storageKey: string;
+  title: string;
+  body: string;
+  confirmLabel: string;
+  mode: DontShowAgainDialogMode;
+}
+
+/**
+ * Pure decision behind the dialog's two buttons: cancelling never persists
+ * the checkbox (even if it's checked) so an accidental cancel can't silently
+ * kill a safety warning; proceeding persists it iff it's checked. Extracted
+ * from the component so it's unit-testable without rendering.
+ *
+ * @internal
+ */
+export function resolveDialogOutcome(
+  action: "proceed" | "cancel",
+  dontShowAgain: boolean,
+): { proceed: boolean; persist: boolean } {
+  if (action === "cancel") return { proceed: false, persist: false };
+  return { proceed: true, persist: dontShowAgain };
+}
+
+function DontShowAgainDialogContent({
+  body,
+  confirmLabel,
+  mode,
+  storage,
+  storageKey,
+  close,
+}: {
+  body: string;
+  confirmLabel: string;
+  mode: DontShowAgainDialogMode;
+  storage: ExtensionStorage;
+  storageKey: string;
+  close: (result?: boolean) => void;
+}) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  function act(action: "proceed" | "cancel") {
+    const outcome = resolveDialogOutcome(action, dontShowAgain);
+    if (outcome.persist) storage.set(storageKey, true);
+    close(outcome.proceed);
+  }
+
+  return (
+    <>
+      <div className="silo-modal-body">{body}</div>
+      <label className="silo-modal-checkbox-row">
+        <input
+          type="checkbox"
+          checked={dontShowAgain}
+          onChange={(e) => setDontShowAgain(e.target.checked)}
+        />
+        Don't show this again
+      </label>
+      <ModalActions>
+        {mode.kind === "confirm" && (
+          <button
+            type="button"
+            className="silo-button"
+            onClick={() => act("cancel")}
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="button"
+          className={
+            mode.kind === "confirm" && mode.danger
+              ? "silo-button-danger"
+              : "silo-button-primary"
+          }
+          onClick={() => act("proceed")}
+          autoFocus
+        >
+          {confirmLabel}
+        </button>
+      </ModalActions>
+    </>
+  );
+}
+
+/**
+ * Pop a confirm/info dialog with a persisted "don't show this again"
+ * checkbox, short-circuiting to `true` (proceed) without opening anything
+ * once the user has suppressed `opts.storageKey`. See
+ * {@link DontShowAgainDialogMode} for the `confirm` vs. `info` shapes.
+ *
+ * @internal
+ */
+export async function confirmWithDontShowAgain(
+  ui: UiService,
+  storage: ExtensionStorage,
+  opts: DontShowAgainDialogOptions,
+): Promise<boolean> {
+  if (storage.get<boolean>(opts.storageKey, false)) return true;
+  const result = await ui.showModal<boolean>(
+    (close) => (
+      <DontShowAgainDialogContent
+        body={opts.body}
+        confirmLabel={opts.confirmLabel}
+        mode={opts.mode}
+        storage={storage}
+        storageKey={opts.storageKey}
+        close={close}
+      />
+    ),
+    {
+      title: opts.title,
+      size: "sm",
+      ariaLabel: opts.title,
+      dismissible: opts.mode.kind === "confirm",
+    },
+  );
+  return result ?? false;
+}

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -40,6 +40,16 @@
 export { Modal, ModalActions } from "./Modal";
 export type { ModalProps } from "./Modal";
 
+// A `ctx.ui.showModal`-based confirm/info dialog with a persisted "don't show
+// this again" checkbox — a capability `ctx.ui.confirm` has no room for.
+// Core-only: it's bespoke host content built on `<Modal>`, not a public
+// contract addition (see the file's header comment for the rationale).
+export { confirmWithDontShowAgain } from "./confirm-with-dont-show-again";
+export type {
+  DontShowAgainDialogMode,
+  DontShowAgainDialogOptions,
+} from "./confirm-with-dont-show-again";
+
 // App identity metadata (version/name) — privileged because its only consumer
 // is `core.about`, part of Silo's identity; not a public-surface capability.
 // See app-service.ts for the rationale.

--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -472,6 +472,19 @@ button.silo-button-sm {
   margin-top: 4px;
 }
 
+.silo-modal-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text);
+}
+
+.silo-modal-checkbox-row input[type="checkbox"] {
+  margin: 0;
+}
+
 .silo-modal-form {
   display: flex;
   flex-direction: column;

--- a/packages/extension-host/src/panels/open-workspace-menu.tsx
+++ b/packages/extension-host/src/panels/open-workspace-menu.tsx
@@ -10,8 +10,16 @@ import type { MenuEntry, Workspace } from "@silo-code/sdk";
 import { getWorkspaceService } from "../extension-host/workspace-service";
 import { getUiService } from "../extension-host/ui-service";
 import { getFileService } from "../extension-host/file-service";
+import { confirmWithDontShowAgain } from "../extension-host/confirm-with-dont-show-again";
+import { getGlobalExtensionStorage } from "../extension-host/extension-storage";
 import { deleteGroup, restoreGroup } from "../state/workspaces";
 import type { ClosedGroupEntry } from "../state/partition-saved-entries";
+
+// Suppression flags are read from the "core.workspaces" extension's own
+// storage bag — the exact same one `ctx.storage.global` resolves to inside
+// that extension (see `getGlobalExtensionStorage` / `context.ts`), so a
+// checkbox ticked here or in the workspaces panel suppresses both.
+const workspacesStorage = getGlobalExtensionStorage("core.workspaces");
 
 // The empty-state "Open workspace" menu — the host-side twin of the workspaces
 // panel's add menu (extensions-core/workspaces/workspace-add-menu.tsx). The
@@ -62,24 +70,26 @@ async function confirmAndDeleteWorkspace(
   id: string,
   name: string,
 ): Promise<void> {
-  const ok = await getUiService().confirm({
+  const ok = await confirmWithDontShowAgain(getUiService(), workspacesStorage, {
+    storageKey: "deleteWorkspace.dontShowAgain",
     title: "Delete workspace?",
     body: `${name} and its saved terminals will be permanently removed.`,
     confirmLabel: "Delete",
-    danger: true,
+    mode: { kind: "confirm", danger: true },
   });
   if (!ok) return;
   getWorkspaceService().delete(id);
 }
 
-/** Confirm, then delete a closed group. Member workspaces are kept and reappear
+/** Confirm, then delete a group. Member workspaces are kept and reappear
  * individually in Saved (deleting a group only ungroups its members). */
 async function confirmAndDeleteGroup(id: string, name: string): Promise<void> {
-  const ok = await getUiService().confirm({
+  const ok = await confirmWithDontShowAgain(getUiService(), workspacesStorage, {
+    storageKey: "deleteGroup.dontShowAgain",
     title: "Delete group?",
     body: `${name} will be removed. Its workspaces stay saved and will appear individually.`,
     confirmLabel: "Delete",
-    danger: true,
+    mode: { kind: "confirm", danger: true },
   });
   if (!ok) return;
   deleteGroup(id);

--- a/packages/extensions-core/src/workspaces/WorkspaceStatusItem.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspaceStatusItem.tsx
@@ -13,7 +13,10 @@ import {
   partitionSavedEntries,
 } from "@silo-code/extension-host/internal";
 import { useFolderExistence } from "./workspace-helpers";
-import { buildAddWorkspaceItems } from "./workspace-add-menu";
+import {
+  buildAddWorkspaceItems,
+  confirmAndCloseWorkspace,
+} from "./workspace-add-menu";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import { openWorkspaceProperties } from "./workspace-properties";
 import "./WorkspaceStatusItem.css";
@@ -111,7 +114,10 @@ export function WorkspaceStatusItem({ ctx }: { ctx: ExtensionContext }) {
         if (ws) void openWorkspaceProperties(ctx, home, ws);
       },
     });
-    items.push({ label: "Close", run: () => service.close(activeId) });
+    items.push({
+      label: "Close",
+      run: () => void confirmAndCloseWorkspace(ctx, activeId, active.name),
+    });
     void ctx.ui.showMenu({ items, anchor: buttonRef.current });
   }
 

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
@@ -9,8 +9,6 @@ import { CaretRight, Plus, SquaresFour } from "@phosphor-icons/react";
 import { useSnapshot } from "valtio";
 import {
   store,
-  deleteGroup,
-  closeGroup,
   moveWorkspaceToGroup,
   ungroupWorkspace,
   toggleGroupCollapsed,
@@ -37,7 +35,12 @@ import {
   useFolderExistence,
   type Workspace,
 } from "./workspace-helpers";
-import { buildAddWorkspaceItems } from "./workspace-add-menu";
+import {
+  buildAddWorkspaceItems,
+  confirmAndCloseGroup,
+  confirmAndCloseWorkspace,
+  confirmAndDeleteGroup,
+} from "./workspace-add-menu";
 import { openWorkspaceProperties } from "./workspace-properties";
 import { openGroupProperties, type GroupSnapshot } from "./group-properties";
 import { useWorkspaceDnd } from "./use-workspace-dnd";
@@ -290,7 +293,10 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
     }
 
     if (!ws.closedAt) {
-      items.push({ label: "Close", run: () => service.close(ws.id) });
+      items.push({
+        label: "Close",
+        run: () => void confirmAndCloseWorkspace(ctx, ws.id, ws.name),
+      });
     }
     return items;
   }
@@ -318,11 +324,11 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
         },
         {
           label: "Close Group",
-          run: () => closeGroup(group.id),
+          run: () => void confirmAndCloseGroup(ctx, group.id, group.name),
         },
         {
           label: "Delete Group",
-          run: () => deleteGroup(group.id),
+          run: () => void confirmAndDeleteGroup(ctx, group.id, group.name),
         },
       ],
       toggle: false,
@@ -412,7 +418,7 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
           aria-label="Close workspace"
           onClick={(e) => {
             e.stopPropagation();
-            service.close(ws.id);
+            void confirmAndCloseWorkspace(ctx, ws.id, ws.name);
           }}
         >
           ×
@@ -478,7 +484,7 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
             aria-label="Close group"
             onClick={(e) => {
               e.stopPropagation();
-              closeGroup(group.id);
+              void confirmAndCloseGroup(ctx, group.id, group.name);
             }}
           >
             ×

--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -4,6 +4,7 @@ import { WorkspacesPanel } from "./WorkspacesPanel";
 import { WorkspaceStatusItem } from "./WorkspaceStatusItem";
 import { registerWorkspaceCycle } from "./workspace-cycle";
 import { openNewGroup } from "./group-properties";
+import { confirmAndCloseWorkspace } from "./workspace-add-menu";
 
 export const extension: Extension = {
   id: "core.workspaces",
@@ -79,8 +80,10 @@ export const extension: Extension = {
       id: "workspace.close",
       label: "Close Workspace",
       run: () => {
-        const { activeId } = ctx.workspaces.getState();
-        if (activeId) ctx.workspaces.close(activeId);
+        const { activeId, all } = ctx.workspaces.getState();
+        if (!activeId) return;
+        const ws = all.find((w) => w.id === activeId);
+        if (ws) void confirmAndCloseWorkspace(ctx, activeId, ws.name);
       },
     });
 

--- a/packages/extensions-core/src/workspaces/workspace-add-menu.tsx
+++ b/packages/extensions-core/src/workspaces/workspace-add-menu.tsx
@@ -6,6 +6,8 @@ import {
   Warning,
 } from "@phosphor-icons/react";
 import {
+  closeGroup,
+  confirmWithDontShowAgain,
   deleteGroup,
   restoreGroup,
   type ClosedGroupEntry,
@@ -21,34 +23,72 @@ import type { Workspace } from "./workspace-helpers";
 
 const WorkspaceIcon = SquaresFour;
 
+/** Show the educational "closing keeps terminals alive" popup, then close a
+ * workspace. Skipped once the user opts out via "Don't show this again". */
+export async function confirmAndCloseWorkspace(
+  ctx: ExtensionContext,
+  id: string,
+  name: string,
+): Promise<void> {
+  const ok = await confirmWithDontShowAgain(ctx.ui, ctx.storage.global, {
+    storageKey: "closeWorkspace.dontShowAgain",
+    title: "Close workspace",
+    body: `Closing "${name}" keeps its terminals running in the background — reopen it anytime to pick up where you left off.`,
+    confirmLabel: "Close",
+    mode: { kind: "info" },
+  });
+  if (!ok) return;
+  ctx.workspaces.close(id);
+}
+
 /** Confirm, then hard-delete a workspace (terminals are reaped by delete). */
 export async function confirmAndDeleteWorkspace(
   ctx: ExtensionContext,
   id: string,
   name: string,
 ): Promise<void> {
-  const ok = await ctx.ui.confirm({
+  const ok = await confirmWithDontShowAgain(ctx.ui, ctx.storage.global, {
+    storageKey: "deleteWorkspace.dontShowAgain",
     title: "Delete workspace?",
     body: `${name} and its saved terminals will be permanently removed.`,
     confirmLabel: "Delete",
-    danger: true,
+    mode: { kind: "confirm", danger: true },
   });
   if (!ok) return;
   ctx.workspaces.delete(id);
 }
 
-/** Confirm, then delete a closed group. Member workspaces are kept and reappear
+/** Show the educational "closing keeps terminals alive" popup, then close a
+ * group. Skipped once the user opts out via "Don't show this again". */
+export async function confirmAndCloseGroup(
+  ctx: ExtensionContext,
+  id: string,
+  name: string,
+): Promise<void> {
+  const ok = await confirmWithDontShowAgain(ctx.ui, ctx.storage.global, {
+    storageKey: "closeGroup.dontShowAgain",
+    title: "Close group",
+    body: `Closing "${name}" closes all of its workspaces, but their terminals keep running in the background. Reopen the group anytime to bring them all back.`,
+    confirmLabel: "Close Group",
+    mode: { kind: "info" },
+  });
+  if (!ok) return;
+  closeGroup(id);
+}
+
+/** Confirm, then delete a group. Member workspaces are kept and reappear
  * individually in Saved (deleting a group only ungroups its members). */
 export async function confirmAndDeleteGroup(
   ctx: ExtensionContext,
   id: string,
   name: string,
 ): Promise<void> {
-  const ok = await ctx.ui.confirm({
+  const ok = await confirmWithDontShowAgain(ctx.ui, ctx.storage.global, {
+    storageKey: "deleteGroup.dontShowAgain",
     title: "Delete group?",
     body: `${name} will be removed. Its workspaces stay saved and will appear individually.`,
     confirmLabel: "Delete",
-    danger: true,
+    mode: { kind: "confirm", danger: true },
   });
   if (!ok) return;
   deleteGroup(id);


### PR DESCRIPTION
## Summary

- Closing a workspace or group is a soft-close — terminals keep running in the background; delete is the only action that reaps PTYs. That distinction wasn't visible anywhere in the UI.
- Confirmation coverage was also inconsistent: delete already warned via `ctx.ui.confirm`, close warned about nothing, and deleting an *open* group's context menu item had **no confirmation at all**.
- Adds one educational popup per action — close workspace, close group, delete workspace, delete group — each with its own persisted "don't show this again" checkbox.

## Design

- `ctx.ui.confirm` has no room for a checkbox, so this adds one small `ctx.ui.showModal`-based dialog (`confirm-with-dont-show-again.tsx`) rather than extending the public SDK contract for a single-feature need.
- Two modes: `info` (single acknowledgement button — close isn't destructive, so nothing to cancel) and `confirm` (Cancel + danger-styled primary button, matching the existing delete pattern).
- Cancelling never persists the "don't show again" checkbox, even if it was checked, so an accidental cancel can't silently kill a safety warning.
- Suppression persists via `ctx.storage.global` under `core.workspaces` — no new persistence plumbing needed.
- Fixes a real gap found during exploration: deleting an open group from its context menu previously skipped confirmation entirely.

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all green
- [x] Verified live in the dev app: all four dialogs show correct copy/checkbox/buttons, suppression persists independently per action, cancelling a delete-with-checkbox-checked does not persist suppression, and the previously-missing "Delete Group" confirmation now appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)