### PR TITLE
fix(markdown-preview): render unsaved buffer instead of disk-only

### DIFF
--- a/apps/docs/api/types/interfaces/EditorService.md
+++ b/apps/docs/api/types/interfaces/EditorService.md
@@ -15,7 +15,7 @@ prefer it over reaching into workspace/editor state.
 onDidSave: Event<EditorSaveEvent>;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:323](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L323)
+Defined in: [packages/sdk/src/editor-service.ts:327](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L327)
 
 Fires after an editor tab's contents are saved to disk — a formatter,
 linter, or build-on-save extension's entry point. See [Event](../type-aliases/Event.md).
@@ -285,14 +285,17 @@ through this provider, on every mount. Dispose to unregister.
 getText(editorId): Promise<string | undefined>;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:304](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L304)
+Defined in: [packages/sdk/src/editor-service.ts:307](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L307)
 
 The current buffer text of an open editor tab, including unsaved edits.
 
 Resolves `undefined` when the tab isn't text-backed (e.g. the image
-viewer) or hasn't mounted yet — a lazy-mounted dock panel is **not**
-force-mounted to read its text. It is async precisely because the text
-lives in the mounted editor component, not in host state.
+viewer), has never mounted a text document, and has no retained unsaved
+buffer. A dirty text editor that unmounts on a view switch (e.g. Text →
+Markdown Preview) retains its buffer so presenters can still read it. A
+lazy-mounted dock panel is **not** force-mounted to read its text. It is
+async precisely because the live text lives in the mounted editor
+component, not in host state.
 
 #### Parameters
 
@@ -319,10 +322,11 @@ if (text !== undefined) ctx.log.info(`${text.length} chars`);
 isDirty(editorId): boolean;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:309](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L309)
+Defined in: [packages/sdk/src/editor-service.ts:313](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L313)
 
 Whether an open editor tab has unsaved changes. Returns `false` for an
-unknown id or a tab that isn't mounted / text-backed.
+unknown id or a tab that isn't text-backed and has no retained dirty
+buffer. Stays `true` across a dirty Text → Preview view switch.
 
 #### Parameters
 
@@ -342,7 +346,7 @@ unknown id or a tab that isn't mounted / text-backed.
 getState(): EditorsState;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:336](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L336)
+Defined in: [packages/sdk/src/editor-service.ts:340](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L340)
 
 Current frozen snapshot of editor state. The returned object is
 referentially stable between renders — `getState() === getState()` when
@@ -368,7 +372,7 @@ if (active) ctx.log.info(`Active file: ${active.filePath ?? "(untitled)"}`);
 subscribe(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/editor-service.ts:355](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L355)
+Defined in: [packages/sdk/src/editor-service.ts:359](https://github.com/silo-code/silo/blob/main/packages/sdk/src/editor-service.ts#L359)
 
 Subscribe to changes in the active editor. The listener is called whenever
 `active` changes (tab focus moves, workspace switches, editor opens or

--- a/packages/extension-host/src/extension-host/editor-document-access.test.ts
+++ b/packages/extension-host/src/extension-host/editor-document-access.test.ts
@@ -33,8 +33,46 @@ describe("EditorService.getText / isDirty (B6)", () => {
     expect(svc.isDirty("e1")).toBe(true);
 
     sub.dispose();
-    await expect(svc.getText("e1")).resolves.toBeUndefined();
-    expect(svc.isDirty("e1")).toBe(false);
+    // Dirty unmount retains the buffer for view-switch handoff (Text → Preview).
+    await expect(svc.getText("e1")).resolves.toBe("hello world");
+    expect(svc.isDirty("e1")).toBe(true);
+  });
+
+  it("does not retain clean buffer text after the provider unmounts", async () => {
+    const sub = registerDocumentProvider("e1-clean", {
+      getText: () => "saved on disk",
+      isDirty: () => false,
+    });
+    sub.dispose();
+    await expect(svc.getText("e1-clean")).resolves.toBeUndefined();
+    expect(svc.isDirty("e1-clean")).toBe(false);
+  });
+
+  it("clears retained dirty text when a provider remounts", async () => {
+    const first = registerDocumentProvider("e1-re", {
+      getText: () => "unsaved",
+      isDirty: () => true,
+    });
+    first.dispose();
+    await expect(svc.getText("e1-re")).resolves.toBe("unsaved");
+
+    registerDocumentProvider("e1-re", {
+      getText: () => "restored in monaco",
+      isDirty: () => true,
+    });
+    await expect(svc.getText("e1-re")).resolves.toBe("restored in monaco");
+  });
+
+  it("clears retained dirty text on save", async () => {
+    const sub = registerDocumentProvider("e1-save", {
+      getText: () => "draft",
+      isDirty: () => true,
+    });
+    sub.dispose();
+    await expect(svc.getText("e1-save")).resolves.toBe("draft");
+    emitDidSave({ editorId: "e1-save", filePath: "/ws/a.md" });
+    await expect(svc.getText("e1-save")).resolves.toBeUndefined();
+    expect(svc.isDirty("e1-save")).toBe(false);
   });
 
   it("a stale provider's dispose does not clobber a remounted provider", async () => {

--- a/packages/extension-host/src/extension-host/editor-service.ts
+++ b/packages/extension-host/src/extension-host/editor-service.ts
@@ -36,7 +36,9 @@ const saversAs = new Map<string, () => void | Promise<void>>();
 // (same lifecycle as save handlers). This is how the host reads the live,
 // unsaved buffer for `getText`/`isDirty` without owning the Monaco instance. A
 // tab whose component hasn't mounted has no provider → getText resolves
-// undefined, isDirty is false.
+// undefined, isDirty is false — unless a dirty buffer was retained on the last
+// unmount (view switch Text → Preview): then `retainedDirty` keeps the unsaved
+// text readable so presenters can render it without going to disk.
 
 interface DocumentProvider {
   getText(): string;
@@ -44,6 +46,9 @@ interface DocumentProvider {
 }
 
 const docProviders = new Map<string, DocumentProvider>();
+
+/** Unsaved text retained when a dirty text editor unmounts (e.g. view switch). */
+const retainedDirty = new Map<string, string>();
 
 /**
  * Register the live text/dirty provider for a mounted editor tab. Called by the
@@ -56,11 +61,19 @@ export function registerDocumentProvider(
   provider: DocumentProvider,
 ): Disposable {
   docProviders.set(editorId, provider);
+  // Live provider owns the tab again — drop any handoff retained on the prior
+  // unmount (Text restores from its own hot-exit backup on remount).
+  retainedDirty.delete(editorId);
   return {
     dispose() {
       // Guard against a stale unmount clobbering a remounted provider.
-      if (docProviders.get(editorId) === provider)
-        docProviders.delete(editorId);
+      if (docProviders.get(editorId) !== provider) return;
+      // Keep unsaved text across view switches so Preview (and getText) can
+      // still read it after Monaco unmounts. Clean buffers need no retention —
+      // disk is authoritative.
+      if (provider.isDirty()) retainedDirty.set(editorId, provider.getText());
+      else retainedDirty.delete(editorId);
+      docProviders.delete(editorId);
     },
   };
 }
@@ -80,6 +93,7 @@ const saveEmitter = new EventEmitter<EditorSaveEvent>();
  * @internal — reached by `core.*` editors via `@silo-code/extension-host/internal`.
  */
 export function emitDidSave(event: EditorSaveEvent): void {
+  retainedDirty.delete(event.editorId);
   saveEmitter.fire(event);
 }
 
@@ -248,12 +262,15 @@ export function getEditorService(): EditorService {
     },
     getText(editorId) {
       const provider = docProviders.get(editorId);
-      // Async by contract (buffer text lives in the mounted component); resolve
-      // undefined for a tab that isn't text-backed or hasn't mounted yet.
-      return Promise.resolve(provider ? provider.getText() : undefined);
+      if (provider) return Promise.resolve(provider.getText());
+      // Dirty text retained across a view-switch unmount (Text → Preview).
+      const retained = retainedDirty.get(editorId);
+      return Promise.resolve(retained);
     },
     isDirty(editorId) {
-      return docProviders.get(editorId)?.isDirty() ?? false;
+      const provider = docProviders.get(editorId);
+      if (provider) return provider.isDirty();
+      return retainedDirty.has(editorId);
     },
     onDidSave: saveEmitter.event,
     getState() {

--- a/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
+++ b/packages/extensions-silo/src/markdown-preview/MarkdownPreview.tsx
@@ -12,6 +12,7 @@ import { GITHUB_SANITIZE_SCHEMA } from "./sanitize-schema";
 import { isExternalImageUrl, resolveLocalImagePath } from "./resolveImageSrc";
 import { isValidScrollTop, scrollStorageKey } from "./scroll";
 import { codeBlockLanguage, codeBlockText } from "./mermaid-block";
+import { loadMarkdownSource } from "./load-source";
 import { MermaidDiagram } from "./MermaidDiagram";
 import "./MarkdownPreview.css";
 
@@ -104,16 +105,17 @@ function FrontmatterBlock({ fields }: { fields: Record<string, unknown> }) {
 }
 
 /**
- * Read-only rendered-Markdown view of a `.md` file. Reads the file's text
- * through `ctx.files` (the public primitive — same as the text editor and image
- * viewer), re-reading when the file changes on disk, and renders it with
- * GitHub-flavored Markdown. Text is selectable with a Copy / Select All context
- * menu (Cut/Paste are inert — the preview is read-only). Registers no save
- * handler — it's a presenter.
+ * Read-only rendered-Markdown view of a `.md` file. Prefers the live / retained
+ * editor buffer (`ctx.editors.getText`) so unsaved edits survive a Text →
+ * Preview switch, falling back to `ctx.files.readText` for clean on-disk files.
+ * Re-reads when the file changes on disk. Renders with GitHub-flavored Markdown.
+ * Text is selectable with a Copy / Select All context menu (Cut/Paste are inert
+ * — the preview is read-only). Registers no save handler — it's a presenter.
  */
 export function MarkdownPreview({
   editorId,
   filePath,
+  dockApi,
   ctx,
 }: EditorProps & { ctx: ExtensionContext }) {
   const [content, setContent] = useState<string | null>(null);
@@ -123,6 +125,14 @@ export function MarkdownPreview({
   const hasRestoredScrollRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const scrollSaveTimerRef = useRef<number | null>(null);
+
+  // Text clears the tab dirty flag on unmount; re-assert it from the retained
+  // buffer so the ● survives a Text → Preview switch.
+  useEffect(() => {
+    if (!ctx.editors.isDirty(editorId)) return;
+    dockApi.updateParameters({ dirty: true });
+    return () => dockApi.updateParameters({ dirty: false });
+  }, [editorId, ctx, dockApi]);
 
   const components = useMemo(
     () => ({
@@ -170,32 +180,34 @@ export function MarkdownPreview({
   );
 
   useEffect(() => {
-    if (!filePath) {
-      setError("Markdown preview requires a file path.");
-      return;
-    }
     let cancelled = false;
     const load = () => {
-      ctx.files
-        .readText(filePath)
-        .then((text) => {
-          if (cancelled) return;
-          setContent(text);
+      void loadMarkdownSource({
+        editorId,
+        filePath,
+        getText: (id) => ctx.editors.getText(id),
+        readText: (path) => ctx.files.readText(path),
+      }).then((result) => {
+        if (cancelled) return;
+        if (result.ok) {
+          setContent(result.content);
           setError(null);
-        })
-        .catch((err) => {
-          if (!cancelled) setError(String(err));
-        });
+        } else {
+          setError(result.error);
+        }
+      });
     };
     load();
     // Re-render when the file changes underneath us (external edits, the text
-    // editor saving in another tab).
-    const sub = ctx.files.watch(filePath, () => load());
+    // editor saving in another tab). Prefer live/retained buffer on each load.
+    const sub = filePath
+      ? ctx.files.watch(filePath, () => load())
+      : { dispose() {} };
     return () => {
       cancelled = true;
       sub.dispose();
     };
-  }, [filePath]);
+  }, [filePath, editorId, ctx]);
 
   // Restore the saved scroll position once, the first time content lands (the
   // article's height needs to be present before a scrollTop assignment sticks).

--- a/packages/extensions-silo/src/markdown-preview/load-source.test.ts
+++ b/packages/extensions-silo/src/markdown-preview/load-source.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { loadMarkdownSource } from "./load-source";
+
+describe("loadMarkdownSource", () => {
+  it("prefers the live editor buffer over disk", async () => {
+    const readText = vi.fn(async () => "from disk");
+    const result = await loadMarkdownSource({
+      editorId: "e1",
+      filePath: "/ws/notes.md",
+      getText: async () => "# unsaved",
+      readText,
+    });
+    expect(result).toEqual({ ok: true, content: "# unsaved" });
+    expect(readText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to disk when there is no live buffer", async () => {
+    const result = await loadMarkdownSource({
+      editorId: "e1",
+      filePath: "/ws/notes.md",
+      getText: async () => undefined,
+      readText: async () => "# on disk",
+    });
+    expect(result).toEqual({ ok: true, content: "# on disk" });
+  });
+
+  it("errors when there is no buffer and no file path (untitled)", async () => {
+    const result = await loadMarkdownSource({
+      editorId: "e1",
+      filePath: null,
+      getText: async () => undefined,
+      readText: async () => {
+        throw new Error("should not read");
+      },
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "Markdown preview requires a file path.",
+    });
+  });
+
+  it("surfaces a disk read failure", async () => {
+    const result = await loadMarkdownSource({
+      editorId: "e1",
+      filePath: "/ws/missing.md",
+      getText: async () => undefined,
+      readText: async () => {
+        throw new Error("ENOENT");
+      },
+    });
+    expect(result).toEqual({ ok: false, error: "Error: ENOENT" });
+  });
+
+  it("uses an empty live buffer (new file, unsaved) instead of disk", async () => {
+    // Empty string is still a defined buffer — e.g. user cleared the file.
+    // Distinguishes from `undefined` (no text-backed provider / retention).
+    const readText = vi.fn(async () => "stale disk");
+    const result = await loadMarkdownSource({
+      editorId: "e1",
+      filePath: "/ws/new.md",
+      getText: async () => "",
+      readText,
+    });
+    expect(result).toEqual({ ok: true, content: "" });
+    expect(readText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extensions-silo/src/markdown-preview/load-source.ts
+++ b/packages/extensions-silo/src/markdown-preview/load-source.ts
@@ -1,0 +1,32 @@
+// Where Markdown Preview gets its source text. Pure async helper so the
+// live-buffer-vs-disk preference is unit-testable without mounting React.
+
+export type LoadMarkdownSourceResult =
+  | { ok: true; content: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the markdown source for a preview tab.
+ *
+ * Prefers the live / retained editor buffer (`getText`) so unsaved edits are
+ * visible after a Text → Preview view switch. Falls back to disk when there is
+ * no buffer text (clean file opened directly as Preview, or never mounted).
+ */
+export async function loadMarkdownSource(opts: {
+  editorId: string;
+  filePath: string | null;
+  getText: (editorId: string) => Promise<string | undefined>;
+  readText: (path: string) => Promise<string>;
+}): Promise<LoadMarkdownSourceResult> {
+  const live = await opts.getText(opts.editorId);
+  if (live !== undefined) return { ok: true, content: live };
+  if (!opts.filePath) {
+    return { ok: false, error: "Markdown preview requires a file path." };
+  }
+  try {
+    const content = await opts.readText(opts.filePath);
+    return { ok: true, content };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}

--- a/packages/sdk/src/editor-service.ts
+++ b/packages/sdk/src/editor-service.ts
@@ -291,9 +291,12 @@ export interface EditorService {
    * The current buffer text of an open editor tab, including unsaved edits.
    *
    * Resolves `undefined` when the tab isn't text-backed (e.g. the image
-   * viewer) or hasn't mounted yet — a lazy-mounted dock panel is **not**
-   * force-mounted to read its text. It is async precisely because the text
-   * lives in the mounted editor component, not in host state.
+   * viewer), has never mounted a text document, and has no retained unsaved
+   * buffer. A dirty text editor that unmounts on a view switch (e.g. Text →
+   * Markdown Preview) retains its buffer so presenters can still read it. A
+   * lazy-mounted dock panel is **not** force-mounted to read its text. It is
+   * async precisely because the live text lives in the mounted editor
+   * component, not in host state.
    *
    * @example
    * ```ts
@@ -304,7 +307,8 @@ export interface EditorService {
   getText(editorId: string): Promise<string | undefined>;
   /**
    * Whether an open editor tab has unsaved changes. Returns `false` for an
-   * unknown id or a tab that isn't mounted / text-backed.
+   * unknown id or a tab that isn't text-backed and has no retained dirty
+   * buffer. Stays `true` across a dirty Text → Preview view switch.
    */
   isDirty(editorId: string): boolean;
   /**


### PR DESCRIPTION
## Summary
- Markdown Preview was empty/stale when switching Text → Preview before save, because it only read from disk while the text editor (and its live buffer) had unmounted
- Host now retains dirty buffer text across that view switch so `ctx.editors.getText` / `isDirty` still work; Preview prefers that over disk and re-asserts the tab dirty ●
- Closes #270

## Test plan
- [ ] Create a new `.md` via the file explorer, type content, do **not** save, switch to Preview — rendered content matches the unsaved buffer
- [ ] Edit an existing `.md`, switch to Preview without saving — Preview shows dirty edits, not last-saved disk
- [ ] Save, then switch to Preview — still correct; dirty ● clears as expected
- [ ] Open a clean `.md` directly as Preview (Open With) — still loads from disk
- [ ] `pnpm --filter @silo-code/extension-host exec vitest run src/extension-host/editor-document-access.test.ts`
- [ ] `pnpm --filter @silo-code/extensions-silo exec vitest run src/markdown-preview/load-source.test.ts`


Made with [Cursor](https://cursor.com)