### PR TITLE
fix(git-explorer): scope "View Commits" to the branch, add exact total

### DIFF
--- a/packages/extensions-silo/src/git-explorer/CommitListView.tsx
+++ b/packages/extensions-silo/src/git-explorer/CommitListView.tsx
@@ -13,21 +13,29 @@ import {
 
 const PAGE_SIZE = 50;
 
-/** List page of the "View Commits" flow: current-branch history, with a
- * divider marking the boundary between unpushed and pushed commits. Display
- * `order` is controlled by the parent (its toggle button lives in `GitView`'s
- * shared subview header, next to Back/title). Reads `status` live from the
- * parent (not a snapshot taken when the view opened), so a branch switch
- * underfoot just re-fetches in place. */
+/** List page of the "View Commits" flow: commits unique to the current branch
+ * (scoped against the default branch via `GitAPI.branchBase` — GitHub's PR
+ * "Commits" tab semantics — falling back to the branch's full history when no
+ * default branch can be resolved), with a divider marking the boundary
+ * between unpushed and pushed commits. Display `order` is controlled by the
+ * parent (its toggle button lives in `GitView`'s shared subview header, next
+ * to Back/title). Reads `status` live from the parent (not a snapshot taken
+ * when the view opened), so a branch switch underfoot just re-fetches in
+ * place. */
 export function CommitListView({
   folder,
   status,
   order,
+  onTotalCountChange,
   onSelectCommit,
 }: {
   folder: string;
   status: GitStatus;
   order: CommitOrder;
+  /** Reports the exact total once resolved (see `GitAPI.commitCount`), for
+   * the parent's "Commits (N)" header — independent of how many rows are
+   * currently paged in. */
+  onTotalCountChange?: (count: number | null) => void;
   onSelectCommit: (hash: string) => void;
 }) {
   const [commits, setCommits] = useState<GitLogEntry[]>([]);
@@ -36,12 +44,50 @@ export function CommitListView({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copiedHash, setCopiedHash] = useState<string | null>(null);
+  const [branchBase, setBranchBase] = useState<string | null>(null);
+  const [baseResolved, setBaseResolved] = useState(false);
 
   // Reset pagination when the underlying branch changes so "Load more" starts
   // fresh rather than appending a different branch's tail onto this one's.
   useEffect(() => {
     setLimit(PAGE_SIZE);
   }, [folder, status.branch]);
+
+  // Resolve the boundary that scopes the log to this branch's own commits —
+  // see GitAPI.branchBase — before the first fetch, so the list never briefly
+  // shows the default branch's shared history and then narrows.
+  useEffect(() => {
+    const api = getGitApi();
+    if (!api || !status.branch) {
+      setBranchBase(null);
+      setBaseResolved(true);
+      return;
+    }
+    let cancelled = false;
+    setBaseResolved(false);
+    api.branchBase(folder, status.branch).then((base) => {
+      if (cancelled) return;
+      setBranchBase(base);
+      setBaseResolved(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [folder, status.branch]);
+
+  // Exact total for the parent's "Commits (N)" header — a single cheap
+  // `rev-list --count` call, independent of pagination (`limit`).
+  useEffect(() => {
+    const api = getGitApi();
+    if (!api || !baseResolved) return;
+    let cancelled = false;
+    api.commitCount(folder, branchBase ?? undefined).then((count) => {
+      if (!cancelled) onTotalCountChange?.(count);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [folder, branchBase, baseResolved, onTotalCountChange]);
 
   useEffect(() => {
     const api = getGitApi();
@@ -50,11 +96,12 @@ export function CommitListView({
       setLoading(false);
       return;
     }
+    if (!baseResolved) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
     api
-      .log(folder, limit)
+      .log(folder, limit, branchBase ?? undefined)
       .then(async (entries) => {
         if (cancelled) return;
         setCommits(entries);
@@ -79,7 +126,7 @@ export function CommitListView({
     return () => {
       cancelled = true;
     };
-  }, [folder, limit, status.branch, status.upstream]);
+  }, [folder, limit, status.branch, status.upstream, branchBase, baseResolved]);
 
   function copyHash(hash: string) {
     void navigator.clipboard.writeText(hash);

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -74,6 +74,15 @@ export function GitView({
   // a multi-root workspace's git roots don't share one stack.
   const viewStack = useViewStack(storage, `view:${cacheKey}`, hydrated);
   const [commitOrder, setCommitOrder] = useState<CommitOrder>("oldestFirst");
+  // Exact total for the "Commits (N)" subview header — reported by
+  // CommitListView once it resolves (see GitAPI.commitCount), independent of
+  // how many rows are currently paged in.
+  const [commitsTotal, setCommitsTotal] = useState<number | null>(null);
+  // Clear the stale total on the way out so reopening "Commits" doesn't flash
+  // the previous branch's count before CommitListView re-resolves it.
+  useEffect(() => {
+    if (viewStack.view.kind !== "commits") setCommitsTotal(null);
+  }, [viewStack.view.kind]);
   // Public primitives, read through ctx (stable per extension).
   const editors = ctx.editors;
   const files = ctx.files;
@@ -967,7 +976,11 @@ export function GitView({
               Back
             </button>
             <span className="git-subview-title">
-              {viewStack.view.kind === "commits" ? "Commits" : "Commit"}
+              {viewStack.view.kind === "commits"
+                ? commitsTotal === null
+                  ? "Commits"
+                  : `Commits (${commitsTotal})`
+                : "Commit"}
             </span>
             {viewStack.view.kind === "commits" && (
               <Tooltip
@@ -1000,6 +1013,7 @@ export function GitView({
                 folder={folder}
                 status={status}
                 order={commitOrder}
+                onTotalCountChange={setCommitsTotal}
                 onSelectCommit={(hash) =>
                   viewStack.push({ kind: "commit-detail", hash })
                 }

--- a/packages/extensions-silo/src/git/git-api.ts
+++ b/packages/extensions-silo/src/git/git-api.ts
@@ -110,8 +110,21 @@ export interface GitWorktree {
 export interface GitAPI {
   /** Parsed working-tree status (branch, ahead/behind, per-file changes). */
   status(cwd: string): Promise<GitStatus>;
-  /** Recent commits (most recent first), capped at `limit` (default 50). */
-  log(cwd: string, limit?: number): Promise<GitLogEntry[]>;
+  /**
+   * Recent commits (most recent first), capped at `limit` (default 50). Pass
+   * `base` (from {@link GitAPI.branchBase}) to scope the log to commits
+   * reachable from `HEAD` but not from `base` — GitHub's PR "Commits" tab
+   * semantics — instead of walking `HEAD`'s full ancestry (which eventually
+   * surfaces the default branch's history shared before the fork point).
+   */
+  log(cwd: string, limit?: number, base?: string): Promise<GitLogEntry[]>;
+  /**
+   * Exact commit count for {@link GitAPI.log}'s range (`base..HEAD` when
+   * `base` is given, else all of `HEAD`'s ancestry) — cheap way to show a
+   * "Commits (N)" total (`git rev-list --count`) without paging through
+   * every entry. Resolves to `0` on error (e.g. an empty repo).
+   */
+  commitCount(cwd: string, base?: string): Promise<number>;
   /** Unified diff text for `path` (or the whole tree); `staged` diffs the index. */
   diff(cwd: string, path?: string, staged?: boolean): Promise<string>;
   /** Stage the given paths (`git add`). */
@@ -195,6 +208,16 @@ export interface GitAPI {
     branch: string,
     upstream?: string | null,
   ): Promise<GitLogEntry[]>;
+  /**
+   * The commit to pass as {@link GitAPI.log}'s `base` so the log shows only
+   * `branch`'s own commits — the merge-base between `branch` and the repo's
+   * default branch (resolved from `origin/HEAD`, falling back through
+   * `origin/main`, `origin/master`, `main`, `master`). Resolves to `null` when
+   * `branch` **is** the default branch (nothing to scope against) or no
+   * default branch can be resolved (e.g. no `origin` remote) — either way the
+   * caller should fall back to an unscoped log.
+   */
+  branchBase(cwd: string, branch: string): Promise<string | null>;
   /**
    * Full detail for one commit — message body, parents, and its changed files
    * (each with a status letter, rename origin, and line stats). A merge

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -169,6 +169,31 @@ describe(
       expect(log[0]).toMatchObject({ subject: "two files", filesChanged: 2 });
     });
 
+    it("commitCount reports HEAD's full ancestry with no base, and just the range with one", async () => {
+      await seedCommit();
+
+      await git.createBranch(repo, "feature");
+      writeFileSync(join(repo, "f.txt"), "x\n");
+      await git.stage(repo, ["f.txt"]);
+      await git.commit(repo, "feature work 1");
+      writeFileSync(join(repo, "f.txt"), "y\n");
+      await git.stage(repo, ["f.txt"]);
+      await git.commit(repo, "feature work 2");
+
+      expect(await git.commitCount(repo)).toBe(3);
+      const branchBase = await git.branchBase(repo, "feature");
+      expect(await git.commitCount(repo, branchBase!)).toBe(2);
+    });
+
+    it("commitCount resolves to 0 outside a repository", async () => {
+      const outside = mkdtempSync(join(tmpdir(), "silo-norepo-"));
+      try {
+        expect(await git.commitCount(outside)).toBe(0);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+
     it("log counts a merge commit's filesChanged against its first parent", async () => {
       await seedCommit();
       const base = (await git.branches(repo)).find((b) => b.current)!.name;
@@ -288,6 +313,100 @@ describe(
       const unmerged = await git.unmergedCommits(repo, "wip", "origin/gone");
       expect(unmerged).toHaveLength(1);
       expect(unmerged[0].subject).toBe("wip work");
+    });
+
+    it("branchBase resolves to null when branch is the default branch", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      expect(await git.branchBase(repo, base)).toBeNull();
+    });
+
+    it("branchBase resolves to null when no default branch can be found", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      await git.renameBranch(repo, base, "trunk");
+      expect(await git.branchBase(repo, "trunk")).toBeNull();
+    });
+
+    it("branchBase computes the merge-base for a feature branch off the default branch (falling back to a local main/master)", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      const { stdout: forkPoint } = await realExec(
+        "git",
+        ["rev-parse", "HEAD"],
+        {
+          cwd: repo,
+        },
+      );
+
+      await git.createBranch(repo, "feature");
+      writeFileSync(join(repo, "f.txt"), "x\n");
+      await git.stage(repo, ["f.txt"]);
+      await git.commit(repo, "feature work");
+
+      // The default branch (base) hasn't moved since the fork, so the
+      // merge-base is exactly where "feature" branched off.
+      expect(await git.branchBase(repo, "feature")).toBe(forkPoint.trim());
+    });
+
+    it("branchBase prefers origin/HEAD when a remote's default branch is configured", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+      const remote = mkdtempSync(join(tmpdir(), "silo-gitremote-"));
+      try {
+        await realExec("git", ["init", "--bare", "-q"], { cwd: remote });
+        await realExec("git", ["remote", "add", "origin", remote], {
+          cwd: repo,
+        });
+        await realExec("git", ["push", "-q", "origin", base], { cwd: repo });
+        await realExec("git", ["remote", "set-head", "origin", base], {
+          cwd: repo,
+        });
+        const { stdout: forkPoint } = await realExec(
+          "git",
+          ["rev-parse", "HEAD"],
+          { cwd: repo },
+        );
+
+        await git.createBranch(repo, "feature");
+        writeFileSync(join(repo, "f.txt"), "x\n");
+        await git.stage(repo, ["f.txt"]);
+        await git.commit(repo, "feature work");
+
+        expect(await git.branchBase(repo, "feature")).toBe(forkPoint.trim());
+      } finally {
+        rmSync(remote, { recursive: true, force: true });
+      }
+    });
+
+    it("log(base) scopes commits to just the branch, matching GitHub's PR Commits tab", async () => {
+      await seedCommit();
+      const base = (await git.branches(repo)).find((b) => b.current)!.name;
+
+      await git.createBranch(repo, "feature");
+      writeFileSync(join(repo, "f.txt"), "x\n");
+      await git.stage(repo, ["f.txt"]);
+      await git.commit(repo, "feature work 1");
+      writeFileSync(join(repo, "f.txt"), "y\n");
+      await git.stage(repo, ["f.txt"]);
+      await git.commit(repo, "feature work 2");
+
+      const branchBase = await git.branchBase(repo, "feature");
+      expect(branchBase).not.toBeNull();
+      const scoped = await git.log(repo, 50, branchBase!);
+      expect(scoped.map((c) => c.subject)).toEqual([
+        "feature work 2",
+        "feature work 1",
+      ]);
+
+      // Unscoped, the shared history with `base` (the seed commit) is
+      // included too — the exact confusion this feature exists to avoid.
+      const unscoped = await git.log(repo, 50);
+      expect(unscoped.map((c) => c.subject)).toEqual([
+        "feature work 2",
+        "feature work 1",
+        "init",
+      ]);
     });
 
     it("fetch --prune drops remote-tracking branches deleted upstream", async () => {

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -100,17 +100,29 @@ export function createGitService(exec: ExecFn): GitAPI {
       return parseGitStatus(stdout);
     },
 
-    async log(cwd, limit = 50) {
+    async log(cwd, limit = 50, base) {
       const { stdout, code } = await git(cwd, [
         "log",
         "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%s",
         "--numstat",
         "--diff-merges=first-parent",
         `-${limit}`,
+        ...(base ? [`${base}..HEAD`] : []),
       ]);
       // Any error (e.g. empty repo with no commits) → no history.
       if (code !== 0) return [];
       return parseLog(stdout);
+    },
+
+    async commitCount(cwd, base) {
+      const { stdout, code } = await git(cwd, [
+        "rev-list",
+        "--count",
+        base ? `${base}..HEAD` : "HEAD",
+      ]);
+      if (code !== 0) return 0;
+      const n = parseInt(stdout.trim(), 10);
+      return Number.isFinite(n) ? n : 0;
     },
 
     async diff(cwd, path, staged = false) {
@@ -232,6 +244,57 @@ export function createGitService(exec: ExecFn): GitAPI {
         if (code === 0) return parseLog(stdout);
       }
       return [];
+    },
+
+    async branchBase(cwd, branch) {
+      // Prefer the remote's recorded default branch (`origin/HEAD`, set by
+      // `git clone`/`git remote set-head`); fall back to the common default
+      // names, remote-tracking ref first since it reflects the shared
+      // history more reliably than a possibly-stale local branch.
+      let defaultRef: string | null = null;
+      const sym = await git(cwd, [
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        "refs/remotes/origin/HEAD",
+      ]);
+      if (sym.code === 0 && sym.stdout.trim()) {
+        defaultRef = sym.stdout.trim();
+      } else {
+        for (const candidate of [
+          "origin/main",
+          "origin/master",
+          "main",
+          "master",
+        ]) {
+          const verify = await git(cwd, [
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            candidate,
+          ]);
+          if (verify.code === 0) {
+            defaultRef = candidate;
+            break;
+          }
+        }
+      }
+      if (!defaultRef) return null;
+
+      // Strip a remote prefix (`origin/main` → `main`) to compare against the
+      // current branch's own short name.
+      const defaultShortName = defaultRef.includes("/")
+        ? defaultRef.slice(defaultRef.indexOf("/") + 1)
+        : defaultRef;
+      if (defaultShortName === branch) return null;
+
+      const { stdout, code } = await git(cwd, [
+        "merge-base",
+        defaultRef,
+        "HEAD",
+      ]);
+      if (code !== 0) return null;
+      return stdout.trim() || null;
     },
 
     async commitDetail(cwd, hash) {


### PR DESCRIPTION
## Summary

The "View Commits" panel fetches `git log -N` with no ref, so it walks `HEAD`'s full ancestry. Once a feature branch's own commits run out, the list quietly starts showing the default branch's history from before the fork point — confusing in "oldest first" mode (which mirrors GitHub's PR Commits tab ordering), since that old shared history lands at the top instead of the branch's actual new work.

- New `GitAPI.branchBase(cwd, branch)`: resolves the repo's default branch (`origin/HEAD`, falling back through `origin/main` → `origin/master` → `main` → `master`) and returns its merge-base with `HEAD`. `null` when `branch` *is* the default branch, or none can be resolved (falls back to the unscoped log).
- `GitAPI.log` gained an optional `base` param — scopes to `base..HEAD` (GitHub's PR "Commits" tab semantics) instead of unbounded ancestry.
- New `GitAPI.commitCount(cwd, base?)` (`git rev-list --count`): an exact total independent of pagination, now shown in the subview header as "Commits (N)".
- `CommitListView` resolves `branchBase` before its first fetch and reports the total up to `GitView` via a new `onTotalCountChange` callback.

## Test plan

- [x] `pnpm test` — 274 tests pass, including 7 new ones covering `branchBase` (on-default-branch, no-default-found, merge-base computation, `origin/HEAD` resolution) and `commitCount` (with/without base, outside a repo)
- [x] `pnpm lint` clean
- [x] `pnpm --filter silo exec tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)