### PR TITLE
feat(file-explorer): add worktree badge, icon-button parity, and bug fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,14 @@ All run from the repo root (pnpm workspace).
 - Docs under `docs/` use lowercase kebab-case filenames (`automation.md`,
   `ui-terminology.md`), not ALLCAPS. The only exception is the conventional
   `README.md`.
+- **Commit messages and PR titles are Conventional Commits**: `type(scope):
+summary` — e.g. `feat(git-explorer): add "View Commits" drill-down`,
+  `fix(file-explorer): scope "View Commits" to the branch`. Check `git log`
+  for the type/scope vocabulary already in use before inventing a new scope.
+  This isn't just a style nit: GitHub squash-merges every PR using its title
+  as the resulting commit message on `main`, so an untitled/prose PR title
+  (e.g. "Fix some file explorer bugs") becomes the permanent, non-conventional
+  entry in `git log` — get the title right before opening the PR, not after.
 
 ## Testing — write unit tests for all new functionality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,15 @@ every interactive element (`button`, `input`, `[role="button"]`, …) the accent
 on the shared ring; if you must suppress the native one on a base element use
 `outline: none` (the global rule has higher specificity and still wins on focus).
 
+**Every tooltip uses the SDK `Tooltip`, never the native `title` attribute.**
+`Tooltip` (`packages/sdk/src/Tooltip.tsx`) is the one tooltip implementation —
+consistent 600ms delay, styling, and positioning app-wide, both in the host
+chrome and every extension. A native `title` attribute renders with the
+browser's own (unstyled, immediate-on-hover, per-OS) tooltip instead, which
+looks inconsistent next to every other tooltip in the app. This applies
+everywhere a hover hint is needed, not just on already-interactive elements —
+wrap the target in `<Tooltip content="...">...</Tooltip>`.
+
 ## Commands
 
 All run from the repo root (pnpm workspace).

--- a/packages/extensions-core/src/workspaces/workspace-helpers.test.ts
+++ b/packages/extensions-core/src/workspaces/workspace-helpers.test.ts
@@ -1,5 +1,44 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { formatElapsed } from "./workspace-helpers";
+import { formatElapsed, fullPath } from "./workspace-helpers";
+
+const LRI = "⁦";
+const PDI = "⁩";
+
+describe("fullPath", () => {
+  it("abbreviates a path under home to ~", () => {
+    expect(fullPath("/Users/dave/proj", "/Users/dave")).toBe(
+      `${LRI}~/proj${PDI}`,
+    );
+  });
+
+  it("abbreviates home itself to ~", () => {
+    expect(fullPath("/Users/dave", "/Users/dave")).toBe(`${LRI}~${PDI}`);
+  });
+
+  it("leaves a path outside home untouched", () => {
+    expect(fullPath("/opt/other", "/Users/dave")).toBe(
+      `${LRI}/opt/other${PDI}`,
+    );
+  });
+
+  it("ignores trailing slashes on both folder and home", () => {
+    expect(fullPath("/Users/dave/proj/", "/Users/dave/")).toBe(
+      `${LRI}~/proj${PDI}`,
+    );
+  });
+
+  it("passes the raw path through unchanged when home is empty", () => {
+    expect(fullPath("/Users/dave/proj", "")).toBe(
+      `${LRI}/Users/dave/proj${PDI}`,
+    );
+  });
+
+  it("wraps the result in LRI/PDI isolate marks so a front-truncated, RTL-directioned row doesn't reorder the leading ~ or / to the visual end of the line", () => {
+    const result = fullPath("/Users/dave/proj", "/Users/dave");
+    expect(result.startsWith(LRI)).toBe(true);
+    expect(result.endsWith(PDI)).toBe(true);
+  });
+});
 
 describe("formatElapsed", () => {
   afterEach(() => {

--- a/packages/extensions-core/src/workspaces/workspace-helpers.tsx
+++ b/packages/extensions-core/src/workspaces/workspace-helpers.tsx
@@ -9,13 +9,32 @@ import type { FileService, WorkspaceState } from "@silo-code/sdk";
  */
 export type Workspace = WorkspaceState["all"][number];
 
+// U+2066 LEFT-TO-RIGHT ISOLATE / U+2069 POP DIRECTIONAL ISOLATE. WorkspaceModals
+// renders this text with `truncate="start"`, which flips the row to
+// `direction: rtl` so text-overflow clips at the visual left instead of the
+// right (see .silo-list-row-name[data-truncate="start"]). That trick only
+// repositions the ellipsis; it also hands our LTR path text to the Unicode
+// bidi algorithm as part of an RTL paragraph. A path is almost always a
+// strong-LTR run, but `~` and the leading `/` are bidi-*neutral* — with
+// nothing before them to anchor their direction, the RTL paragraph resolves
+// them against ITS OWN direction and can reorder them to the visual end of
+// the line, so "~/Projects/…/repo" renders as "Projects/…/repo/~". Isolating
+// the text as its own explicit LTR run keeps the neutral characters glued to
+// the text they belong with, regardless of the paragraph they're embedded in.
+const LRI = "⁦";
+const PDI = "⁩";
+
 export function fullPath(folder: string, home: string): string {
   const p = folder.replace(/\/+$/, "");
-  if (!home) return p;
-  const h = home.replace(/\/+$/, "");
-  if (p === h) return "~";
-  if (p.startsWith(h + "/")) return "~" + p.slice(h.length);
-  return p;
+  let result: string;
+  if (!home) {
+    result = p;
+  } else {
+    const h = home.replace(/\/+$/, "");
+    result =
+      p === h ? "~" : p.startsWith(h + "/") ? "~" + p.slice(h.length) : p;
+  }
+  return LRI + result + PDI;
 }
 
 function truncatePath(el: HTMLElement, text: string): string | null {

--- a/packages/extensions-silo/src/file-explorer/FileExplorerPanel.css
+++ b/packages/extensions-silo/src/file-explorer/FileExplorerPanel.css
@@ -66,28 +66,6 @@
   background: var(--silo-color-bg-hover);
 }
 
-.tree-hdr-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--silo-color-text-hi);
-  padding: 3px 4px;
-  border-radius: var(--silo-radius-sm);
-  line-height: 1;
-  font-size: 1.2em;
-  opacity: 0.7;
-  transition:
-    opacity 0.1s,
-    background 0.1s;
-}
-.tree-hdr-btn:hover {
-  opacity: 1;
-  background: var(--silo-color-bg-hover);
-}
-
 .tree-row.new-item-row {
   opacity: 1;
 }
@@ -172,12 +150,39 @@
 
 /* The name is wrapped in an SDK Tooltip, whose host span is the real flex
    child. Let it shrink so a long name (e.g. a deep root) truncates instead of
-   pushing the trailing root actions past the row's clipped right edge. */
+   pushing the trailing root actions past the row's clipped right edge. Root
+   rows nest their Tooltip host inside .tree-root-title instead (below), so
+   this doesn't double-apply there. */
 .tree-row > .silo-tooltip-host {
   flex: 1;
   min-width: 0;
   display: block;
   overflow: hidden;
+}
+
+/* Root row only: name + WT badge (TreeNodes.tsx) share this flex container.
+   flex: 1 here claims the row's available width (same role the rule above
+   plays for non-root rows), but the *name* inside must NOT also be flex: 1 —
+   a flex: 1 block element fills that whole width even when its text is short,
+   stranding the badge out past the visible text at the row's far right. Grow:
+   0 (shrink-to-fit) makes .name hug its own text, with shrink: 1 + min-width:
+   0 still letting it truncate when the row's too narrow for name + badge. */
+.tree-root-title {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+}
+.tree-root-title > .silo-tooltip-host {
+  flex: 0 1 auto;
+  min-width: 0;
+  display: block;
+  overflow: hidden;
+}
+.tree-root-title > .tree-wt-pill-wrap {
+  flex: 0 0 auto;
 }
 
 .tree-row .name {

--- a/packages/extensions-silo/src/file-explorer/Tree.tsx
+++ b/packages/extensions-silo/src/file-explorer/Tree.tsx
@@ -11,8 +11,10 @@ import {
   type NewItem,
   type RowFocusProps,
 } from "./tree-types";
-import { flattenVisible, treeArrowNav } from "./tree-nav";
+import { collapseAllExpanded, flattenVisible, treeArrowNav } from "./tree-nav";
 import { DirNode } from "./TreeNodes";
+import type { GitAPI, GitWorktree } from "../git/git-api";
+import { findWorktreeFor } from "../git/worktree-utils";
 
 // Module-level file clipboard (cut/copy) — reserved for future Paste implementation
 const fileCb = { current: null as { path: string; op: "cut" | "copy" } | null };
@@ -57,6 +59,23 @@ export function Tree({
   const [selected, setSelected] = useState<string | null>(
     () => initialSelected ?? null,
   );
+  // Whether `root` is itself a linked git worktree — drives the header badge
+  // (mirrors the Git panel's; consumes `silo.git` directly, same as
+  // git-explorer does, rather than reaching into that extension's internals).
+  const [worktrees, setWorktrees] = useState<GitWorktree[] | null>(null);
+  useEffect(() => {
+    setWorktrees(null);
+    const api = ctx.getExtension<GitAPI>("silo.git")?.api;
+    if (!api) return;
+    api
+      .worktrees(root)
+      .then(setWorktrees)
+      .catch(() => undefined);
+  }, [ctx, root]);
+  const linkedWorktree = worktrees
+    ? findWorktreeFor(root, worktrees)
+    : undefined;
+  const isWorktree = !!linkedWorktree && !linkedWorktree.isMain;
 
   function selectPath(path: string | null) {
     setSelected(path);
@@ -237,7 +256,7 @@ export function Tree({
   }
 
   function collapseAll() {
-    const next = { [root]: true };
+    const next = collapseAllExpanded(expanded, root);
     setExpanded(next);
     persistExpanded(next);
   }
@@ -549,6 +568,7 @@ export function Tree({
           onNewItemCancel={() => setNewItem(null)}
           selected={selected}
           onDrop={handleDrop}
+          isWorktree={isWorktree}
           rootActions={{
             onNewFile: () => setNewItem({ dir: root, type: "file" }),
             onNewFolder: () => setNewItem({ dir: root, type: "folder" }),

--- a/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
+++ b/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
@@ -7,7 +7,7 @@ import {
   ArrowClockwise,
   ArrowsIn,
 } from "@phosphor-icons/react";
-import { DND_MIME, Tooltip } from "@silo-code/sdk";
+import { Badge, DND_MIME, IconButton, Tooltip } from "@silo-code/sdk";
 import {
   rowIndent,
   ROW_INDENT_PX,
@@ -42,6 +42,7 @@ export function DirNode({
   onNewItemCancel,
   selected,
   onDrop,
+  isWorktree = false,
   rootActions,
 }: {
   path: string;
@@ -51,6 +52,8 @@ export function DirNode({
   listings: Record<string, Listing>;
   onToggle: (path: string, isDir: boolean) => void;
   isRoot?: boolean;
+  /** This root is a linked git worktree — shows the "worktree" header badge. */
+  isWorktree?: boolean;
 } & RowSharedProps) {
   const isExpanded = !!expanded[path];
   const listing = listings[path];
@@ -155,9 +158,31 @@ export function DirNode({
             }}
             onClick={(e) => e.stopPropagation()}
           />
+        ) : isRoot ? (
+          // Name + WT badge share this flex container so the badge sits right
+          // against the (possibly truncated) visible text — .name shrinks to
+          // fit here instead of block-filling the row's full flex:1 share,
+          // which would strand the badge out at the row's far right.
+          <span className="tree-root-title">
+            <Tooltip content={path}>
+              <span className="name">{name.toUpperCase()}</span>
+            </Tooltip>
+            {isWorktree && (
+              // Wrapped in its own span so the Tooltip's host (also a
+              // .silo-tooltip-host, like the name's above) isn't a *direct*
+              // child of .tree-root-title — it'd otherwise match the same
+              // shrink-to-fit rule meant only for the name and start
+              // shrinking the badge instead of staying fixed-size.
+              <span className="tree-wt-pill-wrap">
+                <Tooltip content="Linked git worktree">
+                  <Badge tone="accent">WT</Badge>
+                </Tooltip>
+              </span>
+            )}
+          </span>
         ) : (
           <Tooltip content={path}>
-            <span className="name">{isRoot ? name.toUpperCase() : name}</span>
+            <span className="name">{name}</span>
           </Tooltip>
         )}
         {isRoot && rootActions && (
@@ -166,40 +191,44 @@ export function DirNode({
             onClick={(e) => e.stopPropagation()}
           >
             <Tooltip content="New File">
-              <button
-                className="tree-hdr-btn"
+              <IconButton
+                size="sm"
+                aria-label="New File"
                 tabIndex={-1}
                 onClick={rootActions.onNewFile}
               >
                 <FilePlus size="1.2em" weight="regular" />
-              </button>
+              </IconButton>
             </Tooltip>
             <Tooltip content="New Folder">
-              <button
-                className="tree-hdr-btn"
+              <IconButton
+                size="sm"
+                aria-label="New Folder"
                 tabIndex={-1}
                 onClick={rootActions.onNewFolder}
               >
                 <FolderPlus size="1.2em" weight="regular" />
-              </button>
+              </IconButton>
             </Tooltip>
             <Tooltip content="Refresh">
-              <button
-                className="tree-hdr-btn"
+              <IconButton
+                size="sm"
+                aria-label="Refresh"
                 tabIndex={-1}
                 onClick={rootActions.onRefresh}
               >
                 <ArrowClockwise size="1.2em" weight="regular" />
-              </button>
+              </IconButton>
             </Tooltip>
             <Tooltip content="Collapse All">
-              <button
-                className="tree-hdr-btn"
+              <IconButton
+                size="sm"
+                aria-label="Collapse All"
                 tabIndex={-1}
                 onClick={rootActions.onCollapseAll}
               >
                 <ArrowsIn size="1.2em" weight="regular" />
-              </button>
+              </IconButton>
             </Tooltip>
           </span>
         )}

--- a/packages/extensions-silo/src/file-explorer/tree-nav.test.ts
+++ b/packages/extensions-silo/src/file-explorer/tree-nav.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { flattenVisible, treeArrowNav } from "./tree-nav";
+import { collapseAllExpanded, flattenVisible, treeArrowNav } from "./tree-nav";
 import type { Listing } from "./tree-types";
 
 const root = "/ws";
@@ -173,5 +173,28 @@ describe("treeArrowNav", () => {
         root,
       }),
     ).toBeNull();
+  });
+});
+
+describe("collapseAllExpanded", () => {
+  it("keeps the root expanded and explicitly collapses every other known path", () => {
+    expect(
+      collapseAllExpanded(
+        { "/ws": true, "/ws/src": true, "/ws/src/util": false },
+        root,
+      ),
+    ).toEqual({ "/ws": true, "/ws/src": false, "/ws/src/util": false });
+  });
+
+  it("writes explicit `false`, not just an omitted key — the caller merges this onto storage, which can't clear a key that's simply missing", () => {
+    const next = collapseAllExpanded({ "/ws": true, "/ws/src": true }, root);
+    expect(Object.prototype.hasOwnProperty.call(next, "/ws/src")).toBe(true);
+    expect(next["/ws/src"]).toBe(false);
+  });
+
+  it("is a no-op map when nothing but the root was ever expanded", () => {
+    expect(collapseAllExpanded({ "/ws": true }, root)).toEqual({
+      "/ws": true,
+    });
   });
 });

--- a/packages/extensions-silo/src/file-explorer/tree-nav.ts
+++ b/packages/extensions-silo/src/file-explorer/tree-nav.ts
@@ -72,3 +72,26 @@ export function treeArrowNav(opts: {
   if (parent && parent !== root) return { kind: "focusParent", path: parent };
   return null;
 }
+
+/**
+ * The expanded-map update for "Collapse All": `root` stays expanded, every
+ * other path this tree has ever expanded is explicitly set to `false`.
+ *
+ * Explicit `false` (not just omitting the key) matters because the caller
+ * persists this map by merging it onto shared storage — a merge can only
+ * add/overwrite keys, never clear ones absent from the update. Returning
+ * `{ [root]: true }` alone would leave every previously-expanded
+ * subdirectory stuck at `true` in storage, so the next remount (workspace
+ * switch, hot reload) would reopen them even though this collapse looked
+ * like it took effect locally.
+ */
+export function collapseAllExpanded(
+  expanded: Record<string, boolean>,
+  root: string,
+): Record<string, boolean> {
+  const next: Record<string, boolean> = { [root]: true };
+  for (const path of Object.keys(expanded)) {
+    if (path !== root) next[path] = false;
+  }
+  return next;
+}

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -685,32 +685,27 @@
   animation: branch-spin 0.8s linear infinite;
 }
 
-/* "worktree" header pill on linked-worktree GitViews — clickable into the
- * manager (replaces the header icon on those views). */
-button.git-wt-pill {
+/* "WT" header badge on linked-worktree GitViews — clickable into the manager
+ * (replaces the header icon on those views). Bare button reset around the
+ * SDK design-kit Badge (packages/sdk/src/Badge.tsx) — the pill's own look
+ * comes entirely from Badge/.silo-badge-accent, not from this class, so it
+ * stays pixel-identical to every other accent badge in the app (including
+ * the file-explorer header's, see .tree-wt-pill). */
+.git-wt-pill-btn {
   -webkit-appearance: none;
   appearance: none;
   border: none;
+  background: none;
+  padding: 0;
   cursor: pointer;
   font-family: inherit;
   line-height: inherit;
-}
-
-.git-wt-pill {
   flex-shrink: 0;
-  font-size: var(--silo-font-size-chrome);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--silo-color-accent);
-  background: color-mix(in srgb, var(--silo-color-accent) 16%, transparent);
-  border-radius: 999px;
-  padding: 1px 8px;
 }
 
-button.git-wt-pill:hover {
+.git-wt-pill-btn:hover .silo-badge {
   color: var(--silo-color-text-hi);
-  background: color-mix(in srgb, var(--silo-color-accent) 28%, transparent);
+  background: color-mix(in srgb, var(--silo-color-accent) 32%, transparent);
 }
 
 .git-pending-remove-status {

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -11,6 +11,7 @@ import {
   TreeStructure,
 } from "@phosphor-icons/react";
 import {
+  Badge,
   Tooltip,
   useFocusGroup,
   type ExtensionContext,
@@ -656,13 +657,13 @@ export function GitView({
     <Tooltip content={worktreeManagerButtonTooltip(worktrees)}>
       <button
         type="button"
-        className="git-wt-pill"
+        className="git-wt-pill-btn"
         onClick={(e) => {
           e.stopPropagation();
           openWorktreeManager();
         }}
       >
-        worktree
+        <Badge tone="accent">WT</Badge>
       </button>
     </Tooltip>
   ) : null;

--- a/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
@@ -1,15 +1,12 @@
 import { describe, it, expect } from "vitest";
 import type { GitWorktree } from "../git/git-api";
 import {
-  normalizeFolderPath,
-  samePath,
   buildWorktreeRows,
   isOnlyMainWorktree,
   orphanOpenFolders,
   worktreeActions,
   sanitizeBranchForPath,
   suggestWorktreePath,
-  findWorktreeFor,
   branchesInUse,
   managerWorktreeCount,
   shouldShowWorktreeManagerButton,
@@ -29,26 +26,6 @@ function wt(overrides: Partial<GitWorktree>): GitWorktree {
     ...overrides,
   };
 }
-
-describe("normalizeFolderPath / samePath", () => {
-  it("normalizes separators and trailing slashes", () => {
-    expect(normalizeFolderPath("/a/b/")).toBe("/a/b");
-    expect(normalizeFolderPath("C:\\repos\\proj")).toBe("C:/repos/proj");
-    expect(samePath("/a/b/", "/a/b")).toBe(true);
-  });
-
-  it("treats macOS /private realpaths as their symlinked form", () => {
-    expect(samePath("/private/tmp/x", "/tmp/x")).toBe(true);
-    expect(samePath("/private/var/folders/y", "/var/folders/y")).toBe(true);
-    // "/privateer" or unrelated /private children must not be rewritten.
-    expect(samePath("/privateer/tmp", "/tmp")).toBe(false);
-    expect(normalizeFolderPath("/private/stuff")).toBe("/private/stuff");
-  });
-
-  it("keeps distinct paths distinct", () => {
-    expect(samePath("/a/b", "/a/b2")).toBe(false);
-  });
-});
 
 describe("buildWorktreeRows", () => {
   const main = wt({ path: "/w/repo", isMain: true, branch: "main" });
@@ -242,13 +219,7 @@ describe("sanitizeBranchForPath / suggestWorktreePath", () => {
   });
 });
 
-describe("findWorktreeFor / branchesInUse", () => {
-  it("matches a folder to its worktree through path normalization", () => {
-    const wts = [wt({ path: "/private/tmp/repo", isMain: true })];
-    expect(findWorktreeFor("/tmp/repo/", wts)).toBe(wts[0]);
-    expect(findWorktreeFor("/tmp/other", wts)).toBeUndefined();
-  });
-
+describe("branchesInUse", () => {
   it("collects checked-out branch names, skipping detached entries", () => {
     const wts = [
       wt({ branch: "main", isMain: true }),

--- a/packages/extensions-silo/src/git-explorer/worktree-model.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.ts
@@ -1,29 +1,19 @@
 import { path } from "@silo-code/sdk";
 import type { GitWorktree } from "../git/git-api";
+import {
+  findWorktreeFor,
+  normalizeFolderPath,
+  samePath,
+} from "../git/worktree-utils";
 
-// Pure presentation logic for the worktree manager modal — path identity,
-// row derivation, action gating, and the suggested-path convention. Extracted
-// from WorktreeManager.tsx so the rules are unit-testable without rendering
-// React (per the repo's testing convention; see branch-model.ts).
+// Pure presentation logic for the worktree manager modal — row derivation,
+// action gating, and the suggested-path convention, built on the path-identity
+// primitives from ../git/worktree-utils (shared with any other extension that
+// needs "is this folder a worktree", e.g. the file-explorer header badge).
+// Extracted from WorktreeManager.tsx so the rules are unit-testable without
+// rendering React (per the repo's testing convention; see branch-model.ts).
 
-/**
- * Normalize a folder path for identity comparison: forward slashes, no
- * trailing slash, and macOS realpath'd temp prefixes folded back to their
- * symlinked form (`/private/tmp/x` ⇔ `/tmp/x`) — git reports realpaths while
- * workspace folders may hold the symlinked spelling.
- */
-export function normalizeFolderPath(p: string): string {
-  let n = path.normalize(p);
-  if (n.length > 1 && n.endsWith("/")) n = n.slice(0, -1);
-  const priv = /^\/private(\/(?:tmp|var|etc)(?:\/|$).*)$/.exec(n);
-  if (priv) n = priv[1];
-  return n;
-}
-
-/** Whether two folder paths identify the same directory (see {@link normalizeFolderPath}). */
-export function samePath(a: string, b: string): boolean {
-  return normalizeFolderPath(a) === normalizeFolderPath(b);
-}
+export { normalizeFolderPath, samePath, findWorktreeFor };
 
 /** One worktree row in the manager, with its relationship to the workspace. */
 export interface WorktreeRow {
@@ -159,14 +149,6 @@ export function suggestWorktreePath(repoPath: string, branch: string): string {
   return suffix
     ? path.join(parent, `${repoName}-${suffix}`)
     : path.join(parent, repoName ? `${repoName}-` : "");
-}
-
-/** The worktree whose root is `folder`, if any (see {@link samePath}). */
-export function findWorktreeFor(
-  folder: string,
-  worktrees: GitWorktree[],
-): GitWorktree | undefined {
-  return worktrees.find((wt) => samePath(wt.path, folder));
 }
 
 /**

--- a/packages/extensions-silo/src/git/worktree-utils.test.ts
+++ b/packages/extensions-silo/src/git/worktree-utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import type { GitWorktree } from "./git-api";
+import {
+  normalizeFolderPath,
+  samePath,
+  findWorktreeFor,
+} from "./worktree-utils";
+
+function wt(overrides: Partial<GitWorktree>): GitWorktree {
+  return {
+    path: "/repo",
+    head: "abc",
+    branch: "main",
+    isMain: false,
+    detached: false,
+    bare: false,
+    locked: null,
+    prunable: null,
+    ...overrides,
+  };
+}
+
+describe("normalizeFolderPath / samePath", () => {
+  it("normalizes separators and trailing slashes", () => {
+    expect(normalizeFolderPath("/a/b/")).toBe("/a/b");
+    expect(normalizeFolderPath("C:\\repos\\proj")).toBe("C:/repos/proj");
+    expect(samePath("/a/b/", "/a/b")).toBe(true);
+  });
+
+  it("treats macOS /private realpaths as their symlinked form", () => {
+    expect(samePath("/private/tmp/x", "/tmp/x")).toBe(true);
+    expect(samePath("/private/var/folders/y", "/var/folders/y")).toBe(true);
+    // "/privateer" or unrelated /private children must not be rewritten.
+    expect(samePath("/privateer/tmp", "/tmp")).toBe(false);
+    expect(normalizeFolderPath("/private/stuff")).toBe("/private/stuff");
+  });
+
+  it("keeps distinct paths distinct", () => {
+    expect(samePath("/a/b", "/a/b2")).toBe(false);
+  });
+});
+
+describe("findWorktreeFor", () => {
+  it("matches a folder to its worktree through path normalization", () => {
+    const wts = [wt({ path: "/private/tmp/repo", isMain: true })];
+    expect(findWorktreeFor("/tmp/repo/", wts)).toBe(wts[0]);
+    expect(findWorktreeFor("/tmp/other", wts)).toBeUndefined();
+  });
+});

--- a/packages/extensions-silo/src/git/worktree-utils.ts
+++ b/packages/extensions-silo/src/git/worktree-utils.ts
@@ -1,0 +1,35 @@
+import { path } from "@silo-code/sdk";
+import type { GitWorktree } from "./git-api";
+
+// Pure derivations over `GitWorktree[]` — path identity and "which entry is
+// this folder" lookup. Lives beside the `GitWorktree` type (the provider's own
+// published data shape) so both the git-explorer view and any other extension
+// that needs "is this folder a worktree" (e.g. the file-explorer header badge)
+// import a shared, tested answer instead of each re-deriving path identity.
+
+/**
+ * Normalize a folder path for identity comparison: forward slashes, no
+ * trailing slash, and macOS realpath'd temp prefixes folded back to their
+ * symlinked form (`/private/tmp/x` ⇔ `/tmp/x`) — git reports realpaths while
+ * workspace folders may hold the symlinked spelling.
+ */
+export function normalizeFolderPath(p: string): string {
+  let n = path.normalize(p);
+  if (n.length > 1 && n.endsWith("/")) n = n.slice(0, -1);
+  const priv = /^\/private(\/(?:tmp|var|etc)(?:\/|$).*)$/.exec(n);
+  if (priv) n = priv[1];
+  return n;
+}
+
+/** Whether two folder paths identify the same directory (see {@link normalizeFolderPath}). */
+export function samePath(a: string, b: string): boolean {
+  return normalizeFolderPath(a) === normalizeFolderPath(b);
+}
+
+/** The worktree whose root is `folder`, if any (see {@link samePath}). */
+export function findWorktreeFor(
+  folder: string,
+  worktrees: GitWorktree[],
+): GitWorktree | undefined {
+  return worktrees.find((wt) => samePath(wt.path, folder));
+}


### PR DESCRIPTION
## Summary
- Adds a "WT" badge to the file-explorer header for a root that's a linked git worktree, mirroring the Git panel's existing indicator. Both panels now render the shared SDK `Badge`/`Tooltip` components instead of hand-rolled pill CSS.
- File-explorer's root-row action buttons (New File/Folder, Refresh, Collapse All) now use the SDK `IconButton` for visual parity with the Git panel's own icon buttons.
- Fixes **Collapse All** not durably collapsing: the persisted expanded-map was only ever merged onto, never cleared, so previously-expanded subdirectories reappeared expanded on the next remount (workspace switch, hot reload) even though the collapse looked like it worked in the moment.
- Fixes the workspace settings modal showing paths with a trailing `/~` instead of a leading `~/`: the front-truncation trick (`direction: rtl`) hands the path text to the Unicode bidi algorithm, which reorders the bidi-neutral `~/` prefix to the visual end of the line. Fixed by isolating the path as an explicit LTR run.
- Documents in `CLAUDE.md` that every tooltip in the app must use the SDK `Tooltip`, never the native `title` attribute.

Also moved the worktree-matching logic (`findWorktreeFor`/`samePath`) from `git-explorer` into `git/worktree-utils.ts`, alongside the `GitWorktree` type it operates on — so file-explorer consumes `silo.git` directly as a peer extension via `ctx.getExtension`, rather than reaching into git-explorer's private internals.

## Test plan
- [x] `pnpm test` — all 7 workspace packages pass (unit tests, including new coverage for `collapseAllExpanded` and `fullPath`'s bidi-isolate wrapping)
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` (boundary + stylelint) — clean
- [ ] Manual: open a linked worktree folder in a workspace, confirm the "WT" badge shows in both the Git panel and file-explorer headers, and that Collapse All persists across a workspace switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)