### PR TITLE
fix(diff): scope git diffs to the file's workspace root

### DIFF
--- a/apps/docs/api/types/interfaces/ActiveEditorInfo.md
+++ b/apps/docs/api/types/interfaces/ActiveEditorInfo.md
@@ -1,6 +1,6 @@
 # Interface: ActiveEditorInfo
 
-Defined in: [packages/sdk/src/editor-service.ts:157](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L157)
+Defined in: [packages/sdk/src/editor-service.ts:163](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L163)
 
 A point-in-time snapshot of the focused editor tab. Part of
 [EditorsState](EditorsState.md), returned by [EditorService.getState](EditorService.md#getstate) and
@@ -14,7 +14,7 @@ delivered to [EditorService.subscribe](EditorService.md#subscribe) listeners.
 editorId: string;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:159](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L159)
+Defined in: [packages/sdk/src/editor-service.ts:165](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L165)
 
 The focused editor tab's record id — matches [EditorRecord.id](EditorRecord.md#id).
 
@@ -26,7 +26,7 @@ The focused editor tab's record id — matches [EditorRecord.id](EditorRecord.md
 filePath: string | null;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:164](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L164)
+Defined in: [packages/sdk/src/editor-service.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L170)
 
 The absolute file path of the focused tab, or `null` for an untitled
 buffer.
@@ -39,7 +39,7 @@ buffer.
 viewId: string;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L171)
+Defined in: [packages/sdk/src/editor-service.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L177)
 
 The [Editor.id](Editor.md#id) of the presenter rendering the tab
 (e.g. `"core.text-editor"`, `"silo.markdown-preview"`). Empty string
@@ -54,6 +54,6 @@ the tab was opened).
 mode: EditorMode;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:173](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L173)
+Defined in: [packages/sdk/src/editor-service.ts:179](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L179)
 
 Whether the tab is in text or diff mode.

--- a/apps/docs/api/types/interfaces/DiffContentRequest.md
+++ b/apps/docs/api/types/interfaces/DiffContentRequest.md
@@ -1,10 +1,12 @@
 # Interface: DiffContentRequest
 
-Defined in: [packages/sdk/src/editor-service.ts:127](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L127)
+Defined in: [packages/sdk/src/editor-service.ts:129](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L129)
 
 The request a [DiffContentProvider](../type-aliases/DiffContentProvider.md) receives to resolve a diff's two
-sides — the [OpenDiffSpec](OpenDiffSpec.md)'s `filePath`/`args` plus the folder of the
-workspace the diff lives in (the natural cwd for path-relative providers).
+sides — the [OpenDiffSpec](OpenDiffSpec.md)'s `filePath`/`args` plus the workspace
+folder that contains that file (the natural cwd for path-relative providers).
+In a multi-root workspace this is the matching root (primary or an
+`extraFolder` such as an opened git worktree), not always the primary folder.
 
 ## Properties
 
@@ -14,7 +16,7 @@ workspace the diff lives in (the natural cwd for path-relative providers).
 filePath: string;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:129](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L129)
+Defined in: [packages/sdk/src/editor-service.ts:131](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L131)
 
 The file the diff is OF (from [OpenDiffSpec.filePath](OpenDiffSpec.md#filepath)).
 
@@ -26,7 +28,7 @@ The file the diff is OF (from [OpenDiffSpec.filePath](OpenDiffSpec.md#filepath))
 optional args?: Record<string, unknown>;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:131](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L131)
+Defined in: [packages/sdk/src/editor-service.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L133)
 
 The provider's args (from [OpenDiffSpec.args](OpenDiffSpec.md#args)).
 
@@ -38,6 +40,8 @@ The provider's args (from [OpenDiffSpec.args](OpenDiffSpec.md#args)).
 workspaceFolder: string | null;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L133)
+Defined in: [packages/sdk/src/editor-service.ts:139](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L139)
 
-Folder of the workspace the diff lives in, or `null` if none.
+Workspace root that contains [DiffContentRequest.filePath](#filepath), or
+`null` if none. Prefer this over the workspace primary folder when roots
+differ (e.g. a linked worktree opened alongside).

--- a/apps/docs/api/types/interfaces/EditorSaveEvent.md
+++ b/apps/docs/api/types/interfaces/EditorSaveEvent.md
@@ -1,6 +1,6 @@
 # Interface: EditorSaveEvent
 
-Defined in: [packages/sdk/src/editor-service.ts:206](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L206)
+Defined in: [packages/sdk/src/editor-service.ts:212](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L212)
 
 Payload delivered to [EditorService.onDidSave](EditorService.md#ondidsave) listeners after an
 editor tab's contents are written to disk.
@@ -13,7 +13,7 @@ editor tab's contents are written to disk.
 editorId: string;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:208](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L208)
+Defined in: [packages/sdk/src/editor-service.ts:214](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L214)
 
 The saved tab's editor record id — matches [EditorRecord.id](EditorRecord.md#id).
 
@@ -25,7 +25,7 @@ The saved tab's editor record id — matches [EditorRecord.id](EditorRecord.md#i
 filePath: string;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L213)
+Defined in: [packages/sdk/src/editor-service.ts:219](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L219)
 
 Absolute path the contents were written to. For a save-as (or first save
 of an untitled buffer) this is the newly chosen path, not the old one.

--- a/apps/docs/api/types/interfaces/EditorService.md
+++ b/apps/docs/api/types/interfaces/EditorService.md
@@ -1,6 +1,6 @@
 # Interface: EditorService
 
-Defined in: [packages/sdk/src/editor-service.ts:225](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L225)
+Defined in: [packages/sdk/src/editor-service.ts:231](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L231)
 
 The editor & document domain, exposed as [ExtensionContext.editors](ExtensionContext.md#editors).
 Open files into editor tabs, drive the active editor (save / close), and let
@@ -15,7 +15,7 @@ prefer it over reaching into workspace/editor state.
 onDidSave: Event<EditorSaveEvent>;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:317](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L317)
+Defined in: [packages/sdk/src/editor-service.ts:323](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L323)
 
 Fires after an editor tab's contents are saved to disk — a formatter,
 linter, or build-on-save extension's entry point. See [Event](../type-aliases/Event.md).
@@ -38,7 +38,7 @@ ctx.subscriptions.push(
 open(path, opts?): void;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:230](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L230)
+Defined in: [packages/sdk/src/editor-service.ts:236](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L236)
 
 Open a file in an editor tab. Promotes an existing preview, focuses an
 already-open tab, or opens a new one.
@@ -65,7 +65,7 @@ already-open tab, or opens a new one.
 openUntitled(opts?): void;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:232](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L232)
+Defined in: [packages/sdk/src/editor-service.ts:238](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L238)
 
 Open a fresh untitled editor.
 
@@ -87,7 +87,7 @@ Open a fresh untitled editor.
 openDiff(spec, opts?): void;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:237](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L237)
+Defined in: [packages/sdk/src/editor-service.ts:243](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L243)
 
 Open a diff view. The content is supplied by the [provider](OpenDiffSpec.md#providerid)
 named in `spec` — the editor itself is content-agnostic.
@@ -114,7 +114,7 @@ named in `spec` — the editor itself is content-agnostic.
 save(): boolean;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:239](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L239)
+Defined in: [packages/sdk/src/editor-service.ts:245](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L245)
 
 Save the active editor. Returns false if there's no active saveable editor.
 
@@ -130,7 +130,7 @@ Save the active editor. Returns false if there's no active saveable editor.
 saveAs(): boolean;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:241](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L241)
+Defined in: [packages/sdk/src/editor-service.ts:247](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L247)
 
 Save-as the active editor. Returns false if unavailable.
 
@@ -146,7 +146,7 @@ Save-as the active editor. Returns false if unavailable.
 closeActive(): boolean;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:243](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L243)
+Defined in: [packages/sdk/src/editor-service.ts:249](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L249)
 
 Close the active dock panel. Returns false if there's nothing to close.
 
@@ -162,7 +162,7 @@ Close the active dock panel. Returns false if there's nothing to close.
 editorsFor(path): EditorViewInfo[];
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:252](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L252)
+Defined in: [packages/sdk/src/editor-service.ts:258](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L258)
 
 List the editor views that match `path` (or `null` for an untitled buffer),
 highest-priority first, each flagged whether it's the one the host resolves
@@ -192,7 +192,7 @@ setViewType(
    opts?): void;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:261](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L261)
+Defined in: [packages/sdk/src/editor-service.ts:267](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L267)
 
 Switch an already-open editor tab to a different view in place — without
 closing and reopening it — and persist the choice on the tab. No-op if the
@@ -229,7 +229,7 @@ presenter.
 registerSaveHandler(editorId, handlers): Disposable;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:271](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L271)
+Defined in: [packages/sdk/src/editor-service.ts:277](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L277)
 
 Register save handlers for an editor instance (by its `editorId`), so the
 active-editor `save` / `saveAs` dispatch to it while it's focused. Dispose
@@ -257,7 +257,7 @@ to unregister (do this when the editor unmounts).
 registerDiffContentProvider(providerId, provider): Disposable;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:280](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L280)
+Defined in: [packages/sdk/src/editor-service.ts:286](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L286)
 
 Register a [DiffContentProvider](../type-aliases/DiffContentProvider.md) under `providerId`. A diff opened
 with that `providerId` (see [OpenDiffSpec](OpenDiffSpec.md)) resolves its two sides
@@ -285,7 +285,7 @@ through this provider, on every mount. Dispose to unregister.
 getText(editorId): Promise<string | undefined>;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:298](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L298)
+Defined in: [packages/sdk/src/editor-service.ts:304](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L304)
 
 The current buffer text of an open editor tab, including unsaved edits.
 
@@ -319,7 +319,7 @@ if (text !== undefined) ctx.log.info(`${text.length} chars`);
 isDirty(editorId): boolean;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:303](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L303)
+Defined in: [packages/sdk/src/editor-service.ts:309](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L309)
 
 Whether an open editor tab has unsaved changes. Returns `false` for an
 unknown id or a tab that isn't mounted / text-backed.
@@ -342,7 +342,7 @@ unknown id or a tab that isn't mounted / text-backed.
 getState(): EditorsState;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:330](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L330)
+Defined in: [packages/sdk/src/editor-service.ts:336](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L336)
 
 Current frozen snapshot of editor state. The returned object is
 referentially stable between renders — `getState() === getState()` when
@@ -368,7 +368,7 @@ if (active) ctx.log.info(`Active file: ${active.filePath ?? "(untitled)"}`);
 subscribe(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:349](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L349)
+Defined in: [packages/sdk/src/editor-service.ts:355](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L355)
 
 Subscribe to changes in the active editor. The listener is called whenever
 `active` changes (tab focus moves, workspace switches, editor opens or

--- a/apps/docs/api/types/interfaces/EditorsState.md
+++ b/apps/docs/api/types/interfaces/EditorsState.md
@@ -1,6 +1,6 @@
 # Interface: EditorsState
 
-Defined in: [packages/sdk/src/editor-service.ts:186](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L186)
+Defined in: [packages/sdk/src/editor-service.ts:192](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L192)
 
 A frozen, referentially-stable snapshot of editor domain state. Returned by
 [EditorService.getState](EditorService.md#getstate) and delivered to
@@ -16,7 +16,7 @@ Compatible with `useServiceState` — just pass `ctx.editors` directly.
 active: ActiveEditorInfo | null;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L191)
+Defined in: [packages/sdk/src/editor-service.ts:197](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L197)
 
 The focused editor tab, or `null` when the active dock panel is not an
 editor tab (e.g. a terminal, a dock panel kind, or nothing at all).
@@ -29,7 +29,7 @@ editor tab (e.g. a terminal, a dock panel kind, or nothing at all).
 hydrated: boolean;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:196](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L196)
+Defined in: [packages/sdk/src/editor-service.ts:202](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L202)
 
 `true` once the persisted workspace state has loaded from disk. Matches
 `WorkspaceState.hydrated` — guard state-restoring code on this flag.

--- a/apps/docs/api/types/type-aliases/DiffContentProvider.md
+++ b/apps/docs/api/types/type-aliases/DiffContentProvider.md
@@ -4,7 +4,7 @@
 type DiffContentProvider = (request) => Promise<DiffContent>;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:145](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L145)
+Defined in: [packages/sdk/src/editor-service.ts:151](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L151)
 
 Resolves the two sides of a diff on demand — called by the host whenever a
 diff panel mounts (open, tab switch, app restart), so content stays a pure

--- a/packages/extensions-core/src/editor/DiffPanel.tsx
+++ b/packages/extensions-core/src/editor/DiffPanel.tsx
@@ -26,6 +26,7 @@ import {
   blurTextareaWithin,
   isTextareaFocusedWithin,
 } from "@silo-code/extension-host/internal";
+import { workspaceFolderForPath } from "./workspace-folder-for-path";
 import "./EditorPanel.css";
 
 /** Coalesce burst writes (e.g. an agent rewriting a file) into one reload. */
@@ -71,10 +72,17 @@ export function DiffViewer({
       return;
     }
     const seq = ++fetchSeq.current;
+    // Multi-root (opened worktrees live in extraFolders): scope the provider
+    // cwd to the root that contains the file, not always the primary folder.
+    // Otherwise silo.git runs `git show` in the primary checkout and a tiny
+    // worktree edit looks like a full-file add from the wrong HEAD.
+    const workspaceFolder =
+      workspaceFolderForPath(rec.filePath!, ws.folder, ws.extraFolders ?? []) ??
+      ws.folder;
     provider({
       filePath: rec.filePath!,
       args: rec.args,
-      workspaceFolder: ws.folder,
+      workspaceFolder,
     })
       .then(({ original: orig, modified: mod }) => {
         if (seq !== fetchSeq.current) return;
@@ -86,7 +94,13 @@ export function DiffViewer({
         if (seq !== fetchSeq.current) return;
         setError(String(err));
       });
-  }, [rec?.filePath, rec?.providerId, JSON.stringify(rec?.args), ws?.folder]);
+  }, [
+    rec?.filePath,
+    rec?.providerId,
+    JSON.stringify(rec?.args),
+    ws?.folder,
+    JSON.stringify(ws?.extraFolders ?? []),
+  ]);
 
   // Initial load + reload when the diff's identity changes (open / tab switch /
   // app restart, or a save-as that repoints the record).

--- a/packages/extensions-core/src/editor/workspace-folder-for-path.test.ts
+++ b/packages/extensions-core/src/editor/workspace-folder-for-path.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { workspaceFolderForPath } from "./workspace-folder-for-path";
+
+describe("workspaceFolderForPath", () => {
+  const primary = "/repos/app";
+  const worktree = "/repos/app-fix-x";
+
+  it("returns the primary root for a file under it", () => {
+    expect(
+      workspaceFolderForPath(`${primary}/src/a.ts`, primary, [worktree]),
+    ).toBe(primary);
+  });
+
+  it("returns a worktree extraFolder when the file lives there", () => {
+    expect(
+      workspaceFolderForPath(`${worktree}/src/settings-store.ts`, primary, [
+        worktree,
+      ]),
+    ).toBe(worktree);
+  });
+
+  it("prefers the longest matching root when roots nest", () => {
+    const nested = `${primary}/packages/pkg`;
+    expect(
+      workspaceFolderForPath(`${nested}/src/a.ts`, primary, [nested]),
+    ).toBe(nested);
+  });
+
+  it("returns null when no root contains the path", () => {
+    expect(
+      workspaceFolderForPath("/elsewhere/file.ts", primary, [worktree]),
+    ).toBeNull();
+  });
+
+  it("trims trailing slashes on roots", () => {
+    expect(
+      workspaceFolderForPath(`${worktree}/a.ts`, `${primary}/`, [
+        `${worktree}/`,
+      ]),
+    ).toBe(worktree);
+  });
+
+  it("matches the root path itself", () => {
+    expect(workspaceFolderForPath(worktree, primary, [worktree])).toBe(
+      worktree,
+    );
+  });
+});

--- a/packages/extensions-core/src/editor/workspace-folder-for-path.ts
+++ b/packages/extensions-core/src/editor/workspace-folder-for-path.ts
@@ -1,0 +1,26 @@
+/**
+ * Pick the workspace root that contains `filePath`.
+ *
+ * Multi-root workspaces (primary + `extraFolders`, including opened git
+ * worktrees) must scope path-relative ops — especially `silo.git` diffs — to
+ * the root the file actually lives under. Longest matching prefix wins so a
+ * nested root beats its parent.
+ *
+ * Returns `null` when no root contains the path.
+ */
+export function workspaceFolderForPath(
+  filePath: string,
+  primary: string,
+  extras: readonly string[] = [],
+): string | null {
+  const roots = [primary, ...extras]
+    .map((f) => f.replace(/\/+$/, ""))
+    .filter((f) => f.length > 0);
+  let best: string | null = null;
+  for (const root of roots) {
+    if (filePath === root || filePath.startsWith(`${root}/`)) {
+      if (best === null || root.length > best.length) best = root;
+    }
+  }
+  return best;
+}

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -431,7 +431,9 @@ export function GitView({
       {
         filePath,
         providerId: "silo.git",
-        args: { mode },
+        // cwd pins the git root for this row (worktree vs primary) so the
+        // content provider doesn't rely solely on the workspace primary folder.
+        args: { mode, cwd: folder },
         title: mode === "staged" ? `${base} (staged)` : `${base} (diff)`,
       },
       { workspaceId, preview: true },

--- a/packages/extensions-silo/src/git/index.ts
+++ b/packages/extensions-silo/src/git/index.ts
@@ -58,7 +58,13 @@ export const extension: Extension<GitAPI> = {
     // re-register — the provider registry rejects a duplicate id).
     ctx.subscriptions.push(
       ctx.editors.registerDiffContentProvider("silo.git", async (req) => {
-        const folder = req.workspaceFolder;
+        // Prefer an explicit cwd from the opener (Git panel knows which repo
+        // root the row belongs to); otherwise the host's containing workspace
+        // folder (correct for multi-root / opened worktrees).
+        const folder =
+          typeof req.args?.cwd === "string" && req.args.cwd.length > 0
+            ? req.args.cwd
+            : req.workspaceFolder;
         if (!folder) return { original: "", modified: "" };
         const relative = relativeTo(req.filePath, folder);
         const mode = req.args?.mode as DiffMode | undefined;

--- a/packages/sdk/src/editor-service.ts
+++ b/packages/sdk/src/editor-service.ts
@@ -118,8 +118,10 @@ export interface DiffContent {
 
 /**
  * The request a {@link DiffContentProvider} receives to resolve a diff's two
- * sides — the {@link OpenDiffSpec}'s `filePath`/`args` plus the folder of the
- * workspace the diff lives in (the natural cwd for path-relative providers).
+ * sides — the {@link OpenDiffSpec}'s `filePath`/`args` plus the workspace
+ * folder that contains that file (the natural cwd for path-relative providers).
+ * In a multi-root workspace this is the matching root (primary or an
+ * `extraFolder` such as an opened git worktree), not always the primary folder.
  *
  * @category Consumer Services
  * @public
@@ -129,7 +131,11 @@ export interface DiffContentRequest {
   filePath: string;
   /** The provider's args (from {@link OpenDiffSpec.args}). */
   args?: Record<string, unknown>;
-  /** Folder of the workspace the diff lives in, or `null` if none. */
+  /**
+   * Workspace root that contains {@link DiffContentRequest.filePath}, or
+   * `null` if none. Prefer this over the workspace primary folder when roots
+   * differ (e.g. a linked worktree opened alongside).
+   */
   workspaceFolder: string | null;
 }
 


### PR DESCRIPTION
## Summary
- DiffPanel always passed the workspace **primary** folder to `silo.git`, so a file in an opened worktree (`extraFolders`) ran `git show` against the wrong HEAD and looked like a full-file add.
- Resolve `workspaceFolder` from the containing root (longest matching primary/extra), pin `args.cwd` from the Git panel, and prefer that cwd in the git content provider.
- Clarifies `DiffContentRequest.workspaceFolder` docs for multi-root / worktree cases.

## Test plan
- [x] `pnpm --filter @silo-code/extensions-core exec vitest run src/editor/workspace-folder-for-path.test.ts`
- [x] Manual: primary `silo-extensions` + opened worktree `silo-extensions-fix-agent-monitor-default-sound` — open worktree diff for `settings-store.ts` and confirm only the ~1-line `DEFAULT_SOUND_ENABLED` change (not the feature-branch dump)


Made with [Cursor](https://cursor.com)