### PR TITLE
fix(extension-host): make WorkspaceDock the sole authority on its active panel

### DIFF
--- a/apps/desktop/src/automation/bridge.ts
+++ b/apps/desktop/src/automation/bridge.ts
@@ -16,6 +16,7 @@ import {
   openDiff,
   openPreviewDiff,
   splitActivePanel,
+  getActiveDockApi,
   getOutputLogs,
 } from "@silo-code/extension-host";
 
@@ -488,6 +489,23 @@ async function handleOp(
         new CustomEvent("app:activate-panel", { detail: { panelId } }),
       );
       return { activated: panelId };
+    }
+
+    // Drive the real ctx.terminals.focus() path — including its cross-workspace
+    // branch (switch workspace, then land on the requested tab), which a test
+    // can't reach through activatePanel (that only talks to the dock already
+    // on screen).
+    case "focusTerminal": {
+      const terminalId = String(args.terminalId ?? "");
+      getTerminalService().focus(terminalId);
+      return { focused: terminalId };
+    }
+
+    // Which tab the visible center dock is actually showing. Read from
+    // dockview's own api (not the DOM), so a test can watch the active tab
+    // settle — or catch it flipping away a moment after it was set.
+    case "activePanel": {
+      return { panelId: getActiveDockApi()?.activePanel?.id ?? null };
     }
 
     // Bring a registered side panel into view: expand its slot, then activate

--- a/apps/desktop/src/automation/client.ts
+++ b/apps/desktop/src/automation/client.ts
@@ -309,6 +309,24 @@ export class SiloAutomation {
   }
 
   /**
+   * Drive `ctx.terminals.focus(terminalId)` — the public API an extension's side
+   * panel calls. Unlike {@link activatePanel} this covers the cross-workspace
+   * jump (switch to the terminal's workspace, then land on its tab).
+   */
+  focusTerminal(terminalId: string): Promise<{ focused: string }> {
+    return this.call("focusTerminal", { terminalId });
+  }
+
+  /**
+   * The panel id the visible center dock is showing, straight from dockview —
+   * the ground truth for "which tab am I on", and for watching whether it stays
+   * put.
+   */
+  activePanel(): Promise<{ panelId: string | null }> {
+    return this.call("activePanel");
+  }
+
+  /**
    * Move the active center panel into a new split group (test driver), so a test
    * can build a multi-group center — e.g. open an editor + a terminal, then split
    * so they sit in two groups side by side. Returns the resulting group count.

--- a/apps/desktop/src/automation/cross-workspace-terminal-focus.it.test.ts
+++ b/apps/desktop/src/automation/cross-workspace-terminal-focus.it.test.ts
@@ -1,0 +1,121 @@
+// Integration test (Layer 2): ctx.terminals.focus() into ANOTHER workspace must
+// land on the requested tab — and stay there.
+//
+// Regression guard for the flip-flop (issue #320): `focus()` used to call
+// `setActive()` itself behind a flat `setTimeout(80)` — a guess at how long the
+// destination workspace's dock takes to mount — while that dock's own mount
+// effect was independently restoring whichever tab the workspace was last on.
+// Neither knew about the other, so whichever `setActive()` landed last won: the
+// requested tab activated for a moment and then switched away, intermittently,
+// depending on frame timing and tab count.
+//
+// The assertion that matters is therefore not "does it end up right" — which of
+// the two racers wins is environment-dependent, and the wrong one winning is
+// only the loudest symptom. It's that **no other tab of the destination
+// workspace is ever activated**: with the race in place, the dock's own restore
+// switches to the remembered tab first and it sits there ~70ms before the other
+// racer's timer switches away (measured live), which is the flash users see.
+// One authority means one transition, straight to the requested tab.
+//
+// Runs the jump several times and alternates which tab is requested, so a stale
+// "remembered tab" can't accidentally be the right answer.
+//
+// No DOM focus involved (dockview's active panel is the ground truth), so unlike
+// new-terminal-focus.it this doesn't need the window frontmost.
+//
+// Requires the dev app running (`pnpm dev`); skips otherwise.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[cross-workspace-terminal-focus.it] no dev app reachable on :7878 — " +
+      "skipping. Run `pnpm dev` to exercise this suite.",
+  );
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!available)("cross-workspace ctx.terminals.focus", () => {
+  let folderA: string;
+  let folderB: string;
+  let priorActive: string | null;
+  let wsA: string;
+  let wsB: string;
+  let termB1: string;
+  let termB2: string;
+
+  beforeAll(async () => {
+    priorActive = (await silo.listWorkspaces()).active;
+    folderA = await mkdtemp(join(tmpdir(), "silo-it-xwsfocus-a-"));
+    folderB = await mkdtemp(join(tmpdir(), "silo-it-xwsfocus-b-"));
+    wsA = (await silo.openWorkspace(folderA, "it-xws-a")).id;
+    wsB = (await silo.openWorkspace(folderB, "it-xws-b")).id;
+
+    // Two terminals in B, so B has a "remembered" tab that can lose the race
+    // with the requested one. The second one is active when we leave B.
+    await silo.activateWorkspace(wsB);
+    termB1 = (await silo.openTerminal(folderB)).terminalId;
+    termB2 = (await silo.openTerminal(folderB)).terminalId;
+
+    // And one in A, so leaving A is a realistic "I was working over here" state.
+    await silo.activateWorkspace(wsA);
+    await silo.openTerminal(folderA);
+  }, 60000);
+
+  afterAll(async () => {
+    if (wsA) await silo.deleteWorkspace(wsA);
+    if (wsB) await silo.deleteWorkspace(wsB);
+    if (priorActive) await silo.activateWorkspace(priorActive);
+    await rm(folderA, { recursive: true, force: true });
+    await rm(folderB, { recursive: true, force: true });
+  });
+
+  it(
+    "activates only the requested tab — no flash of the workspace's remembered tab",
+    { timeout: 60000 },
+    async () => {
+      for (let round = 0; round < 4; round++) {
+        // Alternate the target: on the round where we ask for the tab B already
+        // remembers, a regression would look like a pass, so never ask for the
+        // same one twice running.
+        const target = round % 2 === 0 ? termB1 : termB2;
+        const other = round % 2 === 0 ? termB2 : termB1;
+        const wanted = `terminal:${target}`;
+
+        await silo.activateWorkspace(wsA);
+        await sleep(400); // let workspace A settle before timing the jump
+
+        await silo.focusTerminal(target);
+
+        // Sample as fast as the RPC allows for a window that comfortably
+        // outlasts every deferred actor (the dock's restore, its 3-RAF focus
+        // pass, relayoutAndRefit). Tabs belonging to workspace A, and the brief
+        // null while docks swap, are expected in transit — a tab belonging to
+        // workspace B that isn't the one we asked for is the bug.
+        const seen = new Set<string | null>();
+        const started = Date.now();
+        let last: string | null = null;
+        while (Date.now() - started < 1200) {
+          last = (await silo.activePanel()).panelId;
+          seen.add(last);
+        }
+
+        expect(
+          seen,
+          `round ${round}: activated a different tab in the ` +
+            `destination workspace (the flash)`,
+        ).not.toContain(`terminal:${other}`);
+        expect(last, `round ${round}: settled on the wrong tab`).toBe(wanted);
+      }
+    },
+  );
+});

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -206,6 +206,8 @@ faithful. **Intended for a sandbox workspace; never point them at real files.**
 | `sendText`          | `{ terminalId, text, addNewline? }`                  | `{ sent }` — write to a PTY; force-spawns if the tab never mounted                     |
 | `openDiff`          | `{ path: string, mode?: "workingTree" \| "staged" }` | `{ diffId, panelId: "diff:<id>" }`                                                     |
 | `activatePanel`     | `{ panelId: string }`                                | `{ activated }`                                                                        |
+| `focusTerminal`     | `{ terminalId: string }`                             | `{ focused }` — drives `ctx.terminals.focus()`, including the cross-workspace jump     |
+| `activePanel`       | —                                                    | `{ panelId }` — the tab the visible center dock is showing, or `null`                  |
 | `showSidePanel`     | `{ id: string }`                                     | `{ shown, slot?, error? }` — expands the panel's slot and clicks its tab               |
 
 Notes:
@@ -237,6 +239,12 @@ Notes:
   string to `activatePanel`, which dispatches the `app:activate-panel`
   `CustomEvent` (`{ detail: { panelId } }`) on `window` — the same event the
   dock listens for.
+- `focusTerminal` is the cross-workspace counterpart of `activatePanel`: it
+  drives the real `ctx.terminals.focus()` (the API an extension's side panel
+  calls), so it also covers switching to the terminal's workspace first.
+  `activePanel` reads dockview's own active panel — the ground truth for "which
+  tab am I on", and what a test polls to watch a tab settle or catch it flipping
+  away (see `cross-workspace-terminal-focus.it.test.ts` and ADR 0032).
 - `openTerminal` opens a `"shell"` terminal; `args.cwd` is optional.
 
 ```bash

--- a/docs/decisions/0032-dock-active-panel-authority.md
+++ b/docs/decisions/0032-dock-active-panel-authority.md
@@ -1,0 +1,98 @@
+---
+status: accepted
+date: 2026-08-04
+---
+
+# 0032. One authority decides a workspace dock's active panel
+
+## Context
+
+Which tab is active in a workspace's center dock was decided by whoever called
+`panel.api.setActive()` last. On a workspace switch that was three independent
+actors, none of them aware of the others:
+
+1. `WorkspaceDock`'s activation effect, restoring the panel the workspace was
+   last visited on, plus a delayed focus pass.
+2. `relayoutAndRefit`, two animation frames later, re-asserting whatever
+   `api.activePanel` was when it ran (it has to: `layout(force=true)` can hand
+   active status to the wrong panel).
+3. Any caller outside the dock — `ctx.terminals.focus(id)` for a terminal in a
+   different workspace — which activated the workspace and then called
+   `setActive()` behind a flat `setTimeout(80)`, a guess at how long the
+   destination dock takes to mount.
+
+Nothing sequenced (1) and (3), so the outcome depended on frame timing, tab
+count, and render cost: the requested tab activated for a moment and then
+switched away, or the remembered tab flashed first and then switched — measured
+live at a ~70ms window of the wrong tab. The focus half compounded it, because
+driving DOM focus into a panel activates it (dock focus tracking), so a
+still-running focus retry aimed at the old panel could undo a correct
+`setActive()` afterwards.
+
+This was the second instance of the class: an earlier same-workspace variant
+("clicking between two terminal rows focused the wrong one") was fixed by
+scoping the focus grab to one panel's content element, but left the
+cross-workspace activation race untouched.
+
+## Decision
+
+**`WorkspaceDock` is the single authority over which panel is active in its
+workspace.** Nothing outside it calls `setActive()` as part of a workspace
+switch. A caller that wants a specific panel records a _request_
+(`docked/panel-activation-requests.ts`, keyed by workspace id); the dock reads
+it in one place, through one pure resolver
+(`resolveActivationTarget` in `panels/dock-helpers.ts`), with fixed precedence:
+
+    explicit request > panel active when the workspace was last visited > leave dockview's pick
+
+A request whose panel hasn't mounted yet (a first-visit dock restores its layout
+and reconciles panels in later commits) reports _pending_ rather than falling
+through to the remembered panel, and is applied from `onDidAddPanel` the moment
+the panel appears. It is dropped when the workspace goes inactive, so it can
+never fire on a later, unrelated visit.
+
+Focus follows activation under the one existing focus-intent token
+(`focusGen`/`focusPanelContent`): the dock's own focus pass now goes through it
+too, so the newest intent deterministically supersedes an in-flight retry
+instead of fighting it.
+
+## Consequences
+
+- No timer anywhere is keyed to a guessed mount latency, so there is no timing
+  to tune and nothing to go flaky under load.
+- New cross-surface "activate this panel" callers (an editor jump across
+  workspaces, a future `ctx.editors.reveal`) have an obvious correct path:
+  record a request. Reaching for `getActiveDockApi()` across a workspace switch
+  is now the wrong shape by construction, not just by convention.
+- The decision points are unit-testable without a live dockview: the resolver is
+  pure and the request registry is a map.
+- The dock's activation effect carries slightly more logic than before, and the
+  request registry is module state outside the valtio store — deliberately, see
+  below.
+
+## Alternatives considered
+
+- **Retime the timer** — replace `setTimeout(80)` with a real "dock has mounted"
+  signal. Rejected: it sequences (3) after (1) but leaves two authorities, so
+  the next actor added to the switch path reopens the bug.
+- **Promote the desired active panel into the store** (`ws.activePanelId`, with
+  write-back from `onDidActivePanelChange`). Purer as a single-source-of-truth
+  model and would persist across restarts, but `layout(force=true)` produces
+  spurious active-panel changes the write-back would record as user intent;
+  suppressing them needs a flag around every programmatic `setActive()`, which
+  reintroduces exactly the ordering assumptions this ADR removes. Deferred, not
+  rejected — if per-workspace active-tab persistence is wanted later, this is
+  the shape, on top of the single authority established here.
+
+## References
+
+- Issue [#320](https://github.com/silo-code/silo/issues/320) — the bug report.
+- `packages/extension-host/src/docked/panel-activation-requests.ts`
+- `packages/extension-host/src/panels/dock-helpers.ts` (`resolveActivationTarget`)
+- `packages/extension-host/src/panels/WorkspaceDock.tsx` (activation effect)
+- `packages/extension-host/src/docked/dock-api-registry.ts` (`focusGen`,
+  `focusPanelContent`) — the focus-intent token this reuses.
+- `apps/desktop/src/automation/cross-workspace-terminal-focus.it.test.ts` — the
+  live regression guard (fails against the racing implementation).
+- ADR [0021](./0021-keyboard-navigation-architecture.md) — the focus-region
+  model the focus half plugs into.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -65,3 +65,5 @@ A small, obvious choice needs neither.
 | [0028](./0028-sealed-agent-detection.md)                | Sealed agent detection and honest resume             | 2026-07-29 | accepted |
 | [0029](./0029-adornments-vs-registration.md)            | Adornments vs registration                           | 2026-07-31 | accepted |
 | [0030](./0030-activity-chrome.md)                       | Activity as first-class chrome                       | 2026-07-31 | accepted |
+| [0031](./0031-update-check-analytics.md)                | Update-check analytics via a Cloudflare Worker proxy | 2026-08-01 | accepted |
+| [0032](./0032-dock-active-panel-authority.md)           | One authority decides a dock's active panel          | 2026-08-04 | accepted |

--- a/packages/extension-host/src/docked/panel-activation-requests.test.ts
+++ b/packages/extension-host/src/docked/panel-activation-requests.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  requestPanelActivation,
+  peekPanelActivation,
+  clearPanelActivation,
+} from "./panel-activation-requests";
+
+afterEach(() => {
+  clearPanelActivation("w1");
+  clearPanelActivation("w2");
+});
+
+describe("panel activation requests", () => {
+  it("has no request for a workspace nobody asked about", () => {
+    expect(peekPanelActivation("w1")).toBeNull();
+  });
+
+  it("records a request and keeps it readable until cleared", () => {
+    requestPanelActivation("w1", "terminal:t1");
+    // Peek must NOT consume: the dock reads the request on activation and again
+    // from onDidAddPanel, because the panel may not be mounted the first time.
+    expect(peekPanelActivation("w1")).toBe("terminal:t1");
+    expect(peekPanelActivation("w1")).toBe("terminal:t1");
+  });
+
+  it("keeps requests per workspace", () => {
+    requestPanelActivation("w1", "terminal:t1");
+    requestPanelActivation("w2", "editor:e9");
+    expect(peekPanelActivation("w1")).toBe("terminal:t1");
+    expect(peekPanelActivation("w2")).toBe("editor:e9");
+  });
+
+  it("lets a newer request for the same workspace replace an older one", () => {
+    // Two rapid clicks in a side panel: the last one is the live intent.
+    requestPanelActivation("w1", "terminal:t1");
+    requestPanelActivation("w1", "terminal:t2");
+    expect(peekPanelActivation("w1")).toBe("terminal:t2");
+  });
+
+  it("clears only the named workspace", () => {
+    requestPanelActivation("w1", "terminal:t1");
+    requestPanelActivation("w2", "terminal:t2");
+    clearPanelActivation("w1");
+    expect(peekPanelActivation("w1")).toBeNull();
+    expect(peekPanelActivation("w2")).toBe("terminal:t2");
+  });
+
+  it("tolerates clearing a workspace with no pending request", () => {
+    expect(() => clearPanelActivation("w1")).not.toThrow();
+    expect(peekPanelActivation("w1")).toBeNull();
+  });
+});

--- a/packages/extension-host/src/docked/panel-activation-requests.ts
+++ b/packages/extension-host/src/docked/panel-activation-requests.ts
@@ -1,0 +1,57 @@
+// Cross-workspace "make this panel active" requests.
+//
+// A caller outside the dock — `ctx.terminals.focus(id)` for a terminal that
+// lives in a *different* workspace — cannot activate the target panel itself.
+// The destination workspace's dock may not be mounted yet, and the moment it
+// becomes active it runs its own active-panel restore (the panel that was
+// showing when the workspace was last visited). An outside `setActive()` fired
+// on a timer is racing that restore: whichever call lands last wins, so the
+// requested tab flashes active and then flips back.
+//
+// So callers record the *intent* here instead, and `WorkspaceDock` — the single
+// authority over which panel is active in its workspace — applies it. The
+// request deliberately outlives mount and layout restore: the dock consumes it
+// as soon as the panel exists (immediately if it's already there, otherwise
+// from `onDidAddPanel`), and drops it when the workspace goes inactive again,
+// by which point it has either been applied or the panel never showed up.
+//
+// Keyed by workspace id; one pending request per workspace (a newer request
+// replaces an older one — the last caller's intent is the live one).
+
+const requests = new Map<string, string>();
+
+/**
+ * Ask for `panelId` to be the active panel in `workspaceId`'s dock, applied by
+ * that workspace's `WorkspaceDock` once it is active and the panel exists.
+ *
+ * @internal — host-side coordination; extensions reach this through
+ * `ctx.terminals.focus()`.
+ */
+export function requestPanelActivation(
+  workspaceId: string,
+  panelId: string,
+): void {
+  requests.set(workspaceId, panelId);
+}
+
+/**
+ * The panel id a caller is waiting to see active in `workspaceId`, or null.
+ * Read-only — the dock clears it via {@link clearPanelActivation} once applied,
+ * so a request for a not-yet-mounted panel survives until the panel appears.
+ *
+ * @internal
+ */
+export function peekPanelActivation(workspaceId: string): string | null {
+  return requests.get(workspaceId) ?? null;
+}
+
+/**
+ * Drop `workspaceId`'s pending request — after applying it, or when the
+ * workspace goes inactive without it ever becoming applicable (so a stale
+ * request can't yank a tab on some later, unrelated visit).
+ *
+ * @internal
+ */
+export function clearPanelActivation(workspaceId: string): void {
+  requests.delete(workspaceId);
+}

--- a/packages/extension-host/src/extension-host/terminal-service.test.ts
+++ b/packages/extension-host/src/extension-host/terminal-service.test.ts
@@ -36,6 +36,10 @@ const PANEL_CONTENT_ELEMENT = {} as HTMLElement;
 
 import { store } from "../state/store";
 import type { WorkspaceInternal } from "../state/types";
+import {
+  peekPanelActivation,
+  clearPanelActivation,
+} from "../docked/panel-activation-requests";
 import { getTerminalService } from "./terminal-service";
 
 const svc = getTerminalService();
@@ -100,6 +104,9 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
+  // Cross-workspace focus() leaves a pending request behind for the
+  // destination dock to consume — don't leak it into the next test.
+  clearPanelActivation("other");
 });
 
 describe("TerminalService.sendText (B7)", () => {
@@ -238,7 +245,15 @@ describe("TerminalService.focus", () => {
     expect(focusPanelContent).not.toHaveBeenCalled();
   });
 
-  it("switches the active workspace first when the terminal belongs to a different one", () => {
+  it("hands a cross-workspace focus to the destination dock as a request, touching no dock itself", () => {
+    // Regression test for the flip-flop (issue #320): this path used to call
+    // setActive() itself behind a flat setTimeout(80) — a guess at how long the
+    // destination dock takes to mount — while that dock's own mount effect was
+    // independently restoring the panel the workspace was last on. Whichever
+    // setActive() landed last won, so the requested tab flashed active and then
+    // switched away. Now focus() only records the intent and switches the
+    // workspace; WorkspaceDock (the single authority over its active panel)
+    // applies it deterministically once its dock is up.
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const other = makeWorkspace("other");
     other.terminals = [
@@ -249,14 +264,31 @@ describe("TerminalService.focus", () => {
 
     svc.focus("t3");
     expect(store.activeWorkspaceId).toBe("other");
-    // The cross-workspace path defers activate() itself (setTimeout 80ms) on
-    // top of the same rAF deferral — setActive() shouldn't have run yet.
-    expect(setActive).not.toHaveBeenCalled();
+    expect(peekPanelActivation("other")).toBe("terminal:t3");
 
-    vi.advanceTimersByTime(80);
-    expect(setActive).toHaveBeenCalledTimes(1);
+    // No dock work from here — not now, not on any timer, not on any frame.
+    expect(getActiveDockApi).not.toHaveBeenCalled();
+    expect(setActive).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
     flushRaf();
-    expect(focusPanelContent).toHaveBeenCalledTimes(1);
-    expect(focusPanelContent).toHaveBeenCalledWith(PANEL_CONTENT_ELEMENT);
+    expect(setActive).not.toHaveBeenCalled();
+    expect(focusPanelContent).not.toHaveBeenCalled();
+  });
+
+  it("keeps only the newest cross-workspace request when clicked twice in a row", () => {
+    const other = makeWorkspace("other");
+    other.terminals = [
+      { id: "t3", sessionId: "sess-3", kind: "shell", title: "Terminal" },
+      { id: "t4", sessionId: "sess-4", kind: "shell", title: "Terminal" },
+    ];
+    store.workspaces.other = other;
+    store.workspaceOrder.push("other");
+
+    svc.focus("t3");
+    // Second click lands before the destination dock has applied the first —
+    // the last intent is the live one, and only one tab switch happens.
+    store.activeWorkspaceId = "w"; // still elsewhere as far as this call knows
+    svc.focus("t4");
+    expect(peekPanelActivation("other")).toBe("terminal:t4");
   });
 });

--- a/packages/extension-host/src/extension-host/terminal-service.ts
+++ b/packages/extension-host/src/extension-host/terminal-service.ts
@@ -27,6 +27,7 @@ import {
   focusPanelContent,
   getActiveDockApi,
 } from "../docked/dock-api-registry";
+import { requestPanelActivation } from "../docked/panel-activation-requests";
 import { createHostChannel } from "./output-store";
 import {
   collectLivePtys,
@@ -289,33 +290,40 @@ export function getTerminalService(): TerminalService {
       )?.id;
       if (!wsId) return;
 
-      const activate = () => {
-        const panel = getActiveDockApi()?.getPanel(`terminal:${terminalId}`);
-        panel?.api.setActive();
-        if (!panel) return;
-        // Defer the actual focus grab past this tick, and scope it to this
-        // specific panel's own content — not focusCenterDock()'s "whatever's
-        // visible in the active group" search. With two-plus terminal tabs in
-        // the same group, that generic search can win the race against
-        // dockview's own (async, not synchronous with setActive()) visibility
-        // toggle and land on the *previous* tab's still-visible content,
-        // which reads as "some textarea in the group is focused" and never
-        // retries again — confirmed live: clicking between two terminal rows
-        // in agent-inspector sometimes focused the wrong one. Scoping to
-        // panel.view.content.element removes every other panel from the
-        // search, so there's nothing left to grab but the right one.
-        requestAnimationFrame(() =>
-          focusPanelContent(panel.view.content.element),
-        );
-      };
+      const panelId = `terminal:${terminalId}`;
 
       if (store.activeWorkspaceId !== wsId) {
+        // Cross-workspace: do NOT reach for the dock from here. The target
+        // workspace's dock may not be mounted yet, and the moment it becomes
+        // active it runs its own active-panel restore — a setActive() fired on
+        // a timer here is racing that restore, and whichever call lands last
+        // wins (the requested tab flashes active, then flips back). Record the
+        // intent instead and let WorkspaceDock, the single authority over its
+        // own active panel, apply it — and drive focus — once its dock is up.
+        requestPanelActivation(wsId, panelId);
         activateWorkspace(wsId);
-        // Defer until the new workspace's dock has mounted.
-        setTimeout(activate, 80);
-      } else {
-        activate();
+        return;
       }
+
+      // Same workspace — the dock is already up and nothing else is deciding
+      // its active panel right now, so activate the tab directly.
+      const panel = getActiveDockApi()?.getPanel(panelId);
+      panel?.api.setActive();
+      if (!panel) return;
+      // Defer the actual focus grab past this tick, and scope it to this
+      // specific panel's own content — not focusCenterDock()'s "whatever's
+      // visible in the active group" search. With two-plus terminal tabs in
+      // the same group, that generic search can win the race against
+      // dockview's own (async, not synchronous with setActive()) visibility
+      // toggle and land on the *previous* tab's still-visible content,
+      // which reads as "some textarea in the group is focused" and never
+      // retries again — confirmed live: clicking between two terminal rows
+      // in agent-inspector sometimes focused the wrong one. Scoping to
+      // panel.view.content.element removes every other panel from the
+      // search, so there's nothing left to grab but the right one.
+      requestAnimationFrame(() =>
+        focusPanelContent(panel.view.content.element),
+      );
     },
     closeWorkspace(workspaceId) {
       void reapWorkspaceTerminals(workspaceId);

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -50,8 +50,9 @@ export { executeCommand } from "./extension-host/commands";
 export { contextKeys } from "./extension-host/context-keys";
 export { sidePanelRegistry } from "./extension-host/side-panels";
 export { ensureMonaco } from "./docked/monaco-setup";
-// Test-driver only (the dev automation bridge uses it to set up a center split).
-export { splitActivePanel } from "./docked/dock-api-registry";
+// Test-driver only (the dev automation bridge uses it to set up a center split,
+// and to read which tab the center dock is actually showing).
+export { splitActivePanel, getActiveDockApi } from "./docked/dock-api-registry";
 // Output log query — lets the automation bridge surface logs to external tools.
 export {
   getOutputLogs,

--- a/packages/extension-host/src/panels/WorkspaceDock.tsx
+++ b/packages/extension-host/src/panels/WorkspaceDock.tsx
@@ -29,17 +29,20 @@ import {
   getDockComponents,
 } from "../extension-host/dock-panel-kinds";
 import { ErrorBoundary } from "../components/ErrorBoundary";
-import { setActiveDockApi } from "../docked/dock-api-registry";
+import {
+  setActiveDockApi,
+  focusPanelContent,
+} from "../docked/dock-api-registry";
+import {
+  peekPanelActivation,
+  clearPanelActivation,
+} from "../docked/panel-activation-requests";
 import { getDndService, resolveDndMode } from "../extension-host/dnd-service";
 import { DND_MIME } from "@silo-code/sdk";
 import { setActiveTerminal } from "../extension-host/active-terminal-registry";
 import { setContextKey } from "../extension-host/context-keys";
 import { resolveEditorForRecord } from "../extension-host/editor-registry";
-import {
-  retryFocus,
-  isTextareaFocusedWithin,
-  blurTextareaWithin,
-} from "../extension-host/use-focus-retry";
+import { blurTextareaWithin } from "../extension-host/use-focus-retry";
 import { confirm } from "../extension-host/modal-service";
 import { getThemeBase } from "../layout/presets";
 import { DockTab } from "./DockTab";
@@ -48,6 +51,7 @@ import { GroupAddMenu } from "./GroupAddMenu";
 import {
   findEditorTargetGroup,
   panelToReactivateOnClose,
+  resolveActivationTarget,
 } from "./dock-helpers";
 
 const dnd = getDndService();
@@ -202,27 +206,61 @@ export function WorkspaceDock({
 
   useEffect(() => {
     if (!active || !api) return;
-    setActiveDockApi(api);
-    const root = (api as unknown as { element?: HTMLElement }).element ?? null;
+    const liveApi = api;
+    setActiveDockApi(liveApi);
+    const root =
+      (liveApi as unknown as { element?: HTMLElement }).element ?? null;
 
-    // Restore the panel that was active when this workspace was last visited.
-    // If this is the first activation there is no saved state, so we fall back
-    // to whatever dockview considers active right now.
-    const savedId = lastActivePanelRef.current;
-    const targetPanel =
-      (savedId ? api.getPanel(savedId) : null) ?? api.activePanel;
-    if (targetPanel && targetPanel !== api.activePanel) {
-      targetPanel.api.setActive();
+    // This dock is the SINGLE authority over which panel is active in its
+    // workspace. Nothing outside it calls setActive() on a workspace switch:
+    // a caller that wants a specific panel (ctx.terminals.focus() for a
+    // terminal in another workspace) records a request
+    // (panel-activation-requests) and we apply it here, ahead of the
+    // last-visited restore. Two callers each firing their own setActive() on
+    // their own timing is what made the requested tab flash active and then
+    // flip back to the workspace's remembered tab.
+    //
+    // `applyTarget` returns whether it moved the active tab, so the focus
+    // fallback below knows whether focus is already being driven.
+    let movedActivePanel = false;
+    function applyTarget(): void {
+      const requestedId = peekPanelActivation(workspaceId);
+      const { targetId } = resolveActivationTarget(
+        requestedId,
+        lastActivePanelRef.current,
+        (id) => !!liveApi.getPanel(id),
+      );
+      if (!targetId) return; // nothing mounted to switch to (or still waiting)
+      if (targetId === requestedId) clearPanelActivation(workspaceId);
+      const panel = liveApi.getPanel(targetId);
+      if (!panel || panel === liveApi.activePanel) return;
+      panel.api.setActive();
+      movedActivePanel = true;
+      // Focus follows the tab switch, scoped to this panel's own content —
+      // never a group-wide search, which can land on the previous tab's
+      // still-visible content (see focusPanelContent).
+      focusPanelContent(panel.view.content.element);
     }
+    applyTarget();
 
-    // Delay the focus retry until after relayoutAndRefit (2 RAFs away) to
+    // A request can arrive before its panel exists: a workspace visited for the
+    // first time this session mounts its dock now, and restores its layout /
+    // reconciles its terminal+editor panels in later commits. Apply the pending
+    // request the moment the panel shows up — no timer, no guessed mount delay.
+    const addSub = liveApi.onDidAddPanel(() => {
+      if (peekPanelActivation(workspaceId)) applyTarget();
+    });
+
+    // Delay the focus fallback until after relayoutAndRefit (2 RAFs away) to
     // prevent a one-frame editor flash. layout(force=true) can briefly hand
-    // active status to Monaco; firing retryFocus immediately would land in
-    // the editor, get disrupted on RAF 2, and produce a visible focus flicker.
+    // active status to Monaco; firing it immediately would land in the editor,
+    // get disrupted on RAF 2, and produce a visible focus flicker.
     // useFocusOnActive inside each panel component drives focus from
-    // relayoutAndRefit's setActive() call; this retryFocus is a fallback for
-    // the case where the active panel didn't change (no onDidActiveChange
-    // fires, so useFocusOnActive never triggers).
+    // relayoutAndRefit's setActive() call; this is a fallback for the case
+    // where the active panel didn't change (no onDidActiveChange fires, so
+    // useFocusOnActive never triggers) — when applyTarget DID switch tabs it
+    // has already driven focus, and re-driving it here would be a second,
+    // competing focus intent.
     let cancelled = false;
     let rafId = 0;
     let frame = 0;
@@ -232,21 +270,21 @@ export function WorkspaceDock({
         if (!cancelled) rafId = requestAnimationFrame(step);
         return;
       }
-      if (cancelled) return;
-      const panel = (savedId ? api.getPanel(savedId) : null) ?? api.activePanel;
-      retryFocus(
-        () => (panel ?? api.activePanel)?.focus(),
-        () => isTextareaFocusedWithin(root),
-        () => !cancelled,
-      );
+      if (cancelled || movedActivePanel) return;
+      const panel = liveApi.activePanel;
+      if (panel) focusPanelContent(panel.view.content.element);
     };
     rafId = requestAnimationFrame(step);
 
     return () => {
       cancelled = true;
       cancelAnimationFrame(rafId);
+      addSub.dispose();
+      // Drop any request that never became applicable (its panel never
+      // mounted) so it can't yank a tab on some later, unrelated visit.
+      clearPanelActivation(workspaceId);
       // Save which panel was active so we can restore it on the next visit.
-      lastActivePanelRef.current = api.activePanel?.id ?? null;
+      lastActivePanelRef.current = liveApi.activePanel?.id ?? null;
       // Dispatch synthetic blur/focusout to reset Monaco's _hasFocus tracker.
       // While the dock is invisible the real blur is often dropped, leaving
       // Monaco believing it still owns focus; without this it re-steals via
@@ -254,7 +292,7 @@ export function WorkspaceDock({
       blurTextareaWithin(root);
       setActiveDockApi(null);
     };
-  }, [active, api]);
+  }, [active, api, workspaceId]);
 
   // Push the active editor + editor-view ids into the extension context-keys so
   // menu items / keybindings with `when` clauses can react, and so that

--- a/packages/extension-host/src/panels/dock-helpers.test.ts
+++ b/packages/extension-host/src/panels/dock-helpers.test.ts
@@ -1,8 +1,77 @@
 import { describe, expect, it } from "vitest";
 import {
   panelToReactivateOnClose,
+  resolveActivationTarget,
   shouldShowMaximizeButton,
 } from "./dock-helpers";
+
+// The single decision point for "which tab shows when this workspace becomes
+// active" — the fix for ctx.terminals.focus() losing a race with the dock's own
+// restore (issue #320). An explicit request outranks the remembered tab, and a
+// request whose panel hasn't mounted yet waits instead of letting the
+// remembered tab activate first (which is exactly the visible flip-flop).
+describe("resolveActivationTarget", () => {
+  const mounted =
+    (...ids: string[]) =>
+    (id: string) =>
+      ids.includes(id);
+
+  it("restores the last-visited panel when nothing was requested", () => {
+    expect(
+      resolveActivationTarget(null, "terminal:t1", mounted("terminal:t1")),
+    ).toEqual({ targetId: "terminal:t1", pending: false });
+  });
+
+  it("leaves dockview's pick alone when nothing was requested or remembered", () => {
+    // First-ever activation of a workspace: no saved state to restore.
+    expect(resolveActivationTarget(null, null, mounted("terminal:t1"))).toEqual(
+      {
+        targetId: null,
+        pending: false,
+      },
+    );
+  });
+
+  it("ignores a remembered panel that no longer exists", () => {
+    // The remembered tab was closed while the workspace was in the background.
+    expect(
+      resolveActivationTarget(null, "terminal:gone", mounted("terminal:t1")),
+    ).toEqual({ targetId: null, pending: false });
+  });
+
+  it("prefers an explicit request over the remembered panel", () => {
+    // The whole point: ctx.terminals.focus() asked for t2, the workspace
+    // remembers t1. The request wins — and only once, since the caller clears
+    // it after applying.
+    expect(
+      resolveActivationTarget(
+        "terminal:t2",
+        "terminal:t1",
+        mounted("terminal:t1", "terminal:t2"),
+      ),
+    ).toEqual({ targetId: "terminal:t2", pending: false });
+  });
+
+  it("waits — rather than restoring the remembered panel — while the requested panel is unmounted", () => {
+    // A first-visit dock restores its layout and reconciles panels in later
+    // commits, so the request lands before the panel exists. Activating the
+    // remembered tab now would switch twice and show the flip the user reported.
+    expect(
+      resolveActivationTarget(
+        "terminal:t2",
+        "terminal:t1",
+        mounted("terminal:t1"),
+      ),
+    ).toEqual({ targetId: null, pending: true });
+  });
+
+  it("waits on an unmounted request even with nothing remembered", () => {
+    expect(resolveActivationTarget("terminal:t2", null, mounted())).toEqual({
+      targetId: null,
+      pending: true,
+    });
+  });
+});
 
 describe("panelToReactivateOnClose", () => {
   it("returns null when the closed tab WAS the active one (let dockview's within-group MRU pick)", () => {

--- a/packages/extension-host/src/panels/dock-helpers.ts
+++ b/packages/extension-host/src/panels/dock-helpers.ts
@@ -44,6 +44,46 @@ export function panelToReactivateOnClose(
   return preCloseActivePanelId;
 }
 
+/** What a dock should do about its active panel — see {@link resolveActivationTarget}. */
+export type ActivationTarget = {
+  /** Panel to make active, or null to leave dockview's current pick alone. */
+  targetId: string | null;
+  /** True while a requested panel exists but hasn't mounted yet — keep waiting. */
+  pending: boolean;
+};
+
+// Decide which panel a workspace's dock should make active — the single place
+// that answers "which tab shows when this workspace becomes active", so no two
+// callers can disagree about it.
+//
+// Precedence:
+//  1. An explicit cross-workspace request (`ctx.terminals.focus()` for a
+//     terminal in another workspace — see panel-activation-requests).
+//  2. The panel that was active when this workspace was last visited.
+//  3. Nothing — leave whatever dockview considers active.
+//
+// A requested panel that isn't mounted yet reports `pending` rather than
+// falling through to (2): a fresh dock restores its layout and reconciles its
+// terminal/editor panels in later commits, so the request arrives before the
+// panel exists. Activating the remembered panel meanwhile would produce exactly
+// the flip-flop this whole mechanism removes — better to leave the tab alone
+// for a frame or two and switch once, when the requested panel appears.
+export function resolveActivationTarget(
+  requestedId: string | null,
+  lastActiveId: string | null,
+  hasPanel: (panelId: string) => boolean,
+): ActivationTarget {
+  if (requestedId) {
+    return hasPanel(requestedId)
+      ? { targetId: requestedId, pending: false }
+      : { targetId: null, pending: true };
+  }
+  if (lastActiveId && hasPanel(lastActiveId)) {
+    return { targetId: lastActiveId, pending: false };
+  }
+  return { targetId: null, pending: false };
+}
+
 // Shared action helper — used by both the per-group + menu and the empty
 // workspace watermark. Resolves the workspace folder, then opens a file picker.
 export async function pickFileForWorkspace(


### PR DESCRIPTION
Fixes #320.

## The defect

Three independent actors decided the active panel on a workspace switch, none of them the authority:

1. `WorkspaceDock`'s activation effect — restores the panel the workspace was last visited on, plus a delayed focus pass.
2. `relayoutAndRefit` (2 RAFs later) — re-asserts whatever `api.activePanel` was when it ran. It has to: `layout(force=true)` can hand active status to the wrong panel. The issue report misses this one.
3. `ctx.terminals.focus()` — activated the workspace, then called `setActive()` behind a flat `setTimeout(80)`, a guess at how long the destination dock takes to mount.

Nothing sequenced (1) and (3), so the outcome depended on frame timing, tab count, and render cost. Measured live against the old code: the remembered tab activates at ~23ms and sits there ~70ms before the timer switches away — the flash users see. The focus half compounds it, because driving DOM focus into a panel activates it (dock focus tracking), so a still-running retry aimed at the old panel can undo a correct `setActive()` afterwards.

Retiming the 80ms — a mount promise, an `onDidAddPanel` await — sequences (3) after (1) but leaves two authorities. That's a tuned race, not a fixed one.

## The fix

`WorkspaceDock` is the single authority over which panel is active in its workspace. Nothing outside it calls `setActive()` as part of a workspace switch.

- **`docked/panel-activation-requests.ts`** — a caller that wants a specific panel records the intent, keyed by workspace id. No timing in it.
- **`ctx.terminals.focus()` cross-workspace path** — record the request, `activateWorkspace()`, return. No timer, no `setActive`, no dock access. The same-workspace path is unchanged.
- **`resolveActivationTarget()`** (pure, in `dock-helpers.ts`) — one decision point, fixed precedence: explicit request > last-visited panel > dockview's pick. A request whose panel hasn't mounted yet reports *pending* rather than falling through to the remembered panel (activating it meanwhile is the flip-flop), and gets applied from `onDidAddPanel` the moment the panel appears. Dropped when the workspace goes inactive, so it can never fire on a later visit.
- **Focus** — the dock's bespoke dock-wide `retryFocus` becomes `focusPanelContent(target.view.content.element)`: panel-scoped, and it joins the existing `focusGen` intent token, so the newest intent supersedes an in-flight retry instead of fighting it. It only runs when the reconciler didn't already switch tabs.

Net: one `setActive()` authority per activation, one focus-intent token, zero timers keyed to guessed mount latency.

## Tests

- Unit: the request registry, the pure resolver (contract + the pending/first-visit edge), and a rewritten cross-workspace `focus()` test asserting *no* timer and *no* dock access.
- Integration: `cross-workspace-terminal-focus.it.test.ts` — 4 alternating jumps, sampling the active tab for 1.2s each, asserting no other tab of the destination workspace is ever activated. **Verified to fail against the racing implementation** (`round 0: activated a different tab in the destination workspace`) and pass with this one. Needs two new automation ops, `focusTerminal` and `activePanel`.

## Verified live

Against the running dev app (probes over the automation RPC):

- Cross-workspace jump: one transition, straight to the requested tab (was: wrong tab at ~23ms, requested at ~96ms).
- Plain workspace switching still restores the remembered tab, single observed state, DOM focus lands — for a terminal tab and for a Monaco editor tab.
- Full integration suite: 7 passed, 3 skipped (the focus-sensitive suites, which need the window frontmost).

## Docs

ADR [0032](docs/decisions/0032-dock-active-panel-authority.md) records the invariant and why the store-driven alternative (`ws.activePanelId` + write-back) was deferred rather than taken. Automation op table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)