### PR TITLE
docs(website): add prominent "Star on GitHub" hero button

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -187,6 +187,44 @@ onBeforeUnmount(() => {
 </template>
 
 <style>
+/* Standout "★ Star on GitHub" hero button — targeted by href so it stays
+   styled regardless of its position in the actions list. */
+.VPHero .actions a.VPButton[href="https://github.com/silo-code/silo"] {
+  border-color: transparent;
+  color: #fff;
+  background: linear-gradient(135deg, #8957e5 0%, #d2367a 100%);
+  transition:
+    filter 0.2s,
+    transform 0.2s,
+    box-shadow 0.2s;
+}
+.VPHero .actions a.VPButton[href="https://github.com/silo-code/silo"]:hover {
+  border-color: transparent;
+  color: #fff;
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(137, 87, 229, 0.4);
+}
+
+/* De-emphasize secondary destinations: render them as plain text links
+   rather than buttons. Targeted by href so they stay styled if reordered. */
+.VPHero .actions a.VPButton[href="https://extensions.getsilo.dev"],
+.VPHero .actions a.VPButton[href="https://x.com/silo_code"] {
+  border-color: transparent;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font-weight: 500;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.VPHero .actions a.VPButton[href="https://extensions.getsilo.dev"]:hover,
+.VPHero .actions a.VPButton[href="https://x.com/silo_code"]:hover {
+  border-color: transparent;
+  background: transparent;
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+
 .demo-video {
   padding: 0 24px;
   margin: 2rem 0 3.5rem;

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -6,6 +6,9 @@ hero:
   text: "All your projects, alive at once"
   tagline: "For developers juggling coding agents across many projects. Terminals, agents, and layout stay intact — switch between them instantly. 100% open source, free forever."
   actions:
+    - theme: alt
+      text: ★ Star on GitHub
+      link: https://github.com/silo-code/silo
     - theme: brand
       text: Download →
       link: https://github.com/silo-code/silo/releases/latest
@@ -15,9 +18,6 @@ hero:
     - theme: alt
       text: Extensions
       link: https://extensions.getsilo.dev
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/silo-code/silo
     - theme: alt
       text: Follow on X
       link: https://x.com/silo_code


### PR DESCRIPTION
## What

Reworks the getsilo.dev homepage hero actions to drive GitHub stars.

- Replaces the **View on GitHub** hero action with **★ Star on GitHub**, moved to the first position and given a standout purple→pink gradient (with a subtle hover lift/glow).
- De-emphasizes the **Extensions** and **Follow on X** actions by rendering them as plain, muted text links instead of buttons — sharpening the hierarchy to: Star → Download → Get started → secondary links.

## Where

- `apps/docs/index.md` — hero `actions` list (relabel + reorder).
- `apps/docs/.vitepress/theme/Layout.vue` — CSS for the gradient Star button and the link-styled secondary actions. Targeted by `href` so styling survives reordering. Colors use VitePress theme tokens where possible and work in light and dark.

## Notes

Purely a docs-site (marketing homepage) change — no app/SDK surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)