### PR TITLE
chore(docs): update agent skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,11 @@ The docs site has two layers (see `apps/docs/`):
 
 - **Hand-authored, member-centric pages** — the navigable narrative organized by
   what you do with `ctx`: `apps/docs/api/index.md` (overview + shape diagram), then
-  `apps/docs/api/{registration,state,other}/*.md`, one page per `ctx` member.
+  one subdirectory per `ctx` domain (`apps/docs/api/registration/`,
+  `apps/docs/api/editors/`, `apps/docs/api/state/`, `apps/docs/api/storage/`,
+  `apps/docs/api/other/`, …), one page per `ctx` member. The `apiSidebar` in
+  `apps/docs/.vitepress/config.ts` is the source of truth for the current set of
+  domains.
 - **Generated type leaves** — TypeDoc renders the SDK types into
   `apps/docs/api/types/` (drill-down targets, linked from the member pages).
 
@@ -60,9 +64,9 @@ field):
 3. If it's a genuinely public type, **re-export it from `packages/sdk/src/index.ts`**
    (the barrel is the declared surface; if it's not in the barrel, it's not public).
 4. **If you added a `ctx` member**, add its hand-authored page under
-   `apps/docs/api/<registration|state|other>/<name>.md` (copy an existing one for
-   the shape: blurb → signature → example → type links → see-also) and add it to
-   the `apiSidebar` in `apps/docs/.vitepress/config.ts`. Link it from the overview
+   `apps/docs/api/<domain>/<name>.md` (copy an existing one for the shape:
+   blurb → signature → example → type links → see-also) and add it to the
+   `apiSidebar` in `apps/docs/.vitepress/config.ts`. Link it from the overview
    table in `apps/docs/api/index.md`.
 5. **Regenerate the type reference:** `pnpm docs:api` (writes
    `apps/docs/api/types/`, committed so growth shows in diffs).
@@ -205,3 +209,30 @@ How testing works here:
   no-ops/guards, disabled states, and "hidden/absent" cases (the new editor
   view-switching tests pin the priority tie-break, stale-`viewType` fallback,
   read-only Cut/Paste, and the single-view/diff/untitled hidden cases).
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues in `silo-code/silo`, via the `gh` CLI. See
+`docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`,
+`ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context, mapped to this repo's existing `docs/decisions/` (ADRs) and
+`docs/proposals/` (RFCs). See `docs/agents/domain.md`.
+
+**Path mismatch note**: the installed `domain-modeling`, `improve-codebase-architecture`,
+and `grill-with-docs` skills (from mattpocock/skills) hardcode `CONTEXT.md` and
+`docs/adr/` in their own instructions — they don't read `docs/agents/domain.md`.
+When running them: treat any `docs/adr/` reference as `docs/decisions/` (read
+existing ADRs from there; write new ones there, continuing the existing numbering
+— don't create a separate `docs/adr/` directory); `CONTEXT.md` at the repo root
+has no existing equivalent, so create it fresh if one of these skills needs it.
+These skills have no concept of `docs/proposals/` (RFCs) — that tier is outside
+their vocabulary, so don't expect them to read or write there.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,21 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`docs/decisions/`** — ADRs, the durable "why" behind architecture decisions already made. Read any that touch the area you're about to work in.
+- **`docs/proposals/`** — RFCs, forward-looking designs not yet decided. Check for open proposals relevant to the area.
+- There is no repo-wide `CONTEXT.md` glossary yet. If one is created later (by `/domain-modeling`), read it before exploring.
+
+This repo is a pnpm workspace (`apps/*`, `packages/*`, `examples/extensions/*`), but `docs/decisions/` and `docs/proposals/` are repo-wide, not per-package — there is no `src/<context>/docs/adr/` split to check.
+
+## Use the glossary's vocabulary
+
+No `CONTEXT.md` exists yet, so there's no fixed glossary to defer to. Prefer terminology already used in `docs/decisions/`, `docs/proposals/`, and `docs/ui-terminology.md` over inventing new terms.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary
- Adds `docs/agents/domain.md`, `docs/agents/issue-tracker.md`, and `docs/agents/triage-labels.md`
- Updates `CLAUDE.md` to reference the new agent skill docs

## Test plan
- [ ] Docs render correctly and links resolve

https://claude.ai/code/session_01Vm59PEeudxd1iJQTkkaeqG