### PR TITLE
feat(extension-host): dispatch workspace context-menu contributions (RFC 0013)

### DIFF
--- a/apps/docs/api/registration/register-context-menu-item.md
+++ b/apps/docs/api/registration/register-context-menu-item.md
@@ -2,6 +2,10 @@
 
 Add a command to the right-click context menu of a built-in surface — the file-explorer entry, an editor tab, a terminal tab, or a workspace row. Unlike [`registerMenuItem`](/api/registration/register-menu-item) (the menubar), the invoked command receives a typed **target** — which file, which editor, which workspace — as its first argument, and the same target is threaded into the `when` (visibility) and `checked` (toggle checkmark) predicates.
 
+::: info Surface status
+The `"workspace"` surface renders today. The other `MenuSurface` values (`"explorer/item"`, `"editor/tab"`, `"terminal/tab"`) are typed but not yet dispatched — contributions to them register cleanly and appear once those surfaces land (see the [Roadmap](/roadmap#context-menus)).
+:::
+
 ```ts
 ctx.registerContextMenuItem<S extends MenuSurface>(
   item: ContextMenuContribution<S>,

--- a/apps/docs/roadmap.md
+++ b/apps/docs/roadmap.md
@@ -15,50 +15,51 @@ designed. As a primitive ships, its badge flips from
 
 ## Core (`ctx`) primitives
 
-| Primitive                                              | Status                               |                                                                                            |
-| ------------------------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------ |
-| Registration (`register*`)                             | <Badge type="tip" text="stable" />   | [docs](/api/#registration)                                                                 |
-| `executeCommand`                                       | <Badge type="tip" text="stable" />   | [docs](/api/other/execute-command)                                                         |
-| `ctx.workspaces`                                       | <Badge type="tip" text="stable" />   | [docs](/api/state/workspaces)                                                              |
-| `ctx.layout`                                           | <Badge type="tip" text="stable" />   | [docs](/api/state/layout)                                                                  |
-| `ctx.process` (persistent sessions)                    | <Badge type="tip" text="stable" />   | [docs](/api/process/)                                                                      |
-| `ctx.process.exec` (one-shot subprocess)               | <Badge type="tip" text="stable" />   | [docs](/api/process/#one-shot-exec)                                                        |
-| `ctx.processes` (foreground process observer)          | <Badge type="tip" text="stable" />   | [docs](/api/processes/)                                                                    |
-| Extension-API mechanism (`getExtension`)               | <Badge type="tip" text="stable" />   | [docs](/api/other/get-extension)                                                           |
-| `ctx.editors` (documents)                              | <Badge type="tip" text="stable" />   | [docs](/api/editors/)                                                                      |
-| `ctx.terminals` (terminal tabs)                        | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals)                                                               |
-| `ctx.terminals.registerTabDecoration`                  | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals)                                                               |
-| `ctx.terminals.focus`                                  | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals)                                                               |
-| `ctx.terminals.subscribeOsc`                           | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals#osc-events)                                                    |
-| `ctx.terminals.getActive` / `subscribeActive`          | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals#active-terminal)                                               |
-| `ctx.terminals.subscribeOutput`                        | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals#raw-output)                                                    |
-| `ctx.workspaces.registerStatus`                        | <Badge type="tip" text="stable" />   | [docs](/api/state/workspaces)                                                              |
-| `ctx.workspaces.registerSection`                       | <Badge type="tip" text="stable" />   | [docs](/api/state/workspaces#workspace-sections)                                           |
-| `ctx.files`                                            | <Badge type="tip" text="stable" />   | [docs](/api/files/)                                                                        |
-| `ctx.theme` + `ctx.theme.registerPreset`               | <Badge type="tip" text="stable" />   | [docs](/api/theme/)                                                                        |
-| `ctx.dnd` (drag-and-drop)                              | <Badge type="tip" text="stable" />   | [docs](/api/dnd/)                                                                          |
-| `useServiceState` (reactive reads)                     | <Badge type="tip" text="stable" />   | [docs](/api/other/use-service-state)                                                       |
-| `useFocusGroup` (keyboard nav for a group)             | <Badge type="tip" text="stable" />   | [docs](/api/other/use-focus-group)                                                         |
-| `Tooltip` (styled hover popup)                         | <Badge type="tip" text="stable" />   | [docs](/api/other/tooltip)                                                                 |
-| `ctx.ui` (pickers + notify w/ actions + menus)         | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
-| `ctx.ui` (confirm / prompt)                            | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
-| `ctx.ui.showModal` (custom modal content)              | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
-| `ctx.ui.openExternal` (open a URL out)                 | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
-| `ctx.ui.getActiveSelectionText`                        | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
-| `ctx.net` (server-side HTTP, bypasses CORS)            | <Badge type="tip" text="stable" />   | [docs](/api/net/)                                                                          |
-| `ctx.system` (OS, arch, Silo version)                  | <Badge type="tip" text="stable" />   | [docs](/api/system/)                                                                       |
-| `ctx.search` (cross-file content search)               | <Badge type="tip" text="stable" />   | [docs](/api/search/)                                                                       |
-| `ctx.search` (replace-in-files)                        | <Badge type="info" text="planned" /> | [design](/api/search/#replace)                                                             |
-| `ctx.ui` (quickPick / progress)                        | <Badge type="info" text="planned" /> | [design](#ctx-ui)                                                                          |
-| `ctx` events (typed `Event<T>`)                        | <Badge type="tip" text="stable" />   | [docs](/api/other/event)                                                                   |
-| `ctx.editors.getState` / `subscribe`                   | <Badge type="tip" text="stable" />   | [docs](/api/editors/)                                                                      |
-| `path` (cross-platform path utilities)                 | <Badge type="tip" text="stable" />   | [docs](/api/other/path)                                                                    |
-| per-extension settings (page + persistence)            | <Badge type="tip" text="stable" />   | [docs](/api/registration/register-settings-page)                                           |
-| `ctx.storage` (global / workspace)                     | <Badge type="tip" text="stable" />   | [docs](/api/storage/)                                                                      |
-| `ctx.secrets` (host-mediated credentials)              | <Badge type="info" text="planned" /> | [RFC 0004](https://github.com/silo-code/silo/blob/main/docs/proposals/0004-ctx-storage.md) |
-| `ctx.webview` (cross-origin iframe bridge)             | <Badge type="tip" text="stable" />   | [docs](/api/webview/)                                                                      |
-| context-menu contributions (explorer/editor/workspace) | <Badge type="info" text="planned" /> | [design](#context-menus)                                                                   |
-| `ctx.workspaces.registerPropertyPage`                  | <Badge type="info" text="planned" /> | [design](#workspace-property-pages)                                                        |
+| Primitive                                             | Status                               |                                                                                            |
+| ----------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Registration (`register*`)                            | <Badge type="tip" text="stable" />   | [docs](/api/#registration)                                                                 |
+| `executeCommand`                                      | <Badge type="tip" text="stable" />   | [docs](/api/other/execute-command)                                                         |
+| `ctx.workspaces`                                      | <Badge type="tip" text="stable" />   | [docs](/api/state/workspaces)                                                              |
+| `ctx.layout`                                          | <Badge type="tip" text="stable" />   | [docs](/api/state/layout)                                                                  |
+| `ctx.process` (persistent sessions)                   | <Badge type="tip" text="stable" />   | [docs](/api/process/)                                                                      |
+| `ctx.process.exec` (one-shot subprocess)              | <Badge type="tip" text="stable" />   | [docs](/api/process/#one-shot-exec)                                                        |
+| `ctx.processes` (foreground process observer)         | <Badge type="tip" text="stable" />   | [docs](/api/processes/)                                                                    |
+| Extension-API mechanism (`getExtension`)              | <Badge type="tip" text="stable" />   | [docs](/api/other/get-extension)                                                           |
+| `ctx.editors` (documents)                             | <Badge type="tip" text="stable" />   | [docs](/api/editors/)                                                                      |
+| `ctx.terminals` (terminal tabs)                       | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals)                                                               |
+| `ctx.terminals.registerTabDecoration`                 | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals)                                                               |
+| `ctx.terminals.focus`                                 | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals)                                                               |
+| `ctx.terminals.subscribeOsc`                          | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals#osc-events)                                                    |
+| `ctx.terminals.getActive` / `subscribeActive`         | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals#active-terminal)                                               |
+| `ctx.terminals.subscribeOutput`                       | <Badge type="tip" text="stable" />   | [docs](/api/state/terminals#raw-output)                                                    |
+| `ctx.workspaces.registerStatus`                       | <Badge type="tip" text="stable" />   | [docs](/api/state/workspaces)                                                              |
+| `ctx.workspaces.registerSection`                      | <Badge type="tip" text="stable" />   | [docs](/api/state/workspaces#workspace-sections)                                           |
+| `ctx.files`                                           | <Badge type="tip" text="stable" />   | [docs](/api/files/)                                                                        |
+| `ctx.theme` + `ctx.theme.registerPreset`              | <Badge type="tip" text="stable" />   | [docs](/api/theme/)                                                                        |
+| `ctx.dnd` (drag-and-drop)                             | <Badge type="tip" text="stable" />   | [docs](/api/dnd/)                                                                          |
+| `useServiceState` (reactive reads)                    | <Badge type="tip" text="stable" />   | [docs](/api/other/use-service-state)                                                       |
+| `useFocusGroup` (keyboard nav for a group)            | <Badge type="tip" text="stable" />   | [docs](/api/other/use-focus-group)                                                         |
+| `Tooltip` (styled hover popup)                        | <Badge type="tip" text="stable" />   | [docs](/api/other/tooltip)                                                                 |
+| `ctx.ui` (pickers + notify w/ actions + menus)        | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
+| `ctx.ui` (confirm / prompt)                           | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
+| `ctx.ui.showModal` (custom modal content)             | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
+| `ctx.ui.openExternal` (open a URL out)                | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
+| `ctx.ui.getActiveSelectionText`                       | <Badge type="tip" text="stable" />   | [docs](/api/ui/)                                                                           |
+| `ctx.net` (server-side HTTP, bypasses CORS)           | <Badge type="tip" text="stable" />   | [docs](/api/net/)                                                                          |
+| `ctx.system` (OS, arch, Silo version)                 | <Badge type="tip" text="stable" />   | [docs](/api/system/)                                                                       |
+| `ctx.search` (cross-file content search)              | <Badge type="tip" text="stable" />   | [docs](/api/search/)                                                                       |
+| `ctx.search` (replace-in-files)                       | <Badge type="info" text="planned" /> | [design](/api/search/#replace)                                                             |
+| `ctx.ui` (quickPick / progress)                       | <Badge type="info" text="planned" /> | [design](#ctx-ui)                                                                          |
+| `ctx` events (typed `Event<T>`)                       | <Badge type="tip" text="stable" />   | [docs](/api/other/event)                                                                   |
+| `ctx.editors.getState` / `subscribe`                  | <Badge type="tip" text="stable" />   | [docs](/api/editors/)                                                                      |
+| `path` (cross-platform path utilities)                | <Badge type="tip" text="stable" />   | [docs](/api/other/path)                                                                    |
+| per-extension settings (page + persistence)           | <Badge type="tip" text="stable" />   | [docs](/api/registration/register-settings-page)                                           |
+| `ctx.storage` (global / workspace)                    | <Badge type="tip" text="stable" />   | [docs](/api/storage/)                                                                      |
+| `ctx.secrets` (host-mediated credentials)             | <Badge type="info" text="planned" /> | [RFC 0004](https://github.com/silo-code/silo/blob/main/docs/proposals/0004-ctx-storage.md) |
+| `ctx.webview` (cross-origin iframe bridge)            | <Badge type="tip" text="stable" />   | [docs](/api/webview/)                                                                      |
+| context-menu contributions (workspace)                | <Badge type="tip" text="stable" />   | [docs](/api/registration/register-context-menu-item)                                       |
+| context-menu contributions (explorer/editor/terminal) | <Badge type="info" text="planned" /> | [design](#context-menus)                                                                   |
+| `ctx.workspaces.registerPropertyPage`                 | <Badge type="info" text="planned" /> | [design](#workspace-property-pages)                                                        |
 
 ## Extension-owned features
 

--- a/packages/extension-host/src/extension-host/context-menu-items.test.ts
+++ b/packages/extension-host/src/extension-host/context-menu-items.test.ts
@@ -3,8 +3,14 @@ import {
   registerContextMenuItem,
   listContextMenuItems,
   onContextMenuItemsChange,
+  buildContextMenuEntries,
 } from "./context-menu-items";
-import type { ContextMenuContribution, Workspace } from "@silo-code/sdk";
+import type {
+  ContextKeys,
+  ContextMenuContribution,
+  MenuItem,
+  Workspace,
+} from "@silo-code/sdk";
 
 function workspaceItem(
   command: string,
@@ -99,5 +105,100 @@ describe("context-menu-items registry", () => {
     } finally {
       d.dispose();
     }
+  });
+});
+
+// ── buildContextMenuEntries (pure builder) ──────────────────────────────────
+
+const keys = {} as ContextKeys;
+const wsTarget = { id: "ws_1", name: "One" } as Workspace;
+
+function contribution(
+  command: string,
+  extra?: Partial<ContextMenuContribution<"workspace">>,
+): ContextMenuContribution<"workspace"> {
+  return { surface: "workspace", command, ...extra };
+}
+
+function build(
+  items: ContextMenuContribution<"workspace">[],
+  dispatch: (command: string, target: Workspace) => void = () => {},
+) {
+  return buildContextMenuEntries(
+    items,
+    keys,
+    wsTarget,
+    (c) => `label:${c}`,
+    dispatch,
+  );
+}
+
+function labels(entries: ReturnType<typeof build>): string[] {
+  return entries.map((e) => ("label" in e ? e.label : "—"));
+}
+
+describe("buildContextMenuEntries", () => {
+  it("hides items whose when returns false and keeps those without when", () => {
+    const entries = build([
+      contribution("a.show"),
+      contribution("a.hide", { when: () => false }),
+    ]);
+    expect(labels(entries)).toEqual(["label:a.show"]);
+  });
+
+  it("passes keys and the target to when", () => {
+    const when = vi.fn().mockReturnValue(true);
+    build([contribution("a.x", { when })]);
+    expect(when).toHaveBeenCalledWith(keys, wsTarget);
+  });
+
+  it("prefers the explicit label, falling back to resolveLabel", () => {
+    const entries = build([
+      contribution("a.explicit", { label: "Explicit" }),
+      contribution("a.fallback"),
+    ]);
+    expect(labels(entries)).toEqual(["Explicit", "label:a.fallback"]);
+  });
+
+  it("separates groups, sorted lexically, with default group 9_default last", () => {
+    const entries = build([
+      contribution("a.default"), // no group → 9_default
+      contribution("a.early", { group: "1_first" }),
+    ]);
+    expect(
+      entries.map((e) => ("type" in e ? e.type : "label" in e ? e.label : "")),
+    ).toEqual(["label:a.early", "separator", "label:a.default"]);
+  });
+
+  it("does not separate items within the same group and sorts them by order", () => {
+    const entries = build([
+      contribution("a.second", { group: "g", order: 2 }),
+      contribution("a.first", { group: "g", order: 1 }),
+    ]);
+    expect(labels(entries)).toEqual(["label:a.first", "label:a.second"]);
+  });
+
+  it("evaluates checked per row and leaves it undefined when absent", () => {
+    const entries = build([
+      contribution("a.on", { checked: (_k, ws) => ws.id === "ws_1" }),
+      contribution("a.plain"),
+    ]) as MenuItem[];
+    expect(entries[0].checked).toBe(true);
+    expect(entries[1].checked).toBeUndefined();
+  });
+
+  it("dispatches the command with the target when a row runs", () => {
+    const dispatch = vi.fn();
+    const entries = build([contribution("a.run")], dispatch) as MenuItem[];
+    entries[0].run?.();
+    expect(dispatch).toHaveBeenCalledWith("a.run", wsTarget);
+  });
+
+  it("returns no leading separator when the first group is empty after when-filtering", () => {
+    const entries = build([
+      contribution("a.hidden", { group: "1_first", when: () => false }),
+      contribution("a.visible", { group: "2_second" }),
+    ]);
+    expect(labels(entries)).toEqual(["label:a.visible"]);
   });
 });

--- a/packages/extension-host/src/extension-host/context-menu-items.ts
+++ b/packages/extension-host/src/extension-host/context-menu-items.ts
@@ -1,15 +1,20 @@
 import type {
+  ContextKeys,
   ContextMenuContribution,
   Disposable,
+  MenuContext,
+  MenuEntry,
   MenuSurface,
 } from "@silo-code/sdk";
+import { commandRegistry, executeCommand } from "./commands";
+import { contextKeys } from "./context-keys";
 
 // Registered context-menu contributions (RFC 0013). Unlike the menubar's
 // `menuItemRegistry`, contributions carry no `id` — identity is the object
 // itself — so this keeps its own insertion-ordered set instead of reusing
-// `Registry` (which keys by id). Menu *building* (grouping, when/checked
-// evaluation, dispatch with the surface target) happens at the surface's
-// right-click site; this module only stores and lists.
+// `Registry` (which keys by id). A surface's right-click site calls
+// `contextMenuEntriesFor(surface, target)` to append the registered rows to
+// its own menu; the pure builder underneath is exported for tests.
 
 const contributions = new Set<ContextMenuContribution>();
 const listeners = new Set<() => void>();
@@ -56,4 +61,68 @@ export function onContextMenuItemsChange(fn: () => void): Disposable {
       listeners.delete(fn);
     },
   };
+}
+
+/**
+ * Pure menu-building core: filter by `when`, bucket by `group` (default
+ * `"9_default"`, groups sorted lexically — same convention as the menubar's
+ * `groupAndSort`), sort by `order` within each group, separators between
+ * groups, `checked` evaluated per row. Exported for tests; runtime callers
+ * use {@link contextMenuEntriesFor}.
+ */
+export function buildContextMenuEntries<S extends MenuSurface>(
+  items: ContextMenuContribution<S>[],
+  keys: ContextKeys,
+  target: MenuContext[S],
+  resolveLabel: (command: string) => string,
+  dispatch: (command: string, target: MenuContext[S]) => void,
+): MenuEntry[] {
+  const visible = items.filter((c) => !c.when || c.when(keys, target));
+
+  const byGroup = new Map<string, ContextMenuContribution<S>[]>();
+  for (const item of visible) {
+    const g = item.group ?? "9_default";
+    let arr = byGroup.get(g);
+    if (!arr) {
+      arr = [];
+      byGroup.set(g, arr);
+    }
+    arr.push(item);
+  }
+
+  const entries: MenuEntry[] = [];
+  for (const g of [...byGroup.keys()].sort()) {
+    const group = byGroup.get(g)!;
+    group.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    if (entries.length > 0) entries.push({ type: "separator" });
+    for (const item of group) {
+      entries.push({
+        label: item.label ?? resolveLabel(item.command),
+        checked: item.checked ? item.checked(keys, target) : undefined,
+        run: () => dispatch(item.command, target),
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * The registered context-menu rows for `surface`, ready to append to that
+ * surface's `ctx.ui.showMenu` items. Labels fall back to the command's label
+ * (then its id); clicking a row dispatches the command with `target` as its
+ * first argument.
+ */
+export function contextMenuEntriesFor<S extends MenuSurface>(
+  surface: S,
+  target: MenuContext[S],
+): MenuEntry[] {
+  return buildContextMenuEntries(
+    listContextMenuItems(surface),
+    contextKeys,
+    target,
+    (command) => commandRegistry.get(command)?.label ?? command,
+    (command, t) => {
+      executeCommand(command, t);
+    },
+  );
 }

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -114,6 +114,12 @@ export { homeDir } from "./platform";
 // workspace-section-registry.ts.
 export { workspaceSectionRegistry } from "./workspace-section-registry";
 
+// Context-menu contribution read side (RFC 0013) — the *write* side
+// (registerContextMenuItem) is public via ctx; building the merged menu rows
+// for a surface is a core-extension concern (the built-in surface owns its
+// menu and appends these). See context-menu-items.ts.
+export { contextMenuEntriesFor } from "./context-menu-items";
+
 // Editor host-plumbing — the raw Monaco/editor host access that `core.editor`
 // needs but that is wrong to hand to silo.*/third-party (Tier 3 "raw Monaco
 // setup"; see ctx-domains.md → "The editor surface"). NOTE what is deliberately

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.tsx
@@ -24,6 +24,7 @@ import {
   type WorkspaceStatusRow,
 } from "@silo-code/sdk";
 import {
+  contextMenuEntriesFor,
   homeDir,
   workspaceSectionRegistry,
 } from "@silo-code/extension-host/internal";
@@ -297,6 +298,13 @@ export function WorkspacesPanel({ ctx }: { ctx: ExtensionContext }) {
         label: "Close",
         run: () => void confirmAndCloseWorkspace(ctx, ws.id, ws.name),
       });
+    }
+
+    // Extension contributions on the "workspace" surface (RFC 0013), grouped
+    // and separated below the built-in rows.
+    const contributed = contextMenuEntriesFor("workspace", ws);
+    if (contributed.length > 0) {
+      items.push({ type: "separator" }, ...contributed);
     }
     return items;
   }


### PR DESCRIPTION
Third slice of the [Per-workspace extension contributions map](https://github.com/silo-code/silo/issues/241) — resolves ticket #244. With this, the `"workspace"` surface of RFC 0013 works end-to-end: register → rows render in the workspace row's right-click menu → click dispatches the command with the `Workspace` target.

## What

- **`context-menu-items.ts`** grows the menu-building half:
  - `buildContextMenuEntries` — pure, exported for tests: `when`-filter (keys + target), freeform groups bucketed with the menubar's `"9_default"` fallback and lexical group sort, `order` sort within groups (stable for ties), separators between groups, per-row `checked` evaluation, dispatch closure per row.
  - `contextMenuEntriesFor(surface, target)` — wired to the real registry, `contextKeys`, command-label fallback (command label → command id), and `executeCommand(command, target)`.
- **`WorkspacesPanel.tsx`** — appends `contextMenuEntriesFor("workspace", ws)` below the built-in rows (Properties/groups/Close), separated only when contributions exist. Zero contributions ⇒ menu identical to today.
- **`sdk-internal.ts`** — exports `contextMenuEntriesFor` for core surfaces (read side is core-privilege; the write side is public `ctx.registerContextMenuItem`).
- **Docs**: roadmap row split — context-menu contributions (**workspace**) flipped to `stable`, explorer/editor/terminal stay `planned`; member page gains a surface-status callout saying the other three surfaces are typed but not yet dispatched.

## Verification honesty

The builder is thoroughly unit-tested (8 new tests, 15 total in the file), and the no-contribution path — the only one reachable in the shipped app today — is behaviorally identical to the current menu (pinned by the no-leading-separator test). **Rendered-row runtime verification is deferred to the github-actions consumer tickets (#246/#247)**, which register the first real contributions; no bundled extension exercises this surface yet.

## Testing

- 8 new pure-builder tests: when-filtering + predicate args, label fallback, lexical group separation with `9_default` last, in-group order sort, `checked` true/undefined, dispatch-with-target, empty-group separator suppression.
- `pnpm test` green, `pnpm lint` clean, `tsc --noEmit` clean, `pnpm docs:build` passes.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)