### PR TITLE
feat(workspaces): polish properties modal and related surfaces

### DIFF
--- a/packages/extension-host/src/components/SettingsDialog.css
+++ b/packages/extension-host/src/components/SettingsDialog.css
@@ -17,7 +17,7 @@
   /* The modal's reading size, tunable in one place. Children inherit it, and
      pages (incl. contributed ones) can derive from --settings-font so secondary
      text scales with it. */
-  --settings-font: calc(var(--silo-font-size-base) + 2px);
+  --settings-font: calc(var(--silo-font-size-base) + 1px);
   font-size: var(--settings-font);
   /* Shared min-height for a settings page's title row. Sized to a header that
      contains an action button (e.g. Shortcuts' "Edit keybindings.json") so a

--- a/packages/extension-host/src/extension-host/Modal.tsx
+++ b/packages/extension-host/src/extension-host/Modal.tsx
@@ -26,7 +26,8 @@ import { TABBABLE } from "./focus-dom";
 // `dismissible`) Escape + backdrop-click. Only the topmost modal traps/listens.
 //
 // Styled entirely from the `--silo-modal-*` component tokens + `.silo-modal*`
-// classes (theme.css), so it themes with everything else.
+// classes (theme.css), so it themes with everything else. Non-bare modals bump
+// reading size by +1px (`--silo-modal-font`; Settings uses the same bump).
 
 /** z-index step between stacked modals; the base is `--silo-z-modal-base`. */
 const Z_STEP = 10;
@@ -173,8 +174,17 @@ export function Modal({
         tabIndex={-1}
         onMouseDown={(e) => e.stopPropagation()}
       >
-        {title != null && <div className="silo-modal-title">{title}</div>}
-        {children}
+        {bare ? (
+          <>
+            {title != null && <div className="silo-modal-title">{title}</div>}
+            {children}
+          </>
+        ) : (
+          <div className="silo-modal-scale">
+            {title != null && <div className="silo-modal-title">{title}</div>}
+            {children}
+          </div>
+        )}
         {/* Close affordance for dismissible modals — last in the DOM so it
             never steals the initial focus from the modal's real first control,
             but visually pinned to the top-right corner. Bare modals own their

--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -403,9 +403,27 @@ button.silo-button-sm {
   box-shadow: var(--silo-modal-shadow);
   display: flex;
   flex-direction: column;
-  gap: 12px;
   padding: 20px;
   font-family: var(--silo-font-ui);
+  /* Reading size — +1px over the app base (same bump as `--silo-modal-font`).
+     Resolved against the inherited app base so ThemeInjector / uiFontSize
+     still apply. */
+  --silo-modal-font: calc(var(--silo-font-size-base) + 1px);
+}
+
+/* Inner scale wrapper: rebinds the shared size tokens for the modal subtree
+   (title, body, extension content) without a circular custom-property ref on
+   `.silo-modal` itself. Bare modals (Settings) skip this and own their size. */
+.silo-modal-scale {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+  --silo-font-size-base: var(--silo-modal-font);
+  --silo-font-size-sm: calc(var(--silo-modal-font) - 1px);
+  --silo-font-size-chrome: calc(var(--silo-modal-font) - 2px);
+  font-size: var(--silo-modal-font);
 }
 
 /* Corner close button (dismissible modals). Scoped under .silo-modal so the

--- a/packages/extensions-core/src/workspaces/WorkspaceModals.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspaceModals.tsx
@@ -1,28 +1,43 @@
 import { useEffect, useState } from "react";
-import { FolderPlus } from "@phosphor-icons/react";
+import { FolderPlus, GitBranch } from "@phosphor-icons/react";
 import { workspacePropertyPageRegistry } from "@silo-code/extension-host/internal";
 import {
   Tooltip,
+  path,
   useServiceState,
+  type FileService,
   type WorkspaceService,
 } from "@silo-code/sdk";
 import { EditableWorkspaceName } from "./EditableWorkspaceName";
-import { visiblePropertyPages } from "./workspace-properties-model";
-import { fullPath, type Workspace } from "./workspace-helpers";
+import {
+  isLinkedWorktreeGitEntry,
+  partitionWorkspaceFolders,
+  visiblePropertyPages,
+} from "./workspace-properties-model";
+import {
+  FrontTruncatedPath,
+  fullPath,
+  type Workspace,
+} from "./workspace-helpers";
 
 export interface WorkspacePropertiesModalProps {
   wsId: string;
   home: string;
   workspaces: WorkspaceService;
+  files: FileService;
   /** Opens the native folder picker; resolves to the chosen path or null. */
   onPickFolder: () => Promise<string | null>;
+  /** Open the Manage Worktrees modal for this workspace. */
+  onManageWorktrees: () => void;
 }
 
 interface GeneralTabProps {
   ws: Workspace;
   home: string;
   workspaces: WorkspaceService;
+  files: FileService;
   onPickFolder: () => Promise<string | null>;
+  onManageWorktrees: () => void;
 }
 
 const GENERAL_TAB_ID = "general";
@@ -47,7 +62,9 @@ export function WorkspacePropertiesModal({
   wsId,
   home,
   workspaces,
+  files,
   onPickFolder,
+  onManageWorktrees,
 }: WorkspacePropertiesModalProps) {
   const state = useServiceState(workspaces);
   const ws = state.all.find((w) => w.id === wsId);
@@ -103,7 +120,6 @@ export function WorkspacePropertiesModal({
             className={`ws-props-tab${effectiveTab === page.id ? " ws-props-tab-active" : ""}`}
             onClick={() => setActiveTab(page.id)}
           >
-            {page.icon}
             {page.title}
           </button>
         ))}
@@ -114,7 +130,9 @@ export function WorkspacePropertiesModal({
             ws={ws}
             home={home}
             workspaces={workspaces}
+            files={files}
             onPickFolder={onPickFolder}
+            onManageWorktrees={onManageWorktrees}
           />
         ) : (
           activePage && (
@@ -130,9 +148,62 @@ export function WorkspacePropertiesModal({
   );
 }
 
-function GeneralTab({ ws, home, workspaces, onPickFolder }: GeneralTabProps) {
+/**
+ * Classify which of `extras` are linked git worktrees by stating each
+ * folder's `.git` entry. Linked worktrees use a `.git` file; ordinary
+ * folders / the main worktree use a directory (or have no `.git`).
+ */
+function useLinkedWorktreeExtras(
+  extras: readonly string[],
+  files: FileService,
+): ReadonlySet<string> {
+  const [linked, setLinked] = useState<ReadonlySet<string>>(() => new Set());
+  // Stable key so reordering-identical lists don't re-stat.
+  const extrasKey = extras.join("\0");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (extras.length === 0) {
+      setLinked(new Set());
+      return;
+    }
+    void (async () => {
+      const next = new Set<string>();
+      await Promise.all(
+        extras.map(async (folder) => {
+          try {
+            const meta = await files.stat(path.join(folder, ".git"));
+            if (isLinkedWorktreeGitEntry(meta)) next.add(folder);
+          } catch {
+            // Permission / I/O errors — treat as ordinary folder.
+          }
+        }),
+      );
+      if (!cancelled) setLinked(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [extrasKey, extras, files]);
+
+  return linked;
+}
+
+function GeneralTab({
+  ws,
+  home,
+  workspaces,
+  files,
+  onPickFolder,
+  onManageWorktrees,
+}: GeneralTabProps) {
   const extraFolders = ws.extraFolders ?? [];
-  const allFolders = [ws.folder, ...extraFolders];
+  const linkedWorktrees = useLinkedWorktreeExtras(extraFolders, files);
+  const { folders, worktrees } = partitionWorkspaceFolders(
+    ws.folder,
+    extraFolders,
+    linkedWorktrees,
+  );
 
   async function addFolder() {
     const picked = await onPickFolder();
@@ -158,15 +229,16 @@ function GeneralTab({ ws, home, workspaces, onPickFolder }: GeneralTabProps) {
       <div className="ws-prop-section">
         <div className="ws-prop-label-row">
           <span className="ws-prop-label">Folders</span>
-          <span className="ws-prop-count">{allFolders.length}</span>
+          <span className="ws-prop-count">{folders.length}</span>
         </div>
         <div className="ws-folders-list">
-          {allFolders.map((folder, i) => (
+          {folders.map((folder, i) => (
             <div key={folder} className="ws-folder-list-item">
               <Tooltip content={folder}>
-                <span className="ws-folder-list-path" dir="ltr">
-                  {fullPath(folder, home)}
-                </span>
+                <FrontTruncatedPath
+                  className="ws-folder-list-path"
+                  text={fullPath(folder, home)}
+                />
               </Tooltip>
               {i === 0 ? (
                 <span className="ws-folder-primary-badge">primary</span>
@@ -187,6 +259,44 @@ function GeneralTab({ ws, home, workspaces, onPickFolder }: GeneralTabProps) {
         <button type="button" className="ws-prop-add" onClick={addFolder}>
           <FolderPlus size={14} weight="bold" />
           Add Folder…
+        </button>
+      </div>
+
+      <div className="ws-prop-section">
+        <div className="ws-prop-label-row">
+          <span className="ws-prop-label">Worktrees</span>
+          <span className="ws-prop-count">{worktrees.length}</span>
+        </div>
+        {worktrees.length > 0 && (
+          <div className="ws-folders-list">
+            {worktrees.map((folder) => (
+              <div key={folder} className="ws-folder-list-item">
+                <Tooltip content={folder}>
+                  <FrontTruncatedPath
+                    className="ws-folder-list-path"
+                    text={fullPath(folder, home)}
+                  />
+                </Tooltip>
+                <Tooltip content="Close worktree view">
+                  <button
+                    type="button"
+                    className="ws-folder-list-remove"
+                    onClick={() => removeFolder(folder)}
+                  >
+                    ×
+                  </button>
+                </Tooltip>
+              </div>
+            ))}
+          </div>
+        )}
+        <button
+          type="button"
+          className="ws-prop-add"
+          onClick={onManageWorktrees}
+        >
+          <GitBranch size={14} weight="bold" />
+          Manage Worktrees…
         </button>
       </div>
     </div>

--- a/packages/extensions-core/src/workspaces/WorkspacesPanel.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesPanel.css
@@ -241,45 +241,80 @@
   outline: none;
 }
 
-/* Workspace properties dialog — content layout inside the host <Modal> card
-   (which owns the backdrop/card chrome + width). */
+/* Workspace properties dialog — fixed-height card (via ModalOptions.className)
+   so the tab pane scrolls instead of the modal growing with content. */
+.ws-props-dialog {
+  height: 600px;
+}
+
 .ws-props-modal {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 0;
+  flex: 1;
+  min-height: 0;
 }
 
-/* Tab bar — segmented-control look, matching .ext-tabs (ExtensionsPage.css):
-   a recessed well with the active tab reading as a raised button. Always
-   rendered, even with only the built-in General tab (RFC 0015 decision). */
+/* Tab bar — folder-tab look (same pattern as System Monitor's .sms-tabs):
+   recessed tray with the active tab raised over the tray's bottom edge. */
 .ws-props-tabs {
   display: flex;
-  gap: 2px;
-  background: var(--silo-color-content-bg);
-  border-radius: var(--silo-radius-sm);
-  padding: 2px;
+  flex-shrink: 0;
+  gap: 4px;
+  padding: 6px 0 0 8px;
+  background: var(--silo-color-input-bg);
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm) var(--silo-radius-sm) 0 0;
 }
 
 .ws-props-tab {
+  appearance: none;
   display: flex;
   align-items: center;
   gap: 6px;
   background: transparent;
-  border: none;
-  color: var(--silo-color-text-lo);
-  padding: 4px 10px;
-  border-radius: var(--silo-radius-sm);
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: var(--silo-radius-sm) var(--silo-radius-sm) 0 0;
+  color: var(--silo-color-text);
+  padding: 5px 10px;
+  margin-bottom: -1px;
   cursor: pointer;
   font: inherit;
   font-size: var(--silo-font-size-sm);
+  white-space: nowrap;
+  position: relative;
+  z-index: 1;
+}
+
+.ws-props-tabs .ws-props-tab:hover {
+  background: color-mix(
+    in srgb,
+    var(--silo-color-text) 10%,
+    var(--silo-color-input-bg)
+  );
+}
+
+.ws-props-tabs .ws-props-tab-active:hover {
+  background: var(--silo-color-bg);
 }
 
 .ws-props-tab-active {
-  background: var(--silo-button-bg);
+  background: var(--silo-color-bg);
+  border-color: var(--silo-color-border);
   color: var(--silo-color-text-hi);
+  font-weight: 500;
 }
 
 .ws-props-tab-content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--silo-color-bg);
+  border: 1px solid var(--silo-color-border);
+  border-top: none;
+  border-radius: 0 0 var(--silo-radius-sm) var(--silo-radius-sm);
+  padding: 24px 12px 12px 6px;
   animation: ws-props-in 140ms ease-out;
 }
 
@@ -445,22 +480,22 @@
   border-radius: var(--silo-radius-sm);
 }
 
-/* The Tooltip host wraps ws-folder-list-path and must inherit flex growth. */
-.ws-folder-list-item > .silo-tooltip-host {
+/* Only the path's Tooltip host grows — the ×/badge hosts must stay intrinsic
+   or they steal half the row (flex:1 on every direct .silo-tooltip-host). */
+.ws-folder-list-item > .silo-tooltip-host:has(.ws-folder-list-path) {
   flex: 1;
   min-width: 0;
+  display: block;
 }
 
 .ws-folder-list-path {
-  flex: 1;
+  display: block;
+  width: 100%;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--silo-font-size-sm);
   color: var(--silo-color-text);
-  direction: rtl;
-  text-align: left;
 }
 
 .ws-folder-primary-badge {

--- a/packages/extensions-core/src/workspaces/workspace-properties-model.test.ts
+++ b/packages/extensions-core/src/workspaces/workspace-properties-model.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
+  isLinkedWorktreeGitEntry,
+  partitionWorkspaceFolders,
   validateWorkspaceName,
   visiblePropertyPages,
 } from "./workspace-properties-model";
@@ -79,5 +81,58 @@ describe("visiblePropertyPages", () => {
       "show1",
       "show2",
     ]);
+  });
+});
+
+describe("isLinkedWorktreeGitEntry", () => {
+  it("is true when .git exists and is a file", () => {
+    expect(isLinkedWorktreeGitEntry({ isDir: false })).toBe(true);
+  });
+
+  it("is false when .git is a directory (main worktree / ordinary repo)", () => {
+    expect(isLinkedWorktreeGitEntry({ isDir: true })).toBe(false);
+  });
+
+  it("is false when .git is missing", () => {
+    expect(isLinkedWorktreeGitEntry(null)).toBe(false);
+  });
+});
+
+describe("partitionWorkspaceFolders", () => {
+  it("keeps primary in folders and leaves unmarked extras there", () => {
+    expect(
+      partitionWorkspaceFolders("/repo", ["/docs", "/assets"], new Set()),
+    ).toEqual({
+      folders: ["/repo", "/docs", "/assets"],
+      worktrees: [],
+    });
+  });
+
+  it("moves linked-worktree extras into worktrees, preserving order", () => {
+    expect(
+      partitionWorkspaceFolders(
+        "/repo",
+        ["/docs", "/repo-feat", "/assets", "/repo-fix"],
+        new Set(["/repo-feat", "/repo-fix"]),
+      ),
+    ).toEqual({
+      folders: ["/repo", "/docs", "/assets"],
+      worktrees: ["/repo-feat", "/repo-fix"],
+    });
+  });
+
+  it("never classifies the primary as a worktree row", () => {
+    // Even if the primary path appears in the linked set (e.g. the workspace
+    // itself is a linked worktree), it stays under Folders as primary.
+    expect(
+      partitionWorkspaceFolders(
+        "/repo-feat",
+        ["/other"],
+        new Set(["/repo-feat"]),
+      ),
+    ).toEqual({
+      folders: ["/repo-feat", "/other"],
+      worktrees: [],
+    });
   });
 });

--- a/packages/extensions-core/src/workspaces/workspace-properties-model.ts
+++ b/packages/extensions-core/src/workspaces/workspace-properties-model.ts
@@ -25,3 +25,43 @@ export function visiblePropertyPages(
 ): WorkspacePropertyPage[] {
   return pages.filter((p) => p.visible?.(ws) ?? true);
 }
+
+/**
+ * Whether a `.git` entry marks a **linked** git worktree. Linked worktrees
+ * store a `.git` *file* (pointing at the main repo's `worktrees/` dir); the
+ * main worktree and ordinary repos use a `.git` *directory*. Absent → not a
+ * linked worktree.
+ */
+export function isLinkedWorktreeGitEntry(
+  meta: { isDir: boolean } | null,
+): boolean {
+  return meta != null && !meta.isDir;
+}
+
+/** Primary + extras split into ordinary folders vs linked-worktree extras. */
+export interface PartitionedFolders {
+  /** Primary first, then extras that are not linked worktrees. */
+  folders: string[];
+  /** Extras whose `.git` is a file (opened alongside via the worktree manager). */
+  worktrees: string[];
+}
+
+/**
+ * Split a workspace's folder list for the properties modal: the primary root
+ * always stays under Folders; extras known to be linked worktrees move to a
+ * separate Worktrees section so multi-root folders and opened worktrees don't
+ * look like the same thing.
+ */
+export function partitionWorkspaceFolders(
+  primary: string,
+  extras: readonly string[],
+  linkedWorktrees: ReadonlySet<string>,
+): PartitionedFolders {
+  const folders = [primary];
+  const worktrees: string[] = [];
+  for (const folder of extras) {
+    if (linkedWorktrees.has(folder)) worktrees.push(folder);
+    else folders.push(folder);
+  }
+  return { folders, worktrees };
+}

--- a/packages/extensions-core/src/workspaces/workspace-properties.tsx
+++ b/packages/extensions-core/src/workspaces/workspace-properties.tsx
@@ -28,9 +28,20 @@ export async function openWorkspaceProperties(
         wsId={ws.id}
         home={home}
         workspaces={ctx.workspaces}
+        files={ctx.files}
         onPickFolder={() => ctx.ui.pickFolder()}
+        onManageWorktrees={() => {
+          void ctx.executeCommand("silo.git.manageWorktrees", {
+            workspaceId: ws.id,
+          });
+        }}
       />
     ),
-    { title: "Workspace Properties", size: "md", dismissible: true },
+    {
+      title: "Workspace Properties",
+      size: "lg",
+      dismissible: true,
+      className: "ws-props-dialog",
+    },
   );
 }

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -30,8 +30,9 @@
   background: transparent;
   border: none;
   font-family: var(--silo-font-ui);
-  font-size: 14px;
-  font-weight: 600;
+  /* Match .tree-row.root (file explorer): panel em minus 2px, weight 700. */
+  font-size: calc(1em - 2px);
+  font-weight: 700;
   color: var(--silo-color-text-hi);
   letter-spacing: 0.04em;
   cursor: pointer;
@@ -91,7 +92,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 400;
-  font-size: 13px;
+  /* Absolute — don't inherit the root label's size/weight/tracking. */
+  font-size: var(--silo-font-size-base);
   color: var(--silo-color-text);
   letter-spacing: 0;
 }

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -22,8 +22,8 @@ import { ICON_CHECK, ICON_PLUS, ICON_MINUS, ICON_UNDO } from "./git-icons";
 import { summarizeGitError } from "./notify-error";
 import { GitErrorModal } from "./GitErrorModal";
 import { BranchManager } from "./BranchManager";
-import { WorktreeManager } from "./WorktreeManager";
 import { findWorktreeFor } from "./worktree-model";
+import { showWorktreeManager } from "./open-worktree-manager";
 
 const REFRESH_DEBOUNCE_MS = 400;
 // How often the panel fetches in the background so ↑ahead/↓behind stay roughly
@@ -533,18 +533,11 @@ export function GitView({
   // parameterized by `folder`, so a multi-root workspace gets an independent
   // manager per repo.
   function openWorktreeManager() {
-    ctx.ui.showModal(
-      () => (
-        <WorktreeManager
-          ctx={ctx}
-          folder={folder}
-          workspaceId={workspaceId}
-          onChanged={refresh}
-          notifyError={notifyError}
-        />
-      ),
-      { title: "Worktrees", size: "md", dismissible: true },
-    );
+    showWorktreeManager(ctx, {
+      folder,
+      workspaceId,
+      onChanged: refresh,
+    });
   }
 
   // Remove the worktree this view is rooted in. Runs `git worktree remove`

--- a/packages/extensions-silo/src/git-explorer/index.tsx
+++ b/packages/extensions-silo/src/git-explorer/index.tsx
@@ -2,6 +2,12 @@ import type { Extension } from "@silo-code/sdk";
 import type { GitAPI } from "../git/git-api";
 import { GitExplorerPanel } from "./GitExplorerPanel";
 import { setGitApiResolver } from "./git-runtime";
+import {
+  MANAGE_WORKTREES_COMMAND,
+  resolveManageWorktreesTarget,
+  showWorktreeManager,
+  type ManageWorktreesArgs,
+} from "./open-worktree-manager";
 
 // `silo.git-explorer` — the git panel (view). Consumes the `silo.git` provider's
 // GitAPI via getExtension; resolves it at use time so the provider can activate
@@ -26,6 +32,21 @@ export const extension: Extension = {
       ),
       order: 2,
       lazyMount: true,
+    });
+
+    // Workspace properties (and anything else) open the same Worktrees modal
+    // the Git panel menu uses — one implementation, two entry points.
+    ctx.registerCommand({
+      id: MANAGE_WORKTREES_COMMAND,
+      label: "Manage Worktrees…",
+      run: (arg?: unknown) => {
+        const target = resolveManageWorktreesTarget(
+          ctx.workspaces.getState(),
+          arg as ManageWorktreesArgs | undefined,
+        );
+        if (!target) return;
+        showWorktreeManager(ctx, target);
+      },
     });
   },
 };

--- a/packages/extensions-silo/src/git-explorer/open-worktree-manager.test.ts
+++ b/packages/extensions-silo/src/git-explorer/open-worktree-manager.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { resolveManageWorktreesTarget } from "./open-worktree-manager";
+
+const state = {
+  activeId: "a",
+  all: [
+    { id: "a", folder: "/repo-a" },
+    { id: "b", folder: "/repo-b" },
+  ],
+};
+
+describe("resolveManageWorktreesTarget", () => {
+  it("defaults to the active workspace's primary folder", () => {
+    expect(resolveManageWorktreesTarget(state)).toEqual({
+      workspaceId: "a",
+      folder: "/repo-a",
+    });
+  });
+
+  it("honors an explicit workspaceId", () => {
+    expect(resolveManageWorktreesTarget(state, { workspaceId: "b" })).toEqual({
+      workspaceId: "b",
+      folder: "/repo-b",
+    });
+  });
+
+  it("honors an explicit folder override", () => {
+    expect(
+      resolveManageWorktreesTarget(state, {
+        workspaceId: "a",
+        folder: "/repo-a-feat",
+      }),
+    ).toEqual({
+      workspaceId: "a",
+      folder: "/repo-a-feat",
+    });
+  });
+
+  it("returns null when the workspace is missing", () => {
+    expect(
+      resolveManageWorktreesTarget(state, { workspaceId: "missing" }),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no active workspace", () => {
+    expect(
+      resolveManageWorktreesTarget({ activeId: null, all: state.all }),
+    ).toBeNull();
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/open-worktree-manager.tsx
+++ b/packages/extensions-silo/src/git-explorer/open-worktree-manager.tsx
@@ -1,0 +1,80 @@
+import type { ExtensionContext, NotifyOptions } from "@silo-code/sdk";
+import { GitErrorModal } from "./GitErrorModal";
+import { summarizeGitError } from "./notify-error";
+import { WorktreeManager } from "./WorktreeManager";
+
+/** Command id — opened from the Git panel menu and workspace properties. */
+export const MANAGE_WORKTREES_COMMAND = "silo.git.manageWorktrees";
+
+export interface ManageWorktreesArgs {
+  /** Workspace whose folders the manager opens against. Defaults to active. */
+  workspaceId?: string;
+  /**
+   * Repo working directory to list worktrees for. Defaults to the workspace's
+   * primary folder.
+   */
+  folder?: string;
+}
+
+/**
+ * Open the host-owned Worktrees modal for a repo folder. Shared by the Git
+ * panel menu and the `silo.git.manageWorktrees` command (workspace properties).
+ */
+export function showWorktreeManager(
+  ctx: ExtensionContext,
+  opts: {
+    folder: string;
+    workspaceId: string;
+    /** Called after create/remove so a live Git view can re-read status. */
+    onChanged?: () => void;
+  },
+): void {
+  const notifyError = (title: string, err: unknown) => {
+    const { detail, summary, hasMore } = summarizeGitError(err, title);
+    const options: NotifyOptions = { title };
+    if (hasMore) {
+      options.actions = [
+        {
+          label: "View details",
+          run: () =>
+            ctx.ui.showModal(
+              (close) => <GitErrorModal detail={detail} onClose={close} />,
+              { title, dismissible: true, size: "lg" },
+            ),
+        },
+      ];
+    }
+    ctx.ui.notify("error", summary, options);
+  };
+
+  ctx.ui.showModal(
+    () => (
+      <WorktreeManager
+        ctx={ctx}
+        folder={opts.folder}
+        workspaceId={opts.workspaceId}
+        onChanged={opts.onChanged ?? (() => {})}
+        notifyError={notifyError}
+      />
+    ),
+    { title: "Worktrees", size: "md", dismissible: true },
+  );
+}
+
+/**
+ * Resolve which workspace + folder a manage-worktrees invocation should open.
+ * Returns `null` when no matching workspace exists.
+ */
+export function resolveManageWorktreesTarget(
+  state: {
+    activeId: string | null;
+    all: readonly { id: string; folder: string }[];
+  },
+  args?: ManageWorktreesArgs,
+): { workspaceId: string; folder: string } | null {
+  const ws = args?.workspaceId
+    ? state.all.find((w) => w.id === args.workspaceId)
+    : state.all.find((w) => w.id === state.activeId);
+  if (!ws) return null;
+  return { workspaceId: ws.id, folder: args?.folder ?? ws.folder };
+}


### PR DESCRIPTION
## Summary
- Fixed-height (600px) workspace properties modal with scrollable tab content, wider `lg` size, and System Monitor–style folder tabs
- Split linked worktrees out of Folders into their own section, with **Manage Worktrees…** opening the shared git worktree manager
- Bump modal/settings reading size by +1px; match git multi-root repo labels to the file explorer root style

## Test plan
- [ ] Open Workspace Properties — modal is 600px tall / 800px wide; long tab content scrolls
- [ ] With a linked worktree open alongside, confirm it appears under Worktrees (not Folders) and × closes the view
- [ ] **Manage Worktrees…** opens the same Worktrees modal as the Git panel menu
- [ ] Tab chrome matches folder-tab look; titles only (no extension icons)
- [ ] Confirm/prompt/other modals and Settings read at base+1px
- [ ] Git panel multi-root header matches Files panel root weight/size


Made with [Cursor](https://cursor.com)