### PR TITLE
feat(git-explorer): make "View Commits" a full-panel takeover

### DIFF
--- a/packages/extensions-silo/src/git-explorer/CommitsTakeover.tsx
+++ b/packages/extensions-silo/src/git-explorer/CommitsTakeover.tsx
@@ -1,0 +1,164 @@
+import { type ReactNode, useEffect, useState } from "react";
+import {
+  CaretLeft,
+  SortAscending,
+  SortDescending,
+} from "@phosphor-icons/react";
+import { Tooltip, type ExtensionContext } from "@silo-code/sdk";
+import type { GitStatus } from "../git/git-api";
+import { CommitListView } from "./CommitListView";
+import { CommitDetailView } from "./CommitDetailView";
+import type { CommitOrder } from "./commit-list-model";
+import { detailPaneSlot, listPaneSlot } from "./takeover-model";
+import type { useViewStack } from "./use-view-stack";
+
+/** Full-panel "View Commits" takeover for one repo — see GitExplorerPanel for
+ * how `isActive` is decided (only one repo's takeover can cover the panel at
+ * a time). Always mounted by `GitView` (off-screen via CSS when inactive) so
+ * `isActive` toggling is a plain class change the browser can transition,
+ * rather than a mount that has no "before" frame to animate from.
+ *
+ * The list/detail panes are likewise both always rendered once opened once —
+ * see `contentMounted` below — so popping back to root (which starts the
+ * exit slide) doesn't blank the content mid-animation, and reopening the same
+ * repo resumes instantly instead of re-fetching. */
+export function CommitsTakeover({
+  ctx,
+  folder,
+  workspaceId,
+  status,
+  viewStack,
+  isActive,
+  branchLabel,
+  worktreePill,
+}: {
+  ctx: ExtensionContext;
+  folder: string;
+  workspaceId: string;
+  status: GitStatus | null;
+  viewStack: ReturnType<typeof useViewStack>;
+  isActive: boolean;
+  branchLabel: string;
+  worktreePill: ReactNode;
+}) {
+  const [commitOrder, setCommitOrder] = useState<CommitOrder>("oldestFirst");
+  // Exact total for the tools-row count — reported by CommitListView once it
+  // resolves (see GitAPI.commitCount), independent of how many rows are paged in.
+  const [commitsTotal, setCommitsTotal] = useState<number | null>(null);
+  // The detail pane needs a hash to render even while it's parked off-screen
+  // (e.g. sliding out after Back) — keep the last one shown so it doesn't
+  // blank mid-animation.
+  const [lastDetailHash, setLastDetailHash] = useState<string | null>(
+    viewStack.view.kind === "commit-detail" ? viewStack.view.hash : null,
+  );
+
+  // Lazily mount the list/detail panes on first open, then leave them mounted
+  // — see the file doc comment for why (smooth exit animation + instant resume).
+  const [contentMounted, setContentMounted] = useState(
+    viewStack.view.kind !== "root",
+  );
+  useEffect(() => {
+    if (viewStack.view.kind !== "root") setContentMounted(true);
+    if (viewStack.view.kind === "commit-detail") {
+      setLastDetailHash(viewStack.view.hash);
+    }
+  }, [viewStack.view]);
+
+  if (!contentMounted) {
+    return (
+      <div
+        className={`git-takeover${isActive ? " git-takeover--active" : ""}`}
+      />
+    );
+  }
+
+  const detailHash =
+    viewStack.view.kind === "commit-detail"
+      ? viewStack.view.hash
+      : lastDetailHash;
+
+  return (
+    <div
+      className={`git-takeover${isActive ? " git-takeover--active" : ""}`}
+      onKeyDown={(e) => {
+        if (e.key === "Escape" && viewStack.canPop) {
+          e.preventDefault();
+          viewStack.pop();
+        }
+      }}
+    >
+      <div className="git-takeover-header">
+        <div className="git-takeover-toolbar">
+          <button className="git-takeover-back" onClick={viewStack.pop}>
+            <CaretLeft size={14} weight="bold" />
+            Back
+          </button>
+          {viewStack.view.kind === "commits" && (
+            <div className="git-takeover-tools">
+              {commitsTotal !== null && (
+                <span className="git-takeover-count">{commitsTotal}</span>
+              )}
+              <Tooltip
+                content={
+                  commitOrder === "oldestFirst"
+                    ? "Showing oldest first — click for newest first"
+                    : "Showing newest first — click for oldest first"
+                }
+              >
+                <button
+                  className="row-action"
+                  onClick={() =>
+                    setCommitOrder((o) =>
+                      o === "oldestFirst" ? "newestFirst" : "oldestFirst",
+                    )
+                  }
+                >
+                  {commitOrder === "oldestFirst" ? (
+                    <SortAscending size={14} />
+                  ) : (
+                    <SortDescending size={14} />
+                  )}
+                </button>
+              </Tooltip>
+            </div>
+          )}
+        </div>
+        <div className="git-takeover-title-row">
+          <span className="git-takeover-branch">{branchLabel}</span>
+          {worktreePill}
+        </div>
+      </div>
+      <div className="git-takeover-body">
+        <div
+          className={`git-takeover-pane git-takeover-pane--${listPaneSlot(viewStack.view)}`}
+        >
+          {status ? (
+            <CommitListView
+              folder={folder}
+              status={status}
+              order={commitOrder}
+              onTotalCountChange={setCommitsTotal}
+              onSelectCommit={(hash) =>
+                viewStack.push({ kind: "commit-detail", hash })
+              }
+            />
+          ) : (
+            <div className="placeholder">Loading…</div>
+          )}
+        </div>
+        <div
+          className={`git-takeover-pane git-takeover-pane--${detailPaneSlot(viewStack.view)}`}
+        >
+          {detailHash && (
+            <CommitDetailView
+              ctx={ctx}
+              folder={folder}
+              workspaceId={workspaceId}
+              hash={detailHash}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -1,8 +1,29 @@
+/* Positioned ancestor for .git-takeover (CommitsTakeover) — it escapes past
+ * .git-panel and .git-explorer-scroll (neither sets `position`, and
+ * .git-explorer-scroll must never get a `transform` either — see below) to
+ * cover this whole viewport, not just the repo's own slot in the scroll list. */
+.git-explorer-viewport {
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+}
+
 .git-explorer-scroll {
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
+  transition: margin-left 220ms ease;
+}
+
+/* Slides left out of view while a repo's commits takeover is open, so the
+ * list visibly "pushes off" as the takeover slides in — see .git-takeover.
+ * Deliberately `margin-left`, not `transform`: a `transform` here would make
+ * this element a containing block for `position: absolute` descendants,
+ * hijacking .git-takeover's escape to .git-explorer-viewport (it's nested
+ * inside .git-panel, itself inside this list) and dragging it off-screen too. */
+.git-explorer-scroll--covered {
+  margin-left: -100%;
 }
 
 .git-panel {
@@ -11,6 +32,15 @@
   gap: 6px;
   padding: 8px 4px 12px;
   font-family: var(--silo-font-ui);
+}
+
+/* Wraps the commit-box + Staged/Changes sections — kept as its own flex
+ * column (mirrors .git-panel's own gap) so it can be aria-hidden as a unit
+ * while this repo's commits takeover covers it. */
+.git-panel-root {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .git-panel + .git-panel {
@@ -797,51 +827,121 @@
   color: var(--silo-color-text);
 }
 
-/* "View Commits" list/detail sub-pages (view-stack.ts) — replace the normal
- * commit-box + Changes sections while a sub-page is open; the branch/sync
- * header above stays put. */
-.git-subview {
+/* "View Commits" full-panel takeover (takeover-model.ts / CommitsTakeover) —
+ * always mounted by GitView, off-screen right until `isActive` (so toggling
+ * the modifier class is a genuine CSS transition, not a mount with no
+ * "before" frame). `position: absolute` escapes past .git-panel and
+ * .git-explorer-scroll (neither sets `position`) up to .git-explorer-viewport,
+ * covering the whole panel rather than just this repo's slot in the list. */
+.git-takeover {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   min-height: 0;
+  background: var(--silo-color-bg);
+  transform: translateX(100%);
+  transition: transform 220ms ease;
+  pointer-events: none;
+  z-index: 1;
 }
 
-.git-subview-header {
+.git-takeover--active {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.git-takeover-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--silo-color-border);
+  flex-shrink: 0;
+}
+
+.git-takeover-toolbar {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--silo-color-border);
+  min-height: 22px;
 }
 
-.git-back-button {
+/* Accent-colored (unlike the muted github-prs back button it's modeled on)
+ * so it reads as an interactive control at rest, not just on hover. */
+.git-takeover-back {
   display: inline-flex;
   align-items: center;
   gap: 2px;
   background: transparent;
   border: none;
-  color: var(--silo-color-text);
+  color: var(--silo-color-accent);
   font-family: var(--silo-font-ui);
   font-size: var(--silo-font-size-sm);
+  font-weight: 600;
   padding: 3px 6px;
+  margin-left: -6px;
   border-radius: var(--silo-radius-sm);
   cursor: pointer;
 }
 
-.git-back-button:hover {
+.git-takeover-back:hover {
   background: var(--silo-color-bg-hover);
-  color: var(--silo-color-text-hi);
 }
 
-.git-subview-title {
-  font-family: var(--silo-font-ui);
+.git-takeover-tools {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.git-takeover-count {
   font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+}
+
+.git-takeover-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.git-takeover-branch {
+  font-family: var(--silo-font-ui);
+  font-size: 1em;
   font-weight: 600;
   color: var(--silo-color-text-hi);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.git-sort-toggle {
-  margin-left: auto;
+.git-takeover-body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.git-takeover-pane {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  transition: transform 220ms ease;
+}
+
+.git-takeover-pane--current {
+  transform: translateX(0);
+}
+
+.git-takeover-pane--parked-left {
+  transform: translateX(-100%);
+}
+
+.git-takeover-pane--parked-right {
+  transform: translateX(100%);
 }
 
 .git-commits-list {

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import {
   useServiceState,
   type ExtensionContext,
@@ -33,6 +33,12 @@ export function GitExplorerPanel({
   const wsState = useServiceState(ctx.workspaces);
   const ws = wsState.all.find((w) => w.id === wsState.activeId) ?? null;
 
+  // Which repo (if any) has the panel-wide "View Commits" takeover open.
+  // Deliberately in-memory only — not persisted — so a relaunch always shows
+  // the multi-repo list first, even though each repo's own list/detail
+  // position is still remembered (see useViewStack's storage persistence).
+  const [activeFolder, setActiveFolder] = useState<string | null>(null);
+
   // Per-workspace, per-repo collapse state lives in the panel's storage bag
   // (which the host swaps and persists per active workspace), not on GitView's
   // own component state — otherwise it resets whenever the view remounts.
@@ -58,26 +64,36 @@ export function GitExplorerPanel({
     });
 
   return (
-    <div className="git-explorer-scroll">
-      {allFolders.map((folder) => (
-        <GitView
-          key={ws.id + "::" + folder}
-          ctx={ctx}
-          cacheKey={ws.id + "::" + folder}
-          workspaceId={ws.id}
-          folder={folder}
-          rootLabel={showLabel ? rootName(folder) : undefined}
-          paused={paused}
-          storage={storage}
-          hydrated={hydrated}
-          collapsed={showLabel && (collapsedMap[folder] ?? false)}
-          onToggleCollapsed={
-            showLabel
-              ? () => persistCollapsed(folder, !(collapsedMap[folder] ?? false))
-              : undefined
-          }
-        />
-      ))}
+    <div className="git-explorer-viewport">
+      <div
+        className={`git-explorer-scroll${activeFolder ? " git-explorer-scroll--covered" : ""}`}
+      >
+        {allFolders.map((folder) => (
+          <GitView
+            key={ws.id + "::" + folder}
+            ctx={ctx}
+            cacheKey={ws.id + "::" + folder}
+            workspaceId={ws.id}
+            folder={folder}
+            rootLabel={showLabel ? rootName(folder) : undefined}
+            paused={paused}
+            storage={storage}
+            hydrated={hydrated}
+            collapsed={showLabel && (collapsedMap[folder] ?? false)}
+            onToggleCollapsed={
+              showLabel
+                ? () =>
+                    persistCollapsed(folder, !(collapsedMap[folder] ?? false))
+                : undefined
+            }
+            isTakeoverActive={activeFolder === folder}
+            onEnterTakeover={() => setActiveFolder(folder)}
+            onExitTakeover={() =>
+              setActiveFolder((f) => (f === folder ? null : f))
+            }
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -2,12 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowsClockwise,
   CaretDown,
-  CaretLeft,
   CaretRight,
   CloudArrowUp,
   DotsThreeVertical,
-  SortAscending,
-  SortDescending,
   TreeStructure,
 } from "@phosphor-icons/react";
 import {
@@ -36,9 +33,8 @@ import {
 import { showWorktreeManager } from "./open-worktree-manager";
 import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
 import { useViewStack } from "./use-view-stack";
-import { CommitListView } from "./CommitListView";
-import { CommitDetailView } from "./CommitDetailView";
-import type { CommitOrder } from "./commit-list-model";
+import { CommitsTakeover } from "./CommitsTakeover";
+import { shouldExitTakeover, shouldPushCommitsOnOpen } from "./takeover-model";
 
 const REFRESH_DEBOUNCE_MS = 400;
 // How often the panel fetches in the background so ↑ahead/↓behind stay roughly
@@ -59,6 +55,9 @@ export function GitView({
   onToggleCollapsed,
   storage,
   hydrated,
+  isTakeoverActive,
+  onEnterTakeover,
+  onExitTakeover,
 }: {
   ctx: ExtensionContext;
   cacheKey: string;
@@ -70,20 +69,20 @@ export function GitView({
   onToggleCollapsed?: () => void;
   storage: ExtensionStorage;
   hydrated: boolean;
+  /** Whether *this* repo is the one panel-wide "View Commits" takeover
+   * (only one repo can cover the panel at a time — see GitExplorerPanel). */
+  isTakeoverActive: boolean;
+  onEnterTakeover: () => void;
+  onExitTakeover: () => void;
 }) {
   // "View Commits" list/detail navigation — keyed per repo root (cacheKey) so
   // a multi-root workspace's git roots don't share one stack.
   const viewStack = useViewStack(storage, `view:${cacheKey}`, hydrated);
-  const [commitOrder, setCommitOrder] = useState<CommitOrder>("oldestFirst");
-  // Exact total for the "Commits (N)" subview header — reported by
-  // CommitListView once it resolves (see GitAPI.commitCount), independent of
-  // how many rows are currently paged in.
-  const [commitsTotal, setCommitsTotal] = useState<number | null>(null);
-  // Clear the stale total on the way out so reopening "Commits" doesn't flash
-  // the previous branch's count before CommitListView re-resolves it.
+  // The takeover auto-closes once this repo's stack pops back to root, from
+  // Back, Escape, or any other path — see takeover-model.ts.
   useEffect(() => {
-    if (viewStack.view.kind !== "commits") setCommitsTotal(null);
-  }, [viewStack.view.kind]);
+    if (shouldExitTakeover(isTakeoverActive, viewStack.view)) onExitTakeover();
+  }, [isTakeoverActive, viewStack.view, onExitTakeover]);
   // Public primitives, read through ctx (stable per extension).
   const editors = ctx.editors;
   const files = ctx.files;
@@ -523,7 +522,14 @@ export function GitView({
       { type: "separator" },
       {
         label: "View Commits",
-        run: () => viewStack.push({ kind: "commits" }),
+        run: () => {
+          // A repo left mid-drill (persisted per-repo) resumes as-is instead
+          // of restarting the list — see takeover-model.ts.
+          if (shouldPushCommitsOnOpen(viewStack.view)) {
+            viewStack.push({ kind: "commits" });
+          }
+          onEnterTakeover();
+        },
       },
       { label: "Manage branches…", run: openBranchManager },
       { label: "Manage worktrees…", run: openWorktreeManager },
@@ -849,8 +855,11 @@ export function GitView({
           )}
         </div>
       )}
-      {!collapsed && viewStack.view.kind === "root" && (
-        <>
+      {!collapsed && (
+        <div
+          className="git-panel-root"
+          aria-hidden={isTakeoverActive || undefined}
+        >
           <div className="commit-area">
             <textarea
               value={message}
@@ -959,79 +968,18 @@ export function GitView({
               ))}
             </Section>
           </div>
-        </>
-      )}
-      {!collapsed && viewStack.view.kind !== "root" && (
-        <div
-          className="git-subview"
-          onKeyDown={(e) => {
-            if (e.key === "Escape" && viewStack.canPop) {
-              e.preventDefault();
-              viewStack.pop();
-            }
-          }}
-        >
-          <div className="git-subview-header">
-            <button className="git-back-button" onClick={viewStack.pop}>
-              <CaretLeft size={14} weight="bold" />
-              Back
-            </button>
-            <span className="git-subview-title">
-              {viewStack.view.kind === "commits"
-                ? commitsTotal === null
-                  ? "Commits"
-                  : `Commits (${commitsTotal})`
-                : "Commit"}
-            </span>
-            {viewStack.view.kind === "commits" && (
-              <Tooltip
-                content={
-                  commitOrder === "oldestFirst"
-                    ? "Showing oldest first — click for newest first"
-                    : "Showing newest first — click for oldest first"
-                }
-              >
-                <button
-                  className="row-action git-sort-toggle"
-                  onClick={() =>
-                    setCommitOrder((o) =>
-                      o === "oldestFirst" ? "newestFirst" : "oldestFirst",
-                    )
-                  }
-                >
-                  {commitOrder === "oldestFirst" ? (
-                    <SortAscending size={14} />
-                  ) : (
-                    <SortDescending size={14} />
-                  )}
-                </button>
-              </Tooltip>
-            )}
-          </div>
-          {viewStack.view.kind === "commits" &&
-            (status ? (
-              <CommitListView
-                folder={folder}
-                status={status}
-                order={commitOrder}
-                onTotalCountChange={setCommitsTotal}
-                onSelectCommit={(hash) =>
-                  viewStack.push({ kind: "commit-detail", hash })
-                }
-              />
-            ) : (
-              <div className="placeholder">Loading…</div>
-            ))}
-          {viewStack.view.kind === "commit-detail" && (
-            <CommitDetailView
-              ctx={ctx}
-              folder={folder}
-              workspaceId={workspaceId}
-              hash={viewStack.view.hash}
-            />
-          )}
         </div>
       )}
+      <CommitsTakeover
+        ctx={ctx}
+        folder={folder}
+        workspaceId={workspaceId}
+        status={status}
+        viewStack={viewStack}
+        isActive={isTakeoverActive}
+        branchLabel={status?.branch ?? "(detached)"}
+        worktreePill={worktreePill}
+      />
     </div>
   );
 }

--- a/packages/extensions-silo/src/git-explorer/takeover-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/takeover-model.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  detailPaneSlot,
+  listPaneSlot,
+  shouldExitTakeover,
+  shouldPushCommitsOnOpen,
+} from "./takeover-model";
+import { ROOT_VIEW, type PanelView } from "./view-stack";
+
+const COMMITS: PanelView = { kind: "commits" };
+const DETAIL: PanelView = { kind: "commit-detail", hash: "abc123" };
+
+describe("shouldPushCommitsOnOpen", () => {
+  it("pushes a fresh commits view when the repo's stack is at root", () => {
+    expect(shouldPushCommitsOnOpen(ROOT_VIEW)).toBe(true);
+  });
+
+  it("does not push when the repo was left mid-drill — resumes as-is", () => {
+    expect(shouldPushCommitsOnOpen(COMMITS)).toBe(false);
+    expect(shouldPushCommitsOnOpen(DETAIL)).toBe(false);
+  });
+});
+
+describe("shouldExitTakeover", () => {
+  it("exits once the active repo's stack pops back to root", () => {
+    expect(shouldExitTakeover(true, ROOT_VIEW)).toBe(true);
+  });
+
+  it("stays open while the active repo is mid-drill", () => {
+    expect(shouldExitTakeover(true, COMMITS)).toBe(false);
+    expect(shouldExitTakeover(true, DETAIL)).toBe(false);
+  });
+
+  it("never exits a repo that isn't the active takeover", () => {
+    expect(shouldExitTakeover(false, ROOT_VIEW)).toBe(false);
+    expect(shouldExitTakeover(false, COMMITS)).toBe(false);
+  });
+});
+
+describe("listPaneSlot / detailPaneSlot", () => {
+  it("centers the list and parks detail off-screen right at the commits view", () => {
+    expect(listPaneSlot(COMMITS)).toBe("current");
+    expect(detailPaneSlot(COMMITS)).toBe("parked-right");
+  });
+
+  it("centers detail and parks the list off-screen left at commit-detail", () => {
+    expect(listPaneSlot(DETAIL)).toBe("parked-left");
+    expect(detailPaneSlot(DETAIL)).toBe("current");
+  });
+
+  it("parks detail off-screen right at root too (nothing pushed yet)", () => {
+    expect(listPaneSlot(ROOT_VIEW)).toBe("current");
+    expect(detailPaneSlot(ROOT_VIEW)).toBe("parked-right");
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/takeover-model.ts
+++ b/packages/extensions-silo/src/git-explorer/takeover-model.ts
@@ -1,0 +1,35 @@
+// Pure rules for the full-panel "View Commits" takeover (GitExplorerPanel +
+// CommitsTakeover). Kept separate from the components so the open/close/pane
+// rules are unit-testable without rendering React.
+import type { PanelView } from "./view-stack";
+
+/** "View Commits" only needs to push a fresh `commits` view when the repo's
+ * own stack is at root — reopening a repo that was left mid-drill (persisted
+ * per-repo) should resume exactly where it was, not restart the list. */
+export function shouldPushCommitsOnOpen(view: PanelView): boolean {
+  return view.kind === "root";
+}
+
+/** The takeover auto-closes once its repo's stack pops back to root — covers
+ * the Back button, Escape, and any other path that empties the stack. */
+export function shouldExitTakeover(
+  isActive: boolean,
+  view: PanelView,
+): boolean {
+  return isActive && view.kind === "root";
+}
+
+export type PaneSlot = "current" | "parked-left" | "parked-right";
+
+/** The commit list is the shallow pane: centered unless a commit detail has
+ * been pushed on top of it, in which case it parks off-screen left (the
+ * "back" direction) while detail slides in from the right. */
+export function listPaneSlot(view: PanelView): PaneSlot {
+  return view.kind === "commit-detail" ? "parked-left" : "current";
+}
+
+/** Mirror of `listPaneSlot`: detail is centered only while it's the current
+ * view; otherwise it parks off-screen right, ready to slide back in. */
+export function detailPaneSlot(view: PanelView): PaneSlot {
+  return view.kind === "commit-detail" ? "current" : "parked-right";
+}


### PR DESCRIPTION
## Summary
- With multiple repos in the git-explorer panel, "View Commits" used to render inside that repo's own (sometimes tiny) slot in the scroll list instead of using the panel's full height.
- It now takes over the whole panel: a two-row header (back button + sort-toggle/count toolbar, then a branch name + WT badge title row), sliding in from the right while the repo list slides out — same slide when drilling further into a single commit's detail.
- Each repo's list/detail position still persists per-repo (resume where you left off), but the takeover itself always starts closed on relaunch — only explicit "View Commits" clicks open it.

## Test plan
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `pnpm test` (285 tests, incl. new `takeover-model.test.ts`)
- [x] Manually verified in the running app with a multi-repo workspace: takeover fills the panel, back button pops one level at a time, slide transition works for both list→commits and commits→commit-detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)