### PR TITLE
fix(git-explorer): treat removing an already-gone worktree as success

### DIFF
--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
@@ -141,6 +141,39 @@ describe("confirmAndRemoveWorktree", () => {
     expect(getPendingWorktreeRemoves()).toHaveLength(0);
   });
 
+  it("treats an already-deregistered worktree as removed instead of erroring", async () => {
+    const removeWorktree = vi.fn(async () => {
+      throw new Error("fatal: '/w/repo-feat' is not a working tree");
+    });
+    const notifyError = vi.fn();
+    const ctx = mockCtx({ confirms: [true] });
+    const onSuccess = vi.fn();
+    let dirty = 0;
+    const stop = subscribeWorktreeListDirty(() => {
+      dirty += 1;
+    });
+    await confirmAndRemoveWorktree({
+      ctx,
+      api: { removeWorktree } as unknown as GitAPI,
+      cwd: "/w/repo",
+      worktreePath: "/w/repo-feat",
+      workspaceId: "ws1",
+      isOpen: true,
+      notifyError,
+      onSuccess,
+    });
+    stop();
+    expect(notifyError).not.toHaveBeenCalled();
+    expect(removeWorktree).toHaveBeenCalledTimes(1);
+    expect(getPendingWorktreeRemoves()).toHaveLength(0);
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      "info",
+      "repo-feat was already removed",
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(dirty).toBe(1);
+  });
+
   it("notifies on failure and clears pending", async () => {
     const notifyError = vi.fn();
     const ctx = mockCtx({ confirms: [true] });

--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
@@ -10,6 +10,10 @@ import {
 import { worktreeDisplayName } from "./pending-worktree-remove-model";
 
 const DIRTY_RE = /contains modified or untracked files|use --force/i;
+// git's message when the path was already deregistered as a worktree — e.g.
+// removed by something outside Silo (another terminal, another tool) since
+// the list this row was drawn from was last fetched.
+const NOT_A_WORKTREE_RE = /is not a working tree/i;
 
 export interface RemoveWorktreeParams {
   ctx: ExtensionContext;
@@ -63,30 +67,44 @@ export async function confirmAndRemoveWorktree(
   if (isOpen) ctx.workspaces.removeFolder(workspaceId, worktreePath);
 
   try {
+    let alreadyGone = false;
     try {
       await api.removeWorktree(cwd, worktreePath);
     } catch (err) {
-      if (!DIRTY_RE.test(String(err))) throw err;
+      if (NOT_A_WORKTREE_RE.test(String(err))) {
+        // The row was stale — this worktree is already gone at the git
+        // level. Nothing left to delete; just resync our own state instead
+        // of surfacing git's fatal error for a no-op.
+        alreadyGone = true;
+      } else if (DIRTY_RE.test(String(err))) {
+        // Clear pending while the force confirm is up (ADR: progress only
+        // after every confirm). Folder stays closed — recoverable via Open
+        // alongside.
+        endPendingWorktreeRemove(worktreePath);
+        const force = await ctx.ui.confirm({
+          title: `"${name}" has uncommitted changes`,
+          body: "Force-remove the worktree and discard them? This can't be undone.",
+          confirmLabel: "Force Remove",
+          danger: true,
+        });
+        if (!force) return;
 
-      // Clear pending while the force confirm is up (ADR: progress only after
-      // every confirm). Folder stays closed — recoverable via Open alongside.
-      endPendingWorktreeRemove(worktreePath);
-      const force = await ctx.ui.confirm({
-        title: `"${name}" has uncommitted changes`,
-        body: "Force-remove the worktree and discard them? This can't be undone.",
-        confirmLabel: "Force Remove",
-        danger: true,
-      });
-      if (!force) return;
-
-      beginPendingWorktreeRemove(worktreePath);
-      await api.removeWorktree(cwd, worktreePath, true);
+        beginPendingWorktreeRemove(worktreePath);
+        await api.removeWorktree(cwd, worktreePath, true);
+      } else {
+        throw err;
+      }
     }
 
     endPendingWorktreeRemove(worktreePath);
     markWorktreeListDirty();
     if (!isWorktreeManagerOpen()) {
-      ctx.ui.notify("info", `Removed worktree ${name}`);
+      ctx.ui.notify(
+        "info",
+        alreadyGone
+          ? `${name} was already removed`
+          : `Removed worktree ${name}`,
+      );
     }
     onSuccess?.();
   } catch (err) {


### PR DESCRIPTION
## Summary
- Removing a worktree row that was fetched before something outside Silo (another terminal, another tool, e.g. a Claude Code `EnterWorktree`/`ExitWorktree` session) had already deregistered it hit git's raw `fatal: '<path>' is not a working tree` and surfaced that as a scary error toast, even though there was nothing left to do.
- `confirmAndRemoveWorktree` now recognizes that specific git message and treats it the same as a successful remove: syncs pending state, marks the worktree list dirty so the stale row disappears, and toasts `"<name> was already removed"` instead of failing.
- Follow-up to #289, found while manually cleaning up the worktree used for that fix.

## Test plan
- [x] `pnpm --filter @silo-code/extensions-silo exec vitest run` — 288 tests pass, including a new case covering the "already deregistered" path
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3QJKsyc9zgWhJjdnNAYDP