### PR TITLE
feat(git-explorer): pending remove feedback for worktrees

### DIFF
--- a/apps/docs/guide/panels.md
+++ b/apps/docs/guide/panels.md
@@ -46,9 +46,12 @@ on disk. From there you can:
   place a worktree _inside_ the repo, add its directory to `.gitignore` so the
   main view's status doesn't fill with its files.)
 - **Remove a worktree** — deletes its directory but keeps the branch. A
-  worktree with uncommitted changes asks for a force-remove first. **Prune
-  stale** clears bookkeeping for worktrees whose directories were deleted
-  manually.
+  worktree with uncommitted changes asks for a force-remove first. While the
+  directory is deleting (large trees can take a while), the manager row shows
+  **removing…**, a StatusBar item tracks progress, and you can dismiss the
+  manager — the remove keeps running. An open folder for that worktree closes
+  as soon as remove starts. **Prune stale** clears bookkeeping for worktrees
+  whose directories were deleted manually.
 
 A Git view whose root is a linked worktree shows a small **worktree** pill next
 to its branch name, and its ⋯ menu gains **Close worktree view** and

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -894,6 +894,21 @@
   background: transparent;
 }
 
+.git-wt-removing {
+  opacity: 0.75;
+  cursor: default;
+}
+
+.git-wt-removing:hover {
+  background: transparent;
+}
+
+.git-pending-remove-status {
+  padding: 0 8px;
+  color: var(--silo-color-text-lo);
+  white-space: nowrap;
+}
+
 /* The row action icons (prune/remove) sit a touch darker than the branch
  * manager's resting `--silo-color-text-lo` so the single trash reads clearly
  * in the two-line row. */

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -904,9 +904,22 @@
 }
 
 .git-pending-remove-status {
-  padding: 0 8px;
-  color: var(--silo-color-text-lo);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  /* Inherit status-bar font-size + --silo-statusbar-text (SDK StatusItem contract). */
+  font: inherit;
+  color: inherit;
   white-space: nowrap;
+  pointer-events: none;
+}
+
+.git-pending-remove-spin {
+  flex-shrink: 0;
+  opacity: 0.85;
+  -webkit-animation: branch-spin 0.8s linear infinite;
+  animation: branch-spin 0.8s linear infinite;
 }
 
 /* The row action icons (prune/remove) sit a touch darker than the branch

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -24,6 +24,7 @@ import { GitErrorModal } from "./GitErrorModal";
 import { BranchManager } from "./BranchManager";
 import { findWorktreeFor } from "./worktree-model";
 import { showWorktreeManager } from "./open-worktree-manager";
+import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
 
 const REFRESH_DEBOUNCE_MS = 400;
 // How often the panel fetches in the background so ↑ahead/↓behind stay roughly
@@ -543,40 +544,21 @@ export function GitView({
   // Remove the worktree this view is rooted in. Runs `git worktree remove`
   // from the main worktree (git refuses to remove the worktree it's run in),
   // then closes this view's root. Dirty trees get a force-remove confirm.
+  // Pending-remove UX (StatusBar + close-on-start) lives in confirmAndRemoveWorktree.
   async function removeThisWorktree() {
     const api = getGitApi();
     if (!api) return;
-    const name = folder.split("/").filter(Boolean).pop() ?? folder;
     const mainPath = worktrees?.find((w) => w.isMain)?.path ?? folder;
-    const ok = await ctx.ui.confirm({
-      title: `Remove worktree "${name}"?`,
-      body: `Deletes the directory at ${folder}. The branch itself is kept.`,
-      confirmLabel: "Remove",
-      danger: true,
+    await confirmAndRemoveWorktree({
+      ctx,
+      api,
+      cwd: mainPath,
+      worktreePath: folder,
+      workspaceId,
+      isOpen: true,
+      notifyError,
+      onSuccess: refresh,
     });
-    if (!ok) return;
-    try {
-      try {
-        await api.removeWorktree(mainPath, folder);
-      } catch (err) {
-        if (
-          !/contains modified or untracked files|use --force/i.test(String(err))
-        ) {
-          throw err;
-        }
-        const force = await ctx.ui.confirm({
-          title: `"${name}" has uncommitted changes`,
-          body: "Force-remove the worktree and discard them? This can't be undone.",
-          confirmLabel: "Force Remove",
-          danger: true,
-        });
-        if (!force) return;
-        await api.removeWorktree(mainPath, folder, true);
-      }
-      ctx.workspaces.removeFolder(workspaceId, folder);
-    } catch (err) {
-      notifyError(`Remove "${name}" failed`, err);
-    }
   }
 
   async function commit() {

--- a/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   ArrowsClockwise,
   Broom,
@@ -16,6 +22,12 @@ import {
 } from "@silo-code/sdk";
 import type { GitWorktree } from "../git/git-api";
 import { getGitApi } from "./git-runtime";
+import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
+import {
+  getPendingWorktreeRemoves,
+  isWorktreeRemovePending,
+  subscribePendingWorktreeRemoves,
+} from "./pending-worktree-remove";
 import {
   branchesInUse,
   buildWorktreeRows,
@@ -54,6 +66,13 @@ export function WorktreeManager({
 }: WorktreeManagerProps) {
   const [worktrees, setWorktrees] = useState<GitWorktree[] | null>(null);
   const [busy, setBusy] = useState(false);
+  // Pending removes outlive this modal — subscribe so rows flip to Removing…
+  // if the user dismissed and reopened mid-delete.
+  useSyncExternalStore(
+    subscribePendingWorktreeRemoves,
+    getPendingWorktreeRemoves,
+    getPendingWorktreeRemoves,
+  );
 
   // Live workspace state so rows flip to "open" immediately after addFolder.
   const wsState = useServiceState(ctx.workspaces);
@@ -109,24 +128,29 @@ export function WorktreeManager({
     return a;
   }
 
+  function rowPending(row: WorktreeRow): boolean {
+    return isWorktreeRemovePending(row.wt.path);
+  }
+
   // Open alongside: the worktree becomes another workspace folder, so File
   // Explorer and the Git panel grow an extra root. The scope roots follow the
   // folder list, so files/terminals in the worktree work immediately.
   async function open(row: WorktreeRow) {
-    if (busy) return;
+    if (busy || rowPending(row)) return;
     ctx.workspaces.addFolder(workspaceId, row.wt.path);
     ctx.ui.notify("info", `Opened ${path.basename(row.wt.path)} alongside`);
   }
 
   // Close the view only — the worktree itself is untouched.
   function closeView(row: WorktreeRow) {
+    if (rowPending(row)) return;
     ctx.workspaces.removeFolder(workspaceId, row.wt.path);
   }
 
   // Clicking a row toggles its view: open it alongside if closed, close it if
   // open. The primary folder and stale (prune-only) rows toggle nothing.
   function toggleView(row: WorktreeRow) {
-    const acts = worktreeActions(row);
+    const acts = worktreeActions(row, rowPending(row));
     if (acts.includes("open")) void open(row);
     else if (acts.includes("close")) closeView(row);
   }
@@ -134,7 +158,8 @@ export function WorktreeManager({
   // Hover hint for a row, standing in for the removed open/close icons: what a
   // click will do, or the path for a row that can't be toggled.
   function toggleHint(row: WorktreeRow): string {
-    const acts = worktreeActions(row);
+    if (rowPending(row)) return "Removing this worktree…";
+    const acts = worktreeActions(row, false);
     if (acts.includes("open")) return "Open alongside your current folders";
     if (acts.includes("close"))
       return "Close this view (the worktree stays on disk)";
@@ -190,43 +215,20 @@ export function WorktreeManager({
 
   async function remove(row: WorktreeRow) {
     const a = api();
-    if (!a || busy) return;
-    const name = path.basename(row.wt.path);
-    const ok = await ctx.ui.confirm({
-      title: `Remove worktree "${name}"?`,
-      body: `Deletes the directory at ${row.wt.path}. The branch itself is kept.`,
-      confirmLabel: "Remove",
-      danger: true,
+    if (!a || busy || rowPending(row)) return;
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: a,
+      cwd: folder,
+      worktreePath: row.wt.path,
+      workspaceId,
+      isOpen: row.isOpen,
+      notifyError,
+      onSuccess: () => {
+        void reload();
+        onChanged();
+      },
     });
-    if (!ok) return;
-    setBusy(true);
-    try {
-      try {
-        await a.removeWorktree(folder, row.wt.path);
-      } catch (err) {
-        // Dirty worktree: git refuses without --force. Confirm the discard.
-        if (
-          !/contains modified or untracked files|use --force/i.test(String(err))
-        ) {
-          throw err;
-        }
-        const force = await ctx.ui.confirm({
-          title: `"${name}" has uncommitted changes`,
-          body: "Force-remove the worktree and discard them? This can't be undone.",
-          confirmLabel: "Force Remove",
-          danger: true,
-        });
-        if (!force) return;
-        await a.removeWorktree(folder, row.wt.path, true);
-      }
-      if (row.isOpen) ctx.workspaces.removeFolder(workspaceId, row.wt.path);
-      await reload();
-      onChanged();
-    } catch (err) {
-      notifyError(`Remove "${name}" failed`, err);
-    } finally {
-      setBusy(false);
-    }
   }
 
   async function prune() {
@@ -254,7 +256,7 @@ export function WorktreeManager({
   // key / Shift+F10 via the focus group, or right-click), mirroring the hover
   // buttons.
   function rowMenuItems(row: WorktreeRow): MenuEntry[] {
-    const acts = worktreeActions(row);
+    const acts = worktreeActions(row, rowPending(row));
     const items: MenuEntry[] = [];
     if (acts.includes("open")) {
       items.push({ label: "Open alongside", run: () => void open(row) });
@@ -287,6 +289,10 @@ export function WorktreeManager({
 
   function rowBadges(row: WorktreeRow) {
     const badges: { label: string; tooltip?: string; warn?: boolean }[] = [];
+    if (rowPending(row)) {
+      badges.push({ label: "removing…" });
+      return badges;
+    }
     if (row.wt.isMain) badges.push({ label: "main" });
     if (row.isCurrent) badges.push({ label: "this view" });
     else if (row.isOpen) badges.push({ label: "open" });
@@ -320,12 +326,14 @@ export function WorktreeManager({
           <div className="git-branch-empty">No worktrees.</div>
         )}
         {rows.map((row, i) => {
-          const acts = worktreeActions(row);
-          const toggleable = acts.includes("open") || acts.includes("close");
+          const pending = rowPending(row);
+          const acts = worktreeActions(row, pending);
+          const toggleable =
+            !pending && (acts.includes("open") || acts.includes("close"));
           return (
             <div
               key={row.wt.path}
-              className={`git-branch-row git-wt-row${row.isOpen ? " git-wt-open" : ""}${toggleable ? "" : " git-wt-static"}`}
+              className={`git-branch-row git-wt-row${row.isOpen && !pending ? " git-wt-open" : ""}${toggleable ? "" : " git-wt-static"}${pending ? " git-wt-removing" : ""}`}
               role="button"
               onClick={() => toggleView(row)}
               onContextMenu={(e) => {
@@ -339,7 +347,11 @@ export function WorktreeManager({
               {...list.getItemProps(i)}
             >
               <span className="git-branch-glyph">
-                <FolderSimple size={15} />
+                {pending ? (
+                  <ArrowsClockwise size={15} className="git-branch-spin" />
+                ) : (
+                  <FolderSimple size={15} />
+                )}
               </span>
               <span className="git-wt-text">
                 <span className="git-wt-title">

--- a/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
@@ -27,6 +27,7 @@ import {
   getPendingWorktreeRemoves,
   isWorktreeRemovePending,
   subscribePendingWorktreeRemoves,
+  subscribeWorktreeListDirty,
 } from "./pending-worktree-remove";
 import {
   branchesInUse,
@@ -100,6 +101,19 @@ export function WorktreeManager({
     void reload();
   }, [reload]);
 
+  // Reload when a remove succeeds from any entry point (e.g. Git view ⋯ while
+  // this modal stays open). Unsubscribe on unmount / reload identity change.
+  useEffect(() => {
+    let active = true;
+    const unsubscribe = subscribeWorktreeListDirty(() => {
+      if (active) void reload();
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [reload]);
+
   const rows = useMemo(
     () => buildWorktreeRows(worktrees ?? [], folder, wsFolder, allFolders),
     [worktrees, folder, wsFolder, allFolders],
@@ -128,29 +142,25 @@ export function WorktreeManager({
     return a;
   }
 
-  function rowPending(row: WorktreeRow): boolean {
-    return isWorktreeRemovePending(row.wt.path);
-  }
-
   // Open alongside: the worktree becomes another workspace folder, so File
   // Explorer and the Git panel grow an extra root. The scope roots follow the
   // folder list, so files/terminals in the worktree work immediately.
   async function open(row: WorktreeRow) {
-    if (busy || rowPending(row)) return;
+    if (busy || isWorktreeRemovePending(row.wt.path)) return;
     ctx.workspaces.addFolder(workspaceId, row.wt.path);
     ctx.ui.notify("info", `Opened ${path.basename(row.wt.path)} alongside`);
   }
 
   // Close the view only — the worktree itself is untouched.
   function closeView(row: WorktreeRow) {
-    if (rowPending(row)) return;
+    if (isWorktreeRemovePending(row.wt.path)) return;
     ctx.workspaces.removeFolder(workspaceId, row.wt.path);
   }
 
   // Clicking a row toggles its view: open it alongside if closed, close it if
   // open. The primary folder and stale (prune-only) rows toggle nothing.
   function toggleView(row: WorktreeRow) {
-    const acts = worktreeActions(row, rowPending(row));
+    const acts = worktreeActions(row, isWorktreeRemovePending(row.wt.path));
     if (acts.includes("open")) void open(row);
     else if (acts.includes("close")) closeView(row);
   }
@@ -158,7 +168,7 @@ export function WorktreeManager({
   // Hover hint for a row, standing in for the removed open/close icons: what a
   // click will do, or the path for a row that can't be toggled.
   function toggleHint(row: WorktreeRow): string {
-    if (rowPending(row)) return "Removing this worktree…";
+    if (isWorktreeRemovePending(row.wt.path)) return "Removing this worktree…";
     const acts = worktreeActions(row, false);
     if (acts.includes("open")) return "Open alongside your current folders";
     if (acts.includes("close"))
@@ -215,7 +225,7 @@ export function WorktreeManager({
 
   async function remove(row: WorktreeRow) {
     const a = api();
-    if (!a || busy || rowPending(row)) return;
+    if (!a || busy || isWorktreeRemovePending(row.wt.path)) return;
     await confirmAndRemoveWorktree({
       ctx,
       api: a,
@@ -256,7 +266,7 @@ export function WorktreeManager({
   // key / Shift+F10 via the focus group, or right-click), mirroring the hover
   // buttons.
   function rowMenuItems(row: WorktreeRow): MenuEntry[] {
-    const acts = worktreeActions(row, rowPending(row));
+    const acts = worktreeActions(row, isWorktreeRemovePending(row.wt.path));
     const items: MenuEntry[] = [];
     if (acts.includes("open")) {
       items.push({ label: "Open alongside", run: () => void open(row) });
@@ -289,8 +299,8 @@ export function WorktreeManager({
 
   function rowBadges(row: WorktreeRow) {
     const badges: { label: string; tooltip?: string; warn?: boolean }[] = [];
-    if (rowPending(row)) {
-      badges.push({ label: "removing…" });
+    if (isWorktreeRemovePending(row.wt.path)) {
+      badges.push({ label: "Removing…" });
       return badges;
     }
     if (row.wt.isMain) badges.push({ label: "main" });
@@ -326,7 +336,7 @@ export function WorktreeManager({
           <div className="git-branch-empty">No worktrees.</div>
         )}
         {rows.map((row, i) => {
-          const pending = rowPending(row);
+          const pending = isWorktreeRemovePending(row.wt.path);
           const acts = worktreeActions(row, pending);
           const toggleable =
             !pending && (acts.includes("open") || acts.includes("close"));

--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
@@ -1,0 +1,156 @@
+import type { ExtensionContext } from "@silo-code/sdk";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
+import {
+  getPendingWorktreeRemoves,
+  isWorktreeManagerOpen,
+  markWorktreeManagerOpen,
+  resetPendingWorktreeRemovesForTests,
+} from "./pending-worktree-remove";
+import type { GitAPI } from "../git/git-api";
+
+function mockCtx(opts: {
+  confirms: boolean[];
+  managerOpen?: boolean;
+}): ExtensionContext {
+  let confirmIdx = 0;
+  const notify = vi.fn();
+  const removeFolder = vi.fn();
+  const ctx = {
+    ui: {
+      confirm: vi.fn(async () => opts.confirms[confirmIdx++] ?? false),
+      notify,
+    },
+    workspaces: { removeFolder },
+  } as unknown as ExtensionContext;
+  if (opts.managerOpen) markWorktreeManagerOpen();
+  return ctx;
+}
+
+describe("confirmAndRemoveWorktree", () => {
+  beforeEach(() => {
+    resetPendingWorktreeRemovesForTests();
+  });
+
+  it("no-ops when the user cancels the first confirm", async () => {
+    const removeWorktree = vi.fn();
+    const ctx = mockCtx({ confirms: [false] });
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: { removeWorktree } as unknown as GitAPI,
+      cwd: "/w/repo",
+      worktreePath: "/w/repo-feat",
+      workspaceId: "ws1",
+      isOpen: true,
+      notifyError: vi.fn(),
+    });
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(getPendingWorktreeRemoves()).toHaveLength(0);
+  });
+
+  it("closes the folder on start, clears pending on success, toasts when manager closed", async () => {
+    const removeWorktree = vi.fn(async () => {});
+    const ctx = mockCtx({ confirms: [true] });
+    const onSuccess = vi.fn();
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: { removeWorktree } as unknown as GitAPI,
+      cwd: "/w/repo",
+      worktreePath: "/w/repo-feat",
+      workspaceId: "ws1",
+      isOpen: true,
+      notifyError: vi.fn(),
+      onSuccess,
+    });
+    expect(ctx.workspaces.removeFolder).toHaveBeenCalledWith(
+      "ws1",
+      "/w/repo-feat",
+    );
+    expect(removeWorktree).toHaveBeenCalledWith("/w/repo", "/w/repo-feat");
+    expect(getPendingWorktreeRemoves()).toHaveLength(0);
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      "info",
+      "Removed worktree repo-feat",
+    );
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("skips the success toast when the manager is open", async () => {
+    const ctx = mockCtx({ confirms: [true], managerOpen: true });
+    expect(isWorktreeManagerOpen()).toBe(true);
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: { removeWorktree: vi.fn(async () => {}) } as unknown as GitAPI,
+      cwd: "/w/repo",
+      worktreePath: "/w/repo-feat",
+      workspaceId: "ws1",
+      isOpen: false,
+      notifyError: vi.fn(),
+    });
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+  });
+
+  it("force-confirms dirty trees and leaves the folder closed if force is declined", async () => {
+    const removeWorktree = vi.fn(async () => {
+      throw new Error("contains modified or untracked files, use --force");
+    });
+    const ctx = mockCtx({ confirms: [true, false] });
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: { removeWorktree } as unknown as GitAPI,
+      cwd: "/w/repo",
+      worktreePath: "/w/repo-feat",
+      workspaceId: "ws1",
+      isOpen: true,
+      notifyError: vi.fn(),
+    });
+    expect(ctx.workspaces.removeFolder).toHaveBeenCalled();
+    expect(removeWorktree).toHaveBeenCalledTimes(1);
+    expect(getPendingWorktreeRemoves()).toHaveLength(0);
+  });
+
+  it("force-removes after a second confirm", async () => {
+    const removeWorktree = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("contains modified or untracked files, use --force"),
+      )
+      .mockResolvedValueOnce(undefined);
+    const ctx = mockCtx({ confirms: [true, true] });
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: { removeWorktree } as unknown as GitAPI,
+      cwd: "/w/repo",
+      worktreePath: "/w/repo-feat",
+      workspaceId: "ws1",
+      isOpen: false,
+      notifyError: vi.fn(),
+    });
+    expect(removeWorktree).toHaveBeenLastCalledWith(
+      "/w/repo",
+      "/w/repo-feat",
+      true,
+    );
+    expect(getPendingWorktreeRemoves()).toHaveLength(0);
+  });
+
+  it("notifies on failure and clears pending", async () => {
+    const notifyError = vi.fn();
+    const ctx = mockCtx({ confirms: [true] });
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: {
+        removeWorktree: vi.fn(async () => {
+          throw new Error("disk full");
+        }),
+      } as unknown as GitAPI,
+      cwd: "/w/repo",
+      worktreePath: "/w/repo-feat",
+      workspaceId: "ws1",
+      isOpen: false,
+      notifyError,
+    });
+    expect(notifyError).toHaveBeenCalled();
+    expect(getPendingWorktreeRemoves()).toHaveLength(0);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
@@ -6,6 +6,7 @@ import {
   isWorktreeManagerOpen,
   markWorktreeManagerOpen,
   resetPendingWorktreeRemovesForTests,
+  subscribeWorktreeListDirty,
 } from "./pending-worktree-remove";
 import type { GitAPI } from "../git/git-api";
 
@@ -52,6 +53,10 @@ describe("confirmAndRemoveWorktree", () => {
     const removeWorktree = vi.fn(async () => {});
     const ctx = mockCtx({ confirms: [true] });
     const onSuccess = vi.fn();
+    let dirty = 0;
+    const stop = subscribeWorktreeListDirty(() => {
+      dirty += 1;
+    });
     await confirmAndRemoveWorktree({
       ctx,
       api: { removeWorktree } as unknown as GitAPI,
@@ -62,6 +67,7 @@ describe("confirmAndRemoveWorktree", () => {
       notifyError: vi.fn(),
       onSuccess,
     });
+    stop();
     expect(ctx.workspaces.removeFolder).toHaveBeenCalledWith(
       "ws1",
       "/w/repo-feat",
@@ -73,6 +79,7 @@ describe("confirmAndRemoveWorktree", () => {
       "Removed worktree repo-feat",
     );
     expect(onSuccess).toHaveBeenCalled();
+    expect(dirty).toBe(1);
   });
 
   it("skips the success toast when the manager is open", async () => {

--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
@@ -5,6 +5,7 @@ import {
   endPendingWorktreeRemove,
   isWorktreeManagerOpen,
   isWorktreeRemovePending,
+  markWorktreeListDirty,
 } from "./pending-worktree-remove";
 import { worktreeDisplayName } from "./pending-worktree-remove-model";
 
@@ -83,6 +84,7 @@ export async function confirmAndRemoveWorktree(
     }
 
     endPendingWorktreeRemove(worktreePath);
+    markWorktreeListDirty();
     if (!isWorktreeManagerOpen()) {
       ctx.ui.notify("info", `Removed worktree ${name}`);
     }

--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
@@ -1,0 +1,94 @@
+import type { ExtensionContext } from "@silo-code/sdk";
+import type { GitAPI } from "../git/git-api";
+import {
+  beginPendingWorktreeRemove,
+  endPendingWorktreeRemove,
+  isWorktreeManagerOpen,
+  isWorktreeRemovePending,
+} from "./pending-worktree-remove";
+import { worktreeDisplayName } from "./pending-worktree-remove-model";
+
+const DIRTY_RE = /contains modified or untracked files|use --force/i;
+
+export interface RemoveWorktreeParams {
+  ctx: ExtensionContext;
+  api: GitAPI;
+  /**
+   * Directory git should run in (main worktree — git refuses to remove the
+   * worktree it's invoked from).
+   */
+  cwd: string;
+  /** Linked worktree path to remove. */
+  worktreePath: string;
+  workspaceId: string;
+  /** Whether `worktreePath` is currently a workspace folder. */
+  isOpen: boolean;
+  notifyError: (title: string, err: unknown) => void;
+  /** After a successful remove (e.g. reload manager list / refresh Git view). */
+  onSuccess?: () => void;
+}
+
+/**
+ * Confirm and run Remove worktree with pending-remove UX (ADR 0025): after
+ * confirms, mark pending, close the folder if open, show StatusBar progress,
+ * toast on success only when the manager is dismissed.
+ */
+export async function confirmAndRemoveWorktree(
+  params: RemoveWorktreeParams,
+): Promise<void> {
+  const {
+    ctx,
+    api,
+    cwd,
+    worktreePath,
+    workspaceId,
+    isOpen,
+    notifyError,
+    onSuccess,
+  } = params;
+
+  if (isWorktreeRemovePending(worktreePath)) return;
+
+  const name = worktreeDisplayName(worktreePath);
+  const ok = await ctx.ui.confirm({
+    title: `Remove worktree "${name}"?`,
+    body: `Deletes the directory at ${worktreePath}. The branch itself is kept.`,
+    confirmLabel: "Remove",
+    danger: true,
+  });
+  if (!ok) return;
+
+  beginPendingWorktreeRemove(worktreePath);
+  if (isOpen) ctx.workspaces.removeFolder(workspaceId, worktreePath);
+
+  try {
+    try {
+      await api.removeWorktree(cwd, worktreePath);
+    } catch (err) {
+      if (!DIRTY_RE.test(String(err))) throw err;
+
+      // Clear pending while the force confirm is up (ADR: progress only after
+      // every confirm). Folder stays closed — recoverable via Open alongside.
+      endPendingWorktreeRemove(worktreePath);
+      const force = await ctx.ui.confirm({
+        title: `"${name}" has uncommitted changes`,
+        body: "Force-remove the worktree and discard them? This can't be undone.",
+        confirmLabel: "Force Remove",
+        danger: true,
+      });
+      if (!force) return;
+
+      beginPendingWorktreeRemove(worktreePath);
+      await api.removeWorktree(cwd, worktreePath, true);
+    }
+
+    endPendingWorktreeRemove(worktreePath);
+    if (!isWorktreeManagerOpen()) {
+      ctx.ui.notify("info", `Removed worktree ${name}`);
+    }
+    onSuccess?.();
+  } catch (err) {
+    endPendingWorktreeRemove(worktreePath);
+    notifyError(`Remove "${name}" failed`, err);
+  }
+}

--- a/packages/extensions-silo/src/git-explorer/index.tsx
+++ b/packages/extensions-silo/src/git-explorer/index.tsx
@@ -1,3 +1,4 @@
+import { useSyncExternalStore } from "react";
 import type { Extension } from "@silo-code/sdk";
 import type { GitAPI } from "../git/git-api";
 import { GitExplorerPanel } from "./GitExplorerPanel";
@@ -8,6 +9,22 @@ import {
   showWorktreeManager,
   type ManageWorktreesArgs,
 } from "./open-worktree-manager";
+import {
+  getPendingRemoveStatusLabel,
+  subscribePendingWorktreeRemoves,
+} from "./pending-worktree-remove";
+import "./GitExplorerPanel.css";
+
+/** Informational StatusBar item while Remove worktree runs (ADR 0025). */
+function PendingWorktreeRemoveStatus() {
+  const label = useSyncExternalStore(
+    subscribePendingWorktreeRemoves,
+    getPendingRemoveStatusLabel,
+    getPendingRemoveStatusLabel,
+  );
+  if (!label) return null;
+  return <span className="git-pending-remove-status">{label}</span>;
+}
 
 // `silo.git-explorer` — the git panel (view). Consumes the `silo.git` provider's
 // GitAPI via getExtension; resolves it at use time so the provider can activate
@@ -32,6 +49,15 @@ export const extension: Extension = {
       ),
       order: 2,
       lazyMount: true,
+    });
+
+    ctx.registerStatusItem({
+      id: "git-pending-worktree-remove",
+      alignment: "left",
+      // After the workspace name; extension zone (priority ≥ 0).
+      priority: 0,
+      tooltip: "A worktree is being removed",
+      component: PendingWorktreeRemoveStatus,
     });
 
     // Workspace properties (and anything else) open the same Worktrees modal

--- a/packages/extensions-silo/src/git-explorer/index.tsx
+++ b/packages/extensions-silo/src/git-explorer/index.tsx
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from "react";
+import { ArrowsClockwise } from "@phosphor-icons/react";
 import type { Extension } from "@silo-code/sdk";
 import type { GitAPI } from "../git/git-api";
 import { GitExplorerPanel } from "./GitExplorerPanel";
@@ -23,7 +24,12 @@ function PendingWorktreeRemoveStatus() {
     getPendingRemoveStatusLabel,
   );
   if (!label) return null;
-  return <span className="git-pending-remove-status">{label}</span>;
+  return (
+    <span className="git-pending-remove-status" aria-live="polite">
+      <ArrowsClockwise size={14} className="git-pending-remove-spin" />
+      <span>{label}</span>
+    </span>
+  );
 }
 
 // `silo.git-explorer` — the git panel (view). Consumes the `silo.git` provider's

--- a/packages/extensions-silo/src/git-explorer/open-worktree-manager.tsx
+++ b/packages/extensions-silo/src/git-explorer/open-worktree-manager.tsx
@@ -1,6 +1,7 @@
 import type { ExtensionContext, NotifyOptions } from "@silo-code/sdk";
 import { GitErrorModal } from "./GitErrorModal";
 import { summarizeGitError } from "./notify-error";
+import { markWorktreeManagerOpen } from "./pending-worktree-remove";
 import { WorktreeManager } from "./WorktreeManager";
 
 /** Command id — opened from the Git panel menu and workspace properties. */
@@ -47,18 +48,21 @@ export function showWorktreeManager(
     ctx.ui.notify("error", summary, options);
   };
 
-  ctx.ui.showModal(
-    () => (
-      <WorktreeManager
-        ctx={ctx}
-        folder={opts.folder}
-        workspaceId={opts.workspaceId}
-        onChanged={opts.onChanged ?? (() => {})}
-        notifyError={notifyError}
-      />
-    ),
-    { title: "Worktrees", size: "md", dismissible: true },
-  );
+  const releaseManagerOpen = markWorktreeManagerOpen();
+  void ctx.ui
+    .showModal(
+      () => (
+        <WorktreeManager
+          ctx={ctx}
+          folder={opts.folder}
+          workspaceId={opts.workspaceId}
+          onChanged={opts.onChanged ?? (() => {})}
+          notifyError={notifyError}
+        />
+      ),
+      { title: "Worktrees", size: "md", dismissible: true },
+    )
+    .finally(releaseManagerOpen);
 }
 
 /**

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove-model.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  pendingRemoveStatusLabel,
+  worktreeDisplayName,
+  isPathPendingRemove,
+  type PendingWorktreeRemove,
+} from "./pending-worktree-remove-model";
+
+describe("pendingRemoveStatusLabel", () => {
+  it("returns null when nothing is pending", () => {
+    expect(pendingRemoveStatusLabel([])).toBeNull();
+  });
+
+  it("names a single pending worktree", () => {
+    expect(
+      pendingRemoveStatusLabel([{ path: "/w/repo-feat", name: "repo-feat" }]),
+    ).toBe("Removing repo-feat…");
+  });
+
+  it("aggregates multiple pending removes", () => {
+    const pending: PendingWorktreeRemove[] = [
+      { path: "/w/a", name: "a" },
+      { path: "/w/b", name: "b" },
+    ];
+    expect(pendingRemoveStatusLabel(pending)).toBe("Removing 2 worktrees…");
+  });
+});
+
+describe("worktreeDisplayName", () => {
+  it("uses the basename", () => {
+    expect(worktreeDisplayName("/w/repo-feat")).toBe("repo-feat");
+  });
+});
+
+describe("isPathPendingRemove", () => {
+  const pending: PendingWorktreeRemove[] = [
+    { path: "/w/repo-feat", name: "repo-feat" },
+  ];
+
+  it("matches normalized path identity", () => {
+    expect(isPathPendingRemove("/w/repo-feat/", pending)).toBe(true);
+    expect(isPathPendingRemove("/w/other", pending)).toBe(false);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove-model.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove-model.ts
@@ -1,0 +1,40 @@
+import { path } from "@silo-code/sdk";
+import { normalizeFolderPath } from "./worktree-model";
+
+/** One in-flight Remove worktree (see ADR 0025). */
+export interface PendingWorktreeRemove {
+  /** Normalized worktree directory path. */
+  path: string;
+  /** Basename used in StatusBar / toast copy. */
+  name: string;
+}
+
+/**
+ * StatusBar label for the current pending-remove set. One path → name; several
+ * → a count. Empty → `null` (hide the item).
+ */
+export function pendingRemoveStatusLabel(
+  pending: readonly PendingWorktreeRemove[],
+): string | null {
+  if (pending.length === 0) return null;
+  if (pending.length === 1) return `Removing ${pending[0]!.name}…`;
+  return `Removing ${pending.length} worktrees…`;
+}
+
+/** Display name for a worktree path (basename; path itself if empty). */
+export function worktreeDisplayName(worktreePath: string): string {
+  const base = path.basename(worktreePath);
+  return base || worktreePath;
+}
+
+/**
+ * Whether a path is in the pending-remove set (path identity via
+ * {@link normalizeFolderPath}).
+ */
+export function isPathPendingRemove(
+  worktreePath: string,
+  pending: readonly PendingWorktreeRemove[],
+): boolean {
+  const key = normalizeFolderPath(worktreePath);
+  return pending.some((p) => p.path === key);
+}

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove.test.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  beginPendingWorktreeRemove,
+  endPendingWorktreeRemove,
+  getPendingRemoveStatusLabel,
+  getPendingWorktreeRemoves,
+  isWorktreeManagerOpen,
+  isWorktreeRemovePending,
+  markWorktreeManagerOpen,
+  resetPendingWorktreeRemovesForTests,
+  subscribePendingWorktreeRemoves,
+} from "./pending-worktree-remove";
+
+describe("pending-worktree-remove store", () => {
+  beforeEach(() => {
+    resetPendingWorktreeRemovesForTests();
+  });
+
+  it("tracks concurrent pending paths and aggregates the StatusBar label", () => {
+    beginPendingWorktreeRemove("/w/repo-feat");
+    expect(isWorktreeRemovePending("/w/repo-feat/")).toBe(true);
+    expect(getPendingRemoveStatusLabel()).toBe("Removing repo-feat…");
+
+    beginPendingWorktreeRemove("/w/repo-other");
+    expect(getPendingWorktreeRemoves()).toHaveLength(2);
+    expect(getPendingRemoveStatusLabel()).toBe("Removing 2 worktrees…");
+
+    endPendingWorktreeRemove("/w/repo-feat");
+    expect(getPendingRemoveStatusLabel()).toBe("Removing repo-other…");
+    endPendingWorktreeRemove("/w/repo-other");
+    expect(getPendingRemoveStatusLabel()).toBeNull();
+  });
+
+  it("notifies subscribers on begin/end and manager open", () => {
+    let ticks = 0;
+    const stop = subscribePendingWorktreeRemoves(() => {
+      ticks += 1;
+    });
+    beginPendingWorktreeRemove("/w/a");
+    const close = markWorktreeManagerOpen();
+    expect(isWorktreeManagerOpen()).toBe(true);
+    close();
+    expect(isWorktreeManagerOpen()).toBe(false);
+    endPendingWorktreeRemove("/w/a");
+    stop();
+    expect(ticks).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove.test.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove.test.ts
@@ -6,9 +6,11 @@ import {
   getPendingWorktreeRemoves,
   isWorktreeManagerOpen,
   isWorktreeRemovePending,
+  markWorktreeListDirty,
   markWorktreeManagerOpen,
   resetPendingWorktreeRemovesForTests,
   subscribePendingWorktreeRemoves,
+  subscribeWorktreeListDirty,
 } from "./pending-worktree-remove";
 
 describe("pending-worktree-remove store", () => {
@@ -44,5 +46,18 @@ describe("pending-worktree-remove store", () => {
     endPendingWorktreeRemove("/w/a");
     stop();
     expect(ticks).toBeGreaterThanOrEqual(4);
+  });
+
+  it("notifies list-dirty listeners and stops after unsubscribe", () => {
+    let dirty = 0;
+    const stop = subscribeWorktreeListDirty(() => {
+      dirty += 1;
+    });
+    markWorktreeListDirty();
+    markWorktreeListDirty();
+    expect(dirty).toBe(2);
+    stop();
+    markWorktreeListDirty();
+    expect(dirty).toBe(2);
   });
 });

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove.ts
@@ -1,0 +1,90 @@
+import { normalizeFolderPath } from "./worktree-model";
+import {
+  pendingRemoveStatusLabel,
+  worktreeDisplayName,
+  type PendingWorktreeRemove,
+} from "./pending-worktree-remove-model";
+
+// Extension-scoped pending Remove worktree set (ADR 0025). Outlives the
+// worktree manager modal so dismiss-and-reopen still shows Removing… rows and
+// the StatusBar item stays accurate.
+
+let pending: PendingWorktreeRemove[] = [];
+/** Nested showModal depth for the worktree manager (usually 0 or 1). */
+let managerOpenDepth = 0;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/** Subscribe to pending-remove / manager-open changes (for StatusBar + modal). */
+export function subscribePendingWorktreeRemoves(
+  listener: () => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Snapshot of in-flight removes (stable order: insertion). */
+export function getPendingWorktreeRemoves(): readonly PendingWorktreeRemove[] {
+  return pending;
+}
+
+export function getPendingRemoveStatusLabel(): string | null {
+  return pendingRemoveStatusLabel(pending);
+}
+
+export function isWorktreeRemovePending(worktreePath: string): boolean {
+  const key = normalizeFolderPath(worktreePath);
+  return pending.some((p) => p.path === key);
+}
+
+export function isWorktreeManagerOpen(): boolean {
+  return managerOpenDepth > 0;
+}
+
+/**
+ * Mark the worktree manager modal open until the returned disposer runs
+ * (typically when `showModal` settles).
+ */
+export function markWorktreeManagerOpen(): () => void {
+  managerOpenDepth += 1;
+  emit();
+  let closed = false;
+  return () => {
+    if (closed) return;
+    closed = true;
+    managerOpenDepth = Math.max(0, managerOpenDepth - 1);
+    emit();
+  };
+}
+
+/** Begin a pending remove (StatusBar + row chrome). Idempotent per path. */
+export function beginPendingWorktreeRemove(worktreePath: string): void {
+  const key = normalizeFolderPath(worktreePath);
+  if (pending.some((p) => p.path === key)) return;
+  pending = [
+    ...pending,
+    { path: key, name: worktreeDisplayName(worktreePath) },
+  ];
+  emit();
+}
+
+/** Clear a path from the pending set (success or failure). */
+export function endPendingWorktreeRemove(worktreePath: string): void {
+  const key = normalizeFolderPath(worktreePath);
+  const next = pending.filter((p) => p.path !== key);
+  if (next.length === pending.length) return;
+  pending = next;
+  emit();
+}
+
+/** Test helper — reset module state between unit tests. */
+export function resetPendingWorktreeRemovesForTests(): void {
+  pending = [];
+  managerOpenDepth = 0;
+  listeners.clear();
+}

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove.ts
@@ -1,5 +1,6 @@
 import { normalizeFolderPath } from "./worktree-model";
 import {
+  isPathPendingRemove,
   pendingRemoveStatusLabel,
   worktreeDisplayName,
   type PendingWorktreeRemove,
@@ -13,9 +14,11 @@ let pending: PendingWorktreeRemove[] = [];
 /** Nested showModal depth for the worktree manager (usually 0 or 1). */
 let managerOpenDepth = 0;
 const listeners = new Set<() => void>();
+/** Open WorktreeManager instances reload when a remove succeeds anywhere. */
+const listDirtyListeners = new Set<() => void>();
 
 function emit(): void {
-  for (const listener of listeners) listener();
+  for (const listener of [...listeners]) listener();
 }
 
 /** Subscribe to pending-remove / manager-open changes (for StatusBar + modal). */
@@ -28,6 +31,23 @@ export function subscribePendingWorktreeRemoves(
   };
 }
 
+/**
+ * Subscribe so an open manager reloads after a successful remove (including
+ * removes started from the Git view while the manager stays open).
+ * Returns an unsubscribe — callers must dispose (e.g. effect cleanup).
+ */
+export function subscribeWorktreeListDirty(listener: () => void): () => void {
+  listDirtyListeners.add(listener);
+  return () => {
+    listDirtyListeners.delete(listener);
+  };
+}
+
+/** Notify open managers that the worktree list may have changed on disk. */
+export function markWorktreeListDirty(): void {
+  for (const listener of [...listDirtyListeners]) listener();
+}
+
 /** Snapshot of in-flight removes (stable order: insertion). */
 export function getPendingWorktreeRemoves(): readonly PendingWorktreeRemove[] {
   return pending;
@@ -38,8 +58,7 @@ export function getPendingRemoveStatusLabel(): string | null {
 }
 
 export function isWorktreeRemovePending(worktreePath: string): boolean {
-  const key = normalizeFolderPath(worktreePath);
-  return pending.some((p) => p.path === key);
+  return isPathPendingRemove(worktreePath, pending);
 }
 
 export function isWorktreeManagerOpen(): boolean {
@@ -64,11 +83,13 @@ export function markWorktreeManagerOpen(): () => void {
 
 /** Begin a pending remove (StatusBar + row chrome). Idempotent per path. */
 export function beginPendingWorktreeRemove(worktreePath: string): void {
-  const key = normalizeFolderPath(worktreePath);
-  if (pending.some((p) => p.path === key)) return;
+  if (isPathPendingRemove(worktreePath, pending)) return;
   pending = [
     ...pending,
-    { path: key, name: worktreeDisplayName(worktreePath) },
+    {
+      path: normalizeFolderPath(worktreePath),
+      name: worktreeDisplayName(worktreePath),
+    },
   ];
   emit();
 }
@@ -87,4 +108,5 @@ export function resetPendingWorktreeRemovesForTests(): void {
   pending = [];
   managerOpenDepth = 0;
   listeners.clear();
+  listDirtyListeners.clear();
 }

--- a/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
@@ -136,6 +136,16 @@ describe("worktreeActions", () => {
     ).toEqual(["prune"]);
   });
 
+  it("offers no actions while a remove is pending", () => {
+    expect(worktreeActions({ ...base, wt: wt({}) }, true)).toEqual([]);
+    expect(
+      worktreeActions(
+        { ...base, isOpen: true, wt: wt({ prunable: "gone" }) },
+        true,
+      ),
+    ).toEqual([]);
+  });
+
   it("offers nothing but remove for the current (unopened-elsewhere) view", () => {
     // isCurrent implies the folder is one of the workspace's folders in
     // practice, but the gate itself: current rows never offer open.

--- a/packages/extensions-silo/src/git-explorer/worktree-model.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.ts
@@ -70,9 +70,14 @@ export type WorktreeAction = "open" | "close" | "remove" | "prune";
  * itself is untouched); `remove` deletes the worktree via git. A **prunable**
  * row (directory already gone) only offers `prune`; the **main** worktree and
  * the workspace's **primary** folder can't be removed, and a **locked**
- * worktree can't be removed either.
+ * worktree can't be removed either. A **pending remove** (disk delete in
+ * flight — ADR 0025) offers nothing until it finishes.
  */
-export function worktreeActions(row: WorktreeRow): WorktreeAction[] {
+export function worktreeActions(
+  row: WorktreeRow,
+  pendingRemove = false,
+): WorktreeAction[] {
+  if (pendingRemove) return [];
   if (row.wt.prunable != null) return ["prune"];
   const actions: WorktreeAction[] = [];
   if (!row.isOpen && !row.isCurrent) actions.push("open");


### PR DESCRIPTION
## Summary
- Implements ADR 0025 pending-remove UX: after confirms, show **removing…** on the manager row and an informational StatusBar item while `git worktree remove` runs.
- Closes the workspace folder when remove starts; dismissible manager; success toast only if the manager was dismissed; shared by manager + Git view ⋯.
- Unit tests for the pending store, status labels, and confirm/remove flow.

Depends on / pairs with docs PR #258 (ADR 0025 + glossary).

## Test plan
- [ ] Remove a linked worktree from Manage worktrees — row shows removing…, StatusBar shows `Removing …`
- [ ] Dismiss the manager mid-remove — StatusBar continues; reopen shows removing… until done
- [ ] Remove an open worktree — folder closes immediately; Files/Git no longer rooted there
- [ ] Dirty worktree — force confirm; cancel leaves folder closed, recoverable via Open alongside
- [ ] Git view ⋯ → Remove worktree… — same StatusBar behavior
- [ ] Failure path — error toast, pending cleared


Made with [Cursor](https://cursor.com)