### PR TITLE
feat(git-explorer): surface worktree manager from the Git header

### DIFF
--- a/apps/docs/guide/panels.md
+++ b/apps/docs/guide/panels.md
@@ -33,7 +33,10 @@ Extensions can add panels to either column — see [Extensions](/guide/extension
 The Git panel's **⋯ → Manage worktrees…** lists every
 [git worktree](https://git-scm.com/docs/git-worktree) of the repo — including
 ones created outside Silo (say, by a coding agent) — no matter where they live
-on disk. From there you can:
+on disk. When the manager would list more than the main worktree, a worktrees
+icon appears in the Git header (before ⋯) as a shortcut into the same modal;
+the tooltip shows the count. On a **linked** worktree view the icon is omitted
+— click the **worktree** pill instead. From the manager you can:
 
 - **Open a worktree alongside** the current folders (click its row). It appears
   as an extra root in both the Files panel and the Git panel — the same
@@ -54,8 +57,8 @@ on disk. From there you can:
   whose directories were deleted manually.
 
 A Git view whose root is a linked worktree shows a small **worktree** pill next
-to its branch name, and its ⋯ menu gains **Close worktree view** and
-**Remove worktree…**.
+to its branch name (click it to open the worktree manager), and its ⋯ menu
+gains **Close worktree view** and **Remove worktree…**.
 
 ## Organizing panels
 

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -237,6 +237,11 @@
   flex-shrink: 0;
 }
 
+/* After .branch-action so accent isn't overridden by text-lo. */
+.branch-action.git-wt-btn {
+  color: var(--silo-color-accent);
+}
+
 .branch-action:hover:not(.working):not(.disabled) {
   background: var(--silo-color-bg-hover);
   color: var(--silo-color-text-hi);
@@ -812,17 +817,32 @@
 }
 
 /* Worktree manager modal (shares the branch-modal shell classes) and the
- * "worktree" header pill on linked-worktree GitViews. */
+ * "worktree" header pill on linked-worktree GitViews — clickable into the
+ * manager (replaces the header icon on those views). */
+button.git-wt-pill {
+  -webkit-appearance: none;
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: inherit;
+}
+
 .git-wt-pill {
   flex-shrink: 0;
   font-size: var(--silo-font-size-chrome);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--silo-color-text-lo);
-  background: color-mix(in srgb, var(--silo-color-text-lo) 14%, transparent);
+  color: var(--silo-color-accent);
+  background: color-mix(in srgb, var(--silo-color-accent) 16%, transparent);
   border-radius: 999px;
   padding: 1px 8px;
+}
+
+button.git-wt-pill:hover {
+  color: var(--silo-color-text-hi);
+  background: color-mix(in srgb, var(--silo-color-accent) 28%, transparent);
 }
 
 /* Worktree rows stack the directory name (with badges) over the checked-out

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -5,6 +5,7 @@ import {
   CaretRight,
   CloudArrowUp,
   DotsThreeVertical,
+  TreeStructure,
 } from "@phosphor-icons/react";
 import {
   Tooltip,
@@ -22,7 +23,11 @@ import { ICON_CHECK, ICON_PLUS, ICON_MINUS, ICON_UNDO } from "./git-icons";
 import { summarizeGitError } from "./notify-error";
 import { GitErrorModal } from "./GitErrorModal";
 import { BranchManager } from "./BranchManager";
-import { findWorktreeFor } from "./worktree-model";
+import {
+  findWorktreeFor,
+  shouldShowWorktreeManagerButton,
+  worktreeManagerButtonTooltip,
+} from "./worktree-model";
 import { showWorktreeManager } from "./open-worktree-manager";
 import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
 
@@ -152,8 +157,9 @@ export function GitView({
         })
         .catch((err) => notifyError("Git status failed", err, true))
         .finally(() => min.then(() => setBusy(false)));
-      // Also learn whether this folder is a linked worktree (drives the
-      // header pill). Cheap read; failures just leave the pill off.
+      // Worktree list drives the linked-worktree header pill and the Manage
+      // worktrees shortcut. Cheap read; on failure keep the last good cache
+      // so a transient error doesn't flicker the button away.
       api
         .worktrees(folder)
         .then((wts) => {
@@ -604,12 +610,31 @@ export function GitView({
     const wt = worktrees ? findWorktreeFor(folder, worktrees) : undefined;
     return wt && !wt.isMain ? wt : undefined;
   })();
+  // Shortcut icon only on the main worktree view — linked views use the
+  // clickable "worktree" pill instead (avoids icon + pill redundancy).
+  const showWorktreeButton =
+    !linkedWorktree && shouldShowWorktreeManagerButton(worktrees);
   // A linked worktree opened alongside is an extra folder; the host no-ops
   // removeFolder on the primary, so only offer "close" for extras.
   const isExtraFolder = (() => {
     const ws = ctx.workspaces.getState().all.find((w) => w.id === workspaceId);
     return ws ? ws.folder !== folder : false;
   })();
+
+  const worktreePill = linkedWorktree ? (
+    <Tooltip content={worktreeManagerButtonTooltip(worktrees)}>
+      <button
+        type="button"
+        className="git-wt-pill"
+        onClick={(e) => {
+          e.stopPropagation();
+          openWorktreeManager();
+        }}
+      >
+        worktree
+      </button>
+    </Tooltip>
+  ) : null;
 
   return (
     <div className="git-panel">
@@ -652,11 +677,7 @@ export function GitView({
                   </span>
                 </Tooltip>
               </span>
-              {linkedWorktree && (
-                <Tooltip content={`Linked worktree at ${folder}`}>
-                  <span className="git-wt-pill">worktree</span>
-                </Tooltip>
-              )}
+              {worktreePill}
               <span
                 className="git-root-remote"
                 onClick={(e) => e.stopPropagation()}
@@ -699,6 +720,17 @@ export function GitView({
                     <ArrowsClockwise size={14} />
                   </button>
                 </Tooltip>
+                {showWorktreeButton && (
+                  <Tooltip content={worktreeManagerButtonTooltip(worktrees)}>
+                    <button
+                      className="branch-action git-wt-btn"
+                      onClick={openWorktreeManager}
+                      aria-label={worktreeManagerButtonTooltip(worktrees)}
+                    >
+                      <TreeStructure size={14} />
+                    </button>
+                  </Tooltip>
+                )}
                 <Tooltip content="More actions">
                   <button
                     className="branch-action git-menu-btn"
@@ -729,11 +761,7 @@ export function GitView({
               </span>
             )}
           </span>
-          {linkedWorktree && (
-            <Tooltip content={`Linked worktree at ${folder}`}>
-              <span className="git-wt-pill">worktree</span>
-            </Tooltip>
-          )}
+          {worktreePill}
           {/* Where the remote state lives: published → the ↑/↓ counts double as
               a Sync button; not yet published → a Publish-branch button. */}
           {status?.upstream ? (
@@ -766,6 +794,17 @@ export function GitView({
               <ArrowsClockwise size={16} />
             </button>
           </Tooltip>
+          {showWorktreeButton && (
+            <Tooltip content={worktreeManagerButtonTooltip(worktrees)}>
+              <button
+                className="branch-action git-wt-btn"
+                onClick={openWorktreeManager}
+                aria-label={worktreeManagerButtonTooltip(worktrees)}
+              >
+                <TreeStructure size={16} />
+              </button>
+            </Tooltip>
+          )}
           {status?.inRepo && (
             <Tooltip content="More actions">
               <button

--- a/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
@@ -9,6 +9,9 @@ import {
   suggestWorktreePath,
   findWorktreeFor,
   branchesInUse,
+  managerWorktreeCount,
+  shouldShowWorktreeManagerButton,
+  worktreeManagerButtonTooltip,
 } from "./worktree-model";
 
 function wt(overrides: Partial<GitWorktree>): GitWorktree {
@@ -192,5 +195,28 @@ describe("findWorktreeFor / branchesInUse", () => {
       wt({ path: "/w/d", branch: null, detached: true }),
     ];
     expect(branchesInUse(wts)).toEqual(new Set(["main", "feat"]));
+  });
+});
+
+describe("shouldShowWorktreeManagerButton", () => {
+  const main = wt({ path: "/w/repo", isMain: true, branch: "main" });
+  const feat = wt({ path: "/w/repo-feat", branch: "feat" });
+  const bare = wt({ path: "/w/repo.git", bare: true });
+  const gone = wt({ path: "/w/gone", prunable: "directory missing" });
+
+  it("hides when the list is unknown or only the main worktree", () => {
+    expect(shouldShowWorktreeManagerButton(null)).toBe(false);
+    expect(shouldShowWorktreeManagerButton(undefined)).toBe(false);
+    expect(shouldShowWorktreeManagerButton([main])).toBe(false);
+    expect(shouldShowWorktreeManagerButton([main, bare])).toBe(false);
+  });
+
+  it("shows when the manager would list more than main (incl. prunable)", () => {
+    expect(shouldShowWorktreeManagerButton([main, feat])).toBe(true);
+    expect(shouldShowWorktreeManagerButton([main, gone])).toBe(true);
+    expect(managerWorktreeCount([main, bare, feat])).toBe(2);
+    expect(worktreeManagerButtonTooltip([main, feat])).toBe(
+      "Manage worktrees (2)",
+    );
   });
 });

--- a/packages/extensions-silo/src/git-explorer/worktree-model.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.ts
@@ -121,6 +121,35 @@ export function findWorktreeFor(
 }
 
 /**
+ * How many worktrees the manager modal would list — non-bare only, matching
+ * {@link buildWorktreeRows}. `null` (list not yet known) counts as zero.
+ */
+export function managerWorktreeCount(
+  worktrees: GitWorktree[] | null | undefined,
+): number {
+  if (!worktrees) return 0;
+  return worktrees.filter((wt) => !wt.bare).length;
+}
+
+/**
+ * Whether the Git header should show the Manage worktrees shortcut: the
+ * manager would list more than the main worktree alone. Driven by the last
+ * successful list (callers keep prior cache on refresh failure).
+ */
+export function shouldShowWorktreeManagerButton(
+  worktrees: GitWorktree[] | null | undefined,
+): boolean {
+  return managerWorktreeCount(worktrees) > 1;
+}
+
+/** Tooltip for the header Manage worktrees button (`N` = manager row count). */
+export function worktreeManagerButtonTooltip(
+  worktrees: GitWorktree[] | null | undefined,
+): string {
+  return `Manage worktrees (${managerWorktreeCount(worktrees)})`;
+}
+
+/**
  * Branch names already checked out in some worktree — git refuses
  * `worktree add` for these, so the create dialog filters them proactively.
  * Detached and bare entries contribute nothing.


### PR DESCRIPTION
## Summary
- When a repo’s worktree manager would list more than the main worktree, show an accent TreeStructure shortcut in the Git header (before ⋯) that opens the existing Worktrees modal.
- On linked worktree views, omit that icon and make the **worktree** pill clickable into the same modal instead.
- Visibility follows the manager’s non-bare row filter (including prunable); last successful list is kept on refresh failure. Docs updated.

## Test plan
- [ ] Open a repo with only the main worktree — no header worktrees icon
- [ ] Create/open a linked worktree — main view shows accent icon with tooltip `Manage worktrees (N)`; click opens manager
- [ ] Linked worktree Git view — no icon; accent **worktree** pill opens manager
- [ ] ⋯ → Manage worktrees… still works with or without the icon
- [ ] Transient worktree-list failure after a successful load keeps the icon visible


Made with [Cursor](https://cursor.com)