### PR TITLE
feat(workspaces): notify when a workspace's extra folder is gone from disk

### DIFF
--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -5,17 +5,27 @@ import { WorkspaceStatusItem } from "./WorkspaceStatusItem";
 import { registerWorkspaceCycle } from "./workspace-cycle";
 import { openNewGroup } from "./group-properties";
 import { confirmAndCloseWorkspace } from "./workspace-add-menu";
+import { checkMissingExtraFolders } from "./missing-folder-notify";
 
 export const extension: Extension = {
   id: "core.workspaces",
   activate(ctx) {
-    // Log workspace lifecycle events to the Application output channel.
+    // Log workspace lifecycle events to the Application output channel, and
+    // (session-lifetime, de-duped per folder) notify if an extra folder no
+    // longer exists on disk — see missing-folder-notify.ts.
     let prev = ctx.workspaces.getState();
+    const notifiedMissingFolders = new Set<string>();
+    const initialWs = prev.all.find((w) => w.id === prev.activeId);
+    if (initialWs) {
+      void checkMissingExtraFolders(ctx, initialWs, notifiedMissingFolders);
+    }
     ctx.subscriptions.push(
       ctx.workspaces.subscribe((state) => {
         if (state.activeId !== prev.activeId && state.activeId) {
           const ws = state.all.find((w) => w.id === state.activeId);
           ctx.log.info(`Workspace activated: ${ws?.name ?? state.activeId}`);
+          if (ws)
+            void checkMissingExtraFolders(ctx, ws, notifiedMissingFolders);
         }
         for (const ws of state.all) {
           if (!prev.all.find((p) => p.id === ws.id)) {

--- a/packages/extensions-core/src/workspaces/missing-folder-notify.test.ts
+++ b/packages/extensions-core/src/workspaces/missing-folder-notify.test.ts
@@ -1,0 +1,107 @@
+import type { ExtensionContext } from "@silo-code/sdk";
+import { describe, it, expect, vi } from "vitest";
+import { checkMissingExtraFolders } from "./missing-folder-notify";
+
+function mockCtx(pathExists: (p: string) => Promise<boolean>): {
+  ctx: ExtensionContext;
+  notify: ReturnType<typeof vi.fn>;
+  removeFolder: ReturnType<typeof vi.fn>;
+} {
+  const notify = vi.fn();
+  const removeFolder = vi.fn();
+  const ctx = {
+    files: { pathExists },
+    ui: { notify },
+    workspaces: { removeFolder },
+  } as unknown as ExtensionContext;
+  return { ctx, notify, removeFolder };
+}
+
+describe("checkMissingExtraFolders", () => {
+  it("notifies once for a missing extra folder, offering to remove it", async () => {
+    const { ctx, notify, removeFolder } = mockCtx(async () => false);
+    const notified = new Set<string>();
+    await checkMissingExtraFolders(
+      ctx,
+      { id: "ws1", extraFolders: ["/w/repo-b"] },
+      notified,
+    );
+
+    expect(notify).toHaveBeenCalledWith(
+      "warn",
+      '"repo-b" could not be found. Remove it from the workspace?',
+      expect.objectContaining({ title: "Workspace folder not found" }),
+    );
+
+    // The notify action removes exactly this folder from this workspace.
+    const options = notify.mock.calls[0]![2];
+    options.actions[0].run();
+    expect(removeFolder).toHaveBeenCalledWith("ws1", "/w/repo-b");
+  });
+
+  it("skips a folder that still exists on disk", async () => {
+    const { ctx, notify } = mockCtx(async () => true);
+    await checkMissingExtraFolders(
+      ctx,
+      { id: "ws1", extraFolders: ["/w/repo-b"] },
+      new Set(),
+    );
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("never checks the primary folder — only extraFolders is read", async () => {
+    const pathExists = vi.fn(async () => false);
+    const { ctx, notify } = mockCtx(pathExists);
+    await checkMissingExtraFolders(ctx, { id: "ws1" }, new Set());
+    expect(pathExists).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("does not re-check or re-notify a folder already in the session set", async () => {
+    const pathExists = vi.fn(async () => false);
+    const { ctx, notify } = mockCtx(pathExists);
+    const notified = new Set([`ws1::/w/repo-b`]);
+    await checkMissingExtraFolders(
+      ctx,
+      { id: "ws1", extraFolders: ["/w/repo-b"] },
+      notified,
+    );
+    expect(pathExists).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("fails open on a pathExists error — doesn't offer to drop an unconfirmed folder", async () => {
+    const { ctx, notify } = mockCtx(async () => {
+      throw new Error("permission denied");
+    });
+    await checkMissingExtraFolders(
+      ctx,
+      { id: "ws1", extraFolders: ["/w/repo-b"] },
+      new Set(),
+    );
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("notifies once per missing folder when there are several", async () => {
+    const { ctx, notify } = mockCtx(async () => false);
+    const notified = new Set<string>();
+    await checkMissingExtraFolders(
+      ctx,
+      { id: "ws1", extraFolders: ["/w/repo-b", "/w/repo-c"] },
+      notified,
+    );
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(notified).toEqual(new Set(["ws1::/w/repo-b", "ws1::/w/repo-c"]));
+  });
+
+  it("keys the de-dup set per workspace, not just per path", async () => {
+    const { ctx, notify } = mockCtx(async () => false);
+    const notified = new Set([`wsA::/w/shared`]);
+    await checkMissingExtraFolders(
+      ctx,
+      { id: "wsB", extraFolders: ["/w/shared"] },
+      notified,
+    );
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/extensions-core/src/workspaces/missing-folder-notify.ts
+++ b/packages/extensions-core/src/workspaces/missing-folder-notify.ts
@@ -1,0 +1,56 @@
+import type { ExtensionContext } from "@silo-code/sdk";
+import { path } from "@silo-code/sdk";
+
+// Silo can't watch for a folder removed entirely outside it (e.g. a linked
+// git worktree deleted via `git worktree remove` run directly, or a second
+// repo attached to a workspace that later got moved/deleted) — every panel
+// that lists workspace folders (Git, File Explorer, …) would otherwise have
+// to detect and explain this on its own. This is the single, panel-agnostic
+// place that notices and offers to fix it.
+
+/** Session-lifetime de-dup key so a folder is only notified about once. */
+function notifyKey(workspaceId: string, folder: string): string {
+  return `${workspaceId}::${folder}`;
+}
+
+/**
+ * Check a workspace's *extra* folders (never the primary — {@link
+ * WorkspaceService.removeFolder} no-ops there, so there'd be nothing to
+ * offer) for ones that no longer exist on disk, and notify once per folder
+ * per app session with a one-click "Remove folder" action. `notified` is the
+ * caller's session-lifetime de-dup set, mutated in place.
+ *
+ * Called on workspace activation, including the already-active workspace at
+ * cold start — see `core.workspaces`' `activate()`.
+ */
+export async function checkMissingExtraFolders(
+  ctx: ExtensionContext,
+  ws: { id: string; extraFolders?: string[] },
+  notified: Set<string>,
+): Promise<void> {
+  for (const folder of ws.extraFolders ?? []) {
+    const key = notifyKey(ws.id, folder);
+    if (notified.has(key)) continue;
+
+    // Fail open on a read error — don't offer to drop a folder we couldn't
+    // actually confirm is gone (mirrors the orphan-worktree disk check in
+    // worktree-model.ts).
+    const exists = await ctx.files.pathExists(folder).catch(() => true);
+    if (exists) continue;
+
+    notified.add(key);
+    ctx.ui.notify(
+      "warn",
+      `"${path.basename(folder)}" could not be found. Remove it from the workspace?`,
+      {
+        title: "Workspace folder not found",
+        actions: [
+          {
+            label: "Remove folder",
+            run: () => ctx.workspaces.removeFolder(ws.id, folder),
+          },
+        ],
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Several panels list workspace folders (Git, File Explorer, …) — each would otherwise need to detect and explain a folder that disappeared outside Silo (e.g. a linked worktree removed via `git worktree remove` run directly, or a second repo that got moved/deleted) on its own. This is one global, panel-agnostic place that notices and offers to fix it, rather than each panel growing its own bespoke "missing folder" handling.
- On workspace activation — including the already-active workspace at cold start — `checkMissingExtraFolders` checks each *extra* folder (never the primary; `ctx.workspaces.removeFolder` no-ops there, so there'd be nothing to offer) via `ctx.files.pathExists`.
- A folder that's gone gets a single `"Workspace folder not found"` toast (`warn`, stays until dismissed) with a one-click **"Remove folder"** action wired to `ctx.workspaces.removeFolder` — no confirm dialog needed, since nothing is deleted, only a reference to an already-gone path.
- De-duped per folder for the app session (an in-memory `workspaceId::path` set) so switching back and forth doesn't nag repeatedly; resets on restart.
- Design worked out interactively with `/grilling` before implementation — see conversation for the full decision log (scope, trigger, dedup policy, wording, etc.).

## Test plan
- [x] `pnpm --filter @silo-code/extensions-core exec vitest run` — 241 tests pass, including 7 new covering: notifies + wires the remove action correctly, skips an existing folder, never touches the primary folder, skips/dedupes an already-notified folder, fails open on a `pathExists` error, notifies once per folder when several are missing, and de-dupes per-workspace (not just per-path).
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] Manually verified live in the running dev app (attached a folder to a workspace, deleted it, confirmed the toast + working "Remove folder" action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3QJKsyc9zgWhJjdnNAYDP