### PR TITLE
docs(sdk): fix Command.run example signature in registerContextMenuItem docs

### DIFF
--- a/apps/docs/api/registration/register-context-menu-item.md
+++ b/apps/docs/api/registration/register-context-menu-item.md
@@ -15,11 +15,17 @@ ctx.registerContextMenuItem<S extends MenuSurface>(
 ## Example
 
 ```tsx
+// Command.run is `(...args: unknown[])` — a context-menu dispatch hands the
+// surface's target (here, the clicked Workspace) as args[0]; narrow it in
+// the body rather than typing the parameter directly (the latter doesn't
+// satisfy Command.run's signature).
 ctx.registerCommand({
   id: "acme.toggleWatch",
   label: "Acme: Watch this workspace",
-  run: (ws: Workspace) =>
-    acmeStore.setWatched(ws.id, !acmeStore.isWatched(ws.id)),
+  run: (...args) => {
+    const ws = args[0] as Workspace;
+    acmeStore.setWatched(ws.id, !acmeStore.isWatched(ws.id));
+  },
 });
 
 ctx.subscriptions.push(

--- a/docs/proposals/0015-workspace-extension-contributions.md
+++ b/docs/proposals/0015-workspace-extension-contributions.md
@@ -277,16 +277,20 @@ ctx.subscriptions.push(
 **2. Context menu actions via RFC 0013's `"workspace"` surface:**
 
 ```ts
+// Command.run is `(...args: unknown[])` — narrow args[0] in the body rather
+// than typing the parameter directly (implemented and confirmed by tsc
+// during the workspace-context-menu ticket; the latter form doesn't satisfy
+// Command.run's actual signature).
 ctx.registerCommand({
   id: "silo.github-actions.refresh-workspace",
   label: "GitHub Actions: Refresh",
-  run: (ws: Workspace) => service.refreshWorkspace(ws.id),
+  run: (...args) => service.refreshWorkspace((args[0] as Workspace).id),
 });
 
 ctx.registerCommand({
   id: "silo.github-actions.clear-alerts-workspace",
   label: "GitHub Actions: Clear Alerts",
-  run: (ws: Workspace) => service.clearAlerts(ws.id),
+  run: (...args) => service.clearAlerts((args[0] as Workspace).id),
 });
 
 ctx.subscriptions.push(
@@ -355,8 +359,10 @@ this represents persistent on/off state rather than a one-shot action:
 ctx.registerCommand({
   id: "silo.github-actions.toggle-enabled-workspace",
   label: "GitHub Actions: Enabled",
-  run: (ws: Workspace) =>
-    ghStore.setWorkspaceEnabled(ws.id, !ghStore.getWorkspaceEnabled(ws.id)),
+  run: (...args) => {
+    const ws = args[0] as Workspace;
+    ghStore.setWorkspaceEnabled(ws.id, !ghStore.getWorkspaceEnabled(ws.id));
+  },
 });
 
 ctx.subscriptions.push(


### PR DESCRIPTION
Small accuracy fix discovered while implementing ticket [#247](https://github.com/silo-code/silo/issues/247) (github-actions context-menu actions) on the [Per-workspace extension contributions map](https://github.com/silo-code/silo/issues/241).

## What

Both the SDK doc's example (`api/registration/register-context-menu-item.md`) and RFC 0015's worked example typed the command's `run` handler parameter directly:

```ts
run: (ws: Workspace) => ...
```

This doesn't satisfy `Command.run`'s actual signature (`(...args: unknown[]) => unknown | Promise<unknown>`) — confirmed by `tsc` while writing the real implementation, which every future extension author copying this example would also hit. Fixed both to the correct pattern:

```ts
run: (...args) => {
  const ws = args[0] as Workspace;
  ...
}
```

## Testing

`pnpm docs:build` passes (dead-link/render check); this is a doc-only, non-code-path change.