### PR TITLE
feat(layout): add Laptop Mode — auto-hide side panels on a small screen

### DIFF
--- a/apps/desktop/src/builtins.ts
+++ b/apps/desktop/src/builtins.ts
@@ -5,6 +5,7 @@ import {
   terminal,
   output,
   editor,
+  layout,
   workspaces,
   themes,
   keybindings,
@@ -43,6 +44,7 @@ const builtins: Extension[] = [
   // priority 0, a plain .md open ties to Text (the default view); Preview is
   // opt-in via "Open With" / the breadcrumb switcher.
   editor,
+  layout,
   imageViewer,
   markdownPreview,
   workspaces,

--- a/packages/extension-host/src/extension-host/focus-regions.test.ts
+++ b/packages/extension-host/src/extension-host/focus-regions.test.ts
@@ -10,6 +10,7 @@ import {
   supersedeCenterRetry,
 } from "../docked/dock-api-registry";
 import { registerSidePane } from "../layout/side-pane-registry";
+import { store } from "../state/store";
 
 // Isolate the region MODEL (cycle order / skipping / Tab handoff / click-to-enter)
 // from the center's async retry machinery: mock dock-api-registry so the center
@@ -29,6 +30,8 @@ afterEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
   for (const dispose of sidePaneDisposers.splice(0)) dispose();
+  store.leftPanelAutoHidden = false;
+  store.rightPanelAutoHidden = false;
 });
 
 // ── DOM builders (jsdom has no layout, so side-pane visibility is stubbed via a
@@ -179,6 +182,20 @@ describe("cycleRegionFocus", () => {
     expect(document.activeElement).toBe(editor);
   });
 
+  it("skips a side dock that small-screen mode auto-hid, even though it's rendered at full width (a peek)", () => {
+    // Full clientWidth (200) — as if genuinely peeking — but flagged
+    // autoHidden, which alone must be enough to exclude it: peek is a
+    // mouse-only affordance with no keyboard gesture to invoke it.
+    sidePane("left");
+    const editor = document.createElement("textarea");
+    centerWith(editor);
+    store.leftPanelAutoHidden = true;
+
+    editor.focus();
+    expect(cycleRegionFocus(-1)).toBe(false);
+    expect(document.activeElement).toBe(editor);
+  });
+
   it("skips an empty center (focusEntry returns false)", () => {
     const left = sidePane("left");
     const status = statusBar();
@@ -241,6 +258,17 @@ describe("installRegionTabHandoff", () => {
     expect(e.defaultPrevented).toBe(true);
     expect(mockCenter).toHaveBeenCalled();
     expect(document.activeElement).toBe(editor);
+  });
+
+  it("never hands off out of a small-screen-auto-hidden dock, even from its last tabbable", () => {
+    const left = sidePane("left");
+    centerWith(document.createElement("textarea"));
+    store.leftPanelAutoHidden = true;
+
+    left.focus(); // its only (so "last") tabbable
+    const e = pressTab();
+    expect(e.defaultPrevented).toBe(false);
+    expect(mockCenter).not.toHaveBeenCalled();
   });
 
   it("does not hand off from a non-last tabbable", () => {

--- a/packages/extension-host/src/extension-host/focus-regions.ts
+++ b/packages/extension-host/src/extension-host/focus-regions.ts
@@ -22,12 +22,23 @@ import {
   focusCenterDock,
   supersedeCenterRetry,
 } from "../docked/dock-api-registry";
+import { store } from "../state/store";
 import {
   INTERACTIVE,
   firstTabbable,
   focusFirstOrContainer,
   tabbablesIn,
 } from "./focus-dom";
+
+/** Small-screen mode excludes an auto-hidden panel from Tab order entirely —
+ * peeking or not, since peek is a mouse-only affordance with no keyboard
+ * gesture to invoke it. A manual toggle clears the flag and restores normal
+ * tabbing (see `state/store.ts` `setLeftPanelCollapsed`/`setRightPanelCollapsed`). */
+function isAutoHidden(side: "left" | "right"): boolean {
+  return side === "left"
+    ? store.leftPanelAutoHidden
+    : store.rightPanelAutoHidden;
+}
 
 /**
  * A top-level focus region. The host derives the region cycle, the boundary-Tab
@@ -53,8 +64,10 @@ interface FocusRegion {
   tabbables?(): HTMLElement[];
 }
 
-/** The visible side-pane element for a side, or null when collapsed/empty. */
+/** The visible side-pane element for a side, or null when collapsed/empty/
+ * small-screen-auto-hidden (peeking or not — see `isAutoHidden`). */
 function sidePane(side: "left" | "right"): HTMLElement | null {
+  if (isAutoHidden(side)) return null;
   for (const p of document.querySelectorAll<HTMLElement>(
     `.side-pane[data-slot^="${side}"]`,
   )) {
@@ -91,6 +104,9 @@ function sideRegion(side: "left" | "right", order: number): FocusRegion {
       return focusFirstOrContainer(active);
     },
     tabbables() {
+      // Small-screen-auto-hidden: excluded from the handoff entirely, peeking
+      // or not (see `isAutoHidden`).
+      if (isAutoHidden(side)) return [];
       // Only the ACTIVE panel's tabbables in each pane — a side dock keeps its
       // inactive panels mounted but hidden, and their (unfocusable) tabbables
       // would otherwise be picked as the "last", breaking the handoff.

--- a/packages/extension-host/src/extension-host/layout-service.test.ts
+++ b/packages/extension-host/src/extension-host/layout-service.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { DockviewApi } from "dockview";
 import { getLayoutService } from "./layout-service";
 import { setActiveDockApi } from "../docked/dock-api-registry";
+import { store } from "../state/store";
+import { sidePanelRegistry } from "./side-panels";
 
 // Fake just the slice of DockviewApi that openPanel touches: getPanel for the
 // singleton existence check, addPanel returning a panel whose api.setActive
@@ -81,5 +83,54 @@ describe("LayoutService.openPanel", () => {
     layout.openSingletonPanel("output", { title: "Output" });
     expect(dock.addPanel).toHaveBeenCalledTimes(1);
     expect(dock.panels.get("output")!.api.setActive).toHaveBeenCalled();
+  });
+});
+
+// These three are the public (command/`ctx.layout`) collapse path, which must
+// always clear the corresponding `*PanelAutoHidden` flag — that's what makes
+// an explicit call "stick" instead of being re-hidden by small-screen mode's
+// next auto-hide pass (see extension-host/small-screen-mode.ts).
+describe("LayoutService manual collapse path clears autoHidden", () => {
+  beforeEach(() => {
+    store.leftPanelCollapsed = true;
+    store.rightPanelCollapsed = true;
+    store.leftPanelAutoHidden = true;
+    store.rightPanelAutoHidden = true;
+  });
+
+  afterEach(() => {
+    store.leftPanelCollapsed = false;
+    store.rightPanelCollapsed = false;
+    store.leftPanelAutoHidden = false;
+    store.rightPanelAutoHidden = false;
+  });
+
+  it("setSidePanelCollapsed clears autoHidden for the given side only", () => {
+    layout.setSidePanelCollapsed("left", false);
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.leftPanelAutoHidden).toBe(false);
+    expect(store.rightPanelAutoHidden).toBe(true); // untouched
+  });
+
+  it("toggleSidePanel clears autoHidden", () => {
+    layout.toggleSidePanel("right"); // currently collapsed → expands
+    expect(store.rightPanelCollapsed).toBe(false);
+    expect(store.rightPanelAutoHidden).toBe(false);
+  });
+
+  it("revealSidePanel clears autoHidden for the panel's column", () => {
+    const dispose = sidePanelRegistry.register({
+      id: "test.panel",
+      location: "left",
+      title: "Test",
+      component: () => null,
+    });
+    try {
+      layout.revealSidePanel("test.panel");
+      expect(store.leftPanelCollapsed).toBe(false);
+      expect(store.leftPanelAutoHidden).toBe(false);
+    } finally {
+      dispose.dispose();
+    }
   });
 });

--- a/packages/extension-host/src/extension-host/layout-service.ts
+++ b/packages/extension-host/src/extension-host/layout-service.ts
@@ -1,5 +1,11 @@
 import { subscribe, snapshot } from "valtio";
-import { store, toggleLeftPanel, toggleRightPanel } from "../state/store";
+import {
+  store,
+  toggleLeftPanel,
+  toggleRightPanel,
+  setLeftPanelCollapsed,
+  setRightPanelCollapsed,
+} from "../state/store";
 import { sidePanelRegistry } from "./side-panels";
 import { activateSidePaneTab } from "../layout/side-pane-registry";
 import { getActiveDockApi } from "../docked/dock-api-registry";
@@ -45,8 +51,8 @@ export function getLayoutService(): LayoutService {
       else toggleRightPanel();
     },
     setSidePanelCollapsed(location, collapsed) {
-      if (location === "left") store.leftPanelCollapsed = collapsed;
-      else store.rightPanelCollapsed = collapsed;
+      if (location === "left") setLeftPanelCollapsed(collapsed);
+      else setRightPanelCollapsed(collapsed);
     },
     openPanel(kindId, params, options) {
       const api = getActiveDockApi();
@@ -85,8 +91,8 @@ export function getLayoutService(): LayoutService {
       store.activeSidePanelTabs[slot] = id;
       activateSidePaneTab(slot, id);
       // Expand the column so it's actually on screen.
-      if (location === "left") store.leftPanelCollapsed = false;
-      else store.rightPanelCollapsed = false;
+      if (location === "left") setLeftPanelCollapsed(false);
+      else setRightPanelCollapsed(false);
     },
   };
   return service;

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -315,3 +315,16 @@ export type { TerminalForeground } from "./terminal-foreground";
 // internal barrel. The component itself is now public (@silo-code/sdk); the
 // host component file re-exports from SDK and owns the CSS load.
 export { Tooltip } from "../components/Tooltip";
+
+// Small-screen-mode settings (global on/off + width threshold) — read/write
+// for the `core.layout` settings page. The auto-hide/peek behavior itself is
+// host-internal (small-screen-mode.ts, wired directly into AppShell); only the
+// two user-facing preferences need a settings-page seam.
+export {
+  setSmallScreenModeEnabled,
+  setSmallScreenThresholdPx,
+} from "../state/store";
+export {
+  DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
+  MIN_SMALL_SCREEN_THRESHOLD_PX,
+} from "../state/types";

--- a/packages/extension-host/src/extension-host/small-screen-mode.test.ts
+++ b/packages/extension-host/src/extension-host/small-screen-mode.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  computeSmallScreenActive,
+  nextPeekWidthPx,
+  beginPeekResize,
+  installSmallScreenMode,
+} from "./small-screen-mode";
+import {
+  store,
+  setLeftPanelCollapsed,
+  setRightPanelCollapsed,
+} from "../state/store";
+import {
+  DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
+  DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
+  MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
+  MAX_SMALL_SCREEN_PEEK_WIDTH_PX,
+} from "../state/types";
+
+function setInnerWidth(px: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    value: px,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function resetStore(): void {
+  store.leftPanelCollapsed = false;
+  store.rightPanelCollapsed = false;
+  store.leftPanelAutoHidden = false;
+  store.rightPanelAutoHidden = false;
+  store.leftPanelPeeking = false;
+  store.rightPanelPeeking = false;
+  store.leftPanelPeekDragging = false;
+  store.rightPanelPeekDragging = false;
+  store.smallScreenPeekWidthLeftPx = DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX;
+  store.smallScreenPeekWidthRightPx = DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX;
+  store.smallScreenModeEnabled = true;
+  store.smallScreenThresholdPx = DEFAULT_SMALL_SCREEN_THRESHOLD_PX;
+  store.workspaces = {};
+  store.workspaceOrder = [];
+  store.activeWorkspaceId = null;
+}
+
+function moveMouse(x: number, target: EventTarget = document): void {
+  target.dispatchEvent(
+    new MouseEvent("mousemove", { clientX: x, bubbles: true }),
+  );
+}
+
+/** A side column split into a top + bottom pane (bottom-docked panel), both
+ * nested in AppShell's peek wrapper — mirrors the real DOM `.side-peek-host`
+ * wraps around `<SideColumn>`, which renders two `.side-pane` elements when
+ * split. Returns the bottom pane's element to dispatch events "on". */
+function renderSplitSideColumn(side: "left" | "right"): HTMLElement {
+  const host = document.createElement("div");
+  host.className = `side-peek-host side-peek-host--${side}`;
+  const top = document.createElement("div");
+  top.className = "side-pane";
+  top.dataset.slot = side;
+  const bottom = document.createElement("div");
+  bottom.className = "side-pane";
+  bottom.dataset.slot = `${side}-bottom`;
+  host.append(top, bottom);
+  document.body.appendChild(host);
+  return bottom;
+}
+
+describe("computeSmallScreenActive", () => {
+  it("enters small-screen once width drops below the raw threshold", () => {
+    expect(computeSmallScreenActive(false, 1439, 1440, 80)).toBe(true);
+    expect(computeSmallScreenActive(false, 1440, 1440, 80)).toBe(false);
+  });
+
+  it("stays active inside the hysteresis band once already active", () => {
+    // Below threshold+hysteresis but at/above threshold — the dead zone.
+    expect(computeSmallScreenActive(true, 1500, 1440, 80)).toBe(true);
+  });
+
+  it("exits small-screen only once width clears threshold + hysteresis", () => {
+    expect(computeSmallScreenActive(true, 1519, 1440, 80)).toBe(true);
+    expect(computeSmallScreenActive(true, 1520, 1440, 80)).toBe(false);
+  });
+
+  it("stays active well below threshold regardless of hysteresis", () => {
+    expect(computeSmallScreenActive(true, 800, 1440, 80)).toBe(true);
+  });
+});
+
+describe("installSmallScreenMode", () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetStore();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    dispose?.();
+    vi.useRealTimers();
+  });
+
+  it("auto-hides open panels immediately when launched already small", () => {
+    setInnerWidth(1200);
+    dispose = installSmallScreenMode();
+
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.leftPanelAutoHidden).toBe(true);
+    expect(store.rightPanelCollapsed).toBe(true);
+    expect(store.rightPanelAutoHidden).toBe(true);
+  });
+
+  it("does nothing when launched already large", () => {
+    setInnerWidth(1800);
+    dispose = installSmallScreenMode();
+
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.leftPanelAutoHidden).toBe(false);
+  });
+
+  it("auto-hides on a debounced resize below threshold", () => {
+    setInnerWidth(1800);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelCollapsed).toBe(false);
+
+    setInnerWidth(1000);
+    window.dispatchEvent(new Event("resize"));
+    // Not yet — resize is debounced.
+    expect(store.leftPanelCollapsed).toBe(false);
+
+    vi.advanceTimersByTime(250);
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.leftPanelAutoHidden).toBe(true);
+  });
+
+  it("restores auto-hidden panels to prior collapsed/autoHidden=false once the screen grows past the hysteresis band", () => {
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelCollapsed).toBe(true);
+
+    setInnerWidth(1440); // exactly at threshold — inside the hysteresis dead zone
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    expect(store.leftPanelCollapsed).toBe(true); // still hidden — hasn't cleared threshold+hysteresis
+
+    setInnerWidth(1600); // clears threshold + 80px hysteresis
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.leftPanelAutoHidden).toBe(false);
+  });
+
+  it("never touches a panel the user manually collapsed", () => {
+    setInnerWidth(1800);
+    setLeftPanelCollapsed(true); // manual collapse, unrelated to screen size
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelAutoHidden).toBe(false);
+
+    setInnerWidth(1000);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    // Stays collapsed, but small-screen mode never claimed it.
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.leftPanelAutoHidden).toBe(false);
+
+    setInnerWidth(1800);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    // Growing back doesn't force it open — it was never small-screen mode's.
+    expect(store.leftPanelCollapsed).toBe(true);
+  });
+
+  it("a manual reopen while auto-hidden sticks until a fresh large-small round trip", () => {
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.leftPanelAutoHidden).toBe(true);
+
+    setRightPanelCollapsed(store.rightPanelCollapsed); // no-op sanity call
+    setLeftPanelCollapsed(false); // the manual toggle command's path
+    expect(store.leftPanelAutoHidden).toBe(false);
+    expect(store.leftPanelCollapsed).toBe(false);
+
+    // Still small, but nothing re-hides it since no new edge/workspace change fired.
+    vi.advanceTimersByTime(1000);
+    expect(store.leftPanelCollapsed).toBe(false);
+  });
+
+  it("re-hides a newly active workspace's open panels while still small-screen", async () => {
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelCollapsed).toBe(true);
+
+    // A workspace switch (per-workspace collapsed state loaded fresh) reopens
+    // it; the re-hide runs off valtio's (microtask-batched) subscribe, so the
+    // effect lands one tick after the raw store mutation.
+    store.activeWorkspaceId = "ws-2";
+    store.leftPanelCollapsed = false;
+    store.leftPanelAutoHidden = false;
+    await Promise.resolve();
+
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.leftPanelAutoHidden).toBe(true);
+  });
+
+  it("restores auto-hidden panels immediately when the feature is disabled", async () => {
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelCollapsed).toBe(true);
+
+    store.smallScreenModeEnabled = false;
+    await Promise.resolve(); // subscribe's notification is microtask-batched
+
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.leftPanelAutoHidden).toBe(false);
+  });
+
+  it("peeks an auto-hidden left panel after a dwell at the edge, and hides it again after the mouse leaves", () => {
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelAutoHidden).toBe(true);
+
+    moveMouse(2); // within the edge hotspot
+    vi.advanceTimersByTime(100);
+    expect(store.leftPanelPeeking).toBe(false); // dwell not elapsed yet
+
+    vi.advanceTimersByTime(200);
+    expect(store.leftPanelPeeking).toBe(true);
+
+    moveMouse(900); // far from the edge, no pane element in the DOM to be "within"
+    vi.advanceTimersByTime(300);
+    expect(store.leftPanelPeeking).toBe(true); // grace not elapsed yet
+
+    vi.advanceTimersByTime(200);
+    expect(store.leftPanelPeeking).toBe(false);
+  });
+
+  it("stays peeking while the cursor is over the bottom pane of a split side column", () => {
+    // Regression: a split side column (a panel docked at the bottom) renders
+    // two .side-pane elements. The peek used to measure cursor containment
+    // against only the first one found, so hovering the *bottom* pane's tab
+    // bar/content read as "left the peek" and hid it after the grace timer.
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    const bottomPane = renderSplitSideColumn("left");
+
+    moveMouse(2); // dwell at the edge
+    vi.advanceTimersByTime(300);
+    expect(store.leftPanelPeeking).toBe(true);
+
+    moveMouse(150, bottomPane); // far from the edge, but over the bottom pane
+    vi.advanceTimersByTime(1000); // well past the grace delay
+    expect(store.leftPanelPeeking).toBe(true);
+  });
+
+  it("never peeks a manually-collapsed panel", () => {
+    setInnerWidth(1800);
+    setLeftPanelCollapsed(true);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelAutoHidden).toBe(false);
+
+    moveMouse(2);
+    vi.advanceTimersByTime(1000);
+    expect(store.leftPanelPeeking).toBe(false);
+  });
+
+  it("keeps peeking through a resize drag even once the cursor leaves the pre-drag peek-host bounds", () => {
+    // Regression scenario this guards against: growing the overlay naturally
+    // carries the cursor away from wherever the (pre-drag) peek host and edge
+    // hotspot were, which — without the peekDragging escape hatch — would read
+    // as "left the peek" mid-drag and hide it out from under the user.
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelAutoHidden).toBe(true); // already small at launch
+    store.leftPanelPeeking = true; // as if already peeking
+
+    const dragDispose = beginPeekResize("left", 280);
+    expect(store.leftPanelPeekDragging).toBe(true);
+
+    moveMouse(900); // far from the edge and outside any peek host in the DOM
+    vi.advanceTimersByTime(1000);
+    expect(store.leftPanelPeeking).toBe(true);
+
+    dragDispose();
+    expect(store.leftPanelPeekDragging).toBe(false);
+  });
+});
+
+describe("nextPeekWidthPx", () => {
+  it("grows the left panel's overlay when dragging right, shrinks the right panel's", () => {
+    expect(nextPeekWidthPx("left", 280, 50)).toBe(330);
+    expect(nextPeekWidthPx("right", 280, 50)).toBe(230);
+  });
+
+  it("clamps to the configured min/max range", () => {
+    expect(nextPeekWidthPx("left", 280, -1000)).toBe(
+      MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
+    );
+    expect(nextPeekWidthPx("left", 280, 1000)).toBe(
+      MAX_SMALL_SCREEN_PEEK_WIDTH_PX,
+    );
+  });
+});
+
+describe("beginPeekResize", () => {
+  afterEach(() => {
+    store.leftPanelPeekDragging = false;
+    store.smallScreenPeekWidthLeftPx = DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX;
+  });
+
+  it("updates the global peek width live as the mouse moves, and stops on mouseup", () => {
+    store.smallScreenPeekWidthLeftPx = 280;
+    beginPeekResize("left", 100);
+
+    window.dispatchEvent(new MouseEvent("mousemove", { clientX: 150 }));
+    expect(store.smallScreenPeekWidthLeftPx).toBe(330);
+
+    window.dispatchEvent(new MouseEvent("mouseup"));
+    expect(store.leftPanelPeekDragging).toBe(false);
+
+    // No longer listening — a further move doesn't change anything.
+    window.dispatchEvent(new MouseEvent("mousemove", { clientX: 400 }));
+    expect(store.smallScreenPeekWidthLeftPx).toBe(330);
+  });
+
+  it("the returned disposer also stops the drag", () => {
+    store.smallScreenPeekWidthLeftPx = 280;
+    const dispose = beginPeekResize("left", 100);
+    dispose();
+    expect(store.leftPanelPeekDragging).toBe(false);
+
+    window.dispatchEvent(new MouseEvent("mousemove", { clientX: 400 }));
+    expect(store.smallScreenPeekWidthLeftPx).toBe(280);
+  });
+});
+
+describe("installSmallScreenMode: iframe crossing", () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetStore();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    dispose?.();
+    vi.useRealTimers();
+  });
+
+  it("hides a peek once the cursor crosses onto a webview, even with no further mousemove", () => {
+    // Regression: a cross-origin <iframe> (e.g. local-web-viewer in the center
+    // dock) swallows mousemove entirely once the cursor is over it — the
+    // parent document never gets another one to notice the cursor left. Entry
+    // fires a normal `mouseover` on the iframe element itself, though, which
+    // is the only signal we get.
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    moveMouse(2); // dwell at the edge
+    vi.advanceTimersByTime(300);
+    expect(store.leftPanelPeeking).toBe(true);
+
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    iframe.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    // No further mousemove ever arrives — the grace timer alone must do it.
+    vi.advanceTimersByTime(500);
+
+    expect(store.leftPanelPeeking).toBe(false);
+  });
+
+  it("does not force-close mid-drag just because the cursor grazes an iframe", () => {
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    expect(store.leftPanelAutoHidden).toBe(true);
+    store.leftPanelPeeking = true;
+    beginPeekResize("left", 280);
+
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    iframe.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(1000);
+
+    expect(store.leftPanelPeeking).toBe(true);
+  });
+});

--- a/packages/extension-host/src/extension-host/small-screen-mode.ts
+++ b/packages/extension-host/src/extension-host/small-screen-mode.ts
@@ -1,0 +1,388 @@
+// Small screen mode: when the app window's own logical width drops below a
+// threshold (e.g. a MacBook loses its external monitor), auto-collapse the
+// side panels that are currently open, and auto-restore them once the window
+// grows back. While a panel is auto-hidden, hovering the cursor at the
+// window's edge "peeks" it (a transient overlay — see AppShell.tsx's
+// `--peek-width` CSS), which self-hides again once the cursor leaves. The
+// overlay's width is its own global (not per-workspace) preference, resizable
+// by dragging its handle (`beginPeekResize`) — independent of whatever width
+// the panel normally has on a large screen.
+//
+// Centralized here so the resize/hysteresis/debounce/peek-timer logic lives
+// in one place: AppShell only reads the store fields this module writes
+// (`*PanelAutoHidden`, `*PanelPeeking`) to drive collapse/expand and the peek
+// overlay's CSS, and `focus-regions.ts` reads `*PanelAutoHidden` to exclude an
+// auto-hidden panel from Tab order. The manual/public collapse path
+// (`setLeftPanelCollapsed`/`setRightPanelCollapsed` in state/store.ts, used by
+// commands and `ctx.layout`) always clears `*PanelAutoHidden` — that's what
+// makes a manual reopen "stick" instead of being re-hidden by this module.
+
+import { subscribe } from "valtio";
+import { store, setSmallScreenPeekWidthPx } from "../state/store";
+import {
+  SMALL_SCREEN_HYSTERESIS_PX,
+  MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
+  MAX_SMALL_SCREEN_PEEK_WIDTH_PX,
+} from "../state/types";
+
+const RESIZE_DEBOUNCE_MS = 200;
+const EDGE_HOTSPOT_PX = 6;
+const PEEK_DWELL_MS = 220;
+const PEEK_GRACE_MS = 400;
+
+type Side = "left" | "right";
+
+/**
+ * Hysteresis band: enters small-screen at `width < threshold`, but once
+ * active, only exits at `width >= threshold + hysteresisPx`. Pure so the
+ * boundary math is unit-testable without a DOM. Exported for tests.
+ */
+export function computeSmallScreenActive(
+  currentlyActive: boolean,
+  widthPx: number,
+  thresholdPx: number,
+  hysteresisPx: number = SMALL_SCREEN_HYSTERESIS_PX,
+): boolean {
+  if (currentlyActive) return widthPx < thresholdPx + hysteresisPx;
+  return widthPx < thresholdPx;
+}
+
+function collapsedKey(
+  side: Side,
+): "leftPanelCollapsed" | "rightPanelCollapsed" {
+  return side === "left" ? "leftPanelCollapsed" : "rightPanelCollapsed";
+}
+function autoHiddenKey(
+  side: Side,
+): "leftPanelAutoHidden" | "rightPanelAutoHidden" {
+  return side === "left" ? "leftPanelAutoHidden" : "rightPanelAutoHidden";
+}
+function peekingKey(side: Side): "leftPanelPeeking" | "rightPanelPeeking" {
+  return side === "left" ? "leftPanelPeeking" : "rightPanelPeeking";
+}
+function peekDraggingKey(
+  side: Side,
+): "leftPanelPeekDragging" | "rightPanelPeekDragging" {
+  return side === "left" ? "leftPanelPeekDragging" : "rightPanelPeekDragging";
+}
+function peekWidthKey(
+  side: Side,
+): "smallScreenPeekWidthLeftPx" | "smallScreenPeekWidthRightPx" {
+  return side === "left"
+    ? "smallScreenPeekWidthLeftPx"
+    : "smallScreenPeekWidthRightPx";
+}
+
+const SIDES: readonly Side[] = ["left", "right"];
+
+/** Collapse whichever panels are currently open, marking them auto-hidden.
+ * Idempotent — a panel that's already collapsed (manually or already
+ * auto-hidden) is left alone, so this is safe to call on every workspace
+ * switch while small-screen mode is active, not just on the resize edge. */
+function hideOpenPanels(): void {
+  for (const side of SIDES) {
+    if (!store[collapsedKey(side)]) {
+      store[autoHiddenKey(side)] = true;
+      store[collapsedKey(side)] = true;
+    }
+  }
+}
+
+/** Restore whichever panels small-screen mode itself hid. Manually-collapsed
+ * panels (`autoHidden === false`) are left alone. */
+function restoreAutoHiddenPanels(): void {
+  for (const side of SIDES) {
+    if (store[autoHiddenKey(side)]) {
+      store[autoHiddenKey(side)] = false;
+      store[collapsedKey(side)] = false;
+      store[peekingKey(side)] = false;
+      store[peekDraggingKey(side)] = false;
+    }
+  }
+}
+
+/** Whether `target` sits inside the peek wrapper for `side` (AppShell's
+ * `.side-peek-host--left`/`--right`, see AppShell.tsx). Ancestry-based rather
+ * than a bounding-rect check against a queried `.side-pane`: a side column can
+ * split into a top + bottom pane (two separate `.side-pane` elements), and a
+ * rect check against just one of them falsely reports "not engaged" — and
+ * therefore hides the peek — while the cursor is over the other segment's tab
+ * bar/content. `closest()` covers both segments uniformly since they're both
+ * descendants of the one wrapper, regardless of the internal split. */
+function isWithinPeekHost(side: Side, target: EventTarget | null): boolean {
+  return (
+    target instanceof Element && !!target.closest(`.side-peek-host--${side}`)
+  );
+}
+
+/**
+ * Edge-triggered: `hideOpenPanels`/`restoreAutoHiddenPanels` only run exactly
+ * once per genuine large↔small transition (or a workspace switch while
+ * already small), never re-derived from steady state — that's what lets a
+ * manual reopen (Q14: `setLeftPanelCollapsed`/`setRightPanelCollapsed`
+ * clearing `autoHidden`) stick until the next real round-trip, instead of
+ * being immediately re-hidden by the next unrelated store change.
+ */
+function createResizeWatcher() {
+  let active = false;
+
+  function evaluate(widthPx: number): void {
+    if (!store.smallScreenModeEnabled) {
+      if (active) {
+        active = false;
+        restoreAutoHiddenPanels();
+      }
+      return;
+    }
+    const next = computeSmallScreenActive(
+      active,
+      widthPx,
+      store.smallScreenThresholdPx,
+    );
+    if (next === active) return;
+    active = next;
+    if (active) hideOpenPanels();
+    else restoreAutoHiddenPanels();
+  }
+
+  function reevaluateForCurrentWidth(): void {
+    evaluate(window.innerWidth);
+  }
+
+  /** Called whenever `smallScreenModeEnabled`, `smallScreenThresholdPx`, or
+   * `activeWorkspaceId` change — re-runs the width check, and (per the
+   * "applies uniformly across workspaces" decision) re-hides a newly-active
+   * workspace's currently-open panels if the screen is already small. */
+  function onWorkspaceOrSettingChange(): void {
+    reevaluateForCurrentWidth();
+    if (active) hideOpenPanels();
+  }
+
+  return { evaluate, reevaluateForCurrentWidth, onWorkspaceOrSettingChange };
+}
+
+function debounce(fn: () => void, ms: number): () => void {
+  let timer: number | null = null;
+  return () => {
+    if (timer !== null) window.clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      timer = null;
+      fn();
+    }, ms);
+  };
+}
+
+/** Cursor-at-edge dwell-to-peek / leave-to-hide for one side. Only engages
+ * while that side is small-screen-auto-hidden; a manually-collapsed panel
+ * never peeks (Q7). */
+function createEdgeTracker(side: Side) {
+  let dwellTimer: number | null = null;
+  let graceTimer: number | null = null;
+
+  function clearDwell(): void {
+    if (dwellTimer !== null) {
+      window.clearTimeout(dwellTimer);
+      dwellTimer = null;
+    }
+  }
+  function clearGrace(): void {
+    if (graceTimer !== null) {
+      window.clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+  }
+  function scheduleGraceHide(): void {
+    if (graceTimer === null) {
+      graceTimer = window.setTimeout(() => {
+        graceTimer = null;
+        store[peekingKey(side)] = false;
+      }, PEEK_GRACE_MS);
+    }
+  }
+
+  /**
+   * Force a "cursor left" signal without coordinates — the entry point for
+   * the iframe-crossing detector (see `installSmallScreenMode`): a webview in
+   * the center dock (e.g. `local-web-viewer`) swallows `mousemove` the moment
+   * the cursor crosses onto it, since that's a separate document the parent
+   * page can't see into. Without this, a peek that was open right as the
+   * cursor entered the iframe would never get another real `mousemove` to
+   * notice it had left, and would stay open until the cursor re-emerged.
+   */
+  function markDisengaged(): void {
+    clearDwell();
+    if (!store[peekingKey(side)]) return;
+    if (store[peekDraggingKey(side)]) {
+      clearGrace(); // an active drag always counts as engaged
+      return;
+    }
+    scheduleGraceHide();
+  }
+
+  function onMouseMove(x: number, w: number, target: EventTarget | null): void {
+    const autoHidden = store[autoHiddenKey(side)];
+    if (!store.smallScreenModeEnabled || !autoHidden) {
+      clearDwell();
+      if (store[peekingKey(side)]) {
+        clearGrace();
+        store[peekingKey(side)] = false;
+      }
+      return;
+    }
+
+    const nearEdge =
+      side === "left" ? x <= EDGE_HOTSPOT_PX : x >= w - EDGE_HOTSPOT_PX;
+    const peeking = store[peekingKey(side)];
+
+    if (peeking) {
+      // A drag in progress always counts as engaged — growing the overlay can
+      // easily carry the cursor outside the pre-drag peek-host bounds (or, for
+      // the right panel, past the edge hotspot check's math) well before the
+      // overlay itself has resized to keep up.
+      const engaged =
+        nearEdge ||
+        isWithinPeekHost(side, target) ||
+        store[peekDraggingKey(side)];
+      if (engaged) {
+        clearGrace();
+      } else {
+        scheduleGraceHide();
+      }
+      return;
+    }
+
+    if (nearEdge) {
+      if (dwellTimer === null) {
+        dwellTimer = window.setTimeout(() => {
+          dwellTimer = null;
+          store[peekingKey(side)] = true;
+        }, PEEK_DWELL_MS);
+      }
+    } else {
+      clearDwell();
+    }
+  }
+
+  function dispose(): void {
+    clearDwell();
+    clearGrace();
+  }
+
+  return { onMouseMove, markDisengaged, dispose };
+}
+
+/**
+ * Wire up small-screen mode: a debounced window-resize listener, an
+ * immediate check on mount (so launching already-small applies right away),
+ * a subscription that re-checks on workspace switch / settings changes, and
+ * the edge-hover peek trackers. Call once from AppShell; returns a disposer.
+ */
+export function installSmallScreenMode(): () => void {
+  const watcher = createResizeWatcher();
+  const leftEdge = createEdgeTracker("left");
+  const rightEdge = createEdgeTracker("right");
+
+  watcher.reevaluateForCurrentWidth();
+
+  const onResize = debounce(
+    watcher.reevaluateForCurrentWidth,
+    RESIZE_DEBOUNCE_MS,
+  );
+  window.addEventListener("resize", onResize);
+
+  let prevWorkspaceId = store.activeWorkspaceId;
+  let prevEnabled = store.smallScreenModeEnabled;
+  let prevThreshold = store.smallScreenThresholdPx;
+  const unsubscribe = subscribe(store, () => {
+    const changed =
+      store.activeWorkspaceId !== prevWorkspaceId ||
+      store.smallScreenModeEnabled !== prevEnabled ||
+      store.smallScreenThresholdPx !== prevThreshold;
+    prevWorkspaceId = store.activeWorkspaceId;
+    prevEnabled = store.smallScreenModeEnabled;
+    prevThreshold = store.smallScreenThresholdPx;
+    if (changed) watcher.onWorkspaceOrSettingChange();
+  });
+
+  function onMouseMove(e: MouseEvent): void {
+    const w = window.innerWidth;
+    leftEdge.onMouseMove(e.clientX, w, e.target);
+    rightEdge.onMouseMove(e.clientX, w, e.target);
+  }
+  document.addEventListener("mousemove", onMouseMove);
+
+  // The cursor crossing onto a webview (e.g. `local-web-viewer`'s <iframe> in
+  // the center dock) never fires another `mousemove` on this document — it's
+  // a separate document the parent can't see into. `mouseover`, though, still
+  // fires normally on the iframe *element itself* the moment it becomes the
+  // hover target, since that only depends on the parent's own layout. Use
+  // that one crossing event as an explicit "cursor left" signal.
+  function onMouseOverIframe(e: MouseEvent): void {
+    const target = e.target;
+    if (!(target instanceof Element) || !target.closest("iframe")) return;
+    leftEdge.markDisengaged();
+    rightEdge.markDisengaged();
+  }
+  document.addEventListener("mouseover", onMouseOverIframe);
+
+  return () => {
+    window.removeEventListener("resize", onResize);
+    document.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseover", onMouseOverIframe);
+    unsubscribe();
+    leftEdge.dispose();
+    rightEdge.dispose();
+  };
+}
+
+/**
+ * Next peek width for a drag of `deltaX` px from where it started. The
+ * handle sits on the overlay's *inner* edge — dragging right grows the left
+ * panel's overlay but shrinks the right panel's, hence the sign flip. Pure
+ * (clamps to the same range `setSmallScreenPeekWidthPx` enforces) so the
+ * drag math is unit-testable without a DOM. Exported for tests.
+ */
+export function nextPeekWidthPx(
+  side: Side,
+  startWidthPx: number,
+  deltaX: number,
+): number {
+  const raw = side === "left" ? startWidthPx + deltaX : startWidthPx - deltaX;
+  return Math.max(
+    MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
+    Math.min(MAX_SMALL_SCREEN_PEEK_WIDTH_PX, Math.round(raw)),
+  );
+}
+
+/**
+ * Start a peek-overlay resize drag from a `mousedown` on its handle (see
+ * AppShell.tsx). Global (not per-workspace) — the width this writes applies
+ * to every workspace's peek, independent of each workspace's own normal
+ * (large-screen) panel width. Returns a disposer; also self-disposes on
+ * `mouseup`.
+ */
+export function beginPeekResize(side: Side, startClientX: number): () => void {
+  const startWidthPx = store[peekWidthKey(side)];
+  store[peekDraggingKey(side)] = true;
+  document.body.classList.add("panel-resizing");
+
+  function onMove(e: MouseEvent): void {
+    setSmallScreenPeekWidthPx(
+      side,
+      nextPeekWidthPx(side, startWidthPx, e.clientX - startClientX),
+    );
+  }
+  function dispose(): void {
+    window.removeEventListener("mousemove", onMove);
+    window.removeEventListener("mouseup", onUp);
+    document.body.classList.remove("panel-resizing");
+    store[peekDraggingKey(side)] = false;
+  }
+  function onUp(): void {
+    dispose();
+  }
+
+  window.addEventListener("mousemove", onMove);
+  window.addEventListener("mouseup", onUp);
+  return dispose;
+}

--- a/packages/extension-host/src/layout/AppShell.css
+++ b/packages/extension-host/src/layout/AppShell.css
@@ -63,6 +63,91 @@
   background: var(--silo-content-tab-bg);
 }
 
+/* Small-screen-mode peek: the collapsed (0-width) side panel stays clipped by
+ * `overflow: hidden` above — and react-resizable-panels sets that as an
+ * *inline* style on the Panel's own root div, which beats a plain CSS
+ * override regardless of selector specificity. `!important` is the only way
+ * to win against it while peeking; `.side-peek-host.peeking` inside then
+ * renders at its real captured width instead of being clipped to 0. The
+ * raised `z-index` (flex items honor z-index even at `position: static`)
+ * lifts this column above its sibling columns' paint order. */
+.app-col--peeking {
+  overflow: visible !important;
+  position: relative;
+  z-index: 10;
+}
+
+.side-peek-host {
+  height: 100%;
+}
+
+.side-peek-host.peeking {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: var(--peek-width, 400px);
+  background: var(--silo-color-bg);
+  box-shadow: 2px 0 16px rgba(0, 0, 0, 0.3);
+  transition: transform 0.12s ease-out;
+}
+
+.side-peek-host--left.peeking {
+  left: 0;
+}
+
+.side-peek-host--right.peeking {
+  right: 0;
+}
+
+/* `padding-top` on `.app-col` (above) only pushes down *in-flow* content —
+ * it has no effect on an absolutely-positioned child's own `top: 0`, since
+ * that positions relative to the padding edge, not the content edge. So the
+ * peek overlay needs its own explicit offset to clear the traffic-light
+ * reservation, matching `.app-shell.mac .app-col`'s 36px. */
+.app-shell.mac .side-peek-host.peeking {
+  top: 36px;
+}
+
+/* The peek overlay's own resize handle, on its inner edge (away from the
+ * screen edge) — global, independent of the panel's normal (large-screen)
+ * width. Same visual language as react-resizable-panels' own handles
+ * (theme.css): a 1px border-color line, a wider invisible ::after hit area,
+ * and an accent highlight on hover/drag. */
+.peek-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--silo-color-border);
+  cursor: ew-resize;
+  z-index: 1;
+}
+
+.peek-resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -3px;
+  right: -3px;
+  cursor: ew-resize;
+}
+
+.peek-resize-handle:hover,
+.peek-resize-handle.dragging {
+  background: var(--silo-color-accent);
+  transition: background-color 0.1s ease-in-out;
+  transition-delay: 0.5s;
+}
+
+.side-peek-host--left .peek-resize-handle {
+  right: 0;
+}
+
+.side-peek-host--right .peek-resize-handle {
+  left: 0;
+}
+
 .panel-header {
   display: flex;
   align-items: center;

--- a/packages/extension-host/src/layout/AppShell.tsx
+++ b/packages/extension-host/src/layout/AppShell.tsx
@@ -13,6 +13,10 @@ import {
   trackRegionFocus,
 } from "../extension-host/focus-restore";
 import { installRegionTabHandoff } from "../extension-host/focus-regions";
+import {
+  installSmallScreenMode,
+  beginPeekResize,
+} from "../extension-host/small-screen-mode";
 import "./AppShell.css";
 
 // On macOS, `titleBarStyle: "Overlay"` causes the webview to extend under the
@@ -94,6 +98,10 @@ export function AppShell() {
   // editor cursor), skipping the resize handle + dockview chrome between them.
   useEffect(() => installRegionTabHandoff(), []);
 
+  // Small screen mode: auto-hide/auto-restore side panels by window width,
+  // plus the edge-hover peek. See extension-host/small-screen-mode.ts.
+  useEffect(() => installSmallScreenMode(), []);
+
   // macOS eats the click that reactivates an inactive window, so restore focus
   // to the last-focused dock/panel when the window regains focus — the user
   // lands back where they were without a throwaway second click.
@@ -141,11 +149,34 @@ export function AppShell() {
           onExpand={() => {
             store.leftPanelCollapsed = false;
           }}
-          className="app-col"
+          className={`app-col${snap.leftPanelPeeking ? " app-col--peeking" : ""}`}
         >
-          <ErrorBoundary name="side-left">
-            <SideColumn location="left" />
-          </ErrorBoundary>
+          <div
+            className={`side-peek-host side-peek-host--left${
+              snap.leftPanelPeeking ? " peeking" : ""
+            }`}
+            style={
+              snap.leftPanelPeeking
+                ? ({
+                    "--peek-width": `${snap.smallScreenPeekWidthLeftPx}px`,
+                  } as React.CSSProperties)
+                : undefined
+            }
+          >
+            <ErrorBoundary name="side-left">
+              <SideColumn location="left" />
+            </ErrorBoundary>
+            {snap.leftPanelPeeking && (
+              <div
+                className={`peek-resize-handle${snap.leftPanelPeekDragging ? " dragging" : ""}`}
+                onMouseDown={(e) => {
+                  if (e.button !== 0) return;
+                  e.preventDefault();
+                  beginPeekResize("left", e.clientX);
+                }}
+              />
+            )}
+          </div>
         </Panel>
         <PanelResizeHandle onDragging={onPanelDragging} tabIndex={-1} />
         <Panel defaultSize={58} minSize={30} className="app-col">
@@ -167,11 +198,34 @@ export function AppShell() {
           onExpand={() => {
             store.rightPanelCollapsed = false;
           }}
-          className="app-col"
+          className={`app-col${snap.rightPanelPeeking ? " app-col--peeking" : ""}`}
         >
-          <ErrorBoundary name="side-right">
-            <SideColumn location="right" />
-          </ErrorBoundary>
+          <div
+            className={`side-peek-host side-peek-host--right${
+              snap.rightPanelPeeking ? " peeking" : ""
+            }`}
+            style={
+              snap.rightPanelPeeking
+                ? ({
+                    "--peek-width": `${snap.smallScreenPeekWidthRightPx}px`,
+                  } as React.CSSProperties)
+                : undefined
+            }
+          >
+            {snap.rightPanelPeeking && (
+              <div
+                className={`peek-resize-handle${snap.rightPanelPeekDragging ? " dragging" : ""}`}
+                onMouseDown={(e) => {
+                  if (e.button !== 0) return;
+                  e.preventDefault();
+                  beginPeekResize("right", e.clientX);
+                }}
+              />
+            )}
+            <ErrorBoundary name="side-right">
+              <SideColumn location="right" />
+            </ErrorBoundary>
+          </div>
         </Panel>
       </PanelGroup>
       <StatusBar />

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -256,6 +256,23 @@ describe("buildIndex", () => {
     expect(index.editorSettings).toBeUndefined();
     expect(index.terminalSettings).toBeUndefined();
     expect(index.uiFontSize).toBeUndefined();
+    expect(index.smallScreenModeEnabled).toBeUndefined();
+    expect(index.smallScreenThresholdPx).toBeUndefined();
+  });
+
+  it("round-trips small-screen-mode settings when provided", () => {
+    const index = buildIndex({
+      workspaceOrder: [],
+      activeWorkspaceId: null,
+      smallScreenModeEnabled: false,
+      smallScreenThresholdPx: 1600,
+      smallScreenPeekWidthLeftPx: 320,
+      smallScreenPeekWidthRightPx: 260,
+    });
+    expect(index.smallScreenModeEnabled).toBe(false);
+    expect(index.smallScreenThresholdPx).toBe(1600);
+    expect(index.smallScreenPeekWidthLeftPx).toBe(320);
+    expect(index.smallScreenPeekWidthRightPx).toBe(260);
   });
 
   it("round-trips group fields when provided", () => {

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -25,6 +25,14 @@ export interface PersistedIndex {
   activeThemeId?: string;
   editorSettings?: Partial<EditorSettings>;
   terminalSettings?: Partial<TerminalSettings>;
+  // Global (not per-workspace) small-screen-mode preference — see
+  // `small-screen-mode.ts`. Absent in older indexes: defaults applied at hydrate.
+  smallScreenModeEnabled?: boolean;
+  smallScreenThresholdPx?: number;
+  // Small-screen peek overlay width — also global, independent of the
+  // panel's normal (large-screen) width. See `small-screen-mode.ts`.
+  smallScreenPeekWidthLeftPx?: number;
+  smallScreenPeekWidthRightPx?: number;
   // Per-extension global storage (`ctx.storage.global`), keyed by extension id.
   // Global (not per-workspace), so it lives in the index; absent in older
   // indexes, in which case extensions start from their defaults.
@@ -140,6 +148,10 @@ export function buildIndex(snapshot: PersistedIndex): PersistedIndex {
     terminalSettings: snapshot.terminalSettings
       ? { ...snapshot.terminalSettings }
       : undefined,
+    smallScreenModeEnabled: snapshot.smallScreenModeEnabled,
+    smallScreenThresholdPx: snapshot.smallScreenThresholdPx,
+    smallScreenPeekWidthLeftPx: snapshot.smallScreenPeekWidthLeftPx,
+    smallScreenPeekWidthRightPx: snapshot.smallScreenPeekWidthRightPx,
     globalExtensionState: snapshot.globalExtensionState
       ? cloneExtensionState(snapshot.globalExtensionState)
       : undefined,

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -6,6 +6,8 @@ import {
   DEFAULT_UI_FONT_SIZE,
   DEFAULT_EDITOR_SETTINGS,
   DEFAULT_TERMINAL_SETTINGS,
+  DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
+  DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
 } from "./types";
 import type { WorkspaceInternal } from "./types";
 import { loadPanelStateFromWorkspace } from "./workspaces";
@@ -134,6 +136,13 @@ export async function hydrate(configDir: string): Promise<void> {
       ...DEFAULT_TERMINAL_SETTINGS,
       ...index.terminalSettings,
     };
+    store.smallScreenModeEnabled = index.smallScreenModeEnabled ?? true;
+    store.smallScreenThresholdPx =
+      index.smallScreenThresholdPx ?? DEFAULT_SMALL_SCREEN_THRESHOLD_PX;
+    store.smallScreenPeekWidthLeftPx =
+      index.smallScreenPeekWidthLeftPx ?? DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX;
+    store.smallScreenPeekWidthRightPx =
+      index.smallScreenPeekWidthRightPx ?? DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX;
     store.globalExtensionState = index.globalExtensionState
       ? cloneExtensionState(index.globalExtensionState)
       : {};
@@ -278,6 +287,10 @@ async function doPersist(): Promise<void> {
       activeThemeId: store.activeThemeId,
       editorSettings: { ...store.editorSettings },
       terminalSettings: { ...store.terminalSettings },
+      smallScreenModeEnabled: store.smallScreenModeEnabled,
+      smallScreenThresholdPx: store.smallScreenThresholdPx,
+      smallScreenPeekWidthLeftPx: store.smallScreenPeekWidthLeftPx,
+      smallScreenPeekWidthRightPx: store.smallScreenPeekWidthRightPx,
       globalExtensionState: store.globalExtensionState,
       groups: store.groups,
       panelOrder: [...store.panelOrder],

--- a/packages/extension-host/src/state/store.ts
+++ b/packages/extension-host/src/state/store.ts
@@ -6,7 +6,13 @@ import {
   MAX_UI_FONT_SIZE,
   DEFAULT_EDITOR_SETTINGS,
   DEFAULT_TERMINAL_SETTINGS,
+  DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
+  MIN_SMALL_SCREEN_THRESHOLD_PX,
+  DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
+  MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
+  MAX_SMALL_SCREEN_PEEK_WIDTH_PX,
 } from "./types";
+import type { SideLocation } from "@silo-code/sdk";
 
 export const store = proxy<AppState>({
   workspaces: {},
@@ -27,6 +33,16 @@ export const store = proxy<AppState>({
   globalExtensionState: {},
   leftPanelCollapsed: false,
   rightPanelCollapsed: false,
+  smallScreenModeEnabled: true,
+  smallScreenThresholdPx: DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
+  leftPanelAutoHidden: false,
+  rightPanelAutoHidden: false,
+  leftPanelPeeking: false,
+  rightPanelPeeking: false,
+  leftPanelPeekDragging: false,
+  rightPanelPeekDragging: false,
+  smallScreenPeekWidthLeftPx: DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
+  smallScreenPeekWidthRightPx: DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
   sidePanelVisibility: {},
   groups: {},
   panelOrder: [],
@@ -58,12 +74,55 @@ export function reorderSidePanels(orderedIds: string[]) {
   }
 }
 
+/**
+ * Explicit collapse setters for the manual/public path (commands, the status
+ * bar, `ctx.layout`). Always clear the corresponding `*PanelAutoHidden` flag —
+ * an explicit call is by definition not small-screen mode's doing, so it
+ * "promotes" the panel to a manual state that auto-hide/auto-restore leaves
+ * alone until the next full large→small→large round-trip. Small-screen mode
+ * itself (`small-screen-mode.ts`) bypasses these and mutates the collapsed +
+ * autoHidden fields together directly.
+ */
+export function setLeftPanelCollapsed(collapsed: boolean) {
+  store.leftPanelCollapsed = collapsed;
+  store.leftPanelAutoHidden = false;
+}
+
+export function setRightPanelCollapsed(collapsed: boolean) {
+  store.rightPanelCollapsed = collapsed;
+  store.rightPanelAutoHidden = false;
+}
+
 export function toggleLeftPanel() {
-  store.leftPanelCollapsed = !store.leftPanelCollapsed;
+  setLeftPanelCollapsed(!store.leftPanelCollapsed);
 }
 
 export function toggleRightPanel() {
-  store.rightPanelCollapsed = !store.rightPanelCollapsed;
+  setRightPanelCollapsed(!store.rightPanelCollapsed);
+}
+
+export function setSmallScreenModeEnabled(enabled: boolean) {
+  store.smallScreenModeEnabled = enabled;
+}
+
+export function setSmallScreenThresholdPx(px: number) {
+  store.smallScreenThresholdPx = Math.max(
+    MIN_SMALL_SCREEN_THRESHOLD_PX,
+    Math.round(px),
+  );
+}
+
+/** Set the small-screen peek overlay's width for one side — global (not
+ * per-workspace) and independent of the panel's normal (large-screen) width.
+ * Clamped to a sane, usable range regardless of caller (a drag gesture or a
+ * future settings-page field). */
+export function setSmallScreenPeekWidthPx(side: SideLocation, px: number) {
+  const clamped = Math.max(
+    MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
+    Math.min(MAX_SMALL_SCREEN_PEEK_WIDTH_PX, Math.round(px)),
+  );
+  if (side === "left") store.smallScreenPeekWidthLeftPx = clamped;
+  else store.smallScreenPeekWidthRightPx = clamped;
 }
 
 /** Whether a side panel is shown in the dock. Absent = visible (default). */

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -127,6 +127,44 @@ export interface AppState {
   leftPanelCollapsed: boolean;
   rightPanelCollapsed: boolean;
   /**
+   * Small screen mode (RFC-less; see `small-screen-mode.ts`): global (not
+   * per-workspace) on/off switch and the window-width threshold below which a
+   * side panel that's currently open gets auto-collapsed. Persisted in the
+   * global index, like `uiFontSize`.
+   */
+  smallScreenModeEnabled: boolean;
+  smallScreenThresholdPx: number;
+  /**
+   * True while the respective side panel is collapsed *because* small-screen
+   * mode hid it, as opposed to a manual collapse. Drives auto-restore on a
+   * large screen, edge-hover peek eligibility, and Tab-order exclusion.
+   * Ephemeral — recomputed on launch/resize, never persisted.
+   */
+  leftPanelAutoHidden: boolean;
+  rightPanelAutoHidden: boolean;
+  /**
+   * True while an auto-hidden panel is temporarily revealed by an edge-hover
+   * peek. Ephemeral UI state, never persisted.
+   */
+  leftPanelPeeking: boolean;
+  rightPanelPeeking: boolean;
+  /**
+   * True while the user is actively dragging the peek overlay's resize
+   * handle — keeps the peek open even if the cursor briefly moves outside
+   * the overlay's (pre-drag) bounds while growing it. Ephemeral, never
+   * persisted.
+   */
+  leftPanelPeekDragging: boolean;
+  rightPanelPeekDragging: boolean;
+  /**
+   * The peek overlay's width — global (not per-workspace) and independent of
+   * the panel's normal (large-screen) width, since it's a separate, small-
+   * screen-only sizing the user tunes by dragging the peek's own resize
+   * handle. Persisted in the global index, like `smallScreenThresholdPx`.
+   */
+  smallScreenPeekWidthLeftPx: number;
+  smallScreenPeekWidthRightPx: number;
+  /**
    * Side-panel visibility, keyed by panel id. Per-workspace: snapshotted into
    * the active workspace and swapped when the active workspace changes (like
    * the other panel-state fields). Absent = visible (default); only an explicit
@@ -163,6 +201,22 @@ export interface AppState {
 export const DEFAULT_UI_FONT_SIZE = 13;
 export const MIN_UI_FONT_SIZE = 9;
 export const MAX_UI_FONT_SIZE = 24;
+
+/** Default small-screen-mode threshold — tuned for a MacBook's built-in
+ * display once an external monitor is disconnected; user-adjustable in
+ * Settings → Layout. */
+export const DEFAULT_SMALL_SCREEN_THRESHOLD_PX = 1440;
+export const MIN_SMALL_SCREEN_THRESHOLD_PX = 200;
+/** Width above `threshold` a panel must regain before small-screen mode exits
+ * — prevents hide/show flicker right at the boundary. */
+export const SMALL_SCREEN_HYSTERESIS_PX = 80;
+
+/** Default width for the small-screen peek overlay — independent of, and
+ * usually narrower than, the panel's normal (large-screen) width. Drag the
+ * peek's own resize handle to change it; adjustable range below. */
+export const DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX = 400;
+export const MIN_SMALL_SCREEN_PEEK_WIDTH_PX = 180;
+export const MAX_SMALL_SCREEN_PEEK_WIDTH_PX = 600;
 
 export type RenderWhitespace =
   | "none"

--- a/packages/extensions-core/src/index.ts
+++ b/packages/extensions-core/src/index.ts
@@ -13,6 +13,7 @@
 export { extension as menu } from "./menu";
 export { extension as terminal } from "./terminal";
 export { extension as editor } from "./editor";
+export { extension as layout } from "./layout";
 export { extension as workspaces } from "./workspaces";
 export { extension as themes } from "./themes";
 export { extension as keybindings } from "./keybindings";

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { useSnapshot } from "valtio";
+import { Button, Input, Section, SettingRow, Switch } from "@silo-code/sdk";
+import {
+  store,
+  setSmallScreenModeEnabled,
+  setSmallScreenThresholdPx,
+  MIN_SMALL_SCREEN_THRESHOLD_PX,
+} from "@silo-code/extension-host/internal";
+
+// A module of the core.layout extension — small-screen mode's on/off switch
+// and width threshold. The auto-hide/auto-restore/peek behavior itself is
+// host-internal (extension-host/small-screen-mode.ts); this page only edits
+// the two preferences it reads.
+export function LayoutSettingsPage() {
+  const snap = useSnapshot(store);
+  const [thresholdInput, setThresholdInput] = useState(
+    String(snap.smallScreenThresholdPx),
+  );
+
+  // Keep the text field in sync when the stored value changes from elsewhere
+  // (the "use current width" button below, or a future second surface).
+  useEffect(() => {
+    setThresholdInput(String(snap.smallScreenThresholdPx));
+  }, [snap.smallScreenThresholdPx]);
+
+  function commitThreshold(raw: string): void {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= MIN_SMALL_SCREEN_THRESHOLD_PX) {
+      setSmallScreenThresholdPx(n);
+    } else {
+      setThresholdInput(String(snap.smallScreenThresholdPx));
+    }
+  }
+
+  return (
+    <div className="es-page">
+      <div className="es-header">
+        <h2>Layout</h2>
+      </div>
+      <div className="es-scroll silo-scroll">
+        <Section label="Laptop Mode">
+          <SettingRow
+            label="Enable Laptop Mode"
+            hint="Auto-hide side panels when the window narrows past the threshold below, and peek a hidden panel by hovering the window's edge."
+          >
+            <Switch
+              checked={snap.smallScreenModeEnabled}
+              onChange={setSmallScreenModeEnabled}
+              aria-label="Enable Laptop Mode"
+            />
+          </SettingRow>
+          <SettingRow
+            label="Threshold width"
+            hint="Below this window width (in pixels), side panels auto-hide."
+          >
+            <Input
+              type="number"
+              min={MIN_SMALL_SCREEN_THRESHOLD_PX}
+              value={thresholdInput}
+              onChange={(e) => setThresholdInput(e.target.value)}
+              onBlur={(e) => commitThreshold(e.target.value)}
+            />
+          </SettingRow>
+          <SettingRow
+            label="Capture current width"
+            hint="Resize the Silo window to whatever you consider too small, then use this to set the threshold to that exact width."
+          >
+            <Button
+              size="sm"
+              onClick={() => setSmallScreenThresholdPx(window.innerWidth)}
+            >
+              Use current window width
+            </Button>
+          </SettingRow>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-core/src/layout/index.tsx
+++ b/packages/extensions-core/src/layout/index.tsx
@@ -1,0 +1,22 @@
+import type { Extension } from "@silo-code/sdk";
+import { LayoutSettingsPage } from "./LayoutSettingsPage";
+
+// `core.layout` — the "Layout" settings page (small-screen mode's on/off
+// switch + width threshold). The auto-hide/peek behavior itself is
+// host-internal (extension-host/small-screen-mode.ts, always wired into
+// AppShell); this extension only owns the user-facing settings surface, same
+// division as core.editor/core.terminal owning their settings pages over a
+// host-internal core.
+export const extension: Extension = {
+  id: "core.layout",
+  activate(ctx) {
+    ctx.registerSettingsPage({
+      id: "layout",
+      title: "Layout",
+      group: "1_general",
+      // After Keyboard Shortcuts (0), Editor (1), Terminal (2).
+      order: 3,
+      component: LayoutSettingsPage,
+    });
+  },
+};


### PR DESCRIPTION
## Summary

- Auto-collapses the left/right side panels when the app window's own width narrows past a configurable threshold (default 1440px, tuned for a MacBook losing an external monitor), and auto-restores them once it grows back past the threshold + a hysteresis buffer (avoids hide/show flicker at the boundary).
- While a panel is auto-hidden, hovering the cursor at the window's edge "peeks" it as a transient overlay on top of the center content (doesn't reflow the editor); moving the cursor away hides it again after a short grace delay. The peek overlay has its own drag-resizable width — a **global** preference, independent of each panel's normal (large-screen) width.
- A manual reopen (toggle command, status bar, `ctx.layout`) while auto-hidden "sticks" — small-screen mode won't re-hide it until a fresh large→small round trip. Auto-hidden panels are excluded from Tab order entirely (peek is mouse-only).
- New **Settings → Layout** page ("Laptop Mode"): on/off switch, threshold field, and a "use current window width" capture button.
- Centralized in one host module (`extension-host/small-screen-mode.ts`) — the resize/hysteresis/debounce logic, the edge-hover peek timers, and detection of a browser limitation where a cross-origin `<iframe>` in the center dock (e.g. `local-web-viewer`) swallows `mousemove` entirely once hovered, which would otherwise leave a peek stuck open.

## Test plan

- [x] `pnpm test` — 731 tests pass across all packages, including new coverage for the hysteresis math, auto-hide/restore edge cases, manual-override "stickiness", workspace-switch re-hide, the peek dwell/grace timers, the resizable peek width, and the iframe-crossing fix
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean on all touched files
- [x] Manually verified in the running dev app: auto-hide/restore on resize, edge-hover peek (including over a split side column's bottom pane), peek drag-resize, macOS traffic-light clearance while peeking, and the local-web-viewer iframe fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01J56Kv6yrtkocBNiQQdVcSG