### PR TITLE
docs: adr 0025 pending remove worktree and glossary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,16 @@
 # Silo — project guide for Claude
 
-Silo is a local-first, terminal-first code editor (Tauri + React + TypeScript)
-built to **run many workspaces at once and switch between them instantly without
-losing state** — each workspace keeps its terminals, panels, and layout alive in
-the background. The workflow it optimizes for is driving coding agents and shells
-in the foreground, with file editing as a secondary surface (the inverse of
-VS Code). It's also **extensible**: modeled on VS Code / Obsidian with a small
-stable core, a public extension SDK, and first-party features built as
-extensions. It is going **100% open source**, so the bar for boundaries,
-documentation, and a clean public surface is high.
+Silo keeps **all your projects alive at once** — for developers juggling coding
+agents (Tauri + React + TypeScript). Open many workspaces and switch instantly;
+each keeps its terminals, agents, panels, and layout intact in the background.
+**100% open source**, free forever. **Extensible**: modeled on VS Code / Obsidian
+with a small stable core, a public extension SDK, and first-party features built
+as extensions — so the bar for boundaries, documentation, and a clean public
+surface is high.
+
+Product positioning for humans lives in `README.md` / `apps/docs/index.md` /
+`context7.json`. Prefer those over inventing a tagline. This file is agent
+orientation (architecture, boundaries, commands), not marketing copy.
 
 Orientation docs (read when relevant):
 
@@ -91,9 +93,9 @@ the invariant #4 burn-down _and_ the docs site growing. They are the same act.
 `apps/docs` is indexed by [Context7](https://context7.com) (library ID
 `/silo-code/silo`) so coding agents can pull Silo's docs directly. What gets
 indexed and how the project is described there is controlled by the root
-`context7.json` — keep its `description` in sync with the current positioning
-in `README.md` / `apps/docs/index.md` (not the architecture description at the
-top of this file, which is written for Claude, not Context7's audience). The
+`context7.json` — keep its `description` in sync with `README.md` /
+`apps/docs/index.md`, and keep this file's opening + `CONTEXT.md` aligned with
+that same positioning (do not reintroduce older taglines). The
 `context7-refresh` job in `.github/workflows/docs.yml` re-triggers indexing on
 every push to `main`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,47 @@
+# Silo
+
+All your projects, alive at once — for developers juggling coding agents.
+Workspaces keep terminals, agents, and layout intact; switch instantly.
+100% open source. Extensible via a public SDK.
+
+## Language
+
+### Worktrees
+
+**Worktree**:
+A git working tree of a repository — the main checkout or a linked one on
+another branch — that Silo can open as a workspace folder.
+_Avoid_: Clone (a separate repo copy), branch (the ref, not the directory)
+
+**Main worktree**:
+The primary working tree of the repository (git's main checkout). It cannot be
+removed from Silo.
+_Avoid_: Root worktree, primary worktree (prefer "main" to match git)
+
+**Linked worktree**:
+A non-main worktree of the same repository, typically on another branch.
+_Avoid_: Secondary worktree, extra worktree
+
+**Open alongside**:
+Add a worktree's path as another folder in the current workspace so Files, Git,
+and terminals see it next to existing folders — without switching workspaces.
+_Avoid_: Open, attach, mount
+
+**Close view**:
+Remove a worktree's folder from the workspace only. The worktree and its branch
+stay on disk.
+_Avoid_: Close worktree (ambiguous with Remove), detach, unload
+
+**Remove worktree**:
+Delete a linked worktree's directory and git bookkeeping; the branch itself is
+kept. Irreversible for uncommitted work when force-confirmed.
+_Avoid_: Delete worktree, destroy worktree
+
+**Prune stale**:
+Clear git bookkeeping for worktrees whose directories are already gone.
+_Avoid_: Clean, garbage-collect worktrees
+
+**Pending remove**:
+A Remove worktree that has passed every confirm and is still deleting on disk.
+The workspace folder is already closed; the operation is not cancelable.
+_Avoid_: Background delete, queued delete

--- a/docs/decisions/0025-pending-remove-worktree.md
+++ b/docs/decisions/0025-pending-remove-worktree.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+date: 2026-07-17
+---
+
+# 0025. Pending remove for worktrees — close folder on start, StatusBar until done
+
+## Context
+
+Removing a linked git worktree runs `git worktree remove`, which can take a long
+time on a large tree. After the user confirms, Silo previously awaited the
+command with almost no feedback (a modal `busy` flag that only disabled Create /
+Prune). Users could not tell whether remove had started, and dismissing the
+worktree manager gave no lasting signal.
+
+A host `ctx.ui.progress` primitive is still planned ([RFC 0001](../proposals/0001-ctx-ui-slice-2.md))
+but is not required for this first-party flow. The grilled product contract
+(2026-07-17) pins Remove-worktree behavior without waiting on that RFC.
+
+## Decision
+
+**Remove worktree** (manager trash / row menu, and Git view ⋯ → Remove worktree…)
+uses a **pending remove** after every confirm (including force-remove) completes:
+
+1. Mark the worktree path as pending in an **extension-scoped** set that
+   outlives the manager modal.
+2. If that path is open as a workspace folder, **close the folder immediately**
+   (condemned checkout — do not leave Files/Git rooted on a directory git is
+   deleting).
+3. Show per-row **Removing…** in the manager when it is open; other rows stay
+   usable. Concurrent pending removes are allowed.
+4. Show a single aggregated, **informational** StatusBar item until the set is
+   empty (not clickable, not cancelable).
+5. On success: clear pending; toast only if the manager was dismissed. On
+   failure: clear pending, error toast, leave the folder closed; the user can
+   Open alongside again from the manager.
+
+Create and prune are out of scope for this pattern until a second consumer
+justifies generalizing (or `ctx.ui.progress` lands).
+
+## Consequences
+
+- Users get honest progress whether they wait in the modal or dismiss it.
+- Close-on-start can leave a worktree on disk with no open folder if remove
+  fails — recovered via Open alongside, not auto-reopen.
+- Aborting `git worktree remove` mid-flight is unsupported (half-deleted trees /
+  prunable bookkeeping).
+- Does **not** ship `ctx.ui.progress`; git-explorer owns the StatusItem. A later
+  second consumer may motivate RFC 0001 instead of more one-off StatusItems.
+
+## Alternatives considered
+
+- **Wait for `ctx.ui.progress` (RFC 0001)** — deferred: this bug does not need a
+  new public primitive.
+- **Close folder only after disk remove succeeds** — rejected: long zombie open
+  folder against a dying tree.
+- **Auto-re-add the folder on failure** — rejected: surprising if the user has
+  moved on.
+- **Cancelable remove** — rejected: killing git mid-remove is unsafe without a
+  dedicated cleanup path.
+- **Block dismiss while removing** — rejected: contradicts wait-or-dismiss.
+
+## References
+
+- Glossary: `CONTEXT.md` (Remove worktree, Pending remove, Close view).
+- Related: [0018](./0018-host-owned-chrome.md) (host chrome; progress still planned).
+- Deferred: [RFC 0001](../proposals/0001-ctx-ui-slice-2.md) (`ctx.ui.progress`).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -58,3 +58,5 @@ A small, obvious choice needs neither.
 | [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model    | 2026-06-08 | accepted |
 | [0022](./0022-on-disk-storage-layout.md)                | On-disk storage layout: config / app-state / runtime | 2026-06-10 | accepted |
 | [0023](./0023-workspace-groups-host-internal.md)        | Workspace panel groups are host-internal             | 2026-06-30 | accepted |
+| [0024](./0024-release-channels.md)                      | Two release channels: stable and nightly             | 2026-07-01 | accepted |
+| [0025](./0025-pending-remove-worktree.md)               | Pending remove worktree: close folder on start       | 2026-07-17 | accepted |


### PR DESCRIPTION
## Summary
- Adds ADR 0025 for the grilled Remove-worktree UX (pending remove, close folder on start, StatusBar until done).
- Adds `CONTEXT.md` glossary for worktree language and aligns `CLAUDE.md` product positioning with README/docs.
- Restores the missing ADR 0024 row in the decisions index.

## Test plan
- [ ] Skim ADR 0025 against the agreed grill decisions
- [ ] Confirm `CONTEXT.md` / `CLAUDE.md` tagline matches README positioning
- [ ] No `examples/modals/` (or other screenshot) changes in this PR


Made with [Cursor](https://cursor.com)