### PR TITLE
feat(terminals): log PTY create/delete + a periodic per-workspace census

### DIFF
--- a/packages/extension-host/src/extension-host/pty-diagnostics.test.ts
+++ b/packages/extension-host/src/extension-host/pty-diagnostics.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectLivePtys,
+  summarizePtysByWorkspace,
+  formatPtyEventMessage,
+  formatPtySummaryMessage,
+  type PtyEntry,
+  type PtyWorkspaceInput,
+} from "./pty-diagnostics";
+import type { TerminalRecord } from "../state/types";
+
+function terminal(overrides: Partial<TerminalRecord> = {}): TerminalRecord {
+  return {
+    id: "term_1",
+    sessionId: "sess_1",
+    kind: "shell",
+    title: "bash",
+    ...overrides,
+  };
+}
+
+function workspace(
+  overrides: Partial<PtyWorkspaceInput> = {},
+): PtyWorkspaceInput {
+  return {
+    id: "ws_1",
+    name: "my-project",
+    closedAt: null,
+    terminals: [],
+    ...overrides,
+  };
+}
+
+describe("collectLivePtys", () => {
+  it("flattens spawned terminals across workspaces", () => {
+    const workspaces = {
+      ws_1: workspace({
+        id: "ws_1",
+        name: "a",
+        terminals: [terminal({ id: "t1", sessionId: "s1", title: "bash" })],
+      }),
+      ws_2: workspace({
+        id: "ws_2",
+        name: "b",
+        closedAt: "2026-01-01T00:00:00.000Z",
+        terminals: [
+          terminal({ id: "t2", sessionId: "s2", cwd: "/tmp", title: "zsh" }),
+        ],
+      }),
+    };
+
+    const entries = collectLivePtys(workspaces);
+
+    expect(entries).toEqual([
+      {
+        workspaceId: "ws_1",
+        workspaceName: "a",
+        workspaceClosed: false,
+        terminalId: "t1",
+        terminalName: "bash",
+        sessionId: "s1",
+        cwd: undefined,
+      },
+      {
+        workspaceId: "ws_2",
+        workspaceName: "b",
+        workspaceClosed: true,
+        terminalId: "t2",
+        terminalName: "zsh",
+        sessionId: "s2",
+        cwd: "/tmp",
+      },
+    ]);
+  });
+
+  it("prefers the user's custom name over the PTY-derived title", () => {
+    const workspaces = {
+      ws_1: workspace({
+        terminals: [
+          terminal({
+            id: "t1",
+            sessionId: "s1",
+            title: "npm run dev",
+            customName: "dev server",
+          }),
+        ],
+      }),
+    };
+
+    expect(collectLivePtys(workspaces)[0].terminalName).toBe("dev server");
+  });
+
+  it("falls back to the title when customName was cleared to empty string", () => {
+    const workspaces = {
+      ws_1: workspace({
+        terminals: [
+          terminal({
+            id: "t1",
+            sessionId: "s1",
+            title: "bash",
+            customName: "",
+          }),
+        ],
+      }),
+    };
+
+    expect(collectLivePtys(workspaces)[0].terminalName).toBe("bash");
+  });
+
+  it("skips terminals that haven't spawned a PTY yet (empty sessionId)", () => {
+    const workspaces = {
+      ws_1: workspace({
+        terminals: [
+          terminal({ id: "t1", sessionId: "" }),
+          terminal({ id: "t2", sessionId: "s2" }),
+        ],
+      }),
+    };
+
+    const entries = collectLivePtys(workspaces);
+
+    expect(entries.map((e) => e.terminalId)).toEqual(["t2"]);
+  });
+
+  it("skips undefined workspace entries", () => {
+    const workspaces = { ws_1: undefined };
+    expect(collectLivePtys(workspaces)).toEqual([]);
+  });
+});
+
+describe("summarizePtysByWorkspace", () => {
+  it("rolls up count + terminal names per workspace, with no ids", () => {
+    const entries: PtyEntry[] = [
+      {
+        workspaceId: "ws_1",
+        workspaceName: "a",
+        workspaceClosed: false,
+        terminalId: "t1",
+        terminalName: "bash",
+        sessionId: "s1",
+      },
+      {
+        workspaceId: "ws_1",
+        workspaceName: "a",
+        workspaceClosed: false,
+        terminalId: "t2",
+        terminalName: "claude",
+        sessionId: "s2",
+      },
+      {
+        workspaceId: "ws_2",
+        workspaceName: "b",
+        workspaceClosed: true,
+        terminalId: "t3",
+        terminalName: "zsh",
+        sessionId: "s3",
+      },
+    ];
+
+    expect(summarizePtysByWorkspace(entries)).toEqual([
+      {
+        workspaceName: "a",
+        workspaceClosed: false,
+        count: 2,
+        terminals: ["bash", "claude"],
+      },
+      {
+        workspaceName: "b",
+        workspaceClosed: true,
+        count: 1,
+        terminals: ["zsh"],
+      },
+    ]);
+  });
+
+  it("returns an empty list for no entries", () => {
+    expect(summarizePtysByWorkspace([])).toEqual([]);
+  });
+});
+
+describe("formatPtyEventMessage", () => {
+  it("formats without a reason", () => {
+    expect(
+      formatPtyEventMessage("created", {
+        workspaceName: "my-project",
+        terminalId: "t1",
+        sessionId: "s1",
+      }),
+    ).toBe('PTY created: session=s1 workspace="my-project" terminal=t1');
+  });
+
+  it("appends the reason in parens when present", () => {
+    expect(
+      formatPtyEventMessage("deleted", {
+        workspaceName: "my-project",
+        terminalId: "t1",
+        sessionId: "s1",
+        reason: "workspace reaped",
+      }),
+    ).toBe(
+      'PTY deleted: session=s1 workspace="my-project" terminal=t1 (workspace reaped)',
+    );
+  });
+});
+
+describe("formatPtySummaryMessage", () => {
+  function makeEntries(count: number): PtyEntry[] {
+    return Array.from({ length: count }, (_, i) => ({
+      workspaceId: `ws_${i % 3}`,
+      workspaceName: `workspace-${i % 3}`,
+      workspaceClosed: false,
+      terminalId: `t${i}`,
+      terminalName: `term-${i}`,
+      sessionId: `s${i}`,
+    }));
+  }
+
+  it("always emits the per-workspace rollup, regardless of size", () => {
+    const entries = makeEntries(50);
+    const { message, data } = formatPtySummaryMessage(entries);
+
+    expect(message).toBe(
+      "PTY summary: 50 live session(s) across 3 workspace(s)",
+    );
+    expect(data.workspaces).toHaveLength(3);
+    expect(data.workspaces[0]).toEqual({
+      workspaceName: "workspace-0",
+      workspaceClosed: false,
+      count: expect.any(Number),
+      terminals: expect.any(Array),
+    });
+  });
+
+  it("reports zero live sessions cleanly", () => {
+    const { message, data } = formatPtySummaryMessage([]);
+    expect(message).toBe(
+      "PTY summary: 0 live session(s) across 0 workspace(s)",
+    );
+    expect(data).toEqual({ workspaces: [] });
+  });
+});

--- a/packages/extension-host/src/extension-host/pty-diagnostics.ts
+++ b/packages/extension-host/src/extension-host/pty-diagnostics.ts
@@ -1,0 +1,111 @@
+import type { TerminalRecord } from "../state/types";
+
+// Pure logic behind the `silo:terminals` Output channel (terminal-service.ts):
+// flattening/rolling up live PTYs for the periodic dump, and formatting the
+// create/delete event lines. Extracted so it's unit-testable without a real
+// valtio store — terminal-service.ts supplies the live `store.workspaces` and
+// wires these into `createHostChannel("silo:terminals", ...)`.
+
+/** The minimal workspace shape this module needs — decoupled from the full
+ * `WorkspaceInternal` type so the pure functions below are trivial to test. */
+export interface PtyWorkspaceInput {
+  id: string;
+  name: string;
+  closedAt?: string | null;
+  terminals: TerminalRecord[];
+}
+
+/** One live (spawned) PTY, flattened out of a workspace's terminal records. */
+export interface PtyEntry {
+  workspaceId: string;
+  workspaceName: string;
+  workspaceClosed: boolean;
+  terminalId: string;
+  /** Display name — the user's rename if set, else the PTY-derived title. */
+  terminalName: string;
+  sessionId: string;
+  cwd?: string;
+}
+
+/** A workspace's live PTYs, rolled up for the periodic dump — no ids, just
+ * enough to eyeball at a glance whether something's lingering that shouldn't be. */
+export interface PtyWorkspaceSummary {
+  workspaceName: string;
+  workspaceClosed: boolean;
+  count: number;
+  terminals: string[];
+}
+
+/** Every live PTY across all workspaces — a terminal record only counts once
+ * it has actually spawned a session (empty `sessionId` = not spawned yet). */
+export function collectLivePtys(
+  workspaces: Record<string, PtyWorkspaceInput | undefined>,
+): PtyEntry[] {
+  const entries: PtyEntry[] = [];
+  for (const ws of Object.values(workspaces)) {
+    if (!ws) continue;
+    for (const t of ws.terminals) {
+      if (!t.sessionId) continue;
+      entries.push({
+        workspaceId: ws.id,
+        workspaceName: ws.name,
+        workspaceClosed: Boolean(ws.closedAt),
+        terminalId: t.id,
+        terminalName: t.customName || t.title,
+        sessionId: t.sessionId,
+        cwd: t.cwd,
+      });
+    }
+  }
+  return entries;
+}
+
+/** Roll a flat PTY list up into one entry per workspace: a count plus its
+ * terminals' display names — no workspace/terminal/session ids. */
+export function summarizePtysByWorkspace(
+  entries: readonly PtyEntry[],
+): PtyWorkspaceSummary[] {
+  const byWorkspace = new Map<string, PtyWorkspaceSummary>();
+  for (const e of entries) {
+    let summary = byWorkspace.get(e.workspaceId);
+    if (!summary) {
+      summary = {
+        workspaceName: e.workspaceName,
+        workspaceClosed: e.workspaceClosed,
+        count: 0,
+        terminals: [],
+      };
+      byWorkspace.set(e.workspaceId, summary);
+    }
+    summary.count++;
+    summary.terminals.push(e.terminalName);
+  }
+  return Array.from(byWorkspace.values());
+}
+
+/** Format a single "PTY created"/"PTY deleted" event line. */
+export function formatPtyEventMessage(
+  action: "created" | "deleted",
+  info: {
+    workspaceName: string;
+    terminalId: string;
+    sessionId: string;
+    reason?: string;
+  },
+): string {
+  const suffix = info.reason ? ` (${info.reason})` : "";
+  return `PTY ${action}: session=${info.sessionId} workspace="${info.workspaceName}" terminal=${info.terminalId}${suffix}`;
+}
+
+/** Format the periodic dump's message — always the compact per-workspace
+ * rollup (see {@link summarizePtysByWorkspace}), never the raw per-PTY list. */
+export function formatPtySummaryMessage(entries: readonly PtyEntry[]): {
+  message: string;
+  data: { workspaces: PtyWorkspaceSummary[] };
+} {
+  const workspaces = summarizePtysByWorkspace(entries);
+  return {
+    message: `PTY summary: ${entries.length} live session(s) across ${workspaces.length} workspace(s)`,
+    data: { workspaces },
+  };
+}

--- a/packages/extension-host/src/extension-host/terminal-service.ts
+++ b/packages/extension-host/src/extension-host/terminal-service.ts
@@ -1,3 +1,4 @@
+import { subscribe } from "valtio";
 import { store } from "../state/store";
 import {
   activateWorkspace,
@@ -20,6 +21,102 @@ import {
   subscribeActiveTerminal,
 } from "./active-terminal-registry";
 import { focusCenterDock, getActiveDockApi } from "../docked/dock-api-registry";
+import { createHostChannel } from "./output-store";
+import {
+  collectLivePtys,
+  formatPtyEventMessage,
+  formatPtySummaryMessage,
+  type PtyEntry,
+} from "./pty-diagnostics";
+
+// Dedicated Output channel for PTY lifecycle visibility — separate from
+// `silo:application` so it doesn't crowd out other host logs, and so it can be
+// found/filtered on its own when debugging a session that outlived its
+// workspace (soft-close keeps PTYs alive by design; this channel is how you
+// eyeball whether that's actually what's happening).
+const terminalsChannel = createHostChannel("silo:terminals", "Terminals");
+
+/** Log one PTY create/delete event, resolving the workspace name for the line. */
+function logPtyEvent(
+  action: "created" | "deleted",
+  opts: {
+    workspaceId: string;
+    terminalId: string;
+    sessionId: string;
+    reason?: string;
+    level?: "info" | "error";
+  },
+): void {
+  const workspaceName =
+    store.workspaces[opts.workspaceId]?.name ?? opts.workspaceId;
+  const message = formatPtyEventMessage(action, { ...opts, workspaceName });
+  const data = { ...opts, workspaceName };
+  if (opts.level === "error") terminalsChannel.error(message, data);
+  else terminalsChannel.info(message, data);
+}
+
+// ---- create/delete detection ------------------------------------------------
+// A PTY's `sessionId` gets attached to its terminal record from several call
+// sites — TerminalPanel.tsx spawning directly via `ctx.process.spawn` on mount
+// (the common case), this module's own `ensureSession` (the `sendText` lazy-
+// spawn fallback), `close()`, `reapWorkspaceTerminals` — and any future one.
+// Rather than instrument every call site (guaranteed to miss the next one),
+// mirror `processes-service.ts`'s approach: diff the live sessionId set on
+// every store mutation. This is the one place that can't miss a spawn/kill
+// regardless of which layer triggered it.
+
+function logPtySummary(entries: PtyEntry[]): void {
+  const { message, data } = formatPtySummaryMessage(entries);
+  terminalsChannel.info(message, data);
+}
+
+// `null` until the post-hydration baseline is taken — the workspaces restored
+// from disk aren't newly "created", so the first sync after hydration seeds
+// the known set silently (logging one startup summary instead of a batch of
+// false creates).
+let knownPtys: Map<string, PtyEntry> | null = null;
+
+function syncPtyDiagnostics(): void {
+  if (!store.hydrated) return;
+  const current = collectLivePtys(store.workspaces);
+  const currentMap = new Map(current.map((e) => [e.sessionId, e]));
+
+  if (knownPtys === null) {
+    knownPtys = currentMap;
+    logPtySummary(current);
+    return;
+  }
+
+  for (const [sessionId, entry] of currentMap) {
+    if (!knownPtys.has(sessionId)) {
+      logPtyEvent("created", {
+        workspaceId: entry.workspaceId,
+        terminalId: entry.terminalId,
+        sessionId,
+      });
+    }
+  }
+  for (const [sessionId, entry] of knownPtys) {
+    if (!currentMap.has(sessionId)) {
+      logPtyEvent("deleted", {
+        workspaceId: entry.workspaceId,
+        terminalId: entry.terminalId,
+        sessionId,
+        reason: "removed from workspace state",
+      });
+    }
+  }
+  knownPtys = currentMap;
+}
+
+subscribe(store, syncPtyDiagnostics);
+
+// Periodic PTY census — every 5 minutes after the startup log above, dump a
+// per-workspace rollup (count + terminal names). The only way to notice a
+// session that's still alive when nothing should be holding it open.
+setInterval(() => {
+  logPtySummary(collectLivePtys(store.workspaces));
+}, 5 * 60_000);
 
 // `ctx.terminals` — the public contract lives in @silo-code/sdk
 // (terminal-service.ts); this is the host implementation.
@@ -62,7 +159,15 @@ function ensureSession(terminalId: string): Promise<string | null> {
       // Re-resolve the record — it may have moved/closed during the await.
       const rec = findTerminal(found.workspaceId, terminalId);
       if (!rec) {
+        // The terminal was removed while its PTY was still spawning — kill the
+        // now-orphaned session rather than leaking it.
         void session.kill();
+        logPtyEvent("deleted", {
+          workspaceId: found.workspaceId,
+          terminalId,
+          sessionId: session.id,
+          reason: "terminal removed mid-spawn",
+        });
         return null;
       }
       if (!rec.sessionId) rec.sessionId = session.id;
@@ -93,10 +198,23 @@ export async function reapWorkspaceTerminals(
   for (const id of ids) {
     const rec = removeTerminal(workspaceId, id);
     if (rec?.sessionId) {
+      const sessionId = rec.sessionId;
+      // The successful path is already covered by the store-diff (removeTerminal
+      // above drops the sessionId immediately, so the next sync logs "deleted").
+      // A failed kill is the one thing the diff can't see — store already thinks
+      // the PTY is gone, so this is the only trace of a session outliving the
+      // workspace it belonged to.
       kills.push(
-        tauriTerminalClient
-          .deleteTerminal(rec.sessionId)
-          .catch((err) => console.warn("delete terminal failed", err)),
+        tauriTerminalClient.deleteTerminal(sessionId).catch((err) => {
+          console.warn("delete terminal failed", err);
+          logPtyEvent("deleted", {
+            workspaceId,
+            terminalId: id,
+            sessionId,
+            reason: `workspace reap FAILED: ${String(err)}`,
+            level: "error",
+          });
+        }),
       );
     }
   }
@@ -148,9 +266,20 @@ export function getTerminalService(): TerminalService {
       if (!found) return; // unknown id → no-op
       const rec = removeTerminal(found.workspaceId, terminalId);
       if (rec?.sessionId) {
-        tauriTerminalClient
-          .deleteTerminal(rec.sessionId)
-          .catch((err) => console.warn("close terminal failed", err));
+        const { workspaceId } = found;
+        const sessionId = rec.sessionId;
+        // As in reapWorkspaceTerminals: the successful path is covered by the
+        // store-diff; only a failed kill needs its own log.
+        tauriTerminalClient.deleteTerminal(sessionId).catch((err) => {
+          console.warn("close terminal failed", err);
+          logPtyEvent("deleted", {
+            workspaceId,
+            terminalId,
+            sessionId,
+            reason: `terminal close FAILED: ${String(err)}`,
+            level: "error",
+          });
+        });
       }
     },
     rename(terminalId, name) {


### PR DESCRIPTION
## Summary

- Adds a dedicated "Terminals" Output channel (`silo:terminals`) for PTY lifecycle visibility — the tool for debugging a session that outlived its workspace (soft-close keeps PTYs alive by design; this is how you eyeball whether that's actually what's happening).
- Create/delete detection is a store diff over the live `sessionId` set (mirroring `processes-service.ts`'s existing approach), not point-of-call instrumentation. The real spawn path — `TerminalPanel.tsx` calling `ctx.process.spawn` directly on mount — doesn't go through `terminal-service.ts` at all, so instrumenting individual call sites would have silently missed the common case. A store diff can't miss a spawn/kill regardless of which layer triggers it.
- A failed kill still gets its own error-level log line — the one thing the diff can't see, since the terminal record is removed from state either way (success or failure).
- Every 5 minutes, plus once on startup (right after hydration restores persisted state), dumps a compact per-workspace rollup: `{ workspaceName, workspaceClosed, count, terminals: [names] }` — no ids.

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all green
- [x] Verified live against a real running session: reload triggers an immediate startup summary reflecting real state; simulated PTY attach/detach produced exactly one correctly-formatted create and delete log each (no duplication); the periodic rollup matches real per-workspace terminal names with no ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)