### PR TITLE
fix(git-explorer): handle a workspace folder that no longer exists on disk

### DIFF
--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -630,8 +630,36 @@ export function GitView({
     }
   }
 
+  // A folder with no git status to show — either not a repo, or (missing)
+  // gone from disk entirely (deleted/removed outside Silo). Still render the
+  // collapsible root header when there is one, so a multi-root panel keeps
+  // showing *which* folder this is instead of the section vanishing outright.
   if (status && !status.inRepo) {
-    return <div className="placeholder">Not a git repository.</div>;
+    return (
+      <div className="git-panel">
+        {rootLabel && (
+          <button className="git-root-label" onClick={onToggleCollapsed}>
+            <span className="git-root-top">
+              <span className="git-root-chev">
+                {collapsed ? (
+                  <CaretRight size="0.85em" weight="bold" />
+                ) : (
+                  <CaretDown size="0.85em" weight="bold" />
+                )}
+              </span>
+              <span className="git-root-name">{rootLabel.toUpperCase()}</span>
+            </span>
+          </button>
+        )}
+        {!collapsed && (
+          <div className="placeholder">
+            {status.missing
+              ? "This folder could not be found."
+              : "Not a git repository."}
+          </div>
+        )}
+      </div>
+    );
   }
 
   const canCommit = stagedFiles.length > 0 && message.trim().length > 0;

--- a/packages/extensions-silo/src/git/git-api.ts
+++ b/packages/extensions-silo/src/git/git-api.ts
@@ -29,6 +29,13 @@ export interface GitStatus {
   files: GitFileStatus[];
   /** False when the folder isn't inside a git repository. */
   inRepo: boolean;
+  /**
+   * True when the folder itself doesn't exist on disk (as opposed to existing
+   * but not being a git repository) — e.g. a workspace folder whose directory
+   * was deleted or a worktree removed outside Silo. Always paired with
+   * `inRepo: false`.
+   */
+  missing?: boolean;
 }
 
 /** One commit, as listed by {@link GitAPI.log}. */

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -782,3 +782,35 @@ describe(
     });
   },
 );
+
+// A missing `cwd` fails the process spawn itself and *rejects* — unlike a
+// normal git failure, which resolves with a non-zero code (see the ExecFn
+// contract note atop this file). The real-git contract tests above can't
+// exercise that path (Node's execFile masks it as a non-zero exit), so this
+// is a focused mock-`ExecFn` test for status()'s handling of the rejection.
+describe("GitService.status against a rejecting exec (e.g. missing cwd)", () => {
+  it("treats 'no such file or directory' as a missing folder, not a throw", async () => {
+    const execRejects: ExecFn = () =>
+      Promise.reject(
+        new Error("failed to run git: No such file or directory (os error 2)"),
+      );
+    const git = createGitService(execRejects);
+    const s = await git.status("/gone");
+    expect(s).toEqual({
+      branch: null,
+      upstream: null,
+      ahead: 0,
+      behind: 0,
+      files: [],
+      inRepo: false,
+      missing: true,
+    });
+  });
+
+  it("still throws for other spawn failures (e.g. git not installed)", async () => {
+    const execRejects: ExecFn = () =>
+      Promise.reject(new Error("failed to run git: permission denied"));
+    const git = createGitService(execRejects);
+    await expect(git.status("/somewhere")).rejects.toThrow("permission denied");
+  });
+});

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -76,14 +76,35 @@ export function createGitService(exec: ExecFn): GitAPI {
 
   return {
     async status(cwd) {
-      const { stdout, stderr, code } = await git(cwd, [
-        "status",
-        "--porcelain=v2",
-        "-b",
-        // Expand untracked directories into their files (don't collapse a whole
-        // untracked subtree into one `directory/` row).
-        "--untracked-files=all",
-      ]);
+      let stdout: string, stderr: string, code: number;
+      try {
+        ({ stdout, stderr, code } = await git(cwd, [
+          "status",
+          "--porcelain=v2",
+          "-b",
+          // Expand untracked directories into their files (don't collapse a
+          // whole untracked subtree into one `directory/` row).
+          "--untracked-files=all",
+        ]));
+      } catch (err) {
+        // Unlike a normal git failure (resolves with a non-zero code), a
+        // missing `cwd` fails the spawn itself and rejects — e.g. a worktree
+        // or extra folder deleted outside Silo (ADR 0025-adjacent: Silo can't
+        // watch for that). Treat it the same as "not a repository" instead of
+        // throwing the raw OS error on every background refresh.
+        if (/no such file or directory/i.test(String(err))) {
+          return {
+            branch: null,
+            upstream: null,
+            ahead: 0,
+            behind: 0,
+            files: [],
+            inRepo: false,
+            missing: true,
+          };
+        }
+        throw err;
+      }
       if (code !== 0) {
         if (stderr.includes("not a git repository")) {
           return {


### PR DESCRIPTION
## Summary
- A workspace root deleted outside Silo (e.g. a linked worktree removed via `git worktree remove` run directly, not through Silo's own remove flow) broke its Git panel section: `git-service`'s `status()` only special-cased "not a git repository" (git exits non-zero, resolves gracefully) — a **missing `cwd`** instead fails the process spawn itself and *rejects*, which `status()` didn't catch.
- That left `status` permanently `null` for that root, so its section rendered with every header control (push/pull, the `⋯` overflow menu) silently missing — no error, just gone — and re-threw the raw OS error (`failed to run git: No such file or directory (os error 2)`) as a notification toast on every background refresh (e.g. every time the workspace regained focus).
- `status()` now recognizes that specific rejection and returns the same graceful `inRepo: false` shape it already uses for "not a repo", plus a new `missing` flag so `GitView` shows a clear **"This folder could not be found."** instead of the misleading "Not a git repository." — and, for a multi-root panel, still renders the collapsible root header so the broken folder stays identifiable instead of the whole section disappearing.
- Found while manually testing the cleanup flow from #289/#291 — a linked worktree removed via a Claude Code `ExitWorktree` session (bypassing Silo entirely) left the still-attached workspace folder in this broken state.

## Test plan
- [x] `pnpm --filter @silo-code/extensions-silo exec vitest run` — 290 tests pass, including a new mock-`ExecFn` test covering the spawn-rejection path (the real-git contract tests can't exercise this — Node's `execFile` masks a missing `cwd` as a resolved non-zero exit rather than a rejection, unlike the real Tauri `ctx.process.exec`)
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] Manually verified in the running dev app via the automation bridge: attached a second folder to a workspace, deleted it from disk, confirmed the Git panel shows the collapsible header + "This folder could not be found." with no error toast (checked notification logs and page text directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3QJKsyc9zgWhJjdnNAYDP