### PR TITLE
feat(agent-inspector): add show-all-terminals checkbox

### DIFF
--- a/examples/extensions/agent-inspector/src/AgentInspectorPanel.tsx
+++ b/examples/extensions/agent-inspector/src/AgentInspectorPanel.tsx
@@ -52,6 +52,7 @@ function useWorkspaceState(ctx: ExtensionContext): WorkspaceState {
 }
 
 const SCOPE_STORAGE_KEY = "scope";
+const SHOW_ALL_TERMINALS_STORAGE_KEY = "showAllTerminals";
 
 export function AgentInspectorPanel({ ctx }: Props) {
   // A UI preference, not workspace-specific data — global scope, so it's
@@ -63,6 +64,16 @@ export function AgentInspectorPanel({ ctx }: Props) {
   function setScope(next: Scope) {
     setScopeState(next);
     ctx.storage.global.set(SCOPE_STORAGE_KEY, next);
+  }
+  // Off by default: `ctx.agents.getState` reports every tracked terminal,
+  // not just agent ones (see AgentInfo.isAgent's doc comment), so a plain
+  // shell would otherwise clutter a panel meant for watching agent activity.
+  const [showAllTerminals, setShowAllTerminalsState] = useState<boolean>(() =>
+    ctx.storage.global.get<boolean>(SHOW_ALL_TERMINALS_STORAGE_KEY, false),
+  );
+  function setShowAllTerminals(next: boolean) {
+    setShowAllTerminalsState(next);
+    ctx.storage.global.set(SHOW_ALL_TERMINALS_STORAGE_KEY, next);
   }
   const agents = useAgentState(ctx, scope);
   const workspaces = useWorkspaceState(ctx);
@@ -86,12 +97,19 @@ export function AgentInspectorPanel({ ctx }: Props) {
   }, [ctx]);
 
   const visible = useMemo(() => {
-    if (scope === "current" || scope === "all") return agents;
-    const ids = new Set(
-      (scope === "open" ? workspaces.open : workspaces.closed).map((w) => w.id),
-    );
-    return agents.filter((a) => ids.has(a.workspaceId));
-  }, [agents, workspaces, scope]);
+    let byWorkspace = agents;
+    if (scope === "open" || scope === "closed") {
+      const ids = new Set(
+        (scope === "open" ? workspaces.open : workspaces.closed).map(
+          (w) => w.id,
+        ),
+      );
+      byWorkspace = agents.filter((a) => ids.has(a.workspaceId));
+    }
+    return showAllTerminals
+      ? byWorkspace
+      : byWorkspace.filter((a) => a.isAgent);
+  }, [agents, workspaces, scope, showAllTerminals]);
 
   return (
     <div className="ai-panel">
@@ -107,6 +125,15 @@ export function AgentInspectorPanel({ ctx }: Props) {
           <option value="closed">Closed workspaces</option>
           <option value="all">All workspaces</option>
         </select>
+
+        <label className="ai-show-all-label">
+          <input
+            type="checkbox"
+            checked={showAllTerminals}
+            onChange={(e) => setShowAllTerminals(e.target.checked)}
+          />
+          Show all terminals
+        </label>
       </div>
 
       {visible.length === 0 ? (

--- a/examples/extensions/agent-inspector/src/styles.css
+++ b/examples/extensions/agent-inspector/src/styles.css
@@ -35,6 +35,17 @@
   cursor: pointer;
 }
 
+.ai-show-all-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 10px;
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-base);
+  color: var(--silo-color-text-lo);
+  cursor: pointer;
+}
+
 /* ---- list ------------------------------------------------------------------ */
 .ai-list {
   flex: 1;


### PR DESCRIPTION
## Summary
- Add a "Show all terminals" checkbox to the agent-inspector example's toolbar, next to the workspace-scope dropdown
- Off by default — `ctx.agents.getState` reports every tracked terminal (including plain, non-agent shells), so hiding non-agent terminals keeps the panel focused on agent activity
- Preference persisted via `ctx.storage.global`, same pattern as the existing scope selector

## Test plan
- [x] `pnpm test` passes (ran via pre-commit hook)
- [x] `node build.mjs` builds the extension cleanly
- [ ] Restart Silo dev app and manually verify: checkbox unchecked hides non-agent terminals, checked shows them, and the choice persists across reopening the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)