### PR TITLE
feat(git-explorer): add "View Commits" drill-down to the git panel

### DIFF
--- a/packages/extensions-silo/src/git-explorer/CommitDetailView.tsx
+++ b/packages/extensions-silo/src/git-explorer/CommitDetailView.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import { File as FileIcon } from "@phosphor-icons/react";
+import { Tooltip, type ExtensionContext } from "@silo-code/sdk";
+import type { CommitDetail, CommitFileChange } from "../git/git-api";
+import { resolveDiffBase } from "../git/parse-commit-files";
+import { getGitApi } from "./git-runtime";
+import { ICON_OPEN } from "./git-icons";
+
+function statusGlyph(status: CommitFileChange["status"]): string {
+  return status;
+}
+
+/** Detail page of the "View Commits" flow: one commit's full message, stat
+ * summary, and changed files. Row click opens the file's diff for this
+ * commit (vs. its first parent, or the empty tree for a root commit) in the
+ * center dock, same mechanism as the panel's root-level Changes list. The
+ * document icon opens the file's *current* working-tree version — mirroring
+ * what the root panel's "Open file" button does, not a historical snapshot
+ * (there's no editor API for opening arbitrary read-only content outside a
+ * diff) — so it's hidden for a deleted file, which has no current version. */
+export function CommitDetailView({
+  ctx,
+  folder,
+  workspaceId,
+  hash,
+}: {
+  ctx: ExtensionContext;
+  folder: string;
+  workspaceId: string;
+  hash: string;
+}) {
+  const [detail, setDetail] = useState<CommitDetail | null | undefined>(
+    undefined,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const api = getGitApi();
+    if (!api) {
+      setError("Git provider (silo.git) unavailable.");
+      return;
+    }
+    let cancelled = false;
+    setDetail(undefined);
+    setError(null);
+    api
+      .commitDetail(folder, hash)
+      .then((d) => !cancelled && setDetail(d))
+      .catch((err) => !cancelled && setError(String(err)));
+    return () => {
+      cancelled = true;
+    };
+  }, [folder, hash]);
+
+  if (error) return <div className="placeholder">{error}</div>;
+  if (detail === undefined) {
+    return <div className="placeholder">Loading commit…</div>;
+  }
+  if (detail === null) {
+    return <div className="placeholder">Commit not found.</div>;
+  }
+
+  const totals = detail.files.reduce(
+    (acc, f) => ({
+      additions: acc.additions + (f.additions ?? 0),
+      deletions: acc.deletions + (f.deletions ?? 0),
+    }),
+    { additions: 0, deletions: 0 },
+  );
+
+  function openDiff(file: CommitFileChange) {
+    const filePath = `${folder}/${file.path}`;
+    const base = file.path.split("/").pop() ?? file.path;
+    ctx.editors.openDiff(
+      {
+        filePath,
+        providerId: "silo.git",
+        args: {
+          mode: "commit",
+          cwd: folder,
+          commit: detail!.hash,
+          parent: resolveDiffBase(detail!.parents),
+        },
+        title: `${base} (${detail!.shortHash})`,
+      },
+      { workspaceId, preview: true },
+    );
+  }
+
+  function openCurrentFile(file: CommitFileChange) {
+    ctx.editors.open(`${folder}/${file.path}`, { workspaceId });
+  }
+
+  return (
+    <div className="git-commit-detail">
+      <div className="git-commit-detail-message">
+        <div className="git-commit-detail-subject">{detail.subject}</div>
+        {detail.body && (
+          <pre className="git-commit-detail-body">{detail.body}</pre>
+        )}
+        <div className="git-commit-detail-meta">
+          <span>{detail.author}</span>
+          <span>{detail.relativeDate}</span>
+          <code>{detail.shortHash}</code>
+        </div>
+      </div>
+      <div className="git-commit-detail-stats">
+        {detail.files.length} file{detail.files.length === 1 ? "" : "s"} changed
+        {(totals.additions > 0 || totals.deletions > 0) && (
+          <>
+            {" · "}
+            <span className="git-stat-add">+{totals.additions}</span>{" "}
+            <span className="git-stat-del">−{totals.deletions}</span>
+          </>
+        )}
+      </div>
+      <div className="git-commit-detail-files">
+        {detail.files.map((f) => (
+          <div
+            key={f.path}
+            className="git-file-row"
+            onClick={() => openDiff(f)}
+          >
+            <span className="ico file">
+              <FileIcon size="1.3em" weight="regular" aria-hidden="true" />
+            </span>
+            <Tooltip content={f.path}>
+              <span className="file-name">{f.path.split("/").pop()}</span>
+            </Tooltip>
+            {f.origPath && (
+              <span className="file-dir" title={`renamed from ${f.origPath}`}>
+                ← {f.origPath}
+              </span>
+            )}
+            <span className="row-actions" onClick={(e) => e.stopPropagation()}>
+              {f.status !== "D" && (
+                <Tooltip content="Open file">
+                  <button
+                    className="row-action"
+                    tabIndex={-1}
+                    onClick={() => openCurrentFile(f)}
+                  >
+                    {ICON_OPEN}
+                  </button>
+                </Tooltip>
+              )}
+            </span>
+            {f.binary ? (
+              <span className="git-file-stat binary">binary</span>
+            ) : (f.additions ?? 0) > 0 || (f.deletions ?? 0) > 0 ? (
+              <span className="git-file-stat">
+                <span className="git-stat-add">+{f.additions}</span>{" "}
+                <span className="git-stat-del">−{f.deletions}</span>
+              </span>
+            ) : null}
+            <span className={`status-glyph status-${statusGlyph(f.status)}`}>
+              {f.status}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/CommitListView.tsx
+++ b/packages/extensions-silo/src/git-explorer/CommitListView.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from "react";
+import { Check, CopySimple } from "@phosphor-icons/react";
+import { Tooltip } from "@silo-code/sdk";
+import type { GitLogEntry, GitStatus } from "../git/git-api";
+import { getGitApi } from "./git-runtime";
+import {
+  dividerIndex,
+  displayDividerIndex,
+  orderedCommits,
+  type CommitOrder,
+  type UnpushedSet,
+} from "./commit-list-model";
+
+const PAGE_SIZE = 50;
+
+/** List page of the "View Commits" flow: current-branch history, with a
+ * divider marking the boundary between unpushed and pushed commits. Display
+ * `order` is controlled by the parent (its toggle button lives in `GitView`'s
+ * shared subview header, next to Back/title). Reads `status` live from the
+ * parent (not a snapshot taken when the view opened), so a branch switch
+ * underfoot just re-fetches in place. */
+export function CommitListView({
+  folder,
+  status,
+  order,
+  onSelectCommit,
+}: {
+  folder: string;
+  status: GitStatus;
+  order: CommitOrder;
+  onSelectCommit: (hash: string) => void;
+}) {
+  const [commits, setCommits] = useState<GitLogEntry[]>([]);
+  const [unpushed, setUnpushed] = useState<UnpushedSet>(null);
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedHash, setCopiedHash] = useState<string | null>(null);
+
+  // Reset pagination when the underlying branch changes so "Load more" starts
+  // fresh rather than appending a different branch's tail onto this one's.
+  useEffect(() => {
+    setLimit(PAGE_SIZE);
+  }, [folder, status.branch]);
+
+  useEffect(() => {
+    const api = getGitApi();
+    if (!api) {
+      setError("Git provider (silo.git) unavailable.");
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .log(folder, limit)
+      .then(async (entries) => {
+        if (cancelled) return;
+        setCommits(entries);
+        // Detached HEAD: no branch, so "ahead of what?" doesn't apply.
+        if (!status.branch) {
+          setUnpushed(null);
+        } else if (status.upstream) {
+          const unmerged = await api.unmergedCommits(
+            folder,
+            status.branch,
+            status.upstream,
+          );
+          if (!cancelled) setUnpushed(new Set(unmerged.map((c) => c.hash)));
+        } else {
+          // No upstream configured — nothing has ever been pushed, so every
+          // commit currently loaded counts as unpushed.
+          setUnpushed("all");
+        }
+      })
+      .catch((err) => !cancelled && setError(String(err)))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [folder, limit, status.branch, status.upstream]);
+
+  function copyHash(hash: string) {
+    void navigator.clipboard.writeText(hash);
+    setCopiedHash(hash);
+    setTimeout(() => setCopiedHash((h) => (h === hash ? null : h)), 1500);
+  }
+
+  if (error) return <div className="placeholder">{error}</div>;
+  if (loading && commits.length === 0) {
+    return <div className="placeholder">Loading commits…</div>;
+  }
+  if (commits.length === 0) {
+    return <div className="placeholder">No commits yet.</div>;
+  }
+
+  const canonicalDivider = dividerIndex(commits, unpushed);
+  const divider = displayDividerIndex(canonicalDivider, commits.length, order);
+  const displayCommits = orderedCommits(commits, order);
+  // "Load more" fetches deeper (older) history, appended at the end of the
+  // canonical newest-first array — which lands at the *start* of the display
+  // list once reversed for oldest-first. Keep the button next to whichever
+  // end that growth actually appears at.
+  const loadMore = commits.length === limit && (
+    <button
+      className="git-commits-load-more"
+      disabled={loading}
+      onClick={() => setLimit((l) => l + PAGE_SIZE)}
+    >
+      {loading ? "Loading…" : "Load more"}
+    </button>
+  );
+
+  return (
+    <div className="git-commits-list">
+      {unpushed === "all" && commits.length > 0 && (
+        <div className="git-commit-note">No upstream — nothing pushed yet.</div>
+      )}
+      {order === "oldestFirst" && loadMore}
+      {displayCommits.map((c, i) => (
+        <div key={c.hash}>
+          {i === divider && (
+            <div className="git-commit-divider">
+              ↑ {canonicalDivider} commit{canonicalDivider === 1 ? "" : "s"} ·
+              not pushed
+            </div>
+          )}
+          <div
+            className="git-commit-row"
+            role="button"
+            tabIndex={0}
+            onClick={() => onSelectCommit(c.hash)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelectCommit(c.hash);
+              }
+            }}
+          >
+            <div className="git-commit-subject" title={c.subject}>
+              {c.subject}
+            </div>
+            <div className="git-commit-meta">
+              <span className="git-commit-author">{c.author}</span>
+              <span className="git-commit-date">{c.relativeDate}</span>
+              <span className="git-commit-files">
+                {c.filesChanged} file{c.filesChanged === 1 ? "" : "s"}
+              </span>
+            </div>
+            <span
+              className="git-commit-hash-action"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Tooltip content={copiedHash === c.hash ? "Copied" : "Copy hash"}>
+                <button
+                  className="row-action"
+                  tabIndex={-1}
+                  onClick={() => copyHash(c.hash)}
+                >
+                  {copiedHash === c.hash ? (
+                    <Check size={14} />
+                  ) : (
+                    <CopySimple size={14} />
+                  )}
+                </button>
+              </Tooltip>
+              <code className="git-commit-shorthash">{c.shortHash}</code>
+            </span>
+          </div>
+        </div>
+      ))}
+      {order === "newestFirst" && loadMore}
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -801,3 +801,209 @@ button.git-wt-pill:hover {
   overflow-wrap: anywhere;
   color: var(--silo-color-text);
 }
+
+/* "View Commits" list/detail sub-pages (view-stack.ts) — replace the normal
+ * commit-box + Changes sections while a sub-page is open; the branch/sync
+ * header above stays put. */
+.git-subview {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.git-subview-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--silo-color-border);
+}
+
+.git-back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: transparent;
+  border: none;
+  color: var(--silo-color-text);
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+  padding: 3px 6px;
+  border-radius: var(--silo-radius-sm);
+  cursor: pointer;
+}
+
+.git-back-button:hover {
+  background: var(--silo-color-bg-hover);
+  color: var(--silo-color-text-hi);
+}
+
+.git-subview-title {
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+  font-weight: 600;
+  color: var(--silo-color-text-hi);
+}
+
+.git-sort-toggle {
+  margin-left: auto;
+}
+
+.git-commits-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.git-commit-note {
+  padding: 6px 10px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+}
+
+.git-commit-divider {
+  padding: 4px 10px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+  border-top: 1px solid var(--silo-color-border);
+  border-bottom: 1px solid var(--silo-color-border);
+  background: var(--silo-color-bg-hover);
+}
+
+.git-commit-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 10px;
+  cursor: pointer;
+  position: relative;
+}
+
+.git-commit-row:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+.git-commit-subject {
+  font-family: var(--silo-font-ui);
+  color: var(--silo-color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.git-commit-meta {
+  display: flex;
+  gap: 8px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+}
+
+.git-commit-hash-action {
+  position: absolute;
+  right: 8px;
+  top: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  pointer-events: none;
+  background: var(--silo-color-bg-hover);
+  transition: opacity 100ms ease-out;
+}
+
+.git-commit-row:hover .git-commit-hash-action {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.git-commit-shorthash {
+  font-family: var(--silo-font-mono);
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+}
+
+.git-commits-load-more {
+  margin: 8px;
+  padding: 6px;
+  background: transparent;
+  border: 1px solid var(--silo-color-border);
+  border-radius: var(--silo-radius-sm);
+  color: var(--silo-color-text);
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+  cursor: pointer;
+}
+
+.git-commits-load-more:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+.git-commits-load-more:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Commit detail page */
+.git-commit-detail {
+  display: flex;
+  flex-direction: column;
+}
+
+.git-commit-detail-message {
+  padding: 10px;
+  border-bottom: 1px solid var(--silo-color-border);
+}
+
+.git-commit-detail-subject {
+  font-family: var(--silo-font-ui);
+  font-weight: 600;
+  color: var(--silo-color-text-hi);
+  overflow-wrap: anywhere;
+}
+
+.git-commit-detail-body {
+  margin: 6px 0 0;
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.git-commit-detail-meta {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+  font-family: var(--silo-font-mono);
+}
+
+.git-commit-detail-stats {
+  padding: 6px 10px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+  border-bottom: 1px solid var(--silo-color-border);
+}
+
+.git-stat-add {
+  color: var(--silo-color-ok);
+}
+
+.git-stat-del {
+  color: var(--silo-color-err);
+}
+
+.git-commit-detail-files {
+  display: flex;
+  flex-direction: column;
+}
+
+.git-file-stat {
+  font-family: var(--silo-font-mono);
+  font-size: var(--silo-font-size-sm);
+  margin-left: 4px;
+}
+
+.git-file-stat.binary {
+  color: var(--silo-color-text-lo);
+}

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.tsx
@@ -23,10 +23,12 @@ export function GitExplorerPanel({
   ctx,
   storage,
   paused = false,
+  hydrated = true,
 }: {
   ctx: ExtensionContext;
   storage: ExtensionStorage;
   paused?: boolean;
+  hydrated?: boolean;
 }) {
   const wsState = useServiceState(ctx.workspaces);
   const ws = wsState.all.find((w) => w.id === wsState.activeId) ?? null;
@@ -66,6 +68,8 @@ export function GitExplorerPanel({
           folder={folder}
           rootLabel={showLabel ? rootName(folder) : undefined}
           paused={paused}
+          storage={storage}
+          hydrated={hydrated}
           collapsed={showLabel && (collapsedMap[folder] ?? false)}
           onToggleCollapsed={
             showLabel

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -2,15 +2,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowsClockwise,
   CaretDown,
+  CaretLeft,
   CaretRight,
   CloudArrowUp,
   DotsThreeVertical,
+  SortAscending,
+  SortDescending,
   TreeStructure,
 } from "@phosphor-icons/react";
 import {
   Tooltip,
   useFocusGroup,
   type ExtensionContext,
+  type ExtensionStorage,
   type FocusGroupItemProps,
   type MenuEntry,
   type NotifyOptions,
@@ -30,6 +34,10 @@ import {
 } from "./worktree-model";
 import { showWorktreeManager } from "./open-worktree-manager";
 import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
+import { useViewStack } from "./use-view-stack";
+import { CommitListView } from "./CommitListView";
+import { CommitDetailView } from "./CommitDetailView";
+import type { CommitOrder } from "./commit-list-model";
 
 const REFRESH_DEBOUNCE_MS = 400;
 // How often the panel fetches in the background so ↑ahead/↓behind stay roughly
@@ -48,6 +56,8 @@ export function GitView({
   paused,
   collapsed,
   onToggleCollapsed,
+  storage,
+  hydrated,
 }: {
   ctx: ExtensionContext;
   cacheKey: string;
@@ -57,7 +67,13 @@ export function GitView({
   paused: boolean;
   collapsed: boolean;
   onToggleCollapsed?: () => void;
+  storage: ExtensionStorage;
+  hydrated: boolean;
 }) {
+  // "View Commits" list/detail navigation — keyed per repo root (cacheKey) so
+  // a multi-root workspace's git roots don't share one stack.
+  const viewStack = useViewStack(storage, `view:${cacheKey}`, hydrated);
+  const [commitOrder, setCommitOrder] = useState<CommitOrder>("oldestFirst");
   // Public primitives, read through ctx (stable per extension).
   const editors = ctx.editors;
   const files = ctx.files;
@@ -495,6 +511,10 @@ export function GitView({
       { type: "separator" },
       { label: "Fetch", run: fetchRemote },
       { type: "separator" },
+      {
+        label: "View Commits",
+        run: () => viewStack.push({ kind: "commits" }),
+      },
       { label: "Manage branches…", run: openBranchManager },
       { label: "Manage worktrees…", run: openWorktreeManager },
     ];
@@ -819,7 +839,7 @@ export function GitView({
           )}
         </div>
       )}
-      {!collapsed && (
+      {!collapsed && viewStack.view.kind === "root" && (
         <>
           <div className="commit-area">
             <textarea
@@ -930,6 +950,72 @@ export function GitView({
             </Section>
           </div>
         </>
+      )}
+      {!collapsed && viewStack.view.kind !== "root" && (
+        <div
+          className="git-subview"
+          onKeyDown={(e) => {
+            if (e.key === "Escape" && viewStack.canPop) {
+              e.preventDefault();
+              viewStack.pop();
+            }
+          }}
+        >
+          <div className="git-subview-header">
+            <button className="git-back-button" onClick={viewStack.pop}>
+              <CaretLeft size={14} weight="bold" />
+              Back
+            </button>
+            <span className="git-subview-title">
+              {viewStack.view.kind === "commits" ? "Commits" : "Commit"}
+            </span>
+            {viewStack.view.kind === "commits" && (
+              <Tooltip
+                content={
+                  commitOrder === "oldestFirst"
+                    ? "Showing oldest first — click for newest first"
+                    : "Showing newest first — click for oldest first"
+                }
+              >
+                <button
+                  className="row-action git-sort-toggle"
+                  onClick={() =>
+                    setCommitOrder((o) =>
+                      o === "oldestFirst" ? "newestFirst" : "oldestFirst",
+                    )
+                  }
+                >
+                  {commitOrder === "oldestFirst" ? (
+                    <SortAscending size={14} />
+                  ) : (
+                    <SortDescending size={14} />
+                  )}
+                </button>
+              </Tooltip>
+            )}
+          </div>
+          {viewStack.view.kind === "commits" &&
+            (status ? (
+              <CommitListView
+                folder={folder}
+                status={status}
+                order={commitOrder}
+                onSelectCommit={(hash) =>
+                  viewStack.push({ kind: "commit-detail", hash })
+                }
+              />
+            ) : (
+              <div className="placeholder">Loading…</div>
+            ))}
+          {viewStack.view.kind === "commit-detail" && (
+            <CommitDetailView
+              ctx={ctx}
+              folder={folder}
+              workspaceId={workspaceId}
+              hash={viewStack.view.hash}
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/extensions-silo/src/git-explorer/commit-list-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/commit-list-model.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import type { GitLogEntry } from "../git/git-api";
+import {
+  dividerIndex,
+  displayDividerIndex,
+  orderedCommits,
+} from "./commit-list-model";
+
+function entry(hash: string): GitLogEntry {
+  return {
+    hash,
+    shortHash: hash.slice(0, 7),
+    author: "a",
+    relativeDate: "now",
+    subject: hash,
+  };
+}
+
+const commits = [entry("h1"), entry("h2"), entry("h3"), entry("h4")];
+
+describe("dividerIndex", () => {
+  it("marks the boundary after the last unpushed commit", () => {
+    const unpushed = new Set(["h1", "h2"]);
+    expect(dividerIndex(commits, unpushed)).toBe(2);
+  });
+
+  it("returns -1 when nothing is unpushed", () => {
+    expect(dividerIndex(commits, new Set())).toBe(-1);
+  });
+
+  it("returns -1 when every loaded commit is unpushed (boundary not yet loaded)", () => {
+    const unpushed = new Set(commits.map((c) => c.hash));
+    expect(dividerIndex(commits, unpushed)).toBe(-1);
+  });
+
+  it("returns -1 for the 'all unpushed, no upstream' sentinel", () => {
+    expect(dividerIndex(commits, "all")).toBe(-1);
+  });
+
+  it("returns -1 when the distinction doesn't apply (detached HEAD)", () => {
+    expect(dividerIndex(commits, null)).toBe(-1);
+  });
+});
+
+describe("orderedCommits", () => {
+  it("returns the canonical newest-first array unchanged for newestFirst", () => {
+    expect(orderedCommits(commits, "newestFirst")).toEqual(commits);
+  });
+
+  it("reverses to oldest-first (GitHub PR commits-tab convention)", () => {
+    expect(orderedCommits(commits, "oldestFirst")).toEqual(
+      [...commits].reverse(),
+    );
+  });
+
+  it("doesn't mutate the input array", () => {
+    const copy = [...commits];
+    orderedCommits(commits, "oldestFirst");
+    expect(commits).toEqual(copy);
+  });
+});
+
+describe("displayDividerIndex", () => {
+  it("passes through unchanged for newestFirst", () => {
+    expect(displayDividerIndex(2, commits.length, "newestFirst")).toBe(2);
+  });
+
+  it("mirrors the boundary across the list for oldestFirst", () => {
+    // 2 unpushed of 4 total → the boundary sits 2 from the end once reversed.
+    expect(displayDividerIndex(2, commits.length, "oldestFirst")).toBe(2);
+    expect(displayDividerIndex(1, commits.length, "oldestFirst")).toBe(3);
+    expect(displayDividerIndex(3, commits.length, "oldestFirst")).toBe(1);
+  });
+
+  it("stays -1 (no divider) regardless of order", () => {
+    expect(displayDividerIndex(-1, commits.length, "newestFirst")).toBe(-1);
+    expect(displayDividerIndex(-1, commits.length, "oldestFirst")).toBe(-1);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/commit-list-model.ts
+++ b/packages/extensions-silo/src/git-explorer/commit-list-model.ts
@@ -1,0 +1,48 @@
+import type { GitLogEntry } from "../git/git-api";
+
+/** Which loaded commits haven't been pushed — see {@link dividerIndex}. */
+export type UnpushedSet = Set<string> | "all" | null;
+
+/**
+ * Index of the first *pushed* commit in `commits` — where the "N commits ·
+ * not pushed" divider goes (unpushed commits are always a contiguous run at
+ * the top of the log). Returns `-1` when there's nothing to mark: `unpushed`
+ * isn't a hash set (it's `"all"` or `null`), none of the loaded commits are
+ * unpushed, or the boundary lies past the currently loaded page (every
+ * loaded commit is unpushed — `findIndex` finds no pushed one yet).
+ */
+export function dividerIndex(
+  commits: GitLogEntry[],
+  unpushed: UnpushedSet,
+): number {
+  if (!(unpushed instanceof Set)) return -1;
+  const idx = commits.findIndex((c) => !unpushed.has(c.hash));
+  return idx > 0 ? idx : -1;
+}
+
+/** Display order for the commit list — `"newestFirst"` is git's native log
+ * order; `"oldestFirst"` matches GitHub's PR "Commits" tab. */
+export type CommitOrder = "newestFirst" | "oldestFirst";
+
+/** `commits` (always fetched newest-first) rendered in `order`. */
+export function orderedCommits(
+  commits: GitLogEntry[],
+  order: CommitOrder,
+): GitLogEntry[] {
+  return order === "oldestFirst" ? [...commits].reverse() : commits;
+}
+
+/**
+ * Maps a divider position from {@link dividerIndex}'s canonical (newest-first)
+ * indexing to its position in `order`'s display list. Reversing the list
+ * mirrors the boundary: the unpushed run (indices `[0, canonicalIndex)` in
+ * canonical order) becomes the *last* `canonicalIndex` entries once reversed.
+ */
+export function displayDividerIndex(
+  canonicalIndex: number,
+  total: number,
+  order: CommitOrder,
+): number {
+  if (canonicalIndex === -1) return -1;
+  return order === "oldestFirst" ? total - canonicalIndex : canonicalIndex;
+}

--- a/packages/extensions-silo/src/git-explorer/index.tsx
+++ b/packages/extensions-silo/src/git-explorer/index.tsx
@@ -50,8 +50,13 @@ export const extension: Extension = {
       title: "Git",
       // Inject ctx so the panel/view reach workspaces/editors/files through
       // the public primitives, not host getters.
-      component: ({ active, storage }) => (
-        <GitExplorerPanel ctx={ctx} storage={storage} paused={!active} />
+      component: ({ active, storage, hydrated }) => (
+        <GitExplorerPanel
+          ctx={ctx}
+          storage={storage}
+          paused={!active}
+          hydrated={hydrated}
+        />
       ),
       order: 2,
       lazyMount: true,

--- a/packages/extensions-silo/src/git-explorer/use-view-stack.ts
+++ b/packages/extensions-silo/src/git-explorer/use-view-stack.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ExtensionStorage } from "@silo-code/sdk";
+import {
+  currentView,
+  INITIAL_STACK,
+  popView,
+  pushView,
+  restoreStack,
+  serializeStack,
+  type PanelView,
+  type ViewStack,
+} from "./view-stack";
+
+/**
+ * Drives one `GitView`'s internal list/detail navigation. Hydrates the stack
+ * from `storage` once (per `storageKey` — a per-repo-root key, since a
+ * multi-root workspace mounts one `GitView`/stack per folder), then persists
+ * every push/pop back to it so a reload restores the same page.
+ */
+export function useViewStack(
+  storage: ExtensionStorage,
+  storageKey: string,
+  hydrated: boolean,
+) {
+  const [stack, setStack] = useState<ViewStack>(INITIAL_STACK);
+  const [restored, setRestored] = useState(false);
+
+  useEffect(() => {
+    if (!hydrated || restored) return;
+    setStack(restoreStack(storage.get(storageKey)));
+    setRestored(true);
+  }, [hydrated, restored, storage, storageKey]);
+
+  const push = useCallback(
+    (view: PanelView) => {
+      setStack((s) => {
+        const next = pushView(s, view);
+        storage.set(storageKey, serializeStack(next));
+        return next;
+      });
+    },
+    [storage, storageKey],
+  );
+
+  const pop = useCallback(() => {
+    setStack((s) => {
+      const next = popView(s);
+      storage.set(storageKey, serializeStack(next));
+      return next;
+    });
+  }, [storage, storageKey]);
+
+  return {
+    view: currentView(stack),
+    push,
+    pop,
+    canPop: stack.views.length > 1,
+  };
+}

--- a/packages/extensions-silo/src/git-explorer/view-stack.test.ts
+++ b/packages/extensions-silo/src/git-explorer/view-stack.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  currentView,
+  INITIAL_STACK,
+  popView,
+  pushView,
+  restoreStack,
+  ROOT_VIEW,
+  serializeStack,
+} from "./view-stack";
+
+describe("pushView / popView / currentView", () => {
+  it("starts at root", () => {
+    expect(currentView(INITIAL_STACK)).toEqual(ROOT_VIEW);
+  });
+
+  it("pushes onto the stack and pop reverses it", () => {
+    let stack = pushView(INITIAL_STACK, { kind: "commits" });
+    expect(currentView(stack)).toEqual({ kind: "commits" });
+
+    stack = pushView(stack, { kind: "commit-detail", hash: "abc123" });
+    expect(currentView(stack)).toEqual({
+      kind: "commit-detail",
+      hash: "abc123",
+    });
+
+    stack = popView(stack);
+    expect(currentView(stack)).toEqual({ kind: "commits" });
+
+    stack = popView(stack);
+    expect(currentView(stack)).toEqual(ROOT_VIEW);
+  });
+
+  it("popping the root is a no-op — the root can't be popped", () => {
+    const popped = popView(INITIAL_STACK);
+    expect(popped).toBe(INITIAL_STACK);
+    expect(currentView(popped)).toEqual(ROOT_VIEW);
+  });
+});
+
+describe("serializeStack / restoreStack", () => {
+  it("round-trips a multi-level stack", () => {
+    const stack = pushView(pushView(INITIAL_STACK, { kind: "commits" }), {
+      kind: "commit-detail",
+      hash: "deadbeef",
+    });
+    const restored = restoreStack(serializeStack(stack));
+    expect(restored).toEqual(stack);
+  });
+
+  it("falls back to root for a missing or malformed value", () => {
+    expect(restoreStack(undefined)).toEqual(INITIAL_STACK);
+    expect(restoreStack(null)).toEqual(INITIAL_STACK);
+    expect(restoreStack("not an array")).toEqual(INITIAL_STACK);
+  });
+
+  it("drops malformed entries but keeps the well-formed ones", () => {
+    const raw = [
+      { kind: "root" },
+      { kind: "nonsense" },
+      { kind: "commit-detail" }, // missing hash
+      { kind: "commit-detail", hash: "ok" },
+    ];
+    expect(restoreStack(raw)).toEqual({
+      views: [ROOT_VIEW, { kind: "commit-detail", hash: "ok" }],
+    });
+  });
+
+  it("falls back to root when every entry is malformed", () => {
+    expect(restoreStack([{ kind: "nonsense" }])).toEqual(INITIAL_STACK);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/view-stack.ts
+++ b/packages/extensions-silo/src/git-explorer/view-stack.ts
@@ -1,0 +1,56 @@
+// Pure, serializable navigation stack for the git panel's internal
+// list → commit-detail drill-down (the "View Commits" flow). Modeled on the
+// list/detail view-stack pattern used by the (external) github-prs extension:
+// a plain union + push/pop, persisted to the panel's storage bag so a reload
+// restores where the user left off.
+
+/** One "page" the git panel can show, in place of its normal root content. */
+export type PanelView =
+  | { kind: "root" }
+  | { kind: "commits" }
+  | { kind: "commit-detail"; hash: string };
+
+export const ROOT_VIEW: PanelView = { kind: "root" };
+
+export interface ViewStack {
+  /** Root first, current view last. Never empty. */
+  views: PanelView[];
+}
+
+export const INITIAL_STACK: ViewStack = { views: [ROOT_VIEW] };
+
+export function currentView(stack: ViewStack): PanelView {
+  return stack.views[stack.views.length - 1] ?? ROOT_VIEW;
+}
+
+export function pushView(stack: ViewStack, view: PanelView): ViewStack {
+  return { views: [...stack.views, view] };
+}
+
+/** No-op at the root — the root can't be popped. */
+export function popView(stack: ViewStack): ViewStack {
+  if (stack.views.length <= 1) return stack;
+  return { views: stack.views.slice(0, -1) };
+}
+
+function isPanelView(v: unknown): v is PanelView {
+  if (typeof v !== "object" || v === null || !("kind" in v)) return false;
+  const kind = (v as { kind: unknown }).kind;
+  if (kind === "root" || kind === "commits") return true;
+  return (
+    kind === "commit-detail" &&
+    typeof (v as { hash?: unknown }).hash === "string"
+  );
+}
+
+export function serializeStack(stack: ViewStack): unknown {
+  return stack.views;
+}
+
+/** Restore a stack from storage, discarding anything malformed rather than
+ * trusting a corrupted/foreign value — worst case, it falls back to root. */
+export function restoreStack(raw: unknown): ViewStack {
+  if (!Array.isArray(raw)) return INITIAL_STACK;
+  const views = raw.filter(isPanelView);
+  return views.length > 0 ? { views } : INITIAL_STACK;
+}

--- a/packages/extensions-silo/src/git/git-api.ts
+++ b/packages/extensions-silo/src/git/git-api.ts
@@ -38,6 +38,35 @@ export interface GitLogEntry {
   author: string;
   relativeDate: string;
   subject: string;
+  /**
+   * Number of files this commit touched — a merge commit's count is relative
+   * to its **first parent** (same convention as {@link GitAPI.commitDetail}).
+   * Comes free off the same `git log` call (via `--numstat`), no per-commit
+   * follow-up request.
+   */
+  filesChanged: number;
+}
+
+/** One file changed by a commit, as listed by {@link GitAPI.commitDetail}. */
+export interface CommitFileChange {
+  path: string;
+  /** Original path for a rename/copy (from `diff-tree -M`). */
+  origPath?: string;
+  status: "A" | "M" | "D" | "R" | "C" | "T" | "U" | "X";
+  /** True when git reports no line counts for this path (a binary blob). */
+  binary: boolean;
+  /** `null` for a binary file — no line count to show. */
+  additions: number | null;
+  deletions: number | null;
+}
+
+/** A single commit's full message and changed files, as returned by {@link GitAPI.commitDetail}. */
+export interface CommitDetail extends GitLogEntry {
+  /** Commit message body (everything after the subject line); `""` when none. */
+  body: string;
+  /** Parent commit hashes — empty for a root commit, 2+ for a merge. */
+  parents: string[];
+  files: CommitFileChange[];
 }
 
 /** One branch, as listed by {@link GitAPI.branches}. */
@@ -166,6 +195,28 @@ export interface GitAPI {
     branch: string,
     upstream?: string | null,
   ): Promise<GitLogEntry[]>;
+  /**
+   * Full detail for one commit — message body, parents, and its changed files
+   * (each with a status letter, rename origin, and line stats). A merge
+   * commit's files are relative to its **first parent** (`--first-parent`
+   * convention, matching `git log --first-parent`/GitHub's merge view); a root
+   * commit (no parents) is relative to the empty tree, i.e. every file shows
+   * as added. Resolves to `null` if `hash` can't be resolved.
+   */
+  commitDetail(cwd: string, hash: string): Promise<CommitDetail | null>;
+  /**
+   * Whether `path` is a binary file in the given comparison — `"workingTree"`
+   * (`HEAD` vs. the working file), `"staged"` (`HEAD` vs. the index), or
+   * `"commit"` (`ref.parent` vs. `ref.commit`, required for that mode).
+   * Backs the diff content provider's binary guard so a binary blob shows a
+   * placeholder instead of raw bytes garbling the diff editor.
+   */
+  isBinaryDiff(
+    cwd: string,
+    path: string,
+    mode: "workingTree" | "staged" | "commit",
+    ref?: { commit: string; parent: string },
+  ): Promise<boolean>;
   /**
    * All working trees of the repo containing `cwd` (`git worktree list
    * --porcelain`), main worktree first — git lists the whole family from any

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -9,6 +9,7 @@ import { execFile } from "node:child_process";
 import {
   mkdtempSync,
   writeFileSync,
+  renameSync,
   rmSync,
   existsSync,
   realpathSync,
@@ -157,6 +158,40 @@ describe(
       await git.stage(repo, ["a.txt"]);
       await git.commit(repo, "init");
     }
+
+    it("log reports each commit's filesChanged count (--numstat, no extra request)", async () => {
+      writeFileSync(join(repo, "a.txt"), "v1\n");
+      writeFileSync(join(repo, "b.txt"), "v1\n");
+      await git.stage(repo, ["a.txt", "b.txt"]);
+      await git.commit(repo, "two files");
+
+      const log = await git.log(repo);
+      expect(log[0]).toMatchObject({ subject: "two files", filesChanged: 2 });
+    });
+
+    it("log counts a merge commit's filesChanged against its first parent", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+
+      await git.createBranch(repo, "side");
+      writeFileSync(join(repo, "b.txt"), "from side\n");
+      await git.stage(repo, ["b.txt"]);
+      await git.commit(repo, "add b on side");
+      await git.switchBranch(repo, base);
+
+      writeFileSync(join(repo, "c.txt"), "from base\n");
+      await git.stage(repo, ["c.txt"]);
+      await git.commit(repo, "add c on base");
+      await realExec("git", ["merge", "--no-ff", "-m", "merge side", "side"], {
+        cwd: repo,
+      });
+
+      const log = await git.log(repo);
+      const mergeEntry = log.find((c) => c.subject === "merge side")!;
+      // First-parent diff: only b.txt (what the merge itself brought in) —
+      // not c.txt, already on the mainline before the merge.
+      expect(mergeEntry.filesChanged).toBe(1);
+    });
 
     it("creates, lists, switches between, and deletes branches", async () => {
       await seedCommit();
@@ -498,6 +533,133 @@ describe(
         rmSync(remote, { recursive: true, force: true });
         rmSync(other, { recursive: true, force: true });
       }
+    });
+
+    it("commitDetail resolves a root commit's files against the empty tree", async () => {
+      writeFileSync(join(repo, "a.txt"), "hello\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "root commit\n\nSome body text.");
+
+      const log = await git.log(repo);
+      const detail = await git.commitDetail(repo, log[0].hash);
+      expect(detail).toMatchObject({
+        subject: "root commit",
+        body: "Some body text.",
+        parents: [],
+      });
+      expect(detail!.files).toEqual([
+        {
+          path: "a.txt",
+          origPath: undefined,
+          status: "A",
+          binary: false,
+          additions: 1,
+          deletions: 0,
+        },
+      ]);
+    });
+
+    it("commitDetail resolves an ordinary commit's files against its single parent", async () => {
+      await seedCommit();
+      writeFileSync(join(repo, "a.txt"), "v1\nv2\n");
+      await git.stage(repo, ["a.txt"]);
+      await git.commit(repo, "update a");
+
+      const log = await git.log(repo);
+      const detail = await git.commitDetail(repo, log[0].hash);
+      expect(detail!.parents).toHaveLength(1);
+      expect(detail!.files).toEqual([
+        {
+          path: "a.txt",
+          origPath: undefined,
+          status: "M",
+          binary: false,
+          additions: 1,
+          deletions: 0,
+        },
+      ]);
+    });
+
+    it("commitDetail reports a rename with its origin path", async () => {
+      await seedCommit();
+      renameSync(join(repo, "a.txt"), join(repo, "renamed.txt"));
+      await git.stage(repo, ["a.txt", "renamed.txt"]);
+      await git.commit(repo, "rename a");
+
+      const log = await git.log(repo);
+      const detail = await git.commitDetail(repo, log[0].hash);
+      expect(detail!.files).toEqual([
+        expect.objectContaining({
+          path: "renamed.txt",
+          origPath: "a.txt",
+          status: "R",
+        }),
+      ]);
+    });
+
+    it("commitDetail resolves a merge commit's files against its first parent only", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+
+      // Side branch adds b.txt.
+      await git.createBranch(repo, "side");
+      writeFileSync(join(repo, "b.txt"), "from side\n");
+      await git.stage(repo, ["b.txt"]);
+      await git.commit(repo, "add b on side");
+      await git.switchBranch(repo, base);
+
+      // Mainline adds c.txt, then merges side in.
+      writeFileSync(join(repo, "c.txt"), "from base\n");
+      await git.stage(repo, ["c.txt"]);
+      await git.commit(repo, "add c on base");
+      await realExec("git", ["merge", "--no-ff", "-m", "merge side", "side"], {
+        cwd: repo,
+      });
+
+      const log = await git.log(repo);
+      const mergeCommit = log.find((c) => c.subject === "merge side")!;
+      const detail = await git.commitDetail(repo, mergeCommit.hash);
+      expect(detail!.parents).toHaveLength(2);
+      // First-parent diff: only what the merge itself brought in (b.txt from
+      // the side branch) — not c.txt, which was already on the mainline.
+      expect(detail!.files.map((f) => f.path)).toEqual(["b.txt"]);
+    });
+
+    it("commitDetail resolves to null for an unknown hash", async () => {
+      await seedCommit();
+      expect(await git.commitDetail(repo, "0".repeat(40))).toBeNull();
+    });
+
+    it("isBinaryDiff detects a binary file in each mode", async () => {
+      await seedCommit();
+      const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]);
+      writeFileSync(join(repo, "img.png"), binary);
+      await git.stage(repo, ["img.png"]);
+
+      // staged: HEAD (missing) vs the index.
+      expect(await git.isBinaryDiff(repo, "img.png", "staged")).toBe(true);
+      await git.commit(repo, "add binary");
+
+      // workingTree: no further changes, so nothing to diff, but a modified
+      // binary working-tree file still reports as binary.
+      writeFileSync(join(repo, "img.png"), Buffer.concat([binary, binary]));
+      expect(await git.isBinaryDiff(repo, "img.png", "workingTree")).toBe(true);
+
+      // commit: the add-binary commit vs. its parent.
+      const log = await git.log(repo);
+      const addCommit = log.find((c) => c.subject === "add binary")!;
+      expect(
+        await git.isBinaryDiff(repo, "img.png", "commit", {
+          commit: addCommit.hash,
+          parent: addCommit.hash + "^",
+        }),
+      ).toBe(true);
+    });
+
+    it("isBinaryDiff reports false for an ordinary text file", async () => {
+      await seedCommit();
+      writeFileSync(join(repo, "a.txt"), "v2\n");
+      expect(await git.isBinaryDiff(repo, "a.txt", "workingTree")).toBe(false);
     });
   },
 );

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -2,6 +2,12 @@ import type { GitAPI, GitLogEntry } from "./git-api";
 import { parseGitStatus } from "./parse-status";
 import { parseBranches } from "./parse-branches";
 import { parseWorktrees } from "./parse-worktrees";
+import {
+  mergeCommitFiles,
+  parseNameStatus,
+  parseNumstat,
+  resolveDiffBase,
+} from "./parse-commit-files";
 
 // The GitAPI implementation, built on a generic one-shot `exec` (ctx.process.exec
 // in the app; a real-git wrapper in the contract test). This is the whole point
@@ -19,20 +25,35 @@ export type ExecFn = (
   options?: { cwd?: string },
 ) => Promise<{ stdout: string; stderr: string; code: number }>;
 
+// A commit header line — the %H%x09... pretty-format row — vs. a trailing
+// --numstat line ("<add>\t<del>\t<path>", or "-\t-\t<path>" for binary). The
+// 40-hex-char-then-tab shape only ever starts a header, so header lines are
+// unambiguous even interleaved with each commit's own numstat block.
+const LOG_HEADER_RE = /^[0-9a-f]{40}\t/;
+
+/** Parses `git log --pretty=format:%H%x09%h%x09%an%x09%ar%x09%s --numstat
+ * [--diff-merges=first-parent]` output — the file lines under each header
+ * count that commit's `filesChanged`, with no extra request per commit. */
 function parseLog(raw: string): GitLogEntry[] {
-  return raw
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => {
+  const entries: GitLogEntry[] = [];
+  let current: GitLogEntry | null = null;
+  for (const line of raw.split("\n")) {
+    if (LOG_HEADER_RE.test(line)) {
       const [hash, shortHash, author, relativeDate, ...rest] = line.split(TAB);
-      return {
+      current = {
         hash: hash ?? "",
         shortHash: shortHash ?? "",
         author: author ?? "",
         relativeDate: relativeDate ?? "",
         subject: rest.join(TAB),
+        filesChanged: 0,
       };
-    });
+      entries.push(current);
+    } else if (line.trim() && current) {
+      current.filesChanged++;
+    }
+  }
+  return entries;
 }
 
 /** Build a {@link GitAPI} backed by the given one-shot `exec`. */
@@ -83,6 +104,8 @@ export function createGitService(exec: ExecFn): GitAPI {
       const { stdout, code } = await git(cwd, [
         "log",
         "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%s",
+        "--numstat",
+        "--diff-merges=first-parent",
         `-${limit}`,
       ]);
       // Any error (e.g. empty repo with no commits) → no history.
@@ -209,6 +232,74 @@ export function createGitService(exec: ExecFn): GitAPI {
         if (code === 0) return parseLog(stdout);
       }
       return [];
+    },
+
+    async commitDetail(cwd, hash) {
+      const { stdout: metaLine, code: metaCode } = await git(cwd, [
+        "show",
+        "-s",
+        "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%P%x09%s%x09%b",
+        hash,
+      ]);
+      if (metaCode !== 0 || !metaLine) return null;
+      const [
+        h,
+        shortHash,
+        author,
+        relativeDate,
+        parentsRaw,
+        subject,
+        ...bodyParts
+      ] = metaLine.split(TAB);
+      const parents = (parentsRaw ?? "").split(" ").filter(Boolean);
+      const base = resolveDiffBase(parents);
+
+      const [nameStatusResult, numstatResult] = await Promise.all([
+        git(cwd, [
+          "diff-tree",
+          "--no-commit-id",
+          "-r",
+          "-M",
+          "--name-status",
+          base,
+          hash,
+        ]),
+        git(cwd, [
+          "diff-tree",
+          "--no-commit-id",
+          "-r",
+          "--numstat",
+          base,
+          hash,
+        ]),
+      ]);
+      const files = mergeCommitFiles(
+        parseNameStatus(nameStatusResult.stdout),
+        parseNumstat(numstatResult.stdout),
+      );
+
+      return {
+        hash: h ?? hash,
+        shortHash: shortHash ?? "",
+        author: author ?? "",
+        relativeDate: relativeDate ?? "",
+        subject: subject ?? "",
+        filesChanged: files.length,
+        body: bodyParts.join(TAB).trim(),
+        parents,
+        files,
+      };
+    },
+
+    async isBinaryDiff(cwd, path, mode, ref) {
+      const args = ["diff", "--numstat"];
+      if (mode === "workingTree") args.push("HEAD");
+      else if (mode === "staged") args.push("--cached");
+      else if (mode === "commit" && ref) args.push(ref.parent, ref.commit);
+      args.push("--", path);
+      const { stdout, code } = await git(cwd, args);
+      if (code !== 0) return false;
+      return /^-\t-\t/.test(stdout);
     },
 
     async worktrees(cwd) {

--- a/packages/extensions-silo/src/git/index.ts
+++ b/packages/extensions-silo/src/git/index.ts
@@ -9,7 +9,7 @@ import { createGitService } from "./git-service";
 // view and the diff editor consume this via getExtension("silo.git").
 
 /** Diff modes the git content provider understands (carried in OpenDiffSpec.args). */
-type DiffMode = "workingTree" | "staged";
+type DiffMode = "workingTree" | "staged" | "commit";
 
 function relativeTo(absPath: string, folder: string): string {
   return absPath.startsWith(folder + "/")
@@ -68,6 +68,35 @@ export const extension: Extension<GitAPI> = {
         if (!folder) return { original: "", modified: "" };
         const relative = relativeTo(req.filePath, folder);
         const mode = req.args?.mode as DiffMode | undefined;
+        const commit = req.args?.commit as string | undefined;
+        const parent = req.args?.parent as string | undefined;
+        const commitRef =
+          mode === "commit" && commit && parent
+            ? { commit, parent }
+            : undefined;
+
+        // A binary blob fed straight to the diff editor renders as garbled
+        // raw bytes (no text diff makes sense) — check first and short-circuit
+        // with a placeholder, same for every mode this provider serves.
+        const binary = await api.isBinaryDiff(
+          folder,
+          relative,
+          mode ?? "workingTree",
+          commitRef,
+        );
+        if (binary) {
+          const placeholder = "Binary file not shown.";
+          return { original: placeholder, modified: placeholder };
+        }
+
+        if (commitRef) {
+          const [original, modified] = await Promise.all([
+            api.show(folder, `${commitRef.parent}:${relative}`),
+            api.show(folder, `${commitRef.commit}:${relative}`),
+          ]);
+          return { original, modified };
+        }
+
         // original = HEAD; modified = the index (staged) or the working file.
         const [original, modified] = await Promise.all([
           api.show(folder, `HEAD:${relative}`),

--- a/packages/extensions-silo/src/git/parse-commit-files.test.ts
+++ b/packages/extensions-silo/src/git/parse-commit-files.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_TREE_HASH,
+  mergeCommitFiles,
+  parseNameStatus,
+  parseNumstat,
+  resolveDiffBase,
+} from "./parse-commit-files";
+
+describe("resolveDiffBase", () => {
+  it("uses the first parent for an ordinary or merge commit", () => {
+    expect(resolveDiffBase(["p1"])).toBe("p1");
+    expect(resolveDiffBase(["p1", "p2"])).toBe("p1");
+  });
+
+  it("falls back to the empty tree for a root commit (no parents)", () => {
+    expect(resolveDiffBase([])).toBe(EMPTY_TREE_HASH);
+  });
+});
+
+describe("parseNameStatus", () => {
+  it("parses added/modified/deleted rows", () => {
+    const raw = "A\tnew.txt\nM\tchanged.txt\nD\tgone.txt\n";
+    expect(parseNameStatus(raw)).toEqual([
+      { path: "new.txt", status: "A" },
+      { path: "changed.txt", status: "M" },
+      { path: "gone.txt", status: "D" },
+    ]);
+  });
+
+  it("parses a rename row with its similarity-scored status letter", () => {
+    const raw = "R100\told/path.ts\tnew/path.ts\n";
+    expect(parseNameStatus(raw)).toEqual([
+      { path: "new/path.ts", origPath: "old/path.ts", status: "R" },
+    ]);
+  });
+
+  it("ignores blank lines", () => {
+    expect(parseNameStatus("\nA\tfoo\n\n")).toEqual([
+      { path: "foo", status: "A" },
+    ]);
+  });
+});
+
+describe("parseNumstat", () => {
+  it("parses addition/deletion counts", () => {
+    expect(parseNumstat("12\t3\tfoo.ts\n")).toEqual([
+      { path: "foo.ts", additions: 12, deletions: 3 },
+    ]);
+  });
+
+  it("reports binary files as null counts (git's `-\\t-` marker)", () => {
+    expect(parseNumstat("-\t-\timage.png\n")).toEqual([
+      { path: "image.png", additions: null, deletions: null },
+    ]);
+  });
+});
+
+describe("mergeCommitFiles", () => {
+  it("attaches numstat counts to name-status rows by path", () => {
+    const result = mergeCommitFiles(
+      [{ path: "a.ts", status: "M" }],
+      [{ path: "a.ts", additions: 5, deletions: 1 }],
+    );
+    expect(result).toEqual([
+      {
+        path: "a.ts",
+        origPath: undefined,
+        status: "M",
+        binary: false,
+        additions: 5,
+        deletions: 1,
+      },
+    ]);
+  });
+
+  it("flags binary when numstat reports null counts for the path", () => {
+    const result = mergeCommitFiles(
+      [{ path: "logo.png", status: "A" }],
+      [{ path: "logo.png", additions: null, deletions: null }],
+    );
+    expect(result[0]).toMatchObject({ binary: true, additions: null });
+  });
+
+  it("falls back to the rename's origPath when only the delete-side numstat row exists", () => {
+    // A plain (no -M) numstat run reports a rename as delete(old)+add(new);
+    // if the add-side row is missing for some reason, origPath still resolves.
+    const result = mergeCommitFiles(
+      [{ path: "new.ts", origPath: "old.ts", status: "R" }],
+      [{ path: "old.ts", additions: 0, deletions: 10 }],
+    );
+    expect(result[0]).toMatchObject({ additions: 0, deletions: 10 });
+  });
+
+  it("resolves stats as null (not binary) when neither path is found in numstat", () => {
+    const result = mergeCommitFiles(
+      [{ path: "untracked-in-numstat.ts", status: "M" }],
+      [],
+    );
+    expect(result[0]).toMatchObject({
+      binary: false,
+      additions: null,
+      deletions: null,
+    });
+  });
+});

--- a/packages/extensions-silo/src/git/parse-commit-files.ts
+++ b/packages/extensions-silo/src/git/parse-commit-files.ts
@@ -1,0 +1,114 @@
+import type { CommitFileChange } from "./git-api";
+
+// Pure parsers for a commit's changed-file list, built from two separate
+// `git diff-tree` invocations (see git-service.ts's commitDetail): one
+// `--name-status -M` (status letters + rename source, unambiguous — a rename
+// is one `R100\told\tnew` line) and one plain `--numstat` — deliberately
+// *without* `-M`, so a rename reports as delete+add (two simple rows) rather
+// than git's ambiguous `{old => new}` / `old => new` numstat rename syntax.
+// mergeCommitFiles reconciles the two by path, trying both the new and (for a
+// rename) the original path when looking up stats.
+
+const TAB = "\t";
+
+/** The canonical empty-tree object — every git repo has it. Diffing a root
+ * commit (no parents) against it makes every file show as added. */
+export const EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/** The base to diff a commit against: its first parent, or the empty tree
+ * for a root commit (no parents) — the `--first-parent` convention for
+ * merges (see {@link import("./git-api").GitAPI.commitDetail}). */
+export function resolveDiffBase(parents: string[]): string {
+  return parents[0] ?? EMPTY_TREE_HASH;
+}
+
+interface NameStatusRow {
+  path: string;
+  origPath?: string;
+  status: CommitFileChange["status"];
+}
+
+function statusLetter(raw: string): CommitFileChange["status"] {
+  const c = raw[0] as CommitFileChange["status"];
+  return c === "A" ||
+    c === "M" ||
+    c === "D" ||
+    c === "R" ||
+    c === "C" ||
+    c === "T" ||
+    c === "U" ||
+    c === "X"
+    ? c
+    : "M";
+}
+
+/** Parse `git diff-tree --no-commit-id -r -M --name-status <base> <commit>`. */
+export function parseNameStatus(raw: string): NameStatusRow[] {
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split(TAB);
+      const status = statusLetter(parts[0] ?? "M");
+      if (status === "R" || status === "C") {
+        return { path: parts[2] ?? "", origPath: parts[1], status };
+      }
+      return { path: parts[1] ?? "", status };
+    });
+}
+
+interface NumstatRow {
+  path: string;
+  additions: number | null;
+  deletions: number | null;
+}
+
+/** Parse `git diff-tree --no-commit-id -r --numstat <base> <commit>` (no
+ * `-M`, so every row is a plain path — never `{old => new}`). */
+export function parseNumstat(raw: string): NumstatRow[] {
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [add, del, ...rest] = line.split(TAB);
+      const path = rest.join(TAB);
+      const binary = add === "-" || del === "-";
+      return {
+        path,
+        additions: binary ? null : parseInt(add ?? "0", 10),
+        deletions: binary ? null : parseInt(del ?? "0", 10),
+      };
+    });
+}
+
+/**
+ * Reconcile a `--name-status -M` list (correct file identity, incl. renames)
+ * with a plain `--numstat` list (correct per-path line counts, but a rename
+ * appears as separate delete+add rows there). Stats are looked up by the
+ * row's own path, falling back to `origPath` for a rename (whose numstat
+ * "add" row lives at the new path already, so this mainly helps when only
+ * the delete-side numstat row is present, e.g. a rename with no content
+ * change beyond the move).
+ */
+export function mergeCommitFiles(
+  nameStatus: NameStatusRow[],
+  numstat: NumstatRow[],
+): CommitFileChange[] {
+  const statsByPath = new Map<string, NumstatRow>();
+  for (const row of numstat) statsByPath.set(row.path, row);
+
+  return nameStatus.map((row) => {
+    const stats =
+      statsByPath.get(row.path) ?? statsByPath.get(row.origPath ?? "");
+    const additions = stats?.additions ?? null;
+    const deletions = stats?.deletions ?? null;
+    return {
+      path: row.path,
+      origPath: row.origPath,
+      status: row.status,
+      binary: stats !== undefined && additions === null,
+      additions,
+      deletions,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a **View Commits** entry to the git panel's overflow menu: a list/detail drill-down (side-panel view-stack, modeled on the list→detail nav pattern used elsewhere) for browsing the current branch's history without leaving the panel — including commits an agent made locally but never pushed.
- Commit list: oldest/newest toggle in the header (defaults to oldest-first, GitHub's PR "Commits" tab convention), a divider marking the unpushed/pushed boundary, per-row file count (`GitAPI.log()` now folds `--numstat --diff-merges=first-parent` into its existing single call — no per-commit follow-up request), copy-hash, and load-more pagination.
- Commit detail: full message, stat summary, and file list — click a file to open its diff in the center dock (reusing the same `openDiff` mechanism as the panel's root Changes list via a new `"commit"` `DiffMode`), or a document icon to open the file's current version.
- New `GitAPI.commitDetail()` / `isBinaryDiff()`, backed by a pure `parse-commit-files.ts` parser. Merge commits resolve against their first parent; a root commit against the empty tree.
- A binary-file guard added to the shared diff content provider — also fixes root's existing Changes-list diffs, which previously fed raw binary bytes straight into the Monaco diff editor.

## Test plan
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint` (incl. the design-token-only CSS rule)
- [x] `pnpm test` — full repo suite green, including new real-git contract tests in `git-service.test.ts` (root/merge/rename/binary commit resolution) and pure-logic tests for the view-stack, commit-list ordering/divider, and commit-file parsing
- [x] Manually verified in the running dev app against a seeded demo repo (pushed + unpushed commits, a rename, a binary file, a merge commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)