### PR TITLE
fix(terminal): unify link click/hover/right-click behavior across link types

### DIFF
--- a/docs/decisions/0027-terminal-link-policy.md
+++ b/docs/decisions/0027-terminal-link-policy.md
@@ -1,0 +1,97 @@
+---
+status: accepted
+date: 2026-07-21
+---
+
+# 0027. Unified terminal link policy: modifier-click to open, right-click to select
+
+## Context
+
+Terminals in Silo render links from three independent mechanisms that had each
+grown their own — or no — activation behavior:
+
+1. xterm's native OSC-8 hyperlink handler, which fires for the protocol-level
+   hyperlinks CLIs like Claude Code emit (visible text can differ from the
+   actual URI, e.g. "Learn more").
+2. `WebLinksAddon`, which regex-detects bare URLs typed as plain text.
+3. Silo's own file-path link provider (`terminal-links.ts`), which
+   regex-detects path-like spans and opens them in the editor.
+
+A recent bug report showed why "each provider does its own thing" is fragile:
+xterm's built-in OSC-8 fallback opens links via `window.open()`, which the
+Tauri webview doesn't hand off to the OS the way a real browser does — so
+Claude Code's links silently stopped opening on click or Cmd-click, and only
+right-click (native context menu → "Open") still worked. The fix was to give
+xterm a custom `linkHandler` that routes through `ctx.ui.openExternal` (the
+same Tauri-shell opener already used by menu items and extensions).
+
+That fix only covered the OSC-8 path. `WebLinksAddon` had the same
+`window.open()` problem and no modifier gating (any click activated it); the
+file-path provider had its own independently-written modifier check and no
+hover/tooltip or right-click behavior at all. Fixing one provider without a
+shared contract just relocates the next drift — the bug class here is
+"behavior specified per-provider" itself, not any single provider's code.
+
+## Decision
+
+Every link in every terminal — regardless of which of the three mechanisms
+found it — follows the same contract, enforced by one shared, pure policy
+module (`terminal-link-policy.ts`) that all three providers call into for the
+modifier check, tooltip text, and context-menu labels:
+
+- **Activation**: Cmd+click on macOS / Ctrl+click on Windows & Linux opens the
+  link — URLs via `ctx.ui.openExternal` (system browser), paths via the
+  editor (`ctx.editors.open`). A plain click is a no-op for navigation; it
+  doesn't suppress the terminal's normal text-selection/cursor behavior.
+- **Right-click**: landing directly on a link always selects its full
+  underlined span (`Terminal.select`) and shows the context menu with
+  link-specific actions ("Open Link"/"Open File", "Copy Link"/"Copy Path")
+  prepended to the terminal's generic menu (Copy, Paste, Select All, …). This
+  is true even when the `pasteOnRightClick` setting is on — landing on a
+  specific, unambiguous target overrides the blanket paste-on-right-click
+  behavior.
+- **Hover**: any hover (no modifier needed) shows a tooltip naming the action
+  and the modifier, e.g. `Open link (⌘ + click)` / `Open file (⌘ + click)`.
+
+## Consequences
+
+- Consistent, predictable link behavior across Claude Code's OSC-8 links,
+  plain-text URLs, and file paths — the thing the original bug report asked
+  for.
+- One place (`terminal-link-policy.ts`) to change the modifier, wording, or
+  add a link kind later, instead of three.
+- `WebLinksAddon` reports hover position in viewport-relative, 0-based
+  coordinates while the OSC-8 handler and the file-path provider use
+  buffer-absolute, 1-based coordinates; `TerminalPanel.tsx` normalizes the
+  former into the latter so right-click "select the link" behaves identically
+  regardless of source.
+- Establishes the extension point for two pieces of **future work, not built
+  now**: (a) user-configurable link-activation behavior (modifier choice,
+  click-to-open, etc.) — the policy module is where that would plug in; (b)
+  letting extensions contribute their own context-menu entries on links
+  (e.g. a `local-web-viewer`-style extension adding "Open in local web
+  viewer..."), which needs its own permission/ordering design and is out of
+  scope here.
+
+## Alternatives considered
+
+- **Keep fixing providers independently** — rejected: this is exactly the
+  pattern that produced the original regression and the inconsistency, and
+  would keep producing it.
+- **Build user-configurability now** (a settings field for modifier/behavior)
+  — deferred: no concrete requirement yet beyond "we'll want this later";
+  adding an unused settings field ahead of a real UI for it doesn't earn its
+  keep today.
+- **Design the extension-contributed-menu-item API now** — deferred: doing it
+  well needs its own design pass (trust/permission model, ordering against
+  built-in items); noted as future work instead of scoped into this fix.
+
+## References
+
+- `packages/extensions-core/src/terminal/terminal-link-policy.ts` — the
+  shared policy.
+- `packages/extensions-core/src/terminal/terminal-links.ts` — file-path link
+  provider.
+- `packages/extensions-core/src/terminal/TerminalPanel.tsx` — xterm wiring
+  (OSC-8 `linkHandler`, `WebLinksAddon`, right-click menu, tooltip).
+- [0011](./0011-editor-and-terminal-are-core.md) — terminal is a core surface.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -60,3 +60,5 @@ A small, obvious choice needs neither.
 | [0023](./0023-workspace-groups-host-internal.md)        | Workspace panel groups are host-internal             | 2026-06-30 | accepted |
 | [0024](./0024-release-channels.md)                      | Two release channels: stable and nightly             | 2026-07-01 | accepted |
 | [0025](./0025-pending-remove-worktree.md)               | Pending remove worktree: close folder on start       | 2026-07-17 | accepted |
+| [0026](./0026-sdk-component-set.md)                     | A curated presentational component set joins the SDK | 2026-07-18 | accepted |
+| [0027](./0027-terminal-link-policy.md)                  | Unified terminal link policy: modifier-click to open | 2026-07-21 | accepted |

--- a/docs/proposals/0013-context-menu-contributions.md
+++ b/docs/proposals/0013-context-menu-contributions.md
@@ -193,3 +193,13 @@ family, orthogonal design questions):
 2. Multi-select in the explorer — does `explorer/item` pass a single `path` or
    `paths: string[]` when several entries are selected? (Leaning single for v1,
    with a `paths` follow-up.)
+3. A finer-grained `terminal/link` surface — right-click on a specific URL or
+   file-path link inside a terminal's output, distinct from `terminal/tab`
+   (which targets the tab itself). [ADR 0027](../decisions/0027-terminal-link-policy.md)
+   established a unified right-click behavior for terminal links (select the
+   span, show "Open Link"/"Copy Link" or "Open File"/"Copy Path") but that menu
+   is currently hard-coded in the host — there's no contribution point for an
+   extension to add to it. Concrete motivating case: a `local-web-viewer`-style
+   extension adding "Open in local web viewer..." to a URL link's context menu.
+   The context object would need the link's `kind` (`"url" | "path"`) and
+   `text` alongside `terminalId`.

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -2,6 +2,7 @@
 // PTY host (RFC 0010); screen + scrollback persisted/restored via the xterm.js
 // SerializeAddon (VS Code-style "process revive").
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { subscribe, useSnapshot } from "valtio";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -33,6 +34,13 @@ import { xtermThemeFor } from "./xterm-theme";
 import { effectiveFontFamily } from "./terminal-font";
 import { buildTerminalPaste } from "./terminal-path-paste";
 import { findFileLinks, getHomeDir } from "./terminal-links";
+import {
+  isLinkActivationClick,
+  linkMenuLabels,
+  linkTooltipText,
+  type HoveredTerminalLink,
+  type TerminalLinkRange,
+} from "./terminal-link-policy";
 import { findTerminalOwnerId } from "./terminal-lifecycle";
 import { TerminalSearch } from "./TerminalSearch";
 import { Breadcrumb } from "../editor/Breadcrumb";
@@ -54,6 +62,20 @@ function effectiveFontSize(): number {
   return store.uiFontSize + store.terminalSettings.fontSizeOffset + 0.5;
 }
 const cmdKey = isMac ? "⌘" : "Ctrl";
+
+// Matches the hover delay of the shared `Tooltip` component (packages/sdk/src/Tooltip.tsx)
+// so terminal link tooltips feel consistent with the rest of the app.
+const LINK_TOOLTIP_DELAY_MS = 600;
+
+// xterm's built-in OSC-8/web-link fallback opens via `window.open()`, which
+// the Tauri webview doesn't hand off to the OS the way a real browser does.
+// Route through the host's opener (the same path menu items and extensions
+// use) instead.
+function openTerminalLink(ctx: ExtensionContext, uri: string): void {
+  void ctx.ui.openExternal(uri).catch((err: unknown) => {
+    console.warn("[terminal] failed to open external link", uri, err);
+  });
+}
 
 export interface TerminalPanelParams {
   terminalId: string;
@@ -109,6 +131,20 @@ export function TerminalPanel(
   const liveRef = useRef<LiveRefs | null>(null);
   // Active disposer for this terminal's selection source (registered while focused).
   const selSourceRef = useRef<Disposable | null>(null);
+  // The link (if any) currently under the pointer, across all three link
+  // mechanisms (OSC-8, WebLinksAddon, file-path provider) — see ADR 0027.
+  // Read by onContextMenu (right-click selects + shows link actions) and by
+  // the tooltip below. A ref because it's written from xterm's hover
+  // callbacks, which fire far more often than a render can usefully follow.
+  const hoveredLinkRef = useRef<HoveredTerminalLink | null>(null);
+  const linkTooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const [linkTooltip, setLinkTooltip] = useState<{
+    x: number;
+    y: number;
+    text: string;
+  } | null>(null);
   // Live working directory of the terminal's foreground process (RFC 0010 N2),
   // updated from foreground events. The ref feeds "New Terminal Here" (sync,
   // no re-render needed); the state drives the breadcrumb bar.
@@ -177,6 +213,38 @@ export function TerminalPanel(
     }
   }, []);
 
+  // Shared hover/tooltip plumbing for every link provider (ADR 0027): each
+  // provider's `hover`/`leave` callback funnels into these two, so the
+  // tooltip text and the right-click "what's under the pointer" state stay
+  // consistent no matter which mechanism found the link.
+  const showLinkTooltip = useCallback(
+    (
+      event: MouseEvent,
+      kind: HoveredTerminalLink["kind"],
+      text: string,
+      range: TerminalLinkRange,
+    ) => {
+      hoveredLinkRef.current = { kind, text, range };
+      if (linkTooltipTimerRef.current)
+        clearTimeout(linkTooltipTimerRef.current);
+      const x = event.clientX;
+      const y = event.clientY;
+      linkTooltipTimerRef.current = setTimeout(() => {
+        setLinkTooltip({ x, y, text: linkTooltipText(kind, isMac) });
+      }, LINK_TOOLTIP_DELAY_MS);
+    },
+    [],
+  );
+
+  const hideLinkTooltip = useCallback(() => {
+    hoveredLinkRef.current = null;
+    if (linkTooltipTimerRef.current) {
+      clearTimeout(linkTooltipTimerRef.current);
+      linkTooltipTimerRef.current = null;
+    }
+    setLinkTooltip(null);
+  }, []);
+
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -197,13 +265,55 @@ export function TerminalPanel(
       // glyphs from the font instead. Regular text is unaffected.
       customGlyphs: false,
       allowProposedApi: true,
+      // Overrides xterm's default OSC-8 hyperlink activation (see
+      // openTerminalLink above for why the default doesn't work here) and
+      // applies the shared link policy (ADR 0027): Cmd/Ctrl+click to open,
+      // hover shows a tooltip, plain click is a no-op.
+      linkHandler: {
+        activate: (event, uri) => {
+          if (!isLinkActivationClick(event, isMac)) return;
+          openTerminalLink(ctx, uri);
+        },
+        hover: (event, text, range) =>
+          showLinkTooltip(event, "url", text, range),
+        leave: () => hideLinkTooltip(),
+      },
     });
     // xterm v6 removed the bellStyle option; subscribe to onBell with a no-op
     // to suppress any audio the WebView would otherwise play on BEL (0x07).
     term.onBell(() => {});
     const fit = new FitAddon();
     term.loadAddon(fit);
-    term.loadAddon(new WebLinksAddon());
+    term.loadAddon(
+      new WebLinksAddon(
+        (event, uri) => {
+          if (!isLinkActivationClick(event, isMac)) return;
+          openTerminalLink(ctx, uri);
+        },
+        {
+          // WebLinksAddon reports hover position in viewport-relative,
+          // 0-based coordinates; convert to the same buffer-absolute,
+          // 1-based coordinates the other two link providers use (see
+          // terminal-link-policy.ts) so right-click "select the link" works
+          // identically no matter which provider found it.
+          hover: (event, text, location) => {
+            const viewportY = term.buffer.active.viewportY;
+            const range: TerminalLinkRange = {
+              start: {
+                x: location.start.x + 1,
+                y: viewportY + location.start.y + 1,
+              },
+              end: {
+                x: location.end.x + 1,
+                y: viewportY + location.end.y + 1,
+              },
+            };
+            showLinkTooltip(event, "url", text, range);
+          },
+          leave: () => hideLinkTooltip(),
+        },
+      ),
+    );
     // SerializeAddon dumps the buffer (screen + scrollback, alt-screen aware) to
     // a self-contained string we persist for restore — the same mechanism VS
     // Code uses for terminal "process revive".
@@ -244,9 +354,14 @@ export function TerminalPanel(
     term.registerLinkProvider({
       provideLinks(bufferLineNumber, callback) {
         callback(
-          findFileLinks(term, bufferLineNumber, (text) =>
-            openFileFromTerminal(text, terminalId, ctx.editors),
-          ),
+          findFileLinks(term, bufferLineNumber, {
+            isMac,
+            onActivate: (text) =>
+              openFileFromTerminal(text, terminalId, ctx.editors),
+            onHover: (event, text, range) =>
+              showLinkTooltip(event, "path", text, range),
+            onLeave: () => hideLinkTooltip(),
+          }),
         );
       },
     });
@@ -603,6 +718,7 @@ export function TerminalPanel(
       cancelled = true;
       ro.disconnect();
       unsubFont();
+      hideLinkTooltip();
 
       // Capture session info before disposers clear liveRef
       const sessionId = liveRef.current?.sessionId;
@@ -798,13 +914,10 @@ export function TerminalPanel(
 
   function onContextMenu(e: React.MouseEvent) {
     e.preventDefault();
-    // When enabled, right-click pastes instead of opening the context menu. The
-    // paste itself happens in the `auxclick` handler — WebKit grants clipboard
-    // read only on a real click gesture, not on a `contextmenu` event.
-    if (store.terminalSettings.pasteOnRightClick) {
-      return;
-    }
-    const items: MenuEntry[] = [
+    // Capture before hiding — hideLinkTooltip() clears hoveredLinkRef too.
+    const hovered = hoveredLinkRef.current;
+    hideLinkTooltip();
+    const genericItems: MenuEntry[] = [
       { label: "Copy", accelerator: `${cmdKey}C`, run: ctxCopy },
       { label: "Copy as HTML", run: ctxCopyAsHtml },
       { label: "Paste", accelerator: `${cmdKey}V`, run: ctxPaste },
@@ -815,7 +928,51 @@ export function TerminalPanel(
       { type: "separator" },
       { label: "Kill Terminal", danger: true, run: ctxKill },
     ];
-    void ctx.ui.showMenu({ items, at: { x: e.clientX, y: e.clientY } });
+
+    // Right-clicking directly on a link always selects it and shows link
+    // actions (ADR 0027) — this takes priority over pasteOnRightClick, since
+    // landing on a specific, unambiguous target is a stronger signal of
+    // intent than the blanket "paste on right-click" setting.
+    if (hovered) {
+      const live = liveRef.current;
+      if (live) {
+        live.term.select(
+          hovered.range.start.x - 1,
+          hovered.range.start.y - 1,
+          hovered.text.length,
+        );
+      }
+      const labels = linkMenuLabels(hovered.kind);
+      const items: MenuEntry[] = [
+        {
+          label: labels.open,
+          run: () => {
+            if (hovered.kind === "url") openTerminalLink(ctx, hovered.text);
+            else
+              void openFileFromTerminal(hovered.text, terminalId, ctx.editors);
+          },
+        },
+        {
+          label: labels.copy,
+          run: () => void navigator.clipboard.writeText(hovered.text),
+        },
+        { type: "separator" },
+        ...genericItems,
+      ];
+      void ctx.ui.showMenu({ items, at: { x: e.clientX, y: e.clientY } });
+      return;
+    }
+
+    // When enabled, right-click pastes instead of opening the context menu. The
+    // paste itself happens in the `auxclick` handler — WebKit grants clipboard
+    // read only on a real click gesture, not on a `contextmenu` event.
+    if (store.terminalSettings.pasteOnRightClick) {
+      return;
+    }
+    void ctx.ui.showMenu({
+      items: genericItems,
+      at: { x: e.clientX, y: e.clientY },
+    });
   }
 
   async function ctxCopy() {
@@ -974,6 +1131,22 @@ export function TerminalPanel(
           </div>
         )}
       </div>
+      {linkTooltip &&
+        // .silo-tooltip is the host's shared tooltip style (see
+        // packages/extension-host/src/components/Tooltip.css), loaded
+        // globally since other core extensions (e.g. the status bar) use the
+        // Tooltip component. Positioned by hand here since xterm renders
+        // links to canvas — there's no DOM element to anchor a wrapping
+        // Tooltip to.
+        createPortal(
+          <div
+            className="silo-tooltip"
+            style={{ left: linkTooltip.x + 12, top: linkTooltip.y + 16 }}
+          >
+            {linkTooltip.text}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/packages/extensions-core/src/terminal/terminal-link-policy.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-link-policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLinkActivationClick,
+  linkMenuLabels,
+  linkModifierLabel,
+  linkTooltipText,
+} from "./terminal-link-policy";
+
+describe("linkModifierLabel", () => {
+  it("shows the Cmd glyph on macOS", () => {
+    expect(linkModifierLabel(true)).toBe("⌘");
+  });
+
+  it("shows Ctrl elsewhere", () => {
+    expect(linkModifierLabel(false)).toBe("Ctrl");
+  });
+});
+
+describe("isLinkActivationClick", () => {
+  it("requires metaKey (not ctrlKey) on macOS", () => {
+    expect(isLinkActivationClick({ metaKey: true, ctrlKey: false }, true)).toBe(
+      true,
+    );
+    expect(isLinkActivationClick({ metaKey: false, ctrlKey: true }, true)).toBe(
+      false,
+    );
+  });
+
+  it("requires ctrlKey (not metaKey) off macOS", () => {
+    expect(
+      isLinkActivationClick({ metaKey: false, ctrlKey: true }, false),
+    ).toBe(true);
+    expect(
+      isLinkActivationClick({ metaKey: true, ctrlKey: false }, false),
+    ).toBe(false);
+  });
+
+  it("is false for a plain click with no modifier", () => {
+    expect(
+      isLinkActivationClick({ metaKey: false, ctrlKey: false }, true),
+    ).toBe(false);
+    expect(
+      isLinkActivationClick({ metaKey: false, ctrlKey: false }, false),
+    ).toBe(false);
+  });
+});
+
+describe("linkTooltipText", () => {
+  it("labels URLs as a link, macOS modifier", () => {
+    expect(linkTooltipText("url", true)).toBe("Open link (⌘ + click)");
+  });
+
+  it("labels paths as a file, non-macOS modifier", () => {
+    expect(linkTooltipText("path", false)).toBe("Open file (Ctrl + click)");
+  });
+});
+
+describe("linkMenuLabels", () => {
+  it("uses Link wording for URLs", () => {
+    expect(linkMenuLabels("url")).toEqual({
+      open: "Open Link",
+      copy: "Copy Link",
+    });
+  });
+
+  it("uses File/Path wording for paths", () => {
+    expect(linkMenuLabels("path")).toEqual({
+      open: "Open File",
+      copy: "Copy Path",
+    });
+  });
+});

--- a/packages/extensions-core/src/terminal/terminal-link-policy.ts
+++ b/packages/extensions-core/src/terminal/terminal-link-policy.ts
@@ -1,0 +1,51 @@
+// Single source of truth for how a link behaves in the terminal, shared by
+// every link mechanism in play: xterm's native OSC-8 hyperlink handler (what
+// Claude Code and other TUIs emit), the WebLinksAddon (bare URLs typed as
+// plain text), and Silo's own file-path link provider (terminal-links.ts).
+// See ADR 0027 — keeping the modifier/tooltip/menu rules in one place is what
+// stops the three providers from drifting into inconsistent behavior, which
+// is what caused links to stop opening in the first place.
+export type TerminalLinkKind = "url" | "path";
+
+export interface TerminalLinkRange {
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+}
+
+export interface HoveredTerminalLink {
+  kind: TerminalLinkKind;
+  text: string;
+  range: TerminalLinkRange;
+}
+
+/** Display label for the terminal link-activation modifier on this platform. */
+export function linkModifierLabel(isMac: boolean): string {
+  return isMac ? "⌘" : "Ctrl";
+}
+
+/** True if `event` carries the platform's link-activation modifier — Cmd on macOS, Ctrl elsewhere. */
+export function isLinkActivationClick(
+  event: Pick<MouseEvent, "metaKey" | "ctrlKey">,
+  isMac: boolean,
+): boolean {
+  return isMac ? event.metaKey : event.ctrlKey;
+}
+
+/** Hover-tooltip text for a link of the given kind, e.g. "Open link (⌘ + click)". */
+export function linkTooltipText(
+  kind: TerminalLinkKind,
+  isMac: boolean,
+): string {
+  const action = kind === "url" ? "Open link" : "Open file";
+  return `${action} (${linkModifierLabel(isMac)} + click)`;
+}
+
+/** Context-menu action labels for a link of the given kind. */
+export function linkMenuLabels(kind: TerminalLinkKind): {
+  open: string;
+  copy: string;
+} {
+  return kind === "url"
+    ? { open: "Open Link", copy: "Copy Link" }
+    : { open: "Open File", copy: "Copy Path" };
+}

--- a/packages/extensions-core/src/terminal/terminal-links.ts
+++ b/packages/extensions-core/src/terminal/terminal-links.ts
@@ -1,9 +1,14 @@
 // Cmd/Ctrl+click on a file path in terminal output opens it in the editor.
 // This module is pure parsing: it finds path-like spans in a logical terminal
-// line and builds xterm `ILink`s. The actual "open" action is injected by the
-// panel (which owns store + editor access) via the `onActivate` callback.
+// line and builds xterm `ILink`s. The actual "open"/hover behavior is injected
+// by the panel (which owns store + editor access + the shared link policy)
+// via the callbacks below.
 import { Terminal as XTerm, type ILink } from "@xterm/xterm";
 import { homeDir } from "@silo-code/extension-host/internal";
+import {
+  isLinkActivationClick,
+  type TerminalLinkRange,
+} from "./terminal-link-policy";
 
 // Two alternatives:
 //   1. Explicit-prefix paths — `~/...`, `/abs/...`, `./rel/...`, `../rel/...`.
@@ -48,10 +53,17 @@ function collectLogicalLine(
   return { text, startY: y + 1 };
 }
 
+export interface FileLinkCallbacks {
+  isMac: boolean;
+  onActivate: (matchText: string) => void;
+  onHover: (event: MouseEvent, text: string, range: TerminalLinkRange) => void;
+  onLeave: () => void;
+}
+
 export function findFileLinks(
   term: XTerm,
   bufferLineNumber: number,
-  onActivate: (matchText: string) => void,
+  callbacks: FileLinkCallbacks,
 ): ILink[] | undefined {
   const logical = collectLogicalLine(term, bufferLineNumber);
   if (!logical) return undefined;
@@ -66,22 +78,25 @@ export function findFileLinks(
     if (!matchText) continue;
     const startOffset = m.index;
     const endOffsetIncl = startOffset + matchText.length - 1;
-    links.push({
-      range: {
-        start: {
-          x: (startOffset % cols) + 1,
-          y: logical.startY + Math.floor(startOffset / cols),
-        },
-        end: {
-          x: (endOffsetIncl % cols) + 1,
-          y: logical.startY + Math.floor(endOffsetIncl / cols),
-        },
+    const range: TerminalLinkRange = {
+      start: {
+        x: (startOffset % cols) + 1,
+        y: logical.startY + Math.floor(startOffset / cols),
       },
+      end: {
+        x: (endOffsetIncl % cols) + 1,
+        y: logical.startY + Math.floor(endOffsetIncl / cols),
+      },
+    };
+    links.push({
+      range,
       text: matchText,
       activate: (event, text) => {
-        if (!event.metaKey && !event.ctrlKey) return;
-        onActivate(text);
+        if (!isLinkActivationClick(event, callbacks.isMac)) return;
+        callbacks.onActivate(text);
       },
+      hover: (event, text) => callbacks.onHover(event, text, range),
+      leave: () => callbacks.onLeave(),
     });
   }
   return links.length ? links : undefined;


### PR DESCRIPTION
## Summary

- Claude Code's OSC-8 hyperlinks stopped opening on click/Cmd-click because xterm's built-in fallback opens via `window.open()`, which the Tauri webview doesn't hand off to the OS the way a real browser does. Right-click → native "Open Link" still worked, which is what made this hard to spot.
- Fixes activation by routing through `ctx.ui.openExternal` (the same Tauri-shell opener used elsewhere) instead of the default fallback.
- That surfaced a bigger problem: three independent link mechanisms in the terminal (xterm's native OSC-8 handler, `WebLinksAddon` for bare URLs, and Silo's own file-path provider) each had separately-specified — or missing — activation/hover/right-click behavior. Unified all three behind one shared, pure policy module (`terminal-link-policy.ts`, with unit tests) per ADR 0027:
  - Cmd+click (macOS) / Ctrl+click (Windows, Linux) opens a link — URLs to the browser, paths to the editor.
  - Plain click is a no-op for navigation; normal text selection is untouched.
  - Hovering any link shows a tooltip (`Open link (⌘ + click)` / `Open file (⌘ + click)`), reusing the host's existing `.silo-tooltip` style.
  - Right-click directly on a link always selects its full span and shows the context menu with "Open Link/File" and "Copy Link/Path" prepended — even overriding `pasteOnRightClick`.

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` (boundary + stylelint) — clean
- [x] `pnpm test` — all packages green, including 9 new unit tests for the policy module
- [ ] Manual: in a running build, hover/Cmd-click/right-click a Claude Code OSC-8 link, a plain-text URL, and a file path in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)