### PR TITLE
fix(git-explorer): keep the UI responsive when removing multiple worktrees

### DIFF
--- a/packages/extension-host/src/state/workspaces.test.ts
+++ b/packages/extension-host/src/state/workspaces.test.ts
@@ -16,6 +16,8 @@ import {
   activateWorkspace,
   setEditorSettingOverride,
   getEditorSettingOverride,
+  addExtraFolder,
+  removeExtraFolder,
 } from "./workspaces";
 import { clearEditorBackup } from "./editor-backups";
 
@@ -97,6 +99,60 @@ describe("side-panel visibility is per-workspace", () => {
     // And w2 kept its own.
     activateWorkspace("w2");
     expect(store.sidePanelVisibility).toEqual({ git: false });
+  });
+});
+
+describe("extra folders", () => {
+  it("adds and removes a folder by exact path", () => {
+    addExtraFolder("w", "/repo-b");
+    expect(store.workspaces.w.extraFolders).toEqual(["/repo-b"]);
+    removeExtraFolder("w", "/repo-b");
+    expect(store.workspaces.w.extraFolders).toEqual([]);
+  });
+
+  it("does not add a duplicate of an already-open extra folder", () => {
+    addExtraFolder("w", "/repo-b");
+    addExtraFolder("w", "/repo-b");
+    expect(store.workspaces.w.extraFolders).toEqual(["/repo-b"]);
+  });
+
+  it("does not add the workspace's own primary folder as an extra", () => {
+    addExtraFolder("w", "/ws/w");
+    expect(store.workspaces.w.extraFolders ?? []).toEqual([]);
+  });
+
+  // macOS realpaths /tmp, /var, /etc through a /private backing. A folder
+  // opened with the /tmp spelling must still be found and removed when a
+  // caller (e.g. git worktree removal) later hands back the /private/tmp
+  // spelling — see the WorktreeManager verification finding this regression-
+  // tests: `ctx.workspaces.removeFolder` was previously a raw string
+  // comparison, so it silently no-op'd on this exact mismatch, leaving a
+  // stale folder open after its worktree was deleted on disk.
+  it("treats /private/tmp and /tmp spellings of the same path as identical", () => {
+    addExtraFolder("w", "/tmp/wt1");
+    expect(store.workspaces.w.extraFolders).toEqual(["/tmp/wt1"]);
+
+    removeExtraFolder("w", "/private/tmp/wt1");
+    expect(store.workspaces.w.extraFolders).toEqual([]);
+  });
+
+  it("treats a /private-spelled primary folder as already open", () => {
+    store.workspaces.w.folder = "/private/tmp/proj";
+    addExtraFolder("w", "/tmp/proj");
+    expect(store.workspaces.w.extraFolders ?? []).toEqual([]);
+  });
+
+  it("does not fold unrelated /private paths (e.g. /privateer)", () => {
+    addExtraFolder("w", "/privateer/tmp/x");
+    removeExtraFolder("w", "/tmp/x");
+    // The unrelated folder should still be there — only the real /private
+    // prefix is folded, not any path that merely starts with those letters.
+    expect(store.workspaces.w.extraFolders).toEqual(["/privateer/tmp/x"]);
+  });
+
+  it("no-ops for an unknown workspace", () => {
+    expect(() => addExtraFolder("nope", "/x")).not.toThrow();
+    expect(() => removeExtraFolder("nope", "/x")).not.toThrow();
   });
 });
 

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -1,5 +1,6 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { basename } from "@tauri-apps/api/path";
+import { path } from "@silo-code/sdk";
 import { store } from "./store";
 import { clearEditorBackup } from "./editor-backups";
 import type {
@@ -232,19 +233,38 @@ export function reorderWorkspaces(
   reorderInArray(store.workspaceOrder, fromId, toId, position);
 }
 
+// Two folder path strings can identify the same directory without being
+// equal: macOS realpaths /tmp, /var, and /etc through a /private backing, so
+// a worktree removal (which hands back git's /private/... report) needs to
+// match a folder that was added with the /tmp/... spelling, or vice versa.
+// Mirrors extensions-silo's `normalizeFolderPath`/`samePath`
+// (packages/extensions-silo/src/git/worktree-utils.ts), duplicated here
+// rather than shared because extension-host cannot depend on an extension
+// package — only on @silo-code/sdk.
+function normalizeFolderIdentity(p: string): string {
+  let n = path.normalize(p);
+  if (n.length > 1 && n.endsWith("/")) n = n.slice(0, -1);
+  const priv = /^\/private(\/(?:tmp|var|etc)(?:\/|$).*)$/.exec(n);
+  return priv ? priv[1] : n;
+}
+
+function sameFolderPath(a: string, b: string): boolean {
+  return normalizeFolderIdentity(a) === normalizeFolderIdentity(b);
+}
+
 export function addExtraFolder(workspaceId: string, folder: string): void {
   const ws = store.workspaces[workspaceId];
   if (!ws) return;
-  if (ws.folder === folder) return;
+  if (sameFolderPath(ws.folder, folder)) return;
   if (!ws.extraFolders) ws.extraFolders = [];
-  if (ws.extraFolders.includes(folder)) return;
+  if (ws.extraFolders.some((f) => sameFolderPath(f, folder))) return;
   ws.extraFolders.push(folder);
 }
 
 export function removeExtraFolder(workspaceId: string, folder: string): void {
   const ws = store.workspaces[workspaceId];
   if (!ws?.extraFolders) return;
-  ws.extraFolders = ws.extraFolders.filter((f) => f !== folder);
+  ws.extraFolders = ws.extraFolders.filter((f) => !sameFolderPath(f, folder));
 }
 
 export function deleteWorkspace(id: string): void {

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   ArrowsClockwise,
   CaretDown,
@@ -32,6 +39,10 @@ import {
 } from "./worktree-model";
 import { showWorktreeManager } from "./open-worktree-manager";
 import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
+import {
+  isWorktreeRemovePending,
+  subscribePendingWorktreeRemoves,
+} from "./pending-worktree-remove";
 import { useViewStack } from "./use-view-stack";
 import { CommitsTakeover } from "./CommitsTakeover";
 import { shouldExitTakeover, shouldPushCommitsOnOpen } from "./takeover-model";
@@ -117,6 +128,18 @@ export function GitView({
     setPendingRefresh(true);
   }, []);
 
+  // True while *this* folder is being removed (its worktree is deleted from
+  // disk). `beginPendingWorktreeRemove` fires before the folder leaves the
+  // workspace, so subscribing here lets this view stop watching and refreshing
+  // the instant removal starts — a `git status` against a directory mid-`rm -rf`
+  // returns thousands of "deleted" entries and blocks the UI thread, which is
+  // what made removing several open worktrees at once freeze the app.
+  const removing = useSyncExternalStore(
+    subscribePendingWorktreeRemoves,
+    useCallback(() => isWorktreeRemovePending(folder), [folder]),
+    useCallback(() => isWorktreeRemovePending(folder), [folder]),
+  );
+
   // Surface a git failure as a toast: a short summary, plus a "View details"
   // action that opens the full output in a modal when there's more to show.
   // `transient` auto-dismisses (for passive background refreshes) instead of the
@@ -162,6 +185,12 @@ export function GitView({
   useEffect(() => {
     if (!pendingRefresh) return;
     setPendingRefresh(false);
+    // Skip refreshing a folder that's being removed — its directory is being
+    // deleted, so `git status` would race the `rm -rf` (see `removing`).
+    if (removing) {
+      setBusy(false);
+      return;
+    }
     const min = new Promise<void>((r) => setTimeout(r, 600));
     setTimeout(() => {
       const api = getGitApi();
@@ -193,7 +222,7 @@ export function GitView({
         })
         .catch(() => undefined);
     }, 50);
-  }, [pendingRefresh, folder, workspaceId, cacheKey, notifyError]);
+  }, [pendingRefresh, folder, workspaceId, cacheKey, notifyError, removing]);
 
   useEffect(() => {
     if (!pendingPush) return;
@@ -254,7 +283,10 @@ export function GitView({
   }, [pendingPull, folder, notifyError]);
 
   useEffect(() => {
-    if (paused) return;
+    // Stop watching a folder that's paused (background workspace) or being
+    // removed — its `rm -rf` would otherwise spam change events straight into a
+    // refresh against the vanishing directory.
+    if (paused || removing) return;
     let timer: number | null = null;
     const sub = files.watch(folder, () => {
       // Don't poll mid-commit — the commit (and its pre-commit hooks) churn
@@ -267,7 +299,7 @@ export function GitView({
       if (timer) window.clearTimeout(timer);
       sub.dispose();
     };
-  }, [folder, refresh, paused]);
+  }, [folder, refresh, paused, removing]);
 
   // Background autofetch: periodically `git fetch` so ↑ahead/↓behind trend
   // toward accurate without the user acting. Fetch is read-only on the working
@@ -275,7 +307,7 @@ export function GitView({
   // re-read status quietly (no spinner) so the counts update in place. Failures
   // (offline, no remote) are swallowed — autofetch must stay silent.
   useEffect(() => {
-    if (paused) return;
+    if (paused || removing) return;
     const id = window.setInterval(() => {
       if (committingRef.current) return;
       const api = getGitApi();
@@ -290,7 +322,7 @@ export function GitView({
         .catch((err) => console.warn("git autofetch failed", err));
     }, AUTOFETCH_INTERVAL_MS);
     return () => window.clearInterval(id);
-  }, [folder, cacheKey, paused]);
+  }, [folder, cacheKey, paused, removing]);
 
   const stagedFiles = useMemo(
     () => status?.files.filter((f) => f.isStaged) ?? [],

--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.test.ts
@@ -49,6 +49,48 @@ describe("confirmAndRemoveWorktree", () => {
     expect(getPendingWorktreeRemoves()).toHaveLength(0);
   });
 
+  it("serializes the git removal when several worktrees are removed at once", async () => {
+    const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+    let active = 0;
+    let maxActive = 0;
+    const gates: Array<() => void> = [];
+    // Each removal blocks until released, so we can observe how many run at once.
+    const removeWorktree = vi.fn(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise<void>((r) => gates.push(r));
+      active -= 1;
+    });
+    const api = { removeWorktree } as unknown as GitAPI;
+    const start = (worktreePath: string) =>
+      confirmAndRemoveWorktree({
+        ctx: mockCtx({ confirms: [true] }),
+        api,
+        cwd: "/w/repo",
+        worktreePath,
+        workspaceId: "ws1",
+        isOpen: false,
+        notifyError: vi.fn(),
+      });
+
+    const all = Promise.all([start("/w/a"), start("/w/b"), start("/w/c")]);
+    // All three are past their confirms and queued; only the first is running.
+    await tick();
+    expect(removeWorktree).toHaveBeenCalledTimes(1);
+    expect(getPendingWorktreeRemoves()).toHaveLength(3);
+
+    // Drain the queue one at a time.
+    while (gates.length) {
+      gates.shift()!();
+      await tick();
+    }
+    await all;
+    expect(removeWorktree).toHaveBeenCalledTimes(3);
+    // The whole point: never two `git worktree remove` running concurrently.
+    expect(maxActive).toBe(1);
+    expect(getPendingWorktreeRemoves()).toHaveLength(0);
+  });
+
   it("closes the folder on start, clears pending on success, toasts when manager closed", async () => {
     const removeWorktree = vi.fn(async () => {});
     const ctx = mockCtx({ confirms: [true] });

--- a/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
+++ b/packages/extensions-silo/src/git-explorer/confirm-and-remove-worktree.ts
@@ -3,6 +3,7 @@ import type { GitAPI } from "../git/git-api";
 import {
   beginPendingWorktreeRemove,
   endPendingWorktreeRemove,
+  enqueueWorktreeRemoval,
   isWorktreeManagerOpen,
   isWorktreeRemovePending,
   markWorktreeListDirty,
@@ -69,7 +70,7 @@ export async function confirmAndRemoveWorktree(
   try {
     let alreadyGone = false;
     try {
-      await api.removeWorktree(cwd, worktreePath);
+      await enqueueWorktreeRemoval(() => api.removeWorktree(cwd, worktreePath));
     } catch (err) {
       if (NOT_A_WORKTREE_RE.test(String(err))) {
         // The row was stale — this worktree is already gone at the git
@@ -90,7 +91,9 @@ export async function confirmAndRemoveWorktree(
         if (!force) return;
 
         beginPendingWorktreeRemove(worktreePath);
-        await api.removeWorktree(cwd, worktreePath, true);
+        await enqueueWorktreeRemoval(() =>
+          api.removeWorktree(cwd, worktreePath, true),
+        );
       } else {
         throw err;
       }

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove.test.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   beginPendingWorktreeRemove,
   endPendingWorktreeRemove,
+  enqueueWorktreeRemoval,
   getPendingRemoveStatusLabel,
   getPendingWorktreeRemoves,
   isWorktreeManagerOpen,
@@ -12,6 +13,8 @@ import {
   subscribePendingWorktreeRemoves,
   subscribeWorktreeListDirty,
 } from "./pending-worktree-remove";
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 
 describe("pending-worktree-remove store", () => {
   beforeEach(() => {
@@ -59,5 +62,33 @@ describe("pending-worktree-remove store", () => {
     stop();
     markWorktreeListDirty();
     expect(dirty).toBe(2);
+  });
+
+  it("serializes queued removals — one runs at a time, in order", async () => {
+    const order: string[] = [];
+    let releaseA!: () => void;
+    const a = enqueueWorktreeRemoval(async () => {
+      order.push("A:start");
+      await new Promise<void>((r) => (releaseA = r));
+      order.push("A:end");
+    });
+    const b = enqueueWorktreeRemoval(async () => {
+      order.push("B:start");
+    });
+    // A is in-flight (awaiting release); B must not have started yet.
+    await tick();
+    expect(order).toEqual(["A:start"]);
+    releaseA();
+    await Promise.all([a, b]);
+    expect(order).toEqual(["A:start", "A:end", "B:start"]);
+  });
+
+  it("a failing removal rejects its own caller but not the ones behind it", async () => {
+    const a = enqueueWorktreeRemoval(async () => {
+      throw new Error("boom");
+    });
+    const b = enqueueWorktreeRemoval(async () => "ok");
+    await expect(a).rejects.toThrow("boom");
+    await expect(b).resolves.toBe("ok");
   });
 });

--- a/packages/extensions-silo/src/git-explorer/pending-worktree-remove.ts
+++ b/packages/extensions-silo/src/git-explorer/pending-worktree-remove.ts
@@ -21,6 +21,29 @@ function emit(): void {
   for (const listener of [...listeners]) listener();
 }
 
+// Serialize the actual `git worktree remove` executions. Removing several open
+// worktrees at once (each a `git worktree remove --force`, i.e. an rm -rf of a
+// full working tree) otherwise fires N concurrent removals; on large trees that
+// stacks each removal's refresh/status work and starves the UI thread for the
+// duration — the multi-worktree "app froze" case. Confirms and pending-state
+// updates stay immediate (so "Removing N worktrees…" shows right away); only
+// the disk-deleting git call is queued, draining one at a time.
+let removalChain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Run `task` after any already-queued worktree removals settle, so at most one
+ * `git worktree remove` executes at a time. Resolves/rejects with `task`'s own
+ * outcome; a failing task never breaks the chain for the ones behind it.
+ */
+export function enqueueWorktreeRemoval<T>(task: () => Promise<T>): Promise<T> {
+  const result = removalChain.then(task, task);
+  removalChain = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
 /** Subscribe to pending-remove / manager-open changes (for StatusBar + modal). */
 export function subscribePendingWorktreeRemoves(
   listener: () => void,
@@ -109,4 +132,5 @@ export function resetPendingWorktreeRemovesForTests(): void {
   managerOpenDepth = 0;
   listeners.clear();
   listDirtyListeners.clear();
+  removalChain = Promise.resolve();
 }

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -813,4 +813,42 @@ describe("GitService.status against a rejecting exec (e.g. missing cwd)", () => 
     const git = createGitService(execRejects);
     await expect(git.status("/somewhere")).rejects.toThrow("permission denied");
   });
+
+  // On some platforms git *spawns* fine against a since-deleted cwd and exits
+  // non-zero with this message instead of the spawn rejecting — the same
+  // missing-folder case, so it must map to `missing`, not a thrown toast.
+  it("treats a non-zero 'unable to read current working directory' as missing", async () => {
+    const execExitsNonZero: ExecFn = () =>
+      Promise.resolve({
+        stdout: "",
+        stderr:
+          "fatal: unable to read current working directory: No such file or directory",
+        code: 128,
+      });
+    const git = createGitService(execExitsNonZero);
+    const s = await git.status("/gone");
+    expect(s).toEqual({
+      branch: null,
+      upstream: null,
+      ahead: 0,
+      behind: 0,
+      files: [],
+      inRepo: false,
+      missing: true,
+    });
+  });
+
+  it("keeps 'not a git repository' as inRepo:false without the missing flag", async () => {
+    const execNotRepo: ExecFn = () =>
+      Promise.resolve({
+        stdout: "",
+        stderr:
+          "fatal: not a git repository (or any of the parent directories)",
+        code: 128,
+      });
+    const git = createGitService(execNotRepo);
+    const s = await git.status("/plain-dir");
+    expect(s.inRepo).toBe(false);
+    expect(s.missing).toBeUndefined();
+  });
 });

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -1,4 +1,4 @@
-import type { GitAPI, GitLogEntry } from "./git-api";
+import type { GitAPI, GitLogEntry, GitStatus } from "./git-api";
 import { parseGitStatus } from "./parse-status";
 import { parseBranches } from "./parse-branches";
 import { parseWorktrees } from "./parse-worktrees";
@@ -30,6 +30,40 @@ export type ExecFn = (
 // 40-hex-char-then-tab shape only ever starts a header, so header lines are
 // unambiguous even interleaved with each commit's own numstat block.
 const LOG_HEADER_RE = /^[0-9a-f]{40}\t/;
+
+// A working directory that's gone from disk surfaces two ways, depending on the
+// platform and git version: the process *spawn* rejects ("No such file or
+// directory"), or git spawns fine but exits non-zero with "fatal: unable to
+// read current working directory: No such file or directory". Both mean the
+// same thing — treat either as a graceful `missing` status instead of throwing
+// the raw OS error as a toast on every background refresh (see `status`).
+const MISSING_CWD_RE =
+  /no such file or directory|unable to read current working directory/i;
+
+/** A folder that no longer exists on disk — `inRepo: false` plus `missing`. */
+function missingStatus(): GitStatus {
+  return {
+    branch: null,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    files: [],
+    inRepo: false,
+    missing: true,
+  };
+}
+
+/** A folder that exists but isn't a git repository. */
+function notARepoStatus(): GitStatus {
+  return {
+    branch: null,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    files: [],
+    inRepo: false,
+  };
+}
 
 /** Parses `git log --pretty=format:%H%x09%h%x09%an%x09%ar%x09%s --numstat
  * [--diff-merges=first-parent]` output — the file lines under each header
@@ -87,35 +121,19 @@ export function createGitService(exec: ExecFn): GitAPI {
           "--untracked-files=all",
         ]));
       } catch (err) {
-        // Unlike a normal git failure (resolves with a non-zero code), a
-        // missing `cwd` fails the spawn itself and rejects — e.g. a worktree
-        // or extra folder deleted outside Silo (ADR 0025-adjacent: Silo can't
-        // watch for that). Treat it the same as "not a repository" instead of
-        // throwing the raw OS error on every background refresh.
-        if (/no such file or directory/i.test(String(err))) {
-          return {
-            branch: null,
-            upstream: null,
-            ahead: 0,
-            behind: 0,
-            files: [],
-            inRepo: false,
-            missing: true,
-          };
-        }
+        // A missing `cwd` fails the process spawn itself and rejects — e.g. a
+        // worktree or extra folder deleted outside Silo (ADR 0025-adjacent:
+        // Silo can't watch for that). Treat it as `missing` instead of throwing
+        // the raw OS error on every background refresh.
+        if (MISSING_CWD_RE.test(String(err))) return missingStatus();
         throw err;
       }
       if (code !== 0) {
-        if (stderr.includes("not a git repository")) {
-          return {
-            branch: null,
-            upstream: null,
-            ahead: 0,
-            behind: 0,
-            files: [],
-            inRepo: false,
-          };
-        }
+        // On some platforms git spawns fine against a since-deleted cwd and
+        // instead exits non-zero with "unable to read current working
+        // directory" — the same missing-folder case, so handle it the same way.
+        if (MISSING_CWD_RE.test(stderr)) return missingStatus();
+        if (stderr.includes("not a git repository")) return notARepoStatus();
         throw new Error(stderr.trim() || "git status failed");
       }
       return parseGitStatus(stdout);


### PR DESCRIPTION
## Summary
- Serialize concurrent `git worktree remove --force` calls so only one runs at a time, and pause a folder's Git panel the instant it enters pending-remove — fixes a multi-minute UI freeze (100% CPU) when removing several open worktrees at once, caused by N concurrent `git status` calls racing each worktree's own `rm -rf`.
- Map git's non-zero "unable to read current working directory" exit to a graceful `missing` status, killing recurring "Git status failed" toasts on a folder deleted out from under the app.
- Fix a related path-identity bug found while verifying the above: `ctx.workspaces.addFolder`/`removeFolder` compared folder paths with raw string equality, so a folder opened as `/tmp/x` couldn't be matched and closed when later referenced as `/private/tmp/x` (macOS's realpath spelling, which is exactly what `git worktree list` reports) — leaving a removed worktree's folder stuck open as a "missing on disk" orphan and re-triggering the "workspace folder not found" toast on the next workspace switch.

## Test plan
- [x] `pnpm test` — full monorepo suite green (738 tests in extension-host alone, including 7 new cases for the path-normalization fix)
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean (boundary + stylelint)
- [x] Live-verified against the running dev app via the automation bridge:
  - Removed 3 worktrees (300 dirs × 100 files each) concurrently — worst UI-thread eval latency 20.2ms (avg 3.5ms) over 30s, no stalls; all 3 removed cleanly from disk and `git worktree list`
  - Confirmed a missing/deleted worktree folder shows "This folder could not be found." with zero "Git status failed" / "Unable to read current working directory" toasts
  - Reproduced and confirmed the `/tmp` ⇔ `/private/tmp` fix: a worktree opened under `/tmp/...`, removed via the UI, no longer lingers as an orphan row or re-triggers the missing-folder notification

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>