### PR TITLE
fix(git): commit-msg hook PATH + unreadable commit-error modal

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,6 +1,21 @@
 #!/bin/sh
 # Enforce Conventional Commits on every commit message.
 # Bypass in a genuine pinch with:  git commit --no-verify
+
+# Robustly find npx (especially for GUI git clients on macOS)
+if ! command -v npx >/dev/null 2>&1; then
+  export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin"
+  [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"
+  [ -s "$HOME/.asdf/asdf.sh" ] && . "$HOME/.asdf/asdf.sh"
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo ""
+  echo "✖ Commit blocked: 'npx' command not found."
+  echo "  Please ensure npx is in your PATH."
+  exit 1
+fi
+
 npx --no-install commitlint --edit "$1"
 if [ $? -ne 0 ]; then
   echo ""

--- a/packages/extensions-silo/src/git-explorer/GitErrorModal.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitErrorModal.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { CopySimple } from "@phosphor-icons/react";
+
+// The body of the "View details" modal behind a git failure toast (see
+// GitView's `notifyError`). Pulled out of GitView.tsx so the "Copied" button
+// feedback can use local state — the inline `showModal` render prop it used
+// to live in isn't a component, so it can't call hooks.
+
+/** The "View details" modal body for a git failure: full output + copy/close. */
+export function GitErrorModal({
+  detail,
+  onClose,
+}: {
+  detail: string;
+  onClose: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(detail);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <>
+      <pre className="git-error-detail">{detail}</pre>
+      <div className="silo-modal-actions">
+        <button
+          type="button"
+          className="silo-button git-error-copy-button"
+          onClick={handleCopy}
+        >
+          <CopySimple size={14} />
+          {copied ? "Copied" : "Copy"}
+        </button>
+        <button type="button" className="silo-button-primary" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -323,7 +323,7 @@
 
 /* Full git error output, shown in the "View details" modal (ctx.ui.showModal). */
 .git-error-detail {
-  max-height: 50vh;
+  max-height: 25vh;
   overflow: auto;
   margin: 0;
   padding: 10px 12px;
@@ -335,6 +335,18 @@
   font-size: var(--silo-font-size-sm);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  /* Root sets user-select: none for the app's desktop chrome; opt this output
+     back in so the error text (and stack traces) can be selected/copied. */
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/* Icon + label in the error modal's "Copy" button — plain JSX whitespace
+   between the two children collapses to nothing, so space them with flex. */
+.git-error-copy-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 /* Commit area */

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -20,6 +20,7 @@ import { Section, FileRow } from "./git-rows";
 import { buildGitNavItems, navItemKey } from "./git-nav";
 import { ICON_CHECK, ICON_PLUS, ICON_MINUS, ICON_UNDO } from "./git-icons";
 import { summarizeGitError } from "./notify-error";
+import { GitErrorModal } from "./GitErrorModal";
 import { BranchManager } from "./BranchManager";
 import { WorktreeManager } from "./WorktreeManager";
 import { findWorktreeFor } from "./worktree-model";
@@ -103,21 +104,8 @@ export function GitView({
             label: "View details",
             run: () =>
               ctx.ui.showModal(
-                (close) => (
-                  <>
-                    <pre className="git-error-detail">{detail}</pre>
-                    <div className="silo-modal-actions">
-                      <button
-                        type="button"
-                        className="silo-button-primary"
-                        onClick={() => close()}
-                      >
-                        Close
-                      </button>
-                    </div>
-                  </>
-                ),
-                { title, dismissible: true, size: "md" },
+                (close) => <GitErrorModal detail={detail} onClose={close} />,
+                { title, dismissible: true, size: "lg" },
               ),
           },
         ];

--- a/packages/extensions-silo/src/git-explorer/notify-error.test.ts
+++ b/packages/extensions-silo/src/git-explorer/notify-error.test.ts
@@ -72,4 +72,12 @@ describe("summarizeGitError", () => {
       "boom",
     );
   });
+
+  it("strips ANSI escape codes from colorized hook output", () => {
+    const detail = summarizeGitError(
+      "\x1b[32m✓\x1b[39m tests passed\nfatal: \x1b[31mnothing to commit\x1b[39m",
+      "Commit failed",
+    ).detail;
+    expect(detail).toBe("✓ tests passed\nfatal: nothing to commit");
+  });
 });

--- a/packages/extensions-silo/src/git-explorer/notify-error.ts
+++ b/packages/extensions-silo/src/git-explorer/notify-error.ts
@@ -17,6 +17,18 @@ export interface GitErrorSummary {
 /** A line that reads like a conclusive failure (commitlint/lint/test output). */
 const ERROR_MARKER = /(✖|✗|\b(?:failed|blocked|error|fatal)\b)/i;
 
+// eslint-disable-next-line no-control-regex -- matches raw ANSI escape codes to strip them
+const ANSI_ESCAPE = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+/**
+ * Strip ANSI color/cursor escape codes. Hook output (pnpm/turbo/vitest) is
+ * colorized for a terminal; piped through a thrown error and rendered in
+ * `<pre>`, those codes show up as literal garbage like `[32m✓[39m`.
+ */
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE, "");
+}
+
 /**
  * Pick the line that best explains the failure. Plain git errors put the reason
  * on a `fatal:`/`error:` line, so prefer that. Hook output (lint, commitlint,
@@ -46,7 +58,7 @@ export function summarizeGitError(
   err: unknown,
   fallback: string,
 ): GitErrorSummary {
-  const detail = String(err)
+  const detail = stripAnsi(String(err))
     .replace(/^Error:\s*/, "")
     .trim();
   const summary = pickSummaryLine(detail) ?? fallback;


### PR DESCRIPTION
## Summary
- `commit-msg` hook was calling `npx` with no PATH recovery, unlike `pre-commit`. GUI git clients (Silo's own git panel) spawn hooks with a minimal PATH, so `npx` resolved to "command not found" and got misreported as an invalid commit message. Mirrors `pre-commit`'s nvm/asdf/homebrew fallback.
- The "View details" modal shown on a failed commit/push/pull had four problems: raw ANSI escape codes from colorized hook output leaking into the text, no text selection (inherited the app's global `user-select: none`), no copy button, and a cramped 560px/50vh box.

## Changes
- `.githooks/commit-msg`: recover PATH before invoking `npx`/commitlint.
- `notify-error.ts`: strip ANSI escapes from the error text (covers both the toast summary and modal detail); added a regression test.
- `GitErrorModal.tsx` (new): modal body extracted from the inline `showModal` render prop so a "Copied" button state can use `useState`.
- `GitView.tsx`: use `GitErrorModal`, widen the modal `md` → `lg`.
- `GitExplorerPanel.css`: opt `.git-error-detail` back into `user-select: text`; halve `max-height` (`50vh` → `25vh`); space the copy button's icon+label with flex/gap.

## Test plan
- [x] `pnpm --filter @silo-code/extensions-silo exec vitest run` — 188 passed, including new ANSI-stripping test
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [ ] Restart Silo and trigger a failing commit (bad conventional-commit message) to confirm the modal is wider, shorter, selectable, ANSI-free, and the Copy button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)