### PR TITLE
feat(keybindings): edit shortcuts in Settings without opening JSON

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,3 +45,60 @@ _Avoid_: Clean, garbage-collect worktrees
 A Remove worktree that has passed every confirm and is still deleting on disk.
 The workspace folder is already closed; the operation is not cancelable.
 _Avoid_: Background delete, queued delete
+
+### Keybindings
+
+**Keybinding**:
+A single chord bound to a command. Each command has at most one effective
+keybinding.
+_Avoid_: Hotkey, accelerator (native-menu term only), shortcut (prefer for the
+settings page name, not the binding itself)
+
+**Keyboard Shortcuts**:
+The Settings page where users browse and change keybindings.
+_Avoid_: Keybindings page, keymap editor, hotkeys settings
+
+**Chord**:
+One simultaneous key combination (modifiers + key), e.g. Cmd+Shift+S. Not a
+multi-press sequence.
+_Avoid_: Sequence, key chord chain, chord progression
+
+**Default keybinding**:
+The chord an extension or menu declares for a command before any user change.
+_Avoid_: Built-in shortcut, factory binding
+
+**Override**:
+A user-chosen chord for a command that replaces its default.
+_Avoid_: Custom keybinding, remapping, user binding (prefer "override" when
+contrasting with default)
+
+**Unbound**:
+A command the user has explicitly left with no chord, including clearing a
+default.
+_Avoid_: Disabled, removed command, cleared (prefer "unbound" / "remove
+keybinding")
+
+**Effective key**:
+The chord that actually applies to a command right now — override if present,
+otherwise default, unless unbound.
+_Avoid_: Resolved key, active shortcut, current binding (ambiguous with
+"selected row")
+
+**Capture**:
+The inline mode on a Keyboard Shortcuts row where the next chord pressed
+becomes that command's override.
+_Avoid_: Record, listen, key recording, rebind mode
+
+**Reassign**:
+Taking a chord from another command: the previous owner becomes unbound (or
+loses that override) so only one command keeps the chord.
+_Avoid_: Steal, conflict resolve, overwrite
+
+**Reset keybinding**:
+Drop the override so the command returns to its default (or to unbound if it
+had no default).
+_Avoid_: Restore, revert shortcut, clear override (prefer "reset" in the UI)
+
+**Remove keybinding**:
+Make a command unbound — no chord fires it, even if a default existed.
+_Avoid_: Delete keybinding, clear shortcut, unbind (ok in prose; UI says Remove)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,15 +4,19 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Before exploring, read these
 
+- **`CONTEXT.md`** — ubiquitous language / glossary. Prefer these terms over
+  inventing synonyms.
 - **`docs/decisions/`** — ADRs, the durable "why" behind architecture decisions already made. Read any that touch the area you're about to work in.
 - **`docs/proposals/`** — RFCs, forward-looking designs not yet decided. Check for open proposals relevant to the area.
-- There is no repo-wide `CONTEXT.md` glossary yet. If one is created later (by `/domain-modeling`), read it before exploring.
 
 This repo is a pnpm workspace (`apps/*`, `packages/*`, `examples/extensions/*`), but `docs/decisions/` and `docs/proposals/` are repo-wide, not per-package — there is no `src/<context>/docs/adr/` split to check.
 
 ## Use the glossary's vocabulary
 
-No `CONTEXT.md` exists yet, so there's no fixed glossary to defer to. Prefer terminology already used in `docs/decisions/`, `docs/proposals/`, and `docs/ui-terminology.md` over inventing new terms.
+Prefer terminology in `CONTEXT.md` (and, where it doesn't yet cover a concept,
+`docs/decisions/`, `docs/proposals/`, and `docs/ui-terminology.md`) over inventing
+new terms. When you introduce a new domain term, add it to `CONTEXT.md` in the
+same change.
 
 ## Flag ADR conflicts
 

--- a/packages/extension-host/src/extension-host/commands.ts
+++ b/packages/extension-host/src/extension-host/commands.ts
@@ -1,5 +1,6 @@
 import { Registry } from "./registry";
 import type { Command } from "@silo-code/sdk";
+import { isKeybindingCaptureActive } from "./keymap";
 
 export const commandRegistry = new Registry<Command>();
 
@@ -10,6 +11,9 @@ export const commandRegistry = new Registry<Command>();
  * unhandled-rejection warning.
  */
 export function executeCommand(id: string, ...args: unknown[]): boolean {
+  // Keyboard Shortcuts capture mode: swallow dispatch so the chord is recorded
+  // instead of running (covers native-menu accelerators too).
+  if (isKeybindingCaptureActive()) return false;
   const cmd = commandRegistry.get(id);
   if (!cmd) {
     console.warn(`[extensions] unknown command: ${id}`);
@@ -42,6 +46,9 @@ export function executeCommandAsync<T = unknown>(
   id: string,
   ...args: unknown[]
 ): Promise<T> {
+  if (isKeybindingCaptureActive()) {
+    return Promise.resolve(undefined as T);
+  }
   const cmd = commandRegistry.get(id);
   let result: Promise<T>;
   if (!cmd) {

--- a/packages/extension-host/src/extension-host/keybindings.ts
+++ b/packages/extension-host/src/extension-host/keybindings.ts
@@ -4,6 +4,7 @@ import { contextKeys } from "./context-keys";
 import { menuItemRegistry } from "./menu-items";
 import {
   clearKeybindingDefaults,
+  isKeybindingCaptureActive,
   isRemoved,
   overrideKey,
   recordKeybindingDefault,
@@ -127,6 +128,7 @@ function matches(p: ParsedKey, e: KeyboardEvent): boolean {
  * fall through to other handling.
  */
 export function dispatchKey(e: KeyboardEvent): boolean {
+  if (isKeybindingCaptureActive()) return false;
   for (const binding of keybindingRegistry.list()) {
     // Menu-homed commands dispatch via their native menu accelerator (which the
     // menu builder sources from the keymap); skip them here to avoid double-fire.

--- a/packages/extension-host/src/extension-host/keymap.test.ts
+++ b/packages/extension-host/src/extension-host/keymap.test.ts
@@ -3,12 +3,20 @@ import {
   normalizeKey,
   toTauriAccelerator,
   setUserBindings,
+  getUserBindings,
   effectiveKey,
+  defaultKey,
   isRemoved,
+  overrideKey,
   recordMenuDefault,
   clearMenuDefaults,
+  beginMenuDefaultBatch,
+  commitMenuDefaultBatch,
   recordKeybindingDefault,
   clearKeybindingDefaults,
+  setKeybindingCaptureActive,
+  isKeybindingCaptureActive,
+  onKeymapChange,
 } from "./keymap";
 
 describe("normalizeKey", () => {
@@ -47,6 +55,10 @@ describe("user bindings → effective key", () => {
     setUserBindings([]); // reset module state between tests
     clearMenuDefaults();
     clearKeybindingDefaults();
+    setKeybindingCaptureActive(false);
+    // Abandon any half-open batch from a previous test.
+    beginMenuDefaultBatch();
+    commitMenuDefaultBatch();
   });
 
   it("override wins over the menu default", () => {
@@ -81,5 +93,77 @@ describe("user bindings → effective key", () => {
     // @ts-expect-error intentionally malformed
     setUserBindings([{ command: 123 }, null, { key: "cmd+x" }]);
     expect(effectiveKey("anything")).toBeUndefined();
+  });
+
+  it("defaultKey ignores overrides and unbinds", () => {
+    recordMenuDefault("file.save", "CmdOrCtrl+S");
+    setUserBindings([{ command: "file.save", key: "cmd+k" }]);
+    expect(defaultKey("file.save")).toBe("cmd+s");
+    expect(overrideKey("file.save")).toBe("cmd+k");
+    setUserBindings([{ command: "-file.save", key: "" }]);
+    expect(defaultKey("file.save")).toBe("cmd+s");
+    expect(effectiveKey("file.save")).toBeUndefined();
+  });
+
+  it("getUserBindings round-trips overrides and unbinds in sorted order", () => {
+    setUserBindings([
+      { command: "z.cmd", key: "cmd+z" },
+      { command: "-a.cmd", key: "" },
+      { command: "b.cmd", key: "cmd+b" },
+    ]);
+    expect(getUserBindings()).toEqual([
+      { command: "b.cmd", key: "cmd+b" },
+      { command: "z.cmd", key: "cmd+z" },
+      { command: "-a.cmd", key: "" },
+    ]);
+  });
+
+  it("tracks keybinding capture active flag", () => {
+    expect(isKeybindingCaptureActive()).toBe(false);
+    setKeybindingCaptureActive(true);
+    expect(isKeybindingCaptureActive()).toBe(true);
+    setKeybindingCaptureActive(false);
+    expect(isKeybindingCaptureActive()).toBe(false);
+  });
+
+  it("menu-default batches keep the live map intact until commit", () => {
+    recordMenuDefault("file.save", "CmdOrCtrl+S");
+    expect(effectiveKey("file.save")).toBe("cmd+s");
+
+    beginMenuDefaultBatch();
+    // Live map still has the old default while the batch is open.
+    expect(effectiveKey("file.save")).toBe("cmd+s");
+    recordMenuDefault("file.save", "CmdOrCtrl+S");
+    recordMenuDefault("file.saveAs", "CmdOrCtrl+Shift+S");
+    // Staged keys are not live yet.
+    expect(effectiveKey("file.saveAs")).toBeUndefined();
+
+    commitMenuDefaultBatch();
+    expect(effectiveKey("file.save")).toBe("cmd+s");
+    expect(effectiveKey("file.saveAs")).toBe("cmd+shift+s");
+  });
+
+  it("commitMenuDefaultBatch drops defaults that were not re-recorded", () => {
+    recordMenuDefault("file.save", "CmdOrCtrl+S");
+    recordMenuDefault("file.gone", "CmdOrCtrl+G");
+    beginMenuDefaultBatch();
+    recordMenuDefault("file.save", "CmdOrCtrl+S");
+    commitMenuDefaultBatch();
+    expect(effectiveKey("file.save")).toBe("cmd+s");
+    expect(effectiveKey("file.gone")).toBeUndefined();
+  });
+
+  it("commitMenuDefaultBatch does not emit (avoids syncMenu feedback loop)", () => {
+    let emissions = 0;
+    const sub = onKeymapChange(() => {
+      emissions++;
+    });
+    beginMenuDefaultBatch();
+    recordMenuDefault("file.save", "CmdOrCtrl+S");
+    commitMenuDefaultBatch();
+    expect(emissions).toBe(0);
+    setUserBindings([{ command: "file.save", key: "cmd+k" }]);
+    expect(emissions).toBe(1);
+    sub.dispose();
   });
 });

--- a/packages/extension-host/src/extension-host/keymap.ts
+++ b/packages/extension-host/src/extension-host/keymap.ts
@@ -10,7 +10,7 @@
 // Keys are stored in a normalized "cmd+shift+s" form. Converters bridge to the
 // Tauri accelerator form ("CmdOrCtrl+Shift+S") used by the native menu.
 
-import { fsReadText } from "../services/tauri-fs";
+import { fsReadText, fsWriteText } from "../services/tauri-fs";
 import { startWatch, onFileChange } from "../services/tauri-watch";
 import { userConfigDir, userConfigPath } from "../services/user-config";
 import type { Disposable } from "@silo-code/sdk";
@@ -134,7 +134,7 @@ export function displayKey(norm: string): string {
 
 let overrides = new Map<string, string>(); // command → normalized key
 let removed = new Set<string>(); // commands the user unbound
-const menuDefaults = new Map<string, string>(); // command → normalized key (from menu accelerators)
+let menuDefaults = new Map<string, string>(); // command → normalized key (from menu accelerators)
 const keybindingDefaults = new Map<string, string>(); // command → normalized key (from registerKeybinding)
 
 const listeners = new Set<() => void>();
@@ -149,12 +149,37 @@ export function onKeymapChange(fn: () => void): Disposable {
 
 /** Record an extension-declared default (called by the menu builder per item). */
 export function recordMenuDefault(command: string, accelerator: string): void {
-  menuDefaults.set(command, normalizeKey(accelerator));
+  const key = normalizeKey(accelerator);
+  if (menuDefaultBatch) menuDefaultBatch.set(command, key);
+  else menuDefaults.set(command, key);
 }
 
 /** Cleared and rebuilt on every menu sync so stale entries don't linger. */
 export function clearMenuDefaults(): void {
   menuDefaults.clear();
+}
+
+/**
+ * Stage menu-default recording into a side map so a mid-sync
+ * {@link clearMenuDefaults} never blanks the live map the Keyboard Shortcuts
+ * page reads. Pair with {@link commitMenuDefaultBatch}.
+ */
+let menuDefaultBatch: Map<string, string> | null = null;
+
+export function beginMenuDefaultBatch(): void {
+  menuDefaultBatch = new Map();
+}
+
+/** Atomically replace live menu defaults with the staged batch. */
+export function commitMenuDefaultBatch(): void {
+  if (!menuDefaultBatch) return;
+  menuDefaults = menuDefaultBatch;
+  menuDefaultBatch = null;
+  // Do NOT emit here. onKeymapChange → syncMenu → commit would loop forever,
+  // and overlapping syncs can commit a partial batch (menu-homed keys flicker).
+  // Callers that mutate user overrides already emit via setUserBindings; the
+  // live map stays readable throughout the batch so the Shortcuts page never
+  // sees an empty gap.
 }
 
 /**
@@ -180,6 +205,11 @@ export function overrideKey(command: string): string | undefined {
   return overrides.get(command);
 }
 
+/** Extension/menu-declared default, ignoring user overrides and unbinds. */
+export function defaultKey(command: string): string | undefined {
+  return menuDefaults.get(command) ?? keybindingDefaults.get(command);
+}
+
 /** Effective key = override ?? default, unless the user unbound it. */
 export function effectiveKey(command: string): string | undefined {
   if (removed.has(command)) return undefined;
@@ -188,6 +218,38 @@ export function effectiveKey(command: string): string | undefined {
     menuDefaults.get(command) ??
     keybindingDefaults.get(command)
   );
+}
+
+/**
+ * Snapshot of the in-memory user overrides / unbinds, suitable for rewriting
+ * keybindings.json. Sorted for stable diffs.
+ */
+export function getUserBindings(): UserBinding[] {
+  const list: UserBinding[] = [];
+  for (const [command, key] of [...overrides.entries()].sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    list.push({ command, key });
+  }
+  for (const command of [...removed].sort()) {
+    list.push({ command: `-${command}`, key: "" });
+  }
+  return list;
+}
+
+/**
+ * While the Keyboard Shortcuts page is capturing a chord, suppress command
+ * dispatch (registry keybindings and native-menu accelerators alike) so the
+ * pressed keys bind instead of firing.
+ */
+let keybindingCaptureActive = false;
+
+export function setKeybindingCaptureActive(active: boolean): void {
+  keybindingCaptureActive = active;
+}
+
+export function isKeybindingCaptureActive(): boolean {
+  return keybindingCaptureActive;
 }
 
 /** Snapshot of every command that has a default, with its effective key. */
@@ -214,6 +276,22 @@ export function setUserBindings(list: UserBinding[]): void {
     overrides.set(b.command, normalizeKey(b.key));
   }
   emit();
+}
+
+/**
+ * Apply a new user-bindings list in memory and rewrite keybindings.json.
+ * Structured pretty-JSON rewrite — comments/formatting in the file are not
+ * preserved (power users still have the editor escape hatch).
+ */
+export async function saveUserBindings(list: UserBinding[]): Promise<void> {
+  const normalized = list.map((b) =>
+    b.command.startsWith("-")
+      ? { command: b.command, key: b.key }
+      : { command: b.command, key: normalizeKey(b.key) },
+  );
+  setUserBindings(normalized);
+  const path = await keybindingsPath();
+  await fsWriteText(path, `${JSON.stringify(normalized, null, 2)}\n`);
 }
 
 // ── keybindings.json ───────────────────────────────────────────────────────

--- a/packages/extension-host/src/extension-host/menu-items.ts
+++ b/packages/extension-host/src/extension-host/menu-items.ts
@@ -8,7 +8,8 @@ import { Registry } from "./registry";
 import { commandRegistry, executeCommand } from "./commands";
 import { contextKeys, onContextChange } from "./context-keys";
 import {
-  clearMenuDefaults,
+  beginMenuDefaultBatch,
+  commitMenuDefaultBatch,
   effectiveKey,
   onKeymapChange,
   recordMenuDefault,
@@ -20,6 +21,16 @@ import { openSettings } from "./settings-dialog";
 import { getExtensionManager } from "./extension-manager";
 
 export const menuItemRegistry = new Registry<MenuItemContribution>();
+
+/**
+ * Which top-level application menu (if any) a command is homed in. Commands
+ * carry no category of their own — this is the closest thing to one, reused
+ * by the Keybindings settings page to group its command list without adding
+ * a new field to {@link Command}.
+ */
+export function menuFor(command: string): MenuId | undefined {
+  return menuItemRegistry.list().find((i) => i.command === command)?.menu;
+}
 
 // Rebuild the native menu whenever user keybinding overrides change, so a
 // menu-homed command's accelerator reflects its effective key.
@@ -41,6 +52,11 @@ function ensureExtensionManagerSubscription(): void {
     void syncMenu();
   });
 }
+
+/** Coalesce overlapping syncs — a second call joins the in-flight one and
+ *  schedules a follow-up if defaults/accelerators may have changed mid-flight. */
+let syncMenuInFlight: Promise<void> | null = null;
+let syncMenuQueued = false;
 
 const isMac =
   typeof navigator !== "undefined" &&
@@ -226,45 +242,70 @@ async function applyWhenClauses(): Promise<void> {
 }
 
 export async function syncMenu(): Promise<void> {
+  if (syncMenuInFlight) {
+    syncMenuQueued = true;
+    return syncMenuInFlight;
+  }
+  syncMenuInFlight = runSyncMenu().finally(() => {
+    syncMenuInFlight = null;
+    if (syncMenuQueued) {
+      syncMenuQueued = false;
+      void syncMenu();
+    }
+  });
+  return syncMenuInFlight;
+}
+
+async function runSyncMenu(): Promise<void> {
   ensureExtensionManagerSubscription();
   // Drop any previous tracking from a prior sync.
   liveItems = [];
   contextSub?.dispose();
   contextSub = null;
-  // Menu defaults are re-recorded as items are rebuilt below.
-  clearMenuDefaults();
+  // Stage defaults into a side map while rebuilding so the live map (what
+  // Keyboard Shortcuts reads) stays intact until the new set is ready —
+  // otherwise setUserBindings → syncMenu briefly blanks every menu-homed key.
+  beginMenuDefaultBatch();
 
-  const byMenu: Record<MenuId, MenuItemContribution[]> = {
-    file: [],
-    edit: [],
-    view: [],
-    window: [],
-    help: [],
-  };
-  for (const item of menuItemRegistry.list()) {
-    byMenu[item.menu].push(item);
-  }
+  try {
+    const byMenu: Record<MenuId, MenuItemContribution[]> = {
+      file: [],
+      edit: [],
+      view: [],
+      window: [],
+      help: [],
+    };
+    for (const item of menuItemRegistry.list()) {
+      byMenu[item.menu].push(item);
+    }
 
-  const submenus: Submenu[] = [];
-  if (isMac) submenus.push(await buildAppSubmenu());
-  submenus.push(await buildSubmenu("File", [], byMenu.file));
-  submenus.push(
-    await buildSubmenu("Edit", await editPredefinedGroups(), byMenu.edit),
-  );
-  submenus.push(await buildSubmenu("View", [], byMenu.view));
-  submenus.push(
-    await buildSubmenu("Window", await windowPredefinedGroups(), byMenu.window),
-  );
-  submenus.push(await buildHelpSubmenu(byMenu.help));
+    const submenus: Submenu[] = [];
+    if (isMac) submenus.push(await buildAppSubmenu());
+    submenus.push(await buildSubmenu("File", [], byMenu.file));
+    submenus.push(
+      await buildSubmenu("Edit", await editPredefinedGroups(), byMenu.edit),
+    );
+    submenus.push(await buildSubmenu("View", [], byMenu.view));
+    submenus.push(
+      await buildSubmenu(
+        "Window",
+        await windowPredefinedGroups(),
+        byMenu.window,
+      ),
+    );
+    submenus.push(await buildHelpSubmenu(byMenu.help));
 
-  const menu = await Menu.new({ items: submenus });
-  await menu.setAsAppMenu();
+    const menu = await Menu.new({ items: submenus });
+    await menu.setAsAppMenu();
 
-  // Re-evaluate when-clauses whenever context keys change. Fire-and-forget
-  // since setEnabled is async over Tauri IPC.
-  if (liveItems.length > 0) {
-    contextSub = onContextChange(() => {
-      void applyWhenClauses();
-    });
+    // Re-evaluate when-clauses whenever context keys change. Fire-and-forget
+    // since setEnabled is async over Tauri IPC.
+    if (liveItems.length > 0) {
+      contextSub = onContextChange(() => {
+        void applyWhenClauses();
+      });
+    }
+  } finally {
+    commitMenuDefaultBatch();
   }
 }

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -129,6 +129,12 @@ export { workspacePropertyPageRegistry } from "./workspace-property-page-registr
 // menu and appends these). See context-menu-items.ts.
 export { contextMenuEntriesFor } from "./context-menu-items";
 
+// Reading a command's menu placement back out (rather than registering one)
+// is a core-extension-only concern — today the sole caller is `core.keybindings`,
+// which uses it to group the shortcuts list by the same File/View/Window/Help
+// buckets the native menu already uses, instead of duplicating that taxonomy.
+export { menuFor } from "./menu-items";
+
 // Editor host-plumbing — the raw Monaco/editor host access that `core.editor`
 // needs but that is wrong to hand to silo.*/third-party (Tier 3 "raw Monaco
 // setup"; see ctx-domains.md → "The editor surface"). NOTE what is deliberately
@@ -290,8 +296,14 @@ export { keybindingRegistry } from "./keybindings";
 export {
   displayKey,
   effectiveKey,
+  defaultKey,
+  getUserBindings,
+  saveUserBindings,
   keybindingsPath,
   onKeymapChange,
+  overrideKey,
+  isRemoved,
+  setKeybindingCaptureActive,
 } from "./keymap";
 
 // Foreground-process updates for a terminal session (RFC 0010 N1) — consumed by

--- a/packages/extensions-core/src/keybindings/KeybindingsPage.css
+++ b/packages/extensions-core/src/keybindings/KeybindingsPage.css
@@ -28,8 +28,9 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  /* Bleed rows to the pane's left edge so the separators run full-width. */
-  margin-left: calc(var(--settings-pane-pad) * -1);
+  /* Space between groups; the gap itself separates each Section from the one
+     before it, so no group needs its own top margin. */
+  gap: 20px;
 }
 
 .kb-row {
@@ -37,9 +38,12 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  /* Left inset = pane pad so row text lines up with the page title. */
-  padding: 7px 8px 7px var(--settings-pane-pad);
-  border-bottom: 1px solid var(--silo-color-border);
+  padding: 7px 0;
+}
+/* Row separators, same pattern as the SDK's own SettingRow: a top border
+   between adjacent rows, none trailing the last row in a group. */
+.kb-row + .kb-row {
+  border-top: 1px solid var(--silo-color-border);
 }
 
 .kb-cmd {
@@ -57,8 +61,41 @@
   font-family: var(--silo-font-mono, monospace);
 }
 
-.kb-key {
+.kb-key-btn {
   flex: 0 0 auto;
+  max-width: 55%;
+  margin: 0;
+  padding: 2px 4px;
+  border: 1px solid transparent;
+  border-radius: var(--silo-radius-sm);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: right;
+}
+.kb-key-btn:hover {
+  background: var(--silo-color-bg-hover);
+}
+.kb-key-btn-capture,
+.kb-key-btn-confirm {
+  max-width: 70%;
+  border-color: var(--silo-color-accent);
+  background: var(--silo-color-bg-active);
+  text-align: left;
+}
+.kb-key-btn-override .kb-key {
+  border-color: var(--silo-color-accent);
+  color: var(--silo-color-accent);
+}
+.kb-key-btn-unbound .kb-unbound {
+  color: var(--silo-color-text-lo);
+  font-style: italic;
+  text-decoration: line-through;
+  text-decoration-color: var(--silo-color-border-strong);
+}
+
+.kb-key {
+  display: inline-block;
   background: var(--silo-color-bg-active);
   border: 1px solid var(--silo-color-border-strong);
   border-radius: var(--silo-radius-sm);
@@ -69,11 +106,17 @@
   white-space: nowrap;
 }
 .kb-unbound {
-  flex: 0 0 auto;
   color: var(--silo-color-text-lo);
+  padding: 2px 7px;
+}
+.kb-capture-hint {
+  display: block;
+  font-size: calc(var(--settings-font) - 1px);
+  color: var(--silo-color-text-hi);
+  line-height: 1.35;
 }
 
 .kb-empty {
   color: var(--silo-color-text-lo);
-  padding: 12px var(--settings-pane-pad);
+  padding: 12px 0;
 }

--- a/packages/extensions-core/src/keybindings/index.tsx
+++ b/packages/extensions-core/src/keybindings/index.tsx
@@ -1,14 +1,33 @@
-import { useEffect, useReducer, useState } from "react";
-import type { Extension, ExtensionContext } from "@silo-code/sdk";
-import { Button, SearchInput } from "@silo-code/sdk";
+import { useEffect, useReducer, useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import { DotsThreeVertical } from "@phosphor-icons/react";
+import type { Extension, ExtensionContext, MenuEntry } from "@silo-code/sdk";
+import { IconButton, SearchInput, Section, Tooltip } from "@silo-code/sdk";
 import {
   commandRegistry,
   keybindingRegistry,
   displayKey,
   effectiveKey,
+  defaultKey,
+  getUserBindings,
+  saveUserBindings,
   keybindingsPath,
+  menuFor,
   onKeymapChange,
+  overrideKey,
+  isRemoved,
+  setKeybindingCaptureActive,
 } from "@silo-code/extension-host/internal";
+import {
+  bindingsAfterRemove,
+  bindingsAfterReset,
+  bindingsAfterSet,
+  commandMatchesQuery,
+  conflictingCommands,
+  groupCommands,
+  parseCaptureKeydown,
+  rowState,
+} from "./keybindings-model";
 import "./KeybindingsPage.css";
 
 const STARTER = `// Keyboard shortcuts — your overrides win over the defaults.
@@ -17,6 +36,16 @@ const STARTER = `// Keyboard shortcuts — your overrides win over the defaults.
 //   { "key": "cmd+alt+]", "command": "-view.toggleRightPanel" }  // unbind a default
 []
 `;
+
+type CaptureState =
+  | { kind: "idle" }
+  | { kind: "capturing"; commandId: string }
+  | {
+      kind: "confirming";
+      commandId: string;
+      chord: string;
+      reassignFrom: string[];
+    };
 
 async function openKeybindingsFile(ctx: ExtensionContext): Promise<void> {
   const path = await keybindingsPath();
@@ -31,6 +60,9 @@ function makePage(ctx: ExtensionContext) {
   return function KeybindingsPage() {
     const [, force] = useReducer((x: number) => x + 1, 0);
     const [query, setQuery] = useState("");
+    const [capture, setCapture] = useState<CaptureState>({ kind: "idle" });
+    const captureRef = useRef(capture);
+    captureRef.current = capture;
 
     // Re-render when commands, keybindings, or the keymap (overrides) change.
     useEffect(() => {
@@ -44,48 +76,299 @@ function makePage(ctx: ExtensionContext) {
       };
     }, []);
 
-    const q = query.trim().toLowerCase();
+    // Capture / reassign-confirm key handling. Suppresses command dispatch for
+    // the duration so the pressed chord is captured instead of executed.
+    useEffect(() => {
+      const active = capture.kind !== "idle";
+      setKeybindingCaptureActive(active);
+      if (!active) return;
+
+      function onKeyDown(e: KeyboardEvent) {
+        const state = captureRef.current;
+        if (state.kind === "idle") return;
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+
+        const parsed = parseCaptureKeydown(e, {
+          confirming: state.kind === "confirming",
+        });
+        if (parsed.kind === "ignore") return;
+        if (parsed.kind === "cancel") {
+          setCapture({ kind: "idle" });
+          return;
+        }
+        if (parsed.kind === "confirm" && state.kind === "confirming") {
+          void commitBinding(state.commandId, state.chord, state.reassignFrom);
+          return;
+        }
+        if (parsed.kind === "chord") {
+          const entries = commandRegistry.list().map((c) => ({
+            command: c.id,
+            effectiveKey: effectiveKey(c.id),
+          }));
+          const reassignFrom = conflictingCommands(
+            parsed.key,
+            state.commandId,
+            entries,
+          );
+          if (reassignFrom.length > 0) {
+            setCapture({
+              kind: "confirming",
+              commandId: state.commandId,
+              chord: parsed.key,
+              reassignFrom,
+            });
+            return;
+          }
+          void commitBinding(state.commandId, parsed.key, []);
+        }
+      }
+
+      function onPointerDown(e: PointerEvent) {
+        const t = e.target;
+        if (t instanceof Element && t.closest(".kb-key-btn")) return;
+        setCapture({ kind: "idle" });
+      }
+
+      function onFocusIn(e: FocusEvent) {
+        const t = e.target;
+        if (t instanceof Element && t.closest(".kb-key-btn")) return;
+        setCapture({ kind: "idle" });
+      }
+
+      window.addEventListener("keydown", onKeyDown, { capture: true });
+      window.addEventListener("pointerdown", onPointerDown, { capture: true });
+      window.addEventListener("focusin", onFocusIn, { capture: true });
+      return () => {
+        window.removeEventListener("keydown", onKeyDown, { capture: true });
+        window.removeEventListener("pointerdown", onPointerDown, {
+          capture: true,
+        });
+        window.removeEventListener("focusin", onFocusIn, { capture: true });
+        setKeybindingCaptureActive(false);
+      };
+    }, [capture.kind]);
+
+    async function commitBinding(
+      commandId: string,
+      key: string,
+      reassignFrom: string[],
+    ) {
+      const defaults = new Map<string, string>();
+      for (const c of commandRegistry.list()) {
+        const d = defaultKey(c.id);
+        if (d) defaults.set(c.id, d);
+      }
+      const next = bindingsAfterSet(
+        getUserBindings(),
+        commandId,
+        key,
+        reassignFrom,
+        defaults,
+      );
+      try {
+        await saveUserBindings(next);
+      } catch (err) {
+        console.error("[keybindings] save failed", err);
+        ctx.ui.notify("error", "Could not save keybinding");
+      }
+      setCapture({ kind: "idle" });
+    }
+
+    async function resetBinding(commandId: string) {
+      try {
+        await saveUserBindings(
+          bindingsAfterReset(getUserBindings(), commandId),
+        );
+      } catch (err) {
+        console.error("[keybindings] reset failed", err);
+        ctx.ui.notify("error", "Could not reset keybinding");
+      }
+    }
+
+    async function removeBinding(commandId: string) {
+      try {
+        await saveUserBindings(
+          bindingsAfterRemove(getUserBindings(), commandId),
+        );
+      } catch (err) {
+        console.error("[keybindings] remove failed", err);
+        ctx.ui.notify("error", "Could not remove keybinding");
+      }
+    }
+
+    function openPageMenu(anchor: HTMLElement) {
+      const items: MenuEntry[] = [
+        {
+          label: "Edit keybindings.json",
+          run: () => void openKeybindingsFile(ctx),
+        },
+      ];
+      void ctx.ui.showMenu({ items, anchor, align: "end" });
+    }
+
+    function openRowMenu(commandId: string, e: ReactMouseEvent) {
+      e.preventDefault();
+      e.stopPropagation();
+      const state = rowState({
+        unbound: isRemoved(commandId),
+        overrideKey: overrideKey(commandId),
+        defaultKey: defaultKey(commandId),
+        effectiveKey: effectiveKey(commandId),
+      });
+      const items: MenuEntry[] = [
+        {
+          label: "Change Keybinding…",
+          run: () => setCapture({ kind: "capturing", commandId }),
+        },
+        {
+          label: "Reset Keybinding",
+          disabled: state !== "override" && state !== "unbound",
+          run: () => void resetBinding(commandId),
+        },
+        {
+          label: "Remove Keybinding",
+          disabled: state === "unbound" || state === "none",
+          run: () => void removeBinding(commandId),
+        },
+      ];
+      void ctx.ui.showMenu({
+        items,
+        at: { x: e.clientX, y: e.clientY },
+      });
+    }
+
     const rows = commandRegistry
       .list()
-      .filter(
-        (c) =>
-          !q ||
-          c.label.toLowerCase().includes(q) ||
-          c.id.toLowerCase().includes(q),
-      )
+      .filter((c) => {
+        const eff = effectiveKey(c.id);
+        return commandMatchesQuery(query, c, {
+          effective: eff,
+          display: eff ? displayKey(eff) : undefined,
+        });
+      })
       .sort((a, b) => a.label.localeCompare(b.label));
+
+    const sortedGroups = groupCommands(rows, menuFor);
 
     return (
       <div className="kb-page">
         <div className="kb-header">
           <h2>Keyboard Shortcuts</h2>
-          <Button size="sm" onClick={() => void openKeybindingsFile(ctx)}>
-            Edit keybindings.json
-          </Button>
+          <Tooltip content="More options">
+            <IconButton
+              aria-label="More options"
+              onClick={(e) => openPageMenu(e.currentTarget)}
+            >
+              <DotsThreeVertical size={16} weight="bold" />
+            </IconButton>
+          </Tooltip>
         </div>
         <SearchInput
           value={query}
           onValueChange={setQuery}
-          placeholder="Search commands…"
+          placeholder="Search commands or keys…"
           autoFocus
         />
         <div className="kb-list silo-scroll">
-          {rows.map((c) => {
-            const eff = effectiveKey(c.id);
-            return (
-              <div key={c.id} className="kb-row">
-                <div className="kb-cmd">
-                  <span className="kb-label">{c.label}</span>
-                  <span className="kb-id">{c.id}</span>
-                </div>
-                {eff ? (
-                  <kbd className="kb-key">{displayKey(eff)}</kbd>
-                ) : (
-                  <span className="kb-unbound">—</span>
-                )}
-              </div>
-            );
-          })}
+          {sortedGroups.map(([group, cmds]) => (
+            <Section key={group} label={group}>
+              {cmds.map((c) => {
+                const eff = effectiveKey(c.id);
+                const state = rowState({
+                  unbound: isRemoved(c.id),
+                  overrideKey: overrideKey(c.id),
+                  defaultKey: defaultKey(c.id),
+                  effectiveKey: eff,
+                });
+                const isCapturing =
+                  capture.kind === "capturing" && capture.commandId === c.id;
+                const isConfirming =
+                  capture.kind === "confirming" && capture.commandId === c.id;
+                const reassignLabel =
+                  isConfirming && capture.kind === "confirming"
+                    ? (commandRegistry.get(capture.reassignFrom[0])?.label ??
+                      capture.reassignFrom[0])
+                    : "";
+                const reassignExtra =
+                  isConfirming &&
+                  capture.kind === "confirming" &&
+                  capture.reassignFrom.length > 1
+                    ? ` +${capture.reassignFrom.length - 1}`
+                    : "";
+
+                let keyContent: ReactNode;
+                let keyClass = "kb-key-btn";
+                if (isConfirming) {
+                  keyClass += " kb-key-btn-confirm";
+                  keyContent = (
+                    <span className="kb-capture-hint">
+                      Used by {reassignLabel}
+                      {reassignExtra}. Enter to reassign, Esc to cancel.
+                    </span>
+                  );
+                } else if (isCapturing) {
+                  keyClass += " kb-key-btn-capture";
+                  keyContent = (
+                    <span className="kb-capture-hint">
+                      Press desired key combination…
+                    </span>
+                  );
+                } else if (eff) {
+                  keyClass +=
+                    state === "override" ? " kb-key-btn-override" : "";
+                  keyContent = <kbd className="kb-key">{displayKey(eff)}</kbd>;
+                } else if (state === "unbound") {
+                  keyClass += " kb-key-btn-unbound";
+                  keyContent = (
+                    <span className="kb-unbound" title="Unbound">
+                      —
+                    </span>
+                  );
+                } else {
+                  keyClass += " kb-key-btn-empty";
+                  keyContent = <span className="kb-unbound">—</span>;
+                }
+
+                return (
+                  <div
+                    key={c.id}
+                    className="kb-row"
+                    onContextMenu={(e) => openRowMenu(c.id, e)}
+                  >
+                    <div className="kb-cmd">
+                      <span className="kb-label">{c.label}</span>
+                      <span className="kb-id">{c.id}</span>
+                    </div>
+                    <button
+                      type="button"
+                      className={keyClass}
+                      aria-label={
+                        isCapturing || isConfirming
+                          ? `Capture keybinding for ${c.label}`
+                          : `Change keybinding for ${c.label}`
+                      }
+                      onClick={() =>
+                        setCapture({ kind: "capturing", commandId: c.id })
+                      }
+                      ref={(el) => {
+                        if (
+                          el &&
+                          (isCapturing || isConfirming) &&
+                          document.activeElement !== el
+                        ) {
+                          el.focus();
+                        }
+                      }}
+                    >
+                      {keyContent}
+                    </button>
+                  </div>
+                );
+              })}
+            </Section>
+          ))}
           {rows.length === 0 && (
             <div className="kb-empty">No commands match “{query}”.</div>
           )}

--- a/packages/extensions-core/src/keybindings/keybindings-model.test.ts
+++ b/packages/extensions-core/src/keybindings/keybindings-model.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect } from "vitest";
+import type { Command, MenuId } from "@silo-code/sdk";
+import {
+  bindingsAfterRemove,
+  bindingsAfterReset,
+  bindingsAfterSet,
+  commandMatchesQuery,
+  conflictingCommands,
+  groupCommands,
+  groupFor,
+  humanize,
+  parseCaptureKeydown,
+  rowState,
+} from "./keybindings-model";
+
+function cmd(id: string, label = id): Command {
+  return { id, label, run: () => {} };
+}
+
+describe("humanize", () => {
+  it("splits camelCase into words", () => {
+    expect(humanize("webviewBridgeTest")).toBe("Webview Bridge Test");
+  });
+
+  it("splits kebab-case into words", () => {
+    expect(humanize("file-search")).toBe("File Search");
+  });
+
+  it("title-cases a single word", () => {
+    expect(humanize("git")).toBe("Git");
+  });
+});
+
+describe("groupFor", () => {
+  const noMenu = (): MenuId | undefined => undefined;
+
+  it("uses the first segment for a non-core/silo namespace", () => {
+    expect(groupFor(cmd("workspace.new"), noMenu)).toBe("Workspace");
+    expect(groupFor(cmd("settings.close"), noMenu)).toBe("Settings");
+  });
+
+  it("uses the sub-namespace for core/silo ids with 3+ segments", () => {
+    expect(groupFor(cmd("silo.git.manageWorktrees"), noMenu)).toBe("Git");
+    expect(groupFor(cmd("silo.file-search.findInFiles"), noMenu)).toBe(
+      "File Search",
+    );
+    expect(groupFor(cmd("core.updates.check"), noMenu)).toBe("Updates");
+  });
+
+  it("labels the cli sub-namespace as CLI", () => {
+    expect(groupFor(cmd("core.cli.install"), noMenu)).toBe("CLI");
+  });
+
+  it("falls back to the command's menu placement for flat core/silo ids", () => {
+    const menuFor = (id: string): MenuId | undefined =>
+      id === "core.save" ? "file" : undefined;
+    expect(groupFor(cmd("core.save"), menuFor)).toBe("File");
+  });
+
+  it("falls back to General for flat core/silo ids with no menu item", () => {
+    expect(groupFor(cmd("core.nextTab"), noMenu)).toBe("General");
+  });
+});
+
+describe("groupCommands", () => {
+  const noMenu = (): MenuId | undefined => undefined;
+
+  it("buckets commands by group and sorts groups alphabetically", () => {
+    const commands = [
+      cmd("workspace.new", "New Workspace"),
+      cmd("silo.git.manageWorktrees", "Manage Worktrees"),
+      cmd("workspace.close", "Close Workspace"),
+    ];
+    const groups = groupCommands(commands, noMenu);
+    expect(groups.map(([name]) => name)).toEqual(["Git", "Workspace"]);
+    expect(groups[1][1].map((c) => c.id)).toEqual([
+      "workspace.new",
+      "workspace.close",
+    ]);
+  });
+
+  it("always sorts the General bucket last among ordinary groups", () => {
+    const commands = [cmd("core.nextTab"), cmd("workspace.new")];
+    const groups = groupCommands(commands, noMenu);
+    expect(groups.map(([name]) => name)).toEqual(["Workspace", "General"]);
+  });
+
+  it("pins CLI after General", () => {
+    const commands = [
+      cmd("core.cli.install", "Install silo"),
+      cmd("core.nextTab"),
+      cmd("workspace.new"),
+    ];
+    const groups = groupCommands(commands, noMenu);
+    expect(groups.map(([name]) => name)).toEqual([
+      "Workspace",
+      "General",
+      "CLI",
+    ]);
+  });
+
+  it("returns no groups for an empty command list", () => {
+    expect(groupCommands([], noMenu)).toEqual([]);
+  });
+});
+
+describe("rowState", () => {
+  it("reports unbound when the user removed the keybinding", () => {
+    expect(
+      rowState({ unbound: true, defaultKey: "cmd+s", effectiveKey: undefined }),
+    ).toBe("unbound");
+  });
+
+  it("reports override when an override key is present", () => {
+    expect(
+      rowState({
+        unbound: false,
+        overrideKey: "cmd+shift+s",
+        defaultKey: "cmd+s",
+        effectiveKey: "cmd+shift+s",
+      }),
+    ).toBe("override");
+  });
+
+  it("reports default when only a default applies", () => {
+    expect(
+      rowState({
+        unbound: false,
+        defaultKey: "cmd+s",
+        effectiveKey: "cmd+s",
+      }),
+    ).toBe("default");
+  });
+
+  it("reports none when the command has never had a key", () => {
+    expect(rowState({ unbound: false })).toBe("none");
+  });
+});
+
+describe("parseCaptureKeydown", () => {
+  it("cancels on Escape", () => {
+    expect(
+      parseCaptureKeydown(
+        {
+          key: "Escape",
+          code: "Escape",
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        { confirming: false },
+      ),
+    ).toEqual({ kind: "cancel" });
+  });
+
+  it("confirms on Enter only while confirming a reassign", () => {
+    const enter = {
+      key: "Enter",
+      code: "Enter",
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    };
+    expect(parseCaptureKeydown(enter, { confirming: true })).toEqual({
+      kind: "confirm",
+    });
+    expect(parseCaptureKeydown(enter, { confirming: false })).toEqual({
+      kind: "chord",
+      key: "enter",
+    });
+  });
+
+  it("ignores modifier-only presses", () => {
+    expect(
+      parseCaptureKeydown(
+        {
+          key: "Meta",
+          code: "MetaLeft",
+          metaKey: true,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        { confirming: false },
+      ),
+    ).toEqual({ kind: "ignore" });
+  });
+
+  it("builds a normalized chord from modifiers + key", () => {
+    expect(
+      parseCaptureKeydown(
+        {
+          key: "s",
+          code: "KeyS",
+          metaKey: true,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: true,
+        },
+        { confirming: false },
+      ),
+    ).toEqual({ kind: "chord", key: "cmd+shift+s" });
+  });
+});
+
+describe("conflictingCommands", () => {
+  it("lists other commands that hold the same effective key", () => {
+    expect(
+      conflictingCommands("cmd+s", "file.saveAs", [
+        { command: "file.save", effectiveKey: "cmd+s" },
+        { command: "file.saveAs", effectiveKey: "cmd+shift+s" },
+        { command: "edit.copy", effectiveKey: "cmd+c" },
+      ]),
+    ).toEqual(["file.save"]);
+  });
+});
+
+describe("bindingsAfterSet / Reset / Remove", () => {
+  const defaults = new Map([
+    ["file.save", "cmd+s"],
+    ["file.saveAs", "cmd+shift+s"],
+  ]);
+
+  it("sets an override and leaves others alone", () => {
+    expect(
+      bindingsAfterSet([], "file.save", "cmd+alt+s", [], defaults),
+    ).toEqual([{ command: "file.save", key: "cmd+alt+s" }]);
+  });
+
+  it("reassigns by unbinding a default holder of the chord", () => {
+    expect(
+      bindingsAfterSet([], "file.saveAs", "cmd+s", ["file.save"], defaults),
+    ).toEqual([
+      { command: "file.saveAs", key: "cmd+s" },
+      { command: "-file.save", key: "" },
+    ]);
+  });
+
+  it("reassigns by dropping another command's override when that was the key", () => {
+    const current = [{ command: "file.save", key: "cmd+k" }];
+    expect(
+      bindingsAfterSet(
+        current,
+        "file.saveAs",
+        "cmd+k",
+        ["file.save"],
+        defaults,
+      ),
+    ).toEqual([{ command: "file.saveAs", key: "cmd+k" }]);
+  });
+
+  it("reassigns by unbinding when the override equals the victim default", () => {
+    const current = [{ command: "file.save", key: "cmd+s" }];
+    expect(
+      bindingsAfterSet(
+        current,
+        "file.saveAs",
+        "cmd+s",
+        ["file.save"],
+        defaults,
+      ),
+    ).toEqual([
+      { command: "file.saveAs", key: "cmd+s" },
+      { command: "-file.save", key: "" },
+    ]);
+  });
+
+  it("resets by clearing override and unbind entries", () => {
+    const current = [
+      { command: "file.save", key: "cmd+k" },
+      { command: "-file.saveAs", key: "" },
+    ];
+    expect(bindingsAfterReset(current, "file.save")).toEqual([
+      { command: "-file.saveAs", key: "" },
+    ]);
+    expect(bindingsAfterReset(current, "file.saveAs")).toEqual([
+      { command: "file.save", key: "cmd+k" },
+    ]);
+  });
+
+  it("removes by writing an unbind entry", () => {
+    expect(bindingsAfterRemove([], "file.save")).toEqual([
+      { command: "-file.save", key: "" },
+    ]);
+    expect(
+      bindingsAfterRemove(
+        [{ command: "file.save", key: "cmd+k" }],
+        "file.save",
+      ),
+    ).toEqual([{ command: "-file.save", key: "" }]);
+  });
+});
+
+describe("commandMatchesQuery", () => {
+  const save = { id: "file.save", label: "Save File" };
+
+  it("matches label and id", () => {
+    expect(commandMatchesQuery("save", save, {})).toBe(true);
+    expect(commandMatchesQuery("file.save", save, {})).toBe(true);
+    expect(commandMatchesQuery("xyz", save, {})).toBe(false);
+  });
+
+  it("matches effective and display keys", () => {
+    expect(
+      commandMatchesQuery("cmd+s", save, {
+        effective: "cmd+s",
+        display: "Cmd+S",
+      }),
+    ).toBe(true);
+    expect(
+      commandMatchesQuery("cmd+s", save, {
+        effective: "cmd+s",
+        display: "Cmd+S",
+      }),
+    ).toBe(true);
+    expect(
+      commandMatchesQuery("Cmd+S", save, {
+        effective: "cmd+s",
+        display: "Cmd+S",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches empty query as everything", () => {
+    expect(commandMatchesQuery("", save, {})).toBe(true);
+  });
+});

--- a/packages/extensions-core/src/keybindings/keybindings-model.ts
+++ b/packages/extensions-core/src/keybindings/keybindings-model.ts
@@ -1,0 +1,336 @@
+import type { Command, MenuId } from "@silo-code/sdk";
+
+/** Persisted user override / unbind entry (same shape as keybindings.json). */
+export interface UserBinding {
+  key: string;
+  /** Command id. Prefix with "-" to unbind a default. */
+  command: string;
+}
+
+export type KeybindingRowState = "default" | "override" | "unbound" | "none";
+
+export type CaptureParseResult =
+  | { kind: "cancel" }
+  | { kind: "ignore" }
+  | { kind: "confirm" }
+  | { kind: "chord"; key: string };
+
+const MENU_GROUP_LABELS: Record<MenuId, string> = {
+  file: "File",
+  edit: "Edit",
+  view: "View",
+  window: "Window",
+  help: "Help",
+};
+
+const CODE_TO_TOKEN: Record<string, string> = {
+  Equal: "=",
+  Minus: "-",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Backslash: "\\",
+  Semicolon: ";",
+  Quote: "'",
+  Comma: ",",
+  Period: ".",
+  Slash: "/",
+  Backquote: "`",
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  ArrowUp: "up",
+  ArrowDown: "down",
+  PageUp: "pageup",
+  PageDown: "pagedown",
+  Home: "home",
+  End: "end",
+  Enter: "enter",
+  Space: "space",
+  Tab: "tab",
+  Escape: "escape",
+  Backspace: "backspace",
+  Delete: "delete",
+};
+
+const MODIFIER_CODES = new Set([
+  "ShiftLeft",
+  "ShiftRight",
+  "ControlLeft",
+  "ControlRight",
+  "AltLeft",
+  "AltRight",
+  "MetaLeft",
+  "MetaRight",
+]);
+
+export function humanize(segment: string): string {
+  return segment
+    .replace(/[-_]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(" ")
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Buckets a command for the Keybindings settings page. Commands carry no
+ * category of their own, so this is derived from the id's "area.verb"
+ * convention. "core"/"silo" are generic owner namespaces (not functional
+ * areas), so those fall back to their sub-namespace ("silo.git.x" → Git) or,
+ * for flat ids with no sub-namespace, to wherever the command is homed in
+ * the native menu. What's left after that lands in "General".
+ */
+export function groupFor(
+  command: Command,
+  menuFor: (commandId: string) => MenuId | undefined,
+): string {
+  const parts = command.id.split(".");
+  const ns = parts[0];
+  if (ns !== "core" && ns !== "silo") return humanize(ns);
+  if (parts.length >= 3) {
+    // Keep CLI as an acronym; it's a small utility group pinned to the end.
+    if (parts[1] === "cli") return "CLI";
+    return humanize(parts[1]);
+  }
+  const menu = menuFor(command.id);
+  return menu ? MENU_GROUP_LABELS[menu] : "General";
+}
+
+/**
+ * Groups and orders commands for display. "General" is last among ordinary
+ * buckets; "CLI" is pinned after that (install/PATH utilities, not day-to-day).
+ */
+export function groupCommands(
+  commands: Command[],
+  menuFor: (commandId: string) => MenuId | undefined,
+): Array<[string, Command[]]> {
+  const groups = new Map<string, Command[]>();
+  for (const c of commands) {
+    const key = groupFor(c, menuFor);
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(c);
+    else groups.set(key, [c]);
+  }
+  return [...groups.entries()].sort(([a], [b]) => {
+    const rank = (name: string) =>
+      name === "CLI" ? 2 : name === "General" ? 1 : 0;
+    const d = rank(a) - rank(b);
+    if (d !== 0) return d;
+    return a.localeCompare(b);
+  });
+}
+
+/** Which visual state a Keyboard Shortcuts row should use. */
+export function rowState(opts: {
+  unbound: boolean;
+  overrideKey?: string;
+  defaultKey?: string;
+  effectiveKey?: string;
+}): KeybindingRowState {
+  if (opts.unbound) return "unbound";
+  if (opts.overrideKey !== undefined) return "override";
+  if (opts.effectiveKey !== undefined || opts.defaultKey !== undefined) {
+    return "default";
+  }
+  return "none";
+}
+
+/**
+ * Parse a keydown during capture / reassign-confirm.
+ * Escape always cancels; Enter confirms a pending reassign; modifier-only
+ * presses are ignored; anything else becomes a normalized chord.
+ */
+export function parseCaptureKeydown(
+  e: {
+    key: string;
+    code: string;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    altKey: boolean;
+    shiftKey: boolean;
+  },
+  opts: { confirming: boolean },
+): CaptureParseResult {
+  if (e.key === "Escape" || e.code === "Escape") return { kind: "cancel" };
+  if (opts.confirming && (e.key === "Enter" || e.code === "Enter")) {
+    return { kind: "confirm" };
+  }
+  if (MODIFIER_CODES.has(e.code)) return { kind: "ignore" };
+
+  const token = codeToToken(e.code);
+  if (!token) return { kind: "ignore" };
+
+  const mods: string[] = [];
+  if (e.metaKey) mods.push("cmd");
+  if (e.ctrlKey) mods.push("ctrl");
+  if (e.altKey) mods.push("alt");
+  if (e.shiftKey) mods.push("shift");
+  return { kind: "chord", key: [...mods, token].join("+") };
+}
+
+function codeToToken(code: string): string | null {
+  if (CODE_TO_TOKEN[code]) return CODE_TO_TOKEN[code];
+  if (code.startsWith("Key") && code.length === 4) {
+    return code.slice(3).toLowerCase();
+  }
+  if (code.startsWith("Digit") && code.length === 6) return code.slice(5);
+  if (/^F\d{1,2}$/.test(code)) return code.toLowerCase();
+  return null;
+}
+
+/** Commands (other than `commandId`) whose effective key equals `key`. */
+export function conflictingCommands(
+  key: string,
+  commandId: string,
+  entries: ReadonlyArray<{ command: string; effectiveKey?: string }>,
+): string[] {
+  return entries
+    .filter((e) => e.command !== commandId && e.effectiveKey === key)
+    .map((e) => e.command);
+}
+
+function bindingsToMaps(list: UserBinding[]): {
+  overrides: Map<string, string>;
+  removed: Set<string>;
+} {
+  const overrides = new Map<string, string>();
+  const removed = new Set<string>();
+  for (const b of list) {
+    if (typeof b?.command !== "string" || typeof b?.key !== "string") continue;
+    if (b.command.startsWith("-")) {
+      removed.add(b.command.slice(1));
+      continue;
+    }
+    overrides.set(b.command, b.key);
+  }
+  return { overrides, removed };
+}
+
+function mapsToBindings(
+  overrides: Map<string, string>,
+  removed: Set<string>,
+): UserBinding[] {
+  const list: UserBinding[] = [];
+  for (const [command, key] of [...overrides.entries()].sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    list.push({ command, key });
+  }
+  for (const command of [...removed].sort()) {
+    list.push({ command: `-${command}`, key: "" });
+  }
+  return list;
+}
+
+function effectiveOf(
+  command: string,
+  overrides: Map<string, string>,
+  removed: Set<string>,
+  defaults: ReadonlyMap<string, string>,
+): string | undefined {
+  if (removed.has(command)) return undefined;
+  return overrides.get(command) ?? defaults.get(command);
+}
+
+/**
+ * Set `command`'s override to `key`, reassigning (unbinding) every id in
+ * `reassignFrom` so they no longer hold that chord.
+ */
+export function bindingsAfterSet(
+  current: UserBinding[],
+  command: string,
+  key: string,
+  reassignFrom: readonly string[],
+  defaults: ReadonlyMap<string, string>,
+): UserBinding[] {
+  const { overrides, removed } = bindingsToMaps(current);
+  overrides.delete(command);
+  removed.delete(command);
+  overrides.set(command, key);
+
+  for (const other of reassignFrom) {
+    if (other === command) continue;
+    freeKey(other, key, overrides, removed, defaults);
+  }
+  return mapsToBindings(overrides, removed);
+}
+
+/** Drop the override so the command returns to its default (or stays unbound). */
+export function bindingsAfterReset(
+  current: UserBinding[],
+  command: string,
+): UserBinding[] {
+  const { overrides, removed } = bindingsToMaps(current);
+  overrides.delete(command);
+  removed.delete(command);
+  return mapsToBindings(overrides, removed);
+}
+
+/** Make the command unbound — no chord, even if a default existed. */
+export function bindingsAfterRemove(
+  current: UserBinding[],
+  command: string,
+): UserBinding[] {
+  const { overrides, removed } = bindingsToMaps(current);
+  overrides.delete(command);
+  removed.add(command);
+  return mapsToBindings(overrides, removed);
+}
+
+function freeKey(
+  command: string,
+  key: string,
+  overrides: Map<string, string>,
+  removed: Set<string>,
+  defaults: ReadonlyMap<string, string>,
+): void {
+  const override = overrides.get(command);
+  if (override === key) {
+    overrides.delete(command);
+    if (defaults.get(command) === key) removed.add(command);
+    else removed.delete(command);
+    return;
+  }
+  if (effectiveOf(command, overrides, removed, defaults) === key) {
+    overrides.delete(command);
+    removed.add(command);
+  }
+}
+
+/** Filter Keyboard Shortcuts rows by label, id, or key. */
+export function commandMatchesQuery(
+  query: string,
+  command: { id: string; label: string },
+  keyInfo: { effective?: string; display?: string },
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  if (command.label.toLowerCase().includes(q)) return true;
+  if (command.id.toLowerCase().includes(q)) return true;
+
+  const compact = q.replace(/\s+/g, "");
+  const aliased = compact
+    .replace(/⌘/g, "cmd")
+    .replace(/cmdorctrl/g, "cmd")
+    .replace(/commandorcontrol/g, "cmd")
+    .replace(/command/g, "cmd")
+    .replace(/meta/g, "cmd")
+    .replace(/super/g, "cmd")
+    .replace(/⌥/g, "alt")
+    .replace(/option/g, "alt")
+    .replace(/opt/g, "alt")
+    .replace(/control/g, "ctrl")
+    .replace(/⇧/g, "shift");
+
+  if (keyInfo.effective) {
+    if (keyInfo.effective.includes(q) || keyInfo.effective.includes(compact)) {
+      return true;
+    }
+    if (keyInfo.effective.includes(aliased)) return true;
+  }
+  if (keyInfo.display) {
+    const d = keyInfo.display.toLowerCase();
+    if (d.includes(q) || d.replace(/\s+/g, "").includes(compact)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- Make Keyboard Shortcuts in Settings the primary way to change keybindings: inline capture, conflict reassign, reset/remove, search by key, visual default/override/unbound states
- Persist via the existing `keybindings.json` (pretty rewrite); demote “Edit keybindings.json” to the page overflow menu
- Stabilize menu-default batching during sync so File shortcuts don’t blank/flicker when saving or opening the page; pin the CLI group to the end of the list

## Test plan
- [ ] Open Settings → Keyboard Shortcuts; confirm File shortcuts (Cmd+S etc.) stay visible with no flicker
- [ ] Click a key cell, press a chord, confirm it saves and appears as an override
- [ ] Assign a chord already in use; confirm inline “Used by … Enter to reassign”; Enter reassigns, Esc cancels
- [ ] Right-click → Reset / Remove; confirm default vs unbound styling
- [ ] Search by label and by key (e.g. `cmd+s`)
- [ ] Overflow ⋮ → Edit keybindings.json still opens the file
- [ ] Tab away during capture cancels capture without leaving dispatch suppressed


Made with [Cursor](https://cursor.com)