### PR TITLE
fix(git-explorer): don't mislabel unrelated workspace folders as missing worktrees

### DIFF
--- a/.claude/skills/verifier-gui/SKILL.md
+++ b/.claude/skills/verifier-gui/SKILL.md
@@ -155,15 +155,16 @@ editor ops below — `monaco` is not a page global, so `eval` can't reach it.
 
 **Workspaces / panels** (sandbox only — never point at real workspaces)
 
-| Op                  | Args                         | Returns / use                                   |
-| ------------------- | ---------------------------- | ----------------------------------------------- |
-| `listWorkspaces`    | —                            | `{active, workspaces[{id,name,folder}]}`        |
-| `openWorkspace`     | `folder,name`                | create + activate (use a temp dir) → `{id}`     |
-| `activateWorkspace` | `id`                         | switch active → `{active}`                      |
-| `deleteWorkspace`   | `id`                         | reap terminals + remove → `{deleted,active}`    |
-| `splitActivePanel`  | `position?` (l/r/top/bottom) | split center group → `{groups}`                 |
-| `activatePanel`     | `panelId`                    | focus a dock panel → `{activated}`              |
-| `showSidePanel`     | `id`                         | expand slot + activate its tab → `{shown,slot}` |
+| Op                  | Args                         | Returns / use                                                                                              |
+| ------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `listWorkspaces`    | —                            | `{active, workspaces[{id,name,folder}]}`                                                                   |
+| `openWorkspace`     | `folder,name`                | create + activate (use a temp dir) → `{id}`                                                                |
+| `activateWorkspace` | `id`                         | switch active → `{active}`                                                                                 |
+| `addFolder`         | `id,folder`                  | attach a folder, bypassing the native OS picker ("Add Folder…" in Workspace Properties) → `{extraFolders}` |
+| `deleteWorkspace`   | `id`                         | reap terminals + remove → `{deleted,active}`                                                               |
+| `splitActivePanel`  | `position?` (l/r/top/bottom) | split center group → `{groups}`                                                                            |
+| `activatePanel`     | `panelId`                    | focus a dock panel → `{activated}`                                                                         |
+| `showSidePanel`     | `id`                         | expand slot + activate its tab → `{shown,slot}`                                                            |
 
 **Editors / terminals**
 

--- a/apps/desktop/src/automation/bridge.ts
+++ b/apps/desktop/src/automation/bridge.ts
@@ -335,6 +335,17 @@ async function handleOp(
       return { active: store.activeWorkspaceId };
     }
 
+    // Attach a folder to a workspace ("Add Folder…" in Workspace Properties),
+    // bypassing the native OS folder picker that automation can't drive.
+    // Routes through the same WorkspaceService.addFolder the UI uses.
+    case "addFolder": {
+      const id = String(args.id ?? "");
+      const folder = String(args.folder ?? "");
+      getWorkspaceService().addFolder(id, folder);
+      const ws = store.workspaces[id];
+      return { extraFolders: ws?.extraFolders ?? [] };
+    }
+
     // Soft-close — keeps the workspace entry (and its terminal records / PTYs).
     // Counterpart to deleteWorkspace; drives ctx.workspaces.close.
     case "closeWorkspace": {

--- a/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/WorktreeManager.tsx
@@ -41,6 +41,8 @@ import {
   branchesInUse,
   buildWorktreeRows,
   isOnlyMainWorktree,
+  normalizeFolderPath,
+  orphanCandidateFolders,
   orphanOpenFolders,
   worktreeActions,
   type WorktreeRow,
@@ -129,12 +131,47 @@ export function WorktreeManager({
     () => buildWorktreeRows(worktrees ?? [], folder, wsFolder, allFolders),
     [worktrees, folder, wsFolder, allFolders],
   );
-  // Folders still open in the workspace but gone from git's worktree list
-  // (deleted/pruned on disk) — otherwise they'd be invisible in this modal
-  // while still spawning Git panel sections and status errors.
+
+  // Folders open in the workspace but absent from this repo's worktree list
+  // are candidates for "missing on disk" — but absence alone doesn't prove
+  // it; an unrelated folder (a second repo attached to the same workspace)
+  // looks identical to git. Confirm each candidate against disk before
+  // treating it as an orphaned worktree directory rather than just leaving it
+  // out of this modal entirely.
+  const orphanCandidates = useMemo(
+    () => orphanCandidateFolders(rows, allFolders, wsFolder),
+    [rows, allFolders, wsFolder],
+  );
+  const [missingOnDisk, setMissingOnDisk] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    if (orphanCandidates.length === 0) {
+      setMissingOnDisk(new Set());
+      return;
+    }
+    let active = true;
+    void (async () => {
+      const missing = new Set<string>();
+      await Promise.all(
+        orphanCandidates.map(async (f) => {
+          // Fail open on a read error — don't offer to drop a folder we
+          // couldn't actually confirm is gone.
+          const exists = await ctx.files.pathExists(f).catch(() => true);
+          if (!exists) missing.add(normalizeFolderPath(f));
+        }),
+      );
+      if (active) setMissingOnDisk(missing);
+    })();
+    return () => {
+      active = false;
+    };
+  }, [orphanCandidates, ctx.files]);
+
   const displayRows = useMemo(
-    () => [...rows, ...orphanOpenFolders(rows, allFolders, wsFolder, folder)],
-    [rows, allFolders, wsFolder, folder],
+    () => [
+      ...rows,
+      ...orphanOpenFolders(rows, allFolders, wsFolder, folder, missingOnDisk),
+    ],
+    [rows, allFolders, wsFolder, folder, missingOnDisk],
   );
   const anyPrunable = displayRows.some((r) => r.wt.prunable != null);
 

--- a/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.test.ts
@@ -3,6 +3,7 @@ import type { GitWorktree } from "../git/git-api";
 import {
   buildWorktreeRows,
   isOnlyMainWorktree,
+  orphanCandidateFolders,
   orphanOpenFolders,
   worktreeActions,
   sanitizeBranchForPath,
@@ -89,11 +90,40 @@ describe("isOnlyMainWorktree", () => {
   });
 });
 
-describe("orphanOpenFolders", () => {
+describe("orphanCandidateFolders", () => {
   const main = wt({ path: "/w/repo", isMain: true, branch: "main" });
   const feat = wt({ path: "/w/repo-feat", branch: "feat" });
 
-  it("surfaces open folders that git no longer lists", () => {
+  it("collects open folders absent from the worktree list", () => {
+    const rows = buildWorktreeRows([main], "/w/repo", "/w/repo", [
+      "/w/repo",
+      "/w/gone",
+      "/w/other-repo",
+    ]);
+    expect(
+      orphanCandidateFolders(
+        rows,
+        ["/w/repo", "/w/gone", "/w/other-repo"],
+        "/w/repo",
+      ),
+    ).toEqual(["/w/gone", "/w/other-repo"]);
+  });
+
+  it("skips folders already represented in the worktree list", () => {
+    const rows = buildWorktreeRows([main, feat], "/w/repo", "/w/repo", [
+      "/w/repo",
+      "/w/repo-feat",
+    ]);
+    expect(
+      orphanCandidateFolders(rows, ["/w/repo", "/w/repo-feat"], "/w/repo"),
+    ).toEqual([]);
+  });
+});
+
+describe("orphanOpenFolders", () => {
+  const main = wt({ path: "/w/repo", isMain: true, branch: "main" });
+
+  it("surfaces a candidate confirmed missing on disk", () => {
     const rows = buildWorktreeRows([main], "/w/repo", "/w/repo", [
       "/w/repo",
       "/w/gone",
@@ -103,6 +133,7 @@ describe("orphanOpenFolders", () => {
       ["/w/repo", "/w/gone"],
       "/w/repo",
       "/w/repo",
+      new Set(["/w/gone"]),
     );
     expect(orphans).toHaveLength(1);
     expect(orphans[0]).toMatchObject({
@@ -113,17 +144,18 @@ describe("orphanOpenFolders", () => {
     expect(worktreeActions(orphans[0]!)).toEqual(["close"]);
   });
 
-  it("skips folders already represented in the worktree list", () => {
-    const rows = buildWorktreeRows([main, feat], "/w/repo", "/w/repo", [
+  it("leaves out a candidate that still exists on disk — an unrelated folder (e.g. a second repo attached to the workspace), not a deleted worktree", () => {
+    const rows = buildWorktreeRows([main], "/w/repo", "/w/repo", [
       "/w/repo",
-      "/w/repo-feat",
+      "/w/other-repo",
     ]);
     expect(
       orphanOpenFolders(
         rows,
-        ["/w/repo", "/w/repo-feat"],
+        ["/w/repo", "/w/other-repo"],
         "/w/repo",
         "/w/repo",
+        new Set(), // nothing confirmed missing
       ),
     ).toEqual([]);
   });

--- a/packages/extensions-silo/src/git-explorer/worktree-model.ts
+++ b/packages/extensions-silo/src/git-explorer/worktree-model.ts
@@ -65,19 +65,42 @@ export function isOnlyMainWorktree(rows: readonly WorktreeRow[]): boolean {
 }
 
 /**
+ * Workspace folders that are open alongside but absent from this repo's
+ * `git worktree list`. Absence alone isn't proof the directory is
+ * deleted/pruned — it's equally what an *unrelated* folder looks like (a
+ * second repo the user attached to the same workspace, nothing to do with
+ * this repo's worktrees). Callers must confirm on disk (see
+ * {@link orphanOpenFolders}) before treating a candidate as truly orphaned.
+ */
+export function orphanCandidateFolders(
+  rows: readonly WorktreeRow[],
+  allFolders: readonly string[],
+  wsFolder: string,
+): string[] {
+  return allFolders
+    .filter((f) => !samePath(f, wsFolder))
+    .filter((f) => !rows.some((r) => samePath(r.wt.path, f)));
+}
+
+/**
  * Workspace folders that are open alongside but missing from git's worktree
- * list (deleted/pruned on disk while the view stayed open). Surfaced so the
- * manager can still offer Close — they won't appear in `git worktree list`.
+ * list *and* confirmed gone from disk (deleted/pruned while the view stayed
+ * open) — `missingOnDisk` holds normalized ({@link normalizeFolderPath})
+ * paths the caller verified via `ctx.files.pathExists`. A candidate that
+ * still exists on disk is left out entirely: it's not this repo's worktree
+ * to manage, so it doesn't belong in the list (and must never be offered a
+ * "missing on disk" Close that silently drops a perfectly good folder from
+ * the workspace).
  */
 export function orphanOpenFolders(
   rows: readonly WorktreeRow[],
   allFolders: readonly string[],
   wsFolder: string,
   currentFolder: string,
+  missingOnDisk: ReadonlySet<string>,
 ): WorktreeRow[] {
-  return allFolders
-    .filter((f) => !samePath(f, wsFolder))
-    .filter((f) => !rows.some((r) => samePath(r.wt.path, f)))
+  return orphanCandidateFolders(rows, allFolders, wsFolder)
+    .filter((f) => missingOnDisk.has(normalizeFolderPath(f)))
     .map((f) => ({
       wt: {
         path: f,


### PR DESCRIPTION
## Summary
- The Worktrees modal treated any workspace folder absent from the primary repo's `git worktree list` as a deleted/pruned worktree directory ("missing on disk") — with no actual disk check. An unrelated folder attached to the same workspace (e.g. a second, independent repo) looks identical to that case, so it got mislabeled, and its Close (✕) action silently dropped it from the workspace.
- `orphanOpenFolders` now only flags a candidate "missing on disk" once the caller has confirmed via `ctx.files.pathExists` that it's actually gone; a candidate that still exists is left out of the modal entirely, since it isn't this repo's worktree to manage.
- Adds a permanent `addFolder` op to the dev automation bridge (mirrors the existing `openWorkspace` test-driver pattern), so multi-folder-workspace scenarios like this one can be driven without the native OS folder picker, and documents it in the `verifier-gui` skill.

## Test plan
- [x] `pnpm --filter @silo-code/extensions-silo exec vitest run` — 287 tests pass, including new coverage for the disk-confirmed vs. still-exists-on-disk cases in `worktree-model.test.ts`
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] Manually verified in the running dev app via the automation bridge:
  - An unrelated second repo attached to a workspace no longer appears in the Worktrees modal
  - A real linked worktree, once pruned from git's worktree list while its directory is gone, still correctly shows `missing on disk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3QJKsyc9zgWhJjdnNAYDP