### PR TITLE
fix(modal): don't forward dismiss events as showModal results

### DIFF
--- a/packages/extension-host/src/components/ModalHost.tsx
+++ b/packages/extension-host/src/components/ModalHost.tsx
@@ -134,8 +134,10 @@ function CustomModalSlot({ id }: { id: string }) {
     [id],
   );
   if (!entry?.render) return null;
+  // Dismiss must settle with `undefined` — pass a zero-arg wrapper so React
+  // event handlers (X / backdrop) don't forward the MouseEvent as the result.
   return (
-    <Modal {...entry.options} onClose={close}>
+    <Modal {...entry.options} onClose={() => close()}>
       {entry.render(close)}
     </Modal>
   );

--- a/packages/extensions-silo/src/git-explorer/WorktreeCreateDialog.test.ts
+++ b/packages/extensions-silo/src/git-explorer/WorktreeCreateDialog.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isWorktreeCreateResult } from "./WorktreeCreateDialog";
+
+describe("isWorktreeCreateResult", () => {
+  it("accepts a new-branch create result", () => {
+    expect(
+      isWorktreeCreateResult({
+        path: "/tmp/repo-feat",
+        branch: { create: "feat" },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts an existing-branch create result", () => {
+    expect(
+      isWorktreeCreateResult({
+        path: "/tmp/repo-main",
+        branch: { existing: "main" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects cancel / undefined / null", () => {
+    expect(isWorktreeCreateResult(undefined)).toBe(false);
+    expect(isWorktreeCreateResult(null)).toBe(false);
+  });
+
+  it("rejects a truthy dismiss event (no path/branch)", () => {
+    // ModalHost used to forward the React click/mousedown event as the settle
+    // value when the X or backdrop closed a dismissible showModal.
+    expect(isWorktreeCreateResult({ type: "click", target: {} })).toBe(false);
+  });
+
+  it("rejects objects missing a usable branch", () => {
+    expect(isWorktreeCreateResult({ path: "/tmp/x" })).toBe(false);
+    expect(isWorktreeCreateResult({ path: "/tmp/x", branch: {} })).toBe(false);
+    expect(
+      isWorktreeCreateResult({ path: "/tmp/x", branch: { existing: 1 } }),
+    ).toBe(false);
+  });
+
+  it("rejects an empty path", () => {
+    expect(
+      isWorktreeCreateResult({ path: "", branch: { create: "feat" } }),
+    ).toBe(false);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/WorktreeCreateDialog.tsx
+++ b/packages/extensions-silo/src/git-explorer/WorktreeCreateDialog.tsx
@@ -10,6 +10,24 @@ export interface WorktreeCreateResult {
   branch: { existing: string } | { create: string };
 }
 
+/**
+ * Narrow an unknown `showModal` settle value to a real create result. Guards
+ * against cancel/`undefined` and against a dismiss event leaking through as
+ * the result (truthy but no `path`/`branch`).
+ */
+export function isWorktreeCreateResult(
+  value: unknown,
+): value is WorktreeCreateResult {
+  if (value == null || typeof value !== "object") return false;
+  const v = value as { path?: unknown; branch?: unknown };
+  if (typeof v.path !== "string" || v.path.length === 0) return false;
+  if (v.branch == null || typeof v.branch !== "object") return false;
+  const branch = v.branch as { existing?: unknown; create?: unknown };
+  if ("existing" in branch) return typeof branch.existing === "string";
+  if ("create" in branch) return typeof branch.create === "string";
+  return false;
+}
+
 export interface WorktreeCreateDialogProps {
   ctx: ExtensionContext;
   /** The repo the worktree is created from (drives the path suggestion). */

--- a/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
@@ -37,6 +37,7 @@ import {
 } from "./worktree-model";
 import {
   WorktreeCreateDialog,
+  isWorktreeCreateResult,
   type WorktreeCreateResult,
 } from "./WorktreeCreateDialog";
 
@@ -199,7 +200,7 @@ export function WorktreeManager({
       ),
       { title: "Create worktree", dismissible: true, size: "sm" },
     );
-    if (!result) return;
+    if (!isWorktreeCreateResult(result)) return;
     setBusy(true);
     try {
       await a.addWorktree(


### PR DESCRIPTION
## Summary
- Dismissing a `showModal` via X or backdrop was settling the promise with a React `MouseEvent` instead of `undefined`, because `ModalHost` passed the settle callback directly as `onClose`.
- That made Create worktree treat cancel as success and crash on `"existing" in result.branch` (`TypeError: undefined is not an Object`), even when git had already created the worktree.
- Fix: settle dismiss with `undefined` in `ModalHost`, and guard create-worktree with `isWorktreeCreateResult` (+ unit tests).

## Test plan
- [x] `pnpm --filter @silo-code/extensions-silo exec vitest run src/git-explorer/WorktreeCreateDialog.test.ts`
- [x] Manual: open Manage worktrees → Create worktree → dismiss with X, backdrop, and Escape — no "Create worktree failed" toast
- [x] Manual: create a worktree (new branch) — success toast, worktree appears, no error toast


Made with [Cursor](https://cursor.com)