### PR TITLE
fix(terminal): detect delimited file paths that contain spaces

### DIFF
--- a/packages/extensions-core/src/terminal/terminal-link-match.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-link-match.test.ts
@@ -45,4 +45,36 @@ describe("matchFilePaths", () => {
     expect(texts(".git/config")).toEqual([]);
     expect(texts("1/2")).toEqual([]);
   });
+
+  it("matches paths with spaces when wrapped in a delimiter pair", () => {
+    expect(
+      texts(
+        "Write(~/.xerro/documents/Blog Posts/Workspaces Paradigm Shift.md)",
+      ),
+    ).toEqual(["~/.xerro/documents/Blog Posts/Workspaces Paradigm Shift.md"]);
+    expect(texts("[~/My Documents/notes.txt]")).toEqual([
+      "~/My Documents/notes.txt",
+    ]);
+    expect(texts('"/abs/path/with space/file.ts"')).toEqual([
+      "/abs/path/with space/file.ts",
+    ]);
+    expect(texts("'/abs/path/with space/file.ts'")).toEqual([
+      "/abs/path/with space/file.ts",
+    ]);
+  });
+
+  it("does not let a space-containing path run past its delimiter", () => {
+    expect(
+      texts("Write(~/Blog Posts/Shift.md) and also (some other note)"),
+    ).toEqual(["~/Blog Posts/Shift.md"]);
+  });
+
+  it("does not allow spaces in undelimited paths", () => {
+    // The space still breaks the match into two spans (pre-existing
+    // behavior for space-free path detection); it just no longer swallows
+    // trailing prose the way an unbounded space-inclusive class would.
+    expect(
+      texts("Wrote 97 lines to ~/Blog Posts/Shift.md successfully"),
+    ).toEqual(["~/Blog", "Posts/Shift.md"]);
+  });
 });

--- a/packages/extensions-core/src/terminal/terminal-link-match.ts
+++ b/packages/extensions-core/src/terminal/terminal-link-match.ts
@@ -13,8 +13,42 @@
 // Lookbehind excludes every char that can appear in a path segment so we
 // never start a match mid-token (e.g. `playwright-mcp/x.png` must not also
 // yield a second link at `mcp/x.png`).
-export const FILE_PATH_RE =
-  /(?<![A-Za-z0-9_.:/\-@+])(?:(?:~|\.{1,2})?\/[A-Za-z0-9_./\-@+]+|\.?[A-Za-z0-9_\-@+]+\/[A-Za-z0-9_./\-@+]*\.[A-Za-z0-9_\-@+]+)(?::\d+(?::\d+)?)?/g;
+//
+// Path segments never contain a literal space in this "bare" form — without
+// an explicit terminator, a space-inclusive class would run past the path
+// and swallow trailing prose (e.g. any later `word.word` in the same line
+// would get treated as the "extension" a greedy match backtracks onto).
+const PATH_CHARS = String.raw`[A-Za-z0-9_./\-@+]`;
+function pathBody(chars: string): string {
+  return String.raw`(?:(?:~|\.{1,2})?\/${chars}+|\.?[A-Za-z0-9_\-@+]+\/${chars}*\.[A-Za-z0-9_\-@+]+)`;
+}
+const LINE_COL_SUFFIX = String.raw`(?::\d+(?::\d+)?)?`;
+const BARE = String.raw`(?<![A-Za-z0-9_.:/\-@+])${pathBody(PATH_CHARS)}${LINE_COL_SUFFIX}`;
+
+// Paths that carry spaces (e.g. `~/Blog Posts/My Doc.md`) only get matched
+// when explicitly bounded by a delimiter pair — `(...)`, `[...]`, `"..."`,
+// `'...'` — which is how tool output/quoted shells actually present them.
+// The lookbehind/lookahead anchor to the delimiter chars themselves (not
+// consumed by the match), and since none of those delimiter chars are in
+// the space-inclusive class, a greedy match still can't run past its own
+// closing delimiter into unrelated text.
+const PATH_CHARS_SPACED = String.raw`[A-Za-z0-9_./\-@+ ]`;
+const DELIMITER_PAIRS: Array<[string, string]> = [
+  ["(", ")"],
+  ["[", "]"],
+  ['"', '"'],
+  ["'", "'"],
+];
+function delimited(open: string, close: string): string {
+  const o = `\\${open}`;
+  const c = `\\${close}`;
+  return String.raw`(?<=${o})${pathBody(PATH_CHARS_SPACED)}${LINE_COL_SUFFIX}(?=${c})`;
+}
+
+export const FILE_PATH_RE = new RegExp(
+  [...DELIMITER_PAIRS.map(([o, c]) => delimited(o, c)), BARE].join("|"),
+  "g",
+);
 const TRAILING_PUNCT_RE = /[.,;:)\]}>'"]+$/;
 
 /** Find path-like spans in a terminal line (text + start index). */


### PR DESCRIPTION
## Summary
- `FILE_PATH_RE` (terminal path/link detection) excluded spaces from the path character class, so hover/cmd+click detection stopped at the first space in a path — e.g. tool output like `Write(~/Blog Posts/Doc.md)` only underlined `~/Blog`.
- Paths wrapped in an explicit delimiter pair — `(...)`, `[...]`, `"..."`, `'...'` — now allow spaces, since the delimiter gives an unambiguous end boundary that a greedy space-inclusive match can't run past.
- Bare, undelimited paths are intentionally left space-free: without a delimiter there's no way to know where the path ends vs. surrounding prose, and other terminals (iTerm2, Windows Terminal, VS Code) have the same restriction for the same reason.

## Test plan
- [x] `pnpm --filter @silo-code/extensions-core exec vitest run src/terminal/` — 58 tests pass, including new cases for space-containing delimited paths and a regression guard against a space-inclusive match running past its delimiter into unrelated text
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`
- [x] Manually verified in the dev app: `echo "Write(~/.xerro/documents/Projects/Personal/Silo/Blog Posts/Workspaces Paradigm Shift.md)"` now underlines the full path on hover instead of truncating at the first space

🤖 Generated with [Claude Code](https://claude.com/claude-code)