### PR TITLE
feat(layout): give Laptop Mode its own layout and size side columns in px

### DIFF
--- a/packages/extension-host/src/extension-host/focus-regions.test.ts
+++ b/packages/extension-host/src/extension-host/focus-regions.test.ts
@@ -30,8 +30,8 @@ afterEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
   for (const dispose of sidePaneDisposers.splice(0)) dispose();
-  store.leftPanelAutoHidden = false;
-  store.rightPanelAutoHidden = false;
+  store.leftPanelCollapsed = false;
+  store.rightPanelCollapsed = false;
 });
 
 // ── DOM builders (jsdom has no layout, so side-pane visibility is stubbed via a
@@ -182,14 +182,14 @@ describe("cycleRegionFocus", () => {
     expect(document.activeElement).toBe(editor);
   });
 
-  it("skips a side dock that small-screen mode auto-hid, even though it's rendered at full width (a peek)", () => {
-    // Full clientWidth (200) — as if genuinely peeking — but flagged
-    // autoHidden, which alone must be enough to exclude it: peek is a
-    // mouse-only affordance with no keyboard gesture to invoke it.
+  it("skips a collapsed side dock even though it's rendered at full width (a peek)", () => {
+    // Full clientWidth (200) — as if genuinely peeking — but collapsed, which
+    // alone must be enough to exclude it: peek is a mouse-only affordance with
+    // no keyboard gesture to invoke it.
     sidePane("left");
     const editor = document.createElement("textarea");
     centerWith(editor);
-    store.leftPanelAutoHidden = true;
+    store.leftPanelCollapsed = true;
 
     editor.focus();
     expect(cycleRegionFocus(-1)).toBe(false);
@@ -260,10 +260,10 @@ describe("installRegionTabHandoff", () => {
     expect(document.activeElement).toBe(editor);
   });
 
-  it("never hands off out of a small-screen-auto-hidden dock, even from its last tabbable", () => {
+  it("never hands off out of a collapsed (peeking) dock, even from its last tabbable", () => {
     const left = sidePane("left");
     centerWith(document.createElement("textarea"));
-    store.leftPanelAutoHidden = true;
+    store.leftPanelCollapsed = true;
 
     left.focus(); // its only (so "last") tabbable
     const e = pressTab();

--- a/packages/extension-host/src/extension-host/focus-regions.ts
+++ b/packages/extension-host/src/extension-host/focus-regions.ts
@@ -30,14 +30,12 @@ import {
   tabbablesIn,
 } from "./focus-dom";
 
-/** Small-screen mode excludes an auto-hidden panel from Tab order entirely —
- * peeking or not, since peek is a mouse-only affordance with no keyboard
- * gesture to invoke it. A manual toggle clears the flag and restores normal
- * tabbing (see `state/store.ts` `setLeftPanelCollapsed`/`setRightPanelCollapsed`). */
-function isAutoHidden(side: "left" | "right"): boolean {
-  return side === "left"
-    ? store.leftPanelAutoHidden
-    : store.rightPanelAutoHidden;
+/** A collapsed side column is out of Tab order entirely — including while it's
+ * revealed by an edge-hover peek, since peek is a mouse-only affordance with no
+ * keyboard gesture to invoke it (a peeking column has real width, so the
+ * `clientWidth` check below wouldn't catch it on its own). */
+function isCollapsed(side: "left" | "right"): boolean {
+  return side === "left" ? store.leftPanelCollapsed : store.rightPanelCollapsed;
 }
 
 /**
@@ -64,10 +62,10 @@ interface FocusRegion {
   tabbables?(): HTMLElement[];
 }
 
-/** The visible side-pane element for a side, or null when collapsed/empty/
- * small-screen-auto-hidden (peeking or not — see `isAutoHidden`). */
+/** The visible side-pane element for a side, or null when collapsed (peeking
+ * or not — see `isCollapsed`) or empty. */
 function sidePane(side: "left" | "right"): HTMLElement | null {
-  if (isAutoHidden(side)) return null;
+  if (isCollapsed(side)) return null;
   for (const p of document.querySelectorAll<HTMLElement>(
     `.side-pane[data-slot^="${side}"]`,
   )) {
@@ -104,9 +102,9 @@ function sideRegion(side: "left" | "right", order: number): FocusRegion {
       return focusFirstOrContainer(active);
     },
     tabbables() {
-      // Small-screen-auto-hidden: excluded from the handoff entirely, peeking
-      // or not (see `isAutoHidden`).
-      if (isAutoHidden(side)) return [];
+      // Collapsed: excluded from the handoff entirely, peeking or not (see
+      // `isCollapsed`).
+      if (isCollapsed(side)) return [];
       // Only the ACTIVE panel's tabbables in each pane — a side dock keeps its
       // inactive panels mounted but hidden, and their (unfocusable) tabbables
       // would otherwise be picked as the "last", breaking the handoff.

--- a/packages/extension-host/src/extension-host/layout-service.test.ts
+++ b/packages/extension-host/src/extension-host/layout-service.test.ts
@@ -86,39 +86,40 @@ describe("LayoutService.openPanel", () => {
   });
 });
 
-// These three are the public (command/`ctx.layout`) collapse path, which must
-// always clear the corresponding `*PanelAutoHidden` flag — that's what makes
-// an explicit call "stick" instead of being re-hidden by small-screen mode's
-// next auto-hide pass (see extension-host/small-screen-mode.ts).
-describe("LayoutService manual collapse path clears autoHidden", () => {
+// These three are the public (command/`ctx.layout`) collapse path. It writes
+// the *live* layout mode — on a narrow window that's small-screen mode's own
+// layout, which is remembered for the next narrow window rather than folded
+// into the normal-width one (see extension-host/small-screen-mode.ts).
+describe("LayoutService collapse path writes the live layout mode", () => {
   beforeEach(() => {
     store.leftPanelCollapsed = true;
     store.rightPanelCollapsed = true;
-    store.leftPanelAutoHidden = true;
-    store.rightPanelAutoHidden = true;
+    store.smallScreenActive = true;
+    store.inactiveModeCollapsed = { left: false, right: false };
   });
 
   afterEach(() => {
     store.leftPanelCollapsed = false;
     store.rightPanelCollapsed = false;
-    store.leftPanelAutoHidden = false;
-    store.rightPanelAutoHidden = false;
+    store.smallScreenActive = false;
+    store.inactiveModeCollapsed = null;
   });
 
-  it("setSidePanelCollapsed clears autoHidden for the given side only", () => {
+  it("setSidePanelCollapsed expands the given side only, leaving the other mode alone", () => {
     layout.setSidePanelCollapsed("left", false);
     expect(store.leftPanelCollapsed).toBe(false);
-    expect(store.leftPanelAutoHidden).toBe(false);
-    expect(store.rightPanelAutoHidden).toBe(true); // untouched
+    expect(store.rightPanelCollapsed).toBe(true); // untouched
+    // The normal-width layout is untouched by a change made while narrow.
+    expect(store.inactiveModeCollapsed).toEqual({ left: false, right: false });
   });
 
-  it("toggleSidePanel clears autoHidden", () => {
+  it("toggleSidePanel flips the live mode's state", () => {
     layout.toggleSidePanel("right"); // currently collapsed → expands
     expect(store.rightPanelCollapsed).toBe(false);
-    expect(store.rightPanelAutoHidden).toBe(false);
+    expect(store.inactiveModeCollapsed).toEqual({ left: false, right: false });
   });
 
-  it("revealSidePanel clears autoHidden for the panel's column", () => {
+  it("revealSidePanel expands the panel's column", () => {
     const dispose = sidePanelRegistry.register({
       id: "test.panel",
       location: "left",
@@ -128,7 +129,6 @@ describe("LayoutService manual collapse path clears autoHidden", () => {
     try {
       layout.revealSidePanel("test.panel");
       expect(store.leftPanelCollapsed).toBe(false);
-      expect(store.leftPanelAutoHidden).toBe(false);
     } finally {
       dispose.dispose();
     }

--- a/packages/extension-host/src/extension-host/small-screen-mode.test.ts
+++ b/packages/extension-host/src/extension-host/small-screen-mode.test.ts
@@ -28,8 +28,8 @@ function setInnerWidth(px: number): void {
 function resetStore(): void {
   store.leftPanelCollapsed = false;
   store.rightPanelCollapsed = false;
-  store.leftPanelAutoHidden = false;
-  store.rightPanelAutoHidden = false;
+  store.smallScreenActive = false;
+  store.inactiveModeCollapsed = null;
   store.leftPanelPeeking = false;
   store.rightPanelPeeking = false;
   store.leftPanelPeekDragging = false;
@@ -102,25 +102,28 @@ describe("installSmallScreenMode", () => {
     vi.useRealTimers();
   });
 
-  it("auto-hides open panels immediately when launched already small", () => {
+  it("switches to small-screen mode's own layout immediately when launched already small", () => {
     setInnerWidth(1200);
     dispose = installSmallScreenMode();
 
+    expect(store.smallScreenActive).toBe(true);
+    // Nothing recorded for this workspace yet → both columns out of the way.
     expect(store.leftPanelCollapsed).toBe(true);
-    expect(store.leftPanelAutoHidden).toBe(true);
     expect(store.rightPanelCollapsed).toBe(true);
-    expect(store.rightPanelAutoHidden).toBe(true);
+    // ...with the normal-width layout waiting off screen.
+    expect(store.inactiveModeCollapsed).toEqual({ left: false, right: false });
   });
 
   it("does nothing when launched already large", () => {
     setInnerWidth(1800);
     dispose = installSmallScreenMode();
 
+    expect(store.smallScreenActive).toBe(false);
     expect(store.leftPanelCollapsed).toBe(false);
-    expect(store.leftPanelAutoHidden).toBe(false);
+    expect(store.inactiveModeCollapsed).toBeNull();
   });
 
-  it("auto-hides on a debounced resize below threshold", () => {
+  it("switches modes on a debounced resize below threshold", () => {
     setInnerWidth(1800);
     dispose = installSmallScreenMode();
     expect(store.leftPanelCollapsed).toBe(false);
@@ -131,11 +134,11 @@ describe("installSmallScreenMode", () => {
     expect(store.leftPanelCollapsed).toBe(false);
 
     vi.advanceTimersByTime(250);
+    expect(store.smallScreenActive).toBe(true);
     expect(store.leftPanelCollapsed).toBe(true);
-    expect(store.leftPanelAutoHidden).toBe(true);
   });
 
-  it("restores auto-hidden panels to prior collapsed/autoHidden=false once the screen grows past the hysteresis band", () => {
+  it("restores the normal-width layout once the screen grows past the hysteresis band", () => {
     setInnerWidth(1000);
     dispose = installSmallScreenMode();
     expect(store.leftPanelCollapsed).toBe(true);
@@ -143,69 +146,73 @@ describe("installSmallScreenMode", () => {
     setInnerWidth(1440); // exactly at threshold — inside the hysteresis dead zone
     window.dispatchEvent(new Event("resize"));
     vi.advanceTimersByTime(250);
-    expect(store.leftPanelCollapsed).toBe(true); // still hidden — hasn't cleared threshold+hysteresis
+    expect(store.leftPanelCollapsed).toBe(true); // hasn't cleared threshold+hysteresis
 
     setInnerWidth(1600); // clears threshold + 80px hysteresis
     window.dispatchEvent(new Event("resize"));
     vi.advanceTimersByTime(250);
+    expect(store.smallScreenActive).toBe(false);
     expect(store.leftPanelCollapsed).toBe(false);
-    expect(store.leftPanelAutoHidden).toBe(false);
   });
 
-  it("never touches a panel the user manually collapsed", () => {
+  it("keeps a panel the user collapsed on a wide window collapsed when it comes back", () => {
     setInnerWidth(1800);
-    setLeftPanelCollapsed(true); // manual collapse, unrelated to screen size
+    setLeftPanelCollapsed(true); // part of the normal-width layout
     dispose = installSmallScreenMode();
-    expect(store.leftPanelAutoHidden).toBe(false);
 
     setInnerWidth(1000);
     window.dispatchEvent(new Event("resize"));
     vi.advanceTimersByTime(250);
-    // Stays collapsed, but small-screen mode never claimed it.
     expect(store.leftPanelCollapsed).toBe(true);
-    expect(store.leftPanelAutoHidden).toBe(false);
 
     setInnerWidth(1800);
     window.dispatchEvent(new Event("resize"));
     vi.advanceTimersByTime(250);
-    // Growing back doesn't force it open — it was never small-screen mode's.
     expect(store.leftPanelCollapsed).toBe(true);
   });
 
-  it("a manual reopen while auto-hidden sticks until a fresh large-small round trip", () => {
-    setInnerWidth(1000);
+  it("keeps what the user did on the narrow window out of the wide layout", () => {
+    setInnerWidth(1800);
     dispose = installSmallScreenMode();
-    expect(store.leftPanelCollapsed).toBe(true);
-    expect(store.leftPanelAutoHidden).toBe(true);
 
-    setRightPanelCollapsed(store.rightPanelCollapsed); // no-op sanity call
-    setLeftPanelCollapsed(false); // the manual toggle command's path
-    expect(store.leftPanelAutoHidden).toBe(false);
-    expect(store.leftPanelCollapsed).toBe(false);
-
-    // Still small, but nothing re-hides it since no new edge/workspace change fired.
-    vi.advanceTimersByTime(1000);
-    expect(store.leftPanelCollapsed).toBe(false);
-  });
-
-  it("re-hides a newly active workspace's open panels while still small-screen", async () => {
     setInnerWidth(1000);
-    dispose = installSmallScreenMode();
-    expect(store.leftPanelCollapsed).toBe(true);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    // Reopen one column and close the other — both narrow-window decisions.
+    setLeftPanelCollapsed(false);
+    setRightPanelCollapsed(true);
 
-    // A workspace switch (per-workspace collapsed state loaded fresh) reopens
-    // it; the re-hide runs off valtio's (microtask-batched) subscribe, so the
-    // effect lands one tick after the raw store mutation.
-    store.activeWorkspaceId = "ws-2";
-    store.leftPanelCollapsed = false;
-    store.leftPanelAutoHidden = false;
-    await Promise.resolve();
-
-    expect(store.leftPanelCollapsed).toBe(true);
-    expect(store.leftPanelAutoHidden).toBe(true);
+    setInnerWidth(1800);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.rightPanelCollapsed).toBe(false);
   });
 
-  it("restores auto-hidden panels immediately when the feature is disabled", async () => {
+  it("brings the small-screen layout back the next time the window is narrow", () => {
+    setInnerWidth(1800);
+    dispose = installSmallScreenMode();
+
+    setInnerWidth(1000);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    setLeftPanelCollapsed(false); // "I want the left panel open on the laptop"
+
+    setInnerWidth(1800);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    expect(store.leftPanelCollapsed).toBe(false); // wide layout, untouched
+
+    setInnerWidth(1000);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(250);
+    // ...and the narrow window picks up exactly where it left off, rather
+    // than starting over from "hide everything".
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.rightPanelCollapsed).toBe(true);
+  });
+
+  it("leaves small-screen mode immediately when the feature is disabled", async () => {
     setInnerWidth(1000);
     dispose = installSmallScreenMode();
     expect(store.leftPanelCollapsed).toBe(true);
@@ -213,14 +220,14 @@ describe("installSmallScreenMode", () => {
     store.smallScreenModeEnabled = false;
     await Promise.resolve(); // subscribe's notification is microtask-batched
 
+    expect(store.smallScreenActive).toBe(false);
     expect(store.leftPanelCollapsed).toBe(false);
-    expect(store.leftPanelAutoHidden).toBe(false);
   });
 
-  it("peeks an auto-hidden left panel after a dwell at the edge, and hides it again after the mouse leaves", () => {
+  it("peeks a collapsed left panel after a dwell at the edge, and hides it again after the mouse leaves", () => {
     setInnerWidth(1000);
     dispose = installSmallScreenMode();
-    expect(store.leftPanelAutoHidden).toBe(true);
+    expect(store.leftPanelCollapsed).toBe(true);
 
     moveMouse(2); // within the edge hotspot
     vi.advanceTimersByTime(100);
@@ -255,15 +262,32 @@ describe("installSmallScreenMode", () => {
     expect(store.leftPanelPeeking).toBe(true);
   });
 
-  it("never peeks a manually-collapsed panel", () => {
+  it("peeks a panel the user collapsed themselves, on a full-size window", () => {
+    // Peek isn't small-screen mode's alone: any collapsed side panel is one
+    // edge-hover away, however it got collapsed and at any window size.
     setInnerWidth(1800);
     setLeftPanelCollapsed(true);
     dispose = installSmallScreenMode();
-    expect(store.leftPanelAutoHidden).toBe(false);
+    expect(store.smallScreenActive).toBe(false);
 
     moveMouse(2);
     vi.advanceTimersByTime(1000);
-    expect(store.leftPanelPeeking).toBe(false);
+    expect(store.leftPanelPeeking).toBe(true);
+  });
+
+  it("peeks a panel closed by hand while narrow, and never peeks an open one", () => {
+    setInnerWidth(1000);
+    dispose = installSmallScreenMode();
+    setLeftPanelCollapsed(false); // opened on the narrow window...
+
+    moveMouse(2);
+    vi.advanceTimersByTime(1000);
+    expect(store.leftPanelPeeking).toBe(false); // nothing to peek, it's open
+
+    setLeftPanelCollapsed(true); // ...then closed again by hand
+    moveMouse(2);
+    vi.advanceTimersByTime(1000);
+    expect(store.leftPanelPeeking).toBe(true);
   });
 
   it("keeps peeking through a resize drag even once the cursor leaves the pre-drag peek-host bounds", () => {
@@ -273,7 +297,7 @@ describe("installSmallScreenMode", () => {
     // as "left the peek" mid-drag and hide it out from under the user.
     setInnerWidth(1000);
     dispose = installSmallScreenMode();
-    expect(store.leftPanelAutoHidden).toBe(true); // already small at launch
+    expect(store.leftPanelCollapsed).toBe(true); // already small at launch
     store.leftPanelPeeking = true; // as if already peeking
 
     const dragDispose = beginPeekResize("left", 280);
@@ -374,7 +398,7 @@ describe("installSmallScreenMode: iframe crossing", () => {
   it("does not force-close mid-drag just because the cursor grazes an iframe", () => {
     setInnerWidth(1000);
     dispose = installSmallScreenMode();
-    expect(store.leftPanelAutoHidden).toBe(true);
+    expect(store.leftPanelCollapsed).toBe(true);
     store.leftPanelPeeking = true;
     beginPeekResize("left", 280);
 

--- a/packages/extension-host/src/extension-host/small-screen-mode.ts
+++ b/packages/extension-host/src/extension-host/small-screen-mode.ts
@@ -1,28 +1,43 @@
-// Small screen mode: when the app window's own logical width drops below a
-// threshold (e.g. a MacBook loses its external monitor), auto-collapse the
-// side panels that are currently open, and auto-restore them once the window
-// grows back. While a panel is auto-hidden, hovering the cursor at the
-// window's edge "peeks" it (a transient overlay — see AppShell.tsx's
-// `--peek-width` CSS), which self-hides again once the cursor leaves. The
-// overlay's width is its own global (not per-workspace) preference, resizable
-// by dragging its handle (`beginPeekResize`) — independent of whatever width
-// the panel normally has on a large screen.
+// Small screen mode ("Laptop Mode"): when the app window's own logical width
+// drops below a threshold (e.g. a MacBook loses its external monitor), the app
+// switches to a **second layout mode** — its own collapse state and its own
+// column widths — and switches back once the window grows again.
 //
-// Centralized here so the resize/hysteresis/debounce/peek-timer logic lives
-// in one place: AppShell only reads the store fields this module writes
-// (`*PanelAutoHidden`, `*PanelPeeking`) to drive collapse/expand and the peek
-// overlay's CSS, and `focus-regions.ts` reads `*PanelAutoHidden` to exclude an
-// auto-hidden panel from Tab order. The manual/public collapse path
-// (`setLeftPanelCollapsed`/`setRightPanelCollapsed` in state/store.ts, used by
-// commands and `ctx.layout`) always clears `*PanelAutoHidden` — that's what
-// makes a manual reopen "stick" instead of being re-hidden by this module.
+// The two modes are independent layouts, not a temporary tweak of one layout.
+// Collapsing or reopening a side column on a narrow window is remembered for
+// the *next* narrow window and never disturbs the normal-width layout, and vice
+// versa. The live pair is `leftPanelCollapsed`/`rightPanelCollapsed`; the mode
+// that isn't on screen sits in `inactiveModeCollapsed`, and a mode change is
+// just a swap of the two (`swapCollapseMode`). Both are per-workspace: the
+// workspace record stores them in `leftPanelCollapsed`/`rightPanelCollapsed`
+// and `smallScreenCollapsed`, and a workspace switch loads both
+// (`loadPanelStateFromWorkspace`). The column *widths* work the same way —
+// AppShell owns that half, through `layout/column-widths.ts`.
+//
+// Peek: hovering the cursor at the window's edge reveals a collapsed side panel
+// as a transient overlay (see AppShell.tsx's `--peek-width` CSS), which
+// self-hides once the cursor leaves. It applies to *any* collapsed side panel
+// at any window size — small-screen mode makes it load-bearing but doesn't own
+// it. The overlay's width is its own global preference, resizable by dragging
+// its handle (`beginPeekResize`), independent of either mode's column width.
+//
+// Centralized here so the resize/hysteresis/debounce/peek-timer logic lives in
+// one place: AppShell only reads the store fields this module writes
+// (`smallScreenActive`, `*PanelPeeking`) to drive collapse/expand and the peek
+// overlay's CSS, and `focus-regions.ts` keeps a collapsed (or peeking) column
+// out of Tab order.
 
 import { subscribe } from "valtio";
-import { store, setSmallScreenPeekWidthPx } from "../state/store";
+import {
+  store,
+  setSmallScreenPeekWidthPx,
+  swapCollapseMode,
+} from "../state/store";
 import {
   SMALL_SCREEN_HYSTERESIS_PX,
   MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
   MAX_SMALL_SCREEN_PEEK_WIDTH_PX,
+  DEFAULT_SMALL_SCREEN_COLLAPSE,
 } from "../state/types";
 
 const RESIZE_DEBOUNCE_MS = 200;
@@ -52,11 +67,6 @@ function collapsedKey(
 ): "leftPanelCollapsed" | "rightPanelCollapsed" {
   return side === "left" ? "leftPanelCollapsed" : "rightPanelCollapsed";
 }
-function autoHiddenKey(
-  side: Side,
-): "leftPanelAutoHidden" | "rightPanelAutoHidden" {
-  return side === "left" ? "leftPanelAutoHidden" : "rightPanelAutoHidden";
-}
 function peekingKey(side: Side): "leftPanelPeeking" | "rightPanelPeeking" {
   return side === "left" ? "leftPanelPeeking" : "rightPanelPeeking";
 }
@@ -75,30 +85,32 @@ function peekWidthKey(
 
 const SIDES: readonly Side[] = ["left", "right"];
 
-/** Collapse whichever panels are currently open, marking them auto-hidden.
- * Idempotent — a panel that's already collapsed (manually or already
- * auto-hidden) is left alone, so this is safe to call on every workspace
- * switch while small-screen mode is active, not just on the resize edge. */
-function hideOpenPanels(): void {
+/** What the normal-width layout falls back to when we leave small-screen mode
+ * with nothing recorded to go back to (it was already active at launch and no
+ * workspace has loaded yet). Small-screen mode's own default lives in
+ * `state/types.ts` — `loadPanelStateFromWorkspace` needs it too. */
+const DEFAULT_NORMAL_COLLAPSE = { left: false, right: false };
+
+function clearPeek(): void {
   for (const side of SIDES) {
-    if (!store[collapsedKey(side)]) {
-      store[autoHiddenKey(side)] = true;
-      store[collapsedKey(side)] = true;
-    }
+    store[peekingKey(side)] = false;
+    store[peekDraggingKey(side)] = false;
   }
 }
 
-/** Restore whichever panels small-screen mode itself hid. Manually-collapsed
- * panels (`autoHidden === false`) are left alone. */
-function restoreAutoHiddenPanels(): void {
-  for (const side of SIDES) {
-    if (store[autoHiddenKey(side)]) {
-      store[autoHiddenKey(side)] = false;
-      store[collapsedKey(side)] = false;
-      store[peekingKey(side)] = false;
-      store[peekDraggingKey(side)] = false;
-    }
-  }
+/** Switch the live layout to small-screen mode's own — the one this workspace
+ * was last left in on a narrow window, or "both collapsed" the first time. */
+function enterSmallScreenMode(): void {
+  store.smallScreenActive = true;
+  swapCollapseMode(DEFAULT_SMALL_SCREEN_COLLAPSE);
+  clearPeek();
+}
+
+/** ...and back to the normal-width layout, exactly as the user left it. */
+function exitSmallScreenMode(): void {
+  store.smallScreenActive = false;
+  swapCollapseMode(DEFAULT_NORMAL_COLLAPSE);
+  clearPeek();
 }
 
 /** Whether `target` sits inside the peek wrapper for `side` (AppShell's
@@ -116,49 +128,34 @@ function isWithinPeekHost(side: Side, target: EventTarget | null): boolean {
 }
 
 /**
- * Edge-triggered: `hideOpenPanels`/`restoreAutoHiddenPanels` only run exactly
- * once per genuine large↔small transition (or a workspace switch while
- * already small), never re-derived from steady state — that's what lets a
- * manual reopen (Q14: `setLeftPanelCollapsed`/`setRightPanelCollapsed`
- * clearing `autoHidden`) stick until the next real round-trip, instead of
- * being immediately re-hidden by the next unrelated store change.
+ * Edge-triggered: the mode swap runs exactly once per genuine large↔small
+ * transition, never re-derived from steady state — that's what lets the user's
+ * own collapse/reopen inside a mode stand, instead of being overwritten by the
+ * next unrelated store change. A workspace switch needs nothing from here:
+ * `loadPanelStateFromWorkspace` loads both of the incoming workspace's layout
+ * modes and picks the live one by `smallScreenActive`.
  */
 function createResizeWatcher() {
-  let active = false;
-
   function evaluate(widthPx: number): void {
     if (!store.smallScreenModeEnabled) {
-      if (active) {
-        active = false;
-        restoreAutoHiddenPanels();
-      }
+      if (store.smallScreenActive) exitSmallScreenMode();
       return;
     }
     const next = computeSmallScreenActive(
-      active,
+      store.smallScreenActive,
       widthPx,
       store.smallScreenThresholdPx,
     );
-    if (next === active) return;
-    active = next;
-    if (active) hideOpenPanels();
-    else restoreAutoHiddenPanels();
+    if (next === store.smallScreenActive) return;
+    if (next) enterSmallScreenMode();
+    else exitSmallScreenMode();
   }
 
   function reevaluateForCurrentWidth(): void {
     evaluate(window.innerWidth);
   }
 
-  /** Called whenever `smallScreenModeEnabled`, `smallScreenThresholdPx`, or
-   * `activeWorkspaceId` change — re-runs the width check, and (per the
-   * "applies uniformly across workspaces" decision) re-hides a newly-active
-   * workspace's currently-open panels if the screen is already small. */
-  function onWorkspaceOrSettingChange(): void {
-    reevaluateForCurrentWidth();
-    if (active) hideOpenPanels();
-  }
-
-  return { evaluate, reevaluateForCurrentWidth, onWorkspaceOrSettingChange };
+  return { reevaluateForCurrentWidth };
 }
 
 function debounce(fn: () => void, ms: number): () => void {
@@ -172,9 +169,10 @@ function debounce(fn: () => void, ms: number): () => void {
   };
 }
 
-/** Cursor-at-edge dwell-to-peek / leave-to-hide for one side. Only engages
- * while that side is small-screen-auto-hidden; a manually-collapsed panel
- * never peeks (Q7). */
+/** Cursor-at-edge dwell-to-peek / leave-to-hide for one side. Engages whenever
+ * that side is collapsed — however it got that way and whatever the window
+ * size, so reaching a panel you closed yourself is the same gesture as reaching
+ * one small-screen mode closed for you. */
 function createEdgeTracker(side: Side) {
   let dwellTimer: number | null = null;
   let graceTimer: number | null = null;
@@ -220,8 +218,7 @@ function createEdgeTracker(side: Side) {
   }
 
   function onMouseMove(x: number, w: number, target: EventTarget | null): void {
-    const autoHidden = store[autoHiddenKey(side)];
-    if (!store.smallScreenModeEnabled || !autoHidden) {
+    if (!store[collapsedKey(side)]) {
       clearDwell();
       if (store[peekingKey(side)]) {
         clearGrace();
@@ -274,8 +271,8 @@ function createEdgeTracker(side: Side) {
 /**
  * Wire up small-screen mode: a debounced window-resize listener, an
  * immediate check on mount (so launching already-small applies right away),
- * a subscription that re-checks on workspace switch / settings changes, and
- * the edge-hover peek trackers. Call once from AppShell; returns a disposer.
+ * a subscription that re-checks when its settings change, and the edge-hover
+ * peek trackers. Call once from AppShell; returns a disposer.
  */
 export function installSmallScreenMode(): () => void {
   const watcher = createResizeWatcher();
@@ -290,18 +287,17 @@ export function installSmallScreenMode(): () => void {
   );
   window.addEventListener("resize", onResize);
 
-  let prevWorkspaceId = store.activeWorkspaceId;
+  // Toggling the feature or editing the threshold in Settings can cross the
+  // boundary without the window ever resizing — run the same edge check.
   let prevEnabled = store.smallScreenModeEnabled;
   let prevThreshold = store.smallScreenThresholdPx;
   const unsubscribe = subscribe(store, () => {
     const changed =
-      store.activeWorkspaceId !== prevWorkspaceId ||
       store.smallScreenModeEnabled !== prevEnabled ||
       store.smallScreenThresholdPx !== prevThreshold;
-    prevWorkspaceId = store.activeWorkspaceId;
     prevEnabled = store.smallScreenModeEnabled;
     prevThreshold = store.smallScreenThresholdPx;
-    if (changed) watcher.onWorkspaceOrSettingChange();
+    if (changed) watcher.reevaluateForCurrentWidth();
   });
 
   function onMouseMove(e: MouseEvent): void {

--- a/packages/extension-host/src/layout/AppShell.tsx
+++ b/packages/extension-host/src/layout/AppShell.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSnapshot } from "valtio";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
-import type { ImperativePanelHandle } from "react-resizable-panels";
+import type {
+  ImperativePanelGroupHandle,
+  ImperativePanelHandle,
+} from "react-resizable-panels";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { CenterDock } from "../panels/CenterDock";
 import { SideColumn } from "./SideColumn";
@@ -17,6 +20,13 @@ import {
   installSmallScreenMode,
   beginPeekResize,
 } from "../extension-host/small-screen-mode";
+import {
+  columnConstraints,
+  columnLayout,
+  readColumnWidths,
+  widthsFromLayout,
+  writeColumnWidths,
+} from "./column-widths";
 import "./AppShell.css";
 
 // On macOS, `titleBarStyle: "Overlay"` causes the webview to extend under the
@@ -75,14 +85,37 @@ function onTitlebarDoubleClick(e: React.MouseEvent<HTMLDivElement>) {
     });
 }
 
-function onPanelDragging(isDragging: boolean) {
+function markPanelDragging(isDragging: boolean) {
   document.body.classList.toggle("panel-resizing", isDragging);
 }
+
+// The column-width half of small-screen mode's two layout modes (the collapse
+// half lives in small-screen-mode.ts). Both modes' widths — in px, see
+// column-widths.ts — are read once here so the very first paint already has the
+// right columns, and written back as the user drags.
+const columnWidths = readColumnWidths();
 
 export function AppShell() {
   const snap = useSnapshot(store);
   const leftRef = useRef<ImperativePanelHandle>(null);
   const rightRef = useRef<ImperativePanelHandle>(null);
+  const groupRef = useRef<ImperativePanelGroupHandle>(null);
+  const shellRef = useRef<HTMLDivElement>(null);
+  // The window's width in CSS px, tracked live: it's what the side columns'
+  // px widths are converted against, so a window resize re-derives the layout
+  // instead of rescaling the columns with it.
+  const [containerPx, setContainerPx] = useState(() => window.innerWidth);
+
+  useEffect(() => {
+    const el = shellRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const width = entry.contentRect.width;
+      if (width > 0) setContainerPx(width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (snap.leftPanelCollapsed) leftRef.current?.collapse();
@@ -93,6 +126,62 @@ export function AppShell() {
     if (snap.rightPanelCollapsed) rightRef.current?.collapse();
     else rightRef.current?.expand();
   }, [snap.rightPanelCollapsed]);
+
+  // Size the columns from the live mode's px widths. Declared *after* the
+  // collapse effects so it lands on top of their expand(), which would
+  // otherwise reopen a panel at whatever width the library last had for it.
+  // Re-runs whenever the window resizes (keeping the sides put and handing the
+  // difference to the center), on every collapse change (a reopened panel comes
+  // back at its own width), and on a mode switch.
+  useEffect(() => {
+    const group = groupRef.current;
+    if (!group) return;
+    const widths = snap.smallScreenActive
+      ? columnWidths.smallScreen
+      : columnWidths.normal;
+    group.setLayout(
+      columnLayout(
+        widths,
+        {
+          left: snap.leftPanelCollapsed,
+          right: snap.rightPanelCollapsed,
+        },
+        containerPx,
+      ),
+    );
+  }, [
+    containerPx,
+    snap.smallScreenActive,
+    snap.leftPanelCollapsed,
+    snap.rightPanelCollapsed,
+  ]);
+
+  // Record what a drag produced, for whichever mode is on screen. **Only** a
+  // drag: `onLayout` also fires for the layouts we set above and for the
+  // library's own re-validation against new constraints (both of which happen
+  // while the window is being resized), and recording those would let a stint
+  // at a narrow window permanently shrink the columns.
+  const dragging = useRef(false);
+  const onPanelDragging = useCallback((isDragging: boolean) => {
+    dragging.current = isDragging;
+    markPanelDragging(isDragging);
+  }, []);
+
+  const onColumnLayout = useCallback(
+    (layout: number[]) => {
+      if (!dragging.current) return;
+      const mode = store.smallScreenActive ? "smallScreen" : "normal";
+      const next = widthsFromLayout(layout, containerPx, columnWidths[mode]);
+      if (
+        next.left === columnWidths[mode].left &&
+        next.right === columnWidths[mode].right
+      )
+        return;
+      columnWidths[mode] = next;
+      writeColumnWidths(columnWidths);
+    },
+    [containerPx],
+  );
 
   // Tabbing out of a side dock should land in the next region's entry (e.g. the
   // editor cursor), skipping the resize handle + dockview chrome between them.
@@ -128,19 +217,32 @@ export function AppShell() {
   // into the store so the status-bar toggles stay in sync. Valtio no-ops
   // same-value assignments, so this won't fight the effects above.
 
+  // The library only takes percentages, so the px min/max become constraints
+  // for *this* window width and are recomputed as it changes.
+  const { sideMin, sideMax, centerMin } = columnConstraints(containerPx);
+  const initial = columnLayout(
+    snap.smallScreenActive ? columnWidths.smallScreen : columnWidths.normal,
+    { left: snap.leftPanelCollapsed, right: snap.rightPanelCollapsed },
+    containerPx,
+  );
+
   return (
-    <div className={`app-shell${isMac ? " mac" : ""}`}>
+    <div className={`app-shell${isMac ? " mac" : ""}`} ref={shellRef}>
       <div
         className="titlebar-drag"
         onMouseDown={onTitlebarMouseDown}
         onDoubleClick={onTitlebarDoubleClick}
       />
-      <PanelGroup direction="horizontal" autoSaveId="app:main-cols">
+      <PanelGroup
+        ref={groupRef}
+        direction="horizontal"
+        onLayout={onColumnLayout}
+      >
         <Panel
           ref={leftRef}
-          defaultSize={18}
-          minSize={12}
-          maxSize={35}
+          defaultSize={initial[0]}
+          minSize={sideMin}
+          maxSize={sideMax}
           collapsible
           collapsedSize={0}
           onCollapse={() => {
@@ -179,7 +281,7 @@ export function AppShell() {
           </div>
         </Panel>
         <PanelResizeHandle onDragging={onPanelDragging} tabIndex={-1} />
-        <Panel defaultSize={58} minSize={30} className="app-col">
+        <Panel defaultSize={initial[1]} minSize={centerMin} className="app-col">
           <ErrorBoundary name="center-dock">
             <CenterDock />
           </ErrorBoundary>
@@ -187,9 +289,9 @@ export function AppShell() {
         <PanelResizeHandle onDragging={onPanelDragging} tabIndex={-1} />
         <Panel
           ref={rightRef}
-          defaultSize={24}
-          minSize={12}
-          maxSize={45}
+          defaultSize={initial[2]}
+          minSize={sideMin}
+          maxSize={sideMax}
           collapsible
           collapsedSize={0}
           onCollapse={() => {

--- a/packages/extension-host/src/layout/column-widths.test.ts
+++ b/packages/extension-host/src/layout/column-widths.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  columnConstraints,
+  columnLayout,
+  readColumnWidths,
+  widthsFromLayout,
+  writeColumnWidths,
+  DEFAULT_COLUMN_WIDTHS,
+  MAX_COLUMN_PX,
+  MIN_CENTER_PX,
+  MIN_COLUMN_PX,
+} from "./column-widths";
+
+const open = { left: false, right: false };
+
+/** The px width a percentage works out to, for readable assertions. */
+function px(pct: number, containerPx: number): number {
+  return Math.round((pct / 100) * containerPx);
+}
+
+describe("columnLayout", () => {
+  it("turns px widths into percentages, with the center taking the rest", () => {
+    const [left, center, right] = columnLayout(
+      { left: 300, right: 400 },
+      open,
+      2000,
+    );
+    expect(px(left, 2000)).toBe(300);
+    expect(px(right, 2000)).toBe(400);
+    expect(px(center, 2000)).toBe(1300);
+  });
+
+  it("holds the side columns' px steady as the window resizes", () => {
+    const widths = { left: 300, right: 400 };
+    for (const windowPx of [1200, 1600, 2400]) {
+      const [left, , right] = columnLayout(widths, open, windowPx);
+      expect(px(left, windowPx)).toBe(300);
+      expect(px(right, windowPx)).toBe(400);
+    }
+  });
+
+  it("gives a collapsed column nothing", () => {
+    const [left, center, right] = columnLayout(
+      { left: 300, right: 400 },
+      { left: true, right: false },
+      2000,
+    );
+    expect(left).toBe(0);
+    expect(px(right, 2000)).toBe(400);
+    expect(px(center, 2000)).toBe(1600);
+  });
+
+  it("clamps a stored width into the allowed range", () => {
+    const [left, , right] = columnLayout({ left: 40, right: 5000 }, open, 4000);
+    expect(px(left, 4000)).toBe(MIN_COLUMN_PX);
+    expect(px(right, 4000)).toBe(MAX_COLUMN_PX);
+  });
+
+  it("shrinks the sides rather than squeezing the center out of a narrow window", () => {
+    const [left, center, right] = columnLayout(
+      { left: 600, right: 600 },
+      open,
+      900,
+    );
+    expect(px(center, 900)).toBeGreaterThanOrEqual(MIN_CENTER_PX);
+    expect(px(left, 900)).toBeLessThan(600);
+    // Proportional, so an even pair stays even.
+    expect(px(left, 900)).toBe(px(right, 900));
+  });
+
+  it("always adds up to 100%", () => {
+    for (const windowPx of [700, 1440, 3000]) {
+      const layout = columnLayout({ left: 300, right: 500 }, open, windowPx);
+      expect(layout.reduce((a, b) => a + b, 0)).toBeCloseTo(100, 6);
+    }
+  });
+});
+
+describe("columnConstraints", () => {
+  it("expresses the px min/max as percentages of this window", () => {
+    const { sideMin, sideMax } = columnConstraints(2000);
+    expect(px(sideMin, 2000)).toBe(MIN_COLUMN_PX);
+    expect(px(sideMax, 2000)).toBe(MAX_COLUMN_PX);
+  });
+
+  it("stays a valid set of constraints on a window too narrow for them", () => {
+    const { sideMin, sideMax, centerMin } = columnConstraints(500);
+    expect(sideMin).toBeLessThanOrEqual(sideMax);
+    expect(sideMin * 2 + centerMin).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("widthsFromLayout", () => {
+  it("reads back the px the user dragged to", () => {
+    expect(widthsFromLayout([15, 60, 25], 2000, DEFAULT_COLUMN_WIDTHS)).toEqual(
+      {
+        left: 300,
+        right: 500,
+      },
+    );
+  });
+
+  it("keeps a collapsed column's width — that's what it reopens at", () => {
+    expect(
+      widthsFromLayout([0, 75, 25], 2000, { left: 300, right: 400 }),
+    ).toEqual({ left: 300, right: 500 });
+  });
+
+  it("round-trips a layout it produced", () => {
+    const widths = { left: 320, right: 280 };
+    expect(
+      widthsFromLayout(columnLayout(widths, open, 1600), 1600, widths),
+    ).toEqual(widths);
+  });
+});
+
+describe("readColumnWidths / writeColumnWidths", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults both modes when nothing is stored", () => {
+    expect(readColumnWidths()).toEqual({
+      normal: DEFAULT_COLUMN_WIDTHS,
+      smallScreen: DEFAULT_COLUMN_WIDTHS,
+    });
+  });
+
+  it("round-trips each mode's own widths", () => {
+    const widths = {
+      normal: { left: 300, right: 400 },
+      smallScreen: { left: 220, right: 260 },
+    };
+    writeColumnWidths(widths);
+    expect(readColumnWidths()).toEqual(widths);
+  });
+
+  it("falls back to defaults for a corrupt or partial entry", () => {
+    localStorage.setItem("silo:main-column-widths", "{not json");
+    expect(readColumnWidths().normal).toEqual(DEFAULT_COLUMN_WIDTHS);
+
+    localStorage.setItem(
+      "silo:main-column-widths",
+      JSON.stringify({ normal: { left: 5000 } }),
+    );
+    expect(readColumnWidths().normal).toEqual({
+      left: MAX_COLUMN_PX,
+      right: DEFAULT_COLUMN_WIDTHS.right,
+    });
+  });
+});

--- a/packages/extension-host/src/layout/column-widths.ts
+++ b/packages/extension-host/src/layout/column-widths.ts
@@ -1,0 +1,151 @@
+// The main columns' widths — the layout math AppShell drives
+// react-resizable-panels with, plus where those widths are remembered.
+//
+// **Side columns are sized in pixels, the center takes the rest.** The library
+// works in percentages, so a percentage layout would rescale every column as
+// the window resizes — the side panels would grow on a big monitor and shrink
+// on a laptop, when what the user set was "this panel is 320px wide". We keep
+// the two side widths in px and recompute the percentages whenever the window
+// changes size, which leaves the side columns put and gives the center every
+// pixel the window gains or loses. Two numbers are the whole layout.
+//
+// Each of the two layout modes (normal-width / small-screen — see
+// `extension-host/small-screen-mode.ts`) remembers its own pair. Both live in
+// localStorage rather than the app-state index because the layout has to be
+// right on the *first paint*: the index is loaded asynchronously from disk, so
+// reading it would mean painting default columns and then jumping. (That's the
+// same reason react-resizable-panels' own `autoSaveId` used localStorage, which
+// this replaces — its percentage layout is exactly what we're moving off.)
+//
+// Everything here is pure except `readColumnWidths`/`writeColumnWidths`, so the
+// rules below are unit-testable without a DOM or a mounted PanelGroup.
+
+/** A side column narrower than this collapses instead — the drag-to-close
+ * gesture react-resizable-panels gives us for a `collapsible` panel. */
+export const MIN_COLUMN_PX = 200;
+export const MAX_COLUMN_PX = 800;
+/** The center column never gives up more than this, whatever the side columns
+ * would like — the guard for a window too narrow to satisfy everyone. */
+export const MIN_CENTER_PX = 240;
+
+/** The side columns' widths in CSS pixels. */
+export interface ColumnWidths {
+  left: number;
+  right: number;
+}
+
+/** One pair per layout mode. */
+export interface ColumnWidthsByMode {
+  normal: ColumnWidths;
+  smallScreen: ColumnWidths;
+}
+
+export const DEFAULT_COLUMN_WIDTHS: ColumnWidths = { left: 260, right: 340 };
+
+const STORAGE_KEY = "silo:main-column-widths";
+
+function clampPx(px: number): number {
+  return Math.min(MAX_COLUMN_PX, Math.max(MIN_COLUMN_PX, Math.round(px)));
+}
+
+function pct(px: number, containerPx: number): number {
+  return (px / Math.max(containerPx, 1)) * 100;
+}
+
+/**
+ * The `[left, center, right]` percentage layout for these px widths. A
+ * collapsed side contributes nothing; the rest is the center's. When the window
+ * is too narrow to give both sides what they want *and* keep
+ * {@link MIN_CENTER_PX} for the center, the sides shrink proportionally rather
+ * than squeezing the editor out.
+ */
+export function columnLayout(
+  widths: ColumnWidths,
+  collapsed: { left: boolean; right: boolean },
+  containerPx: number,
+): number[] {
+  let left = collapsed.left ? 0 : clampPx(widths.left);
+  let right = collapsed.right ? 0 : clampPx(widths.right);
+  const forSides = Math.max(containerPx - MIN_CENTER_PX, 0);
+  if (left + right > forSides) {
+    const scale = forSides / (left + right);
+    left = Math.floor(left * scale);
+    right = Math.floor(right * scale);
+  }
+  const leftPct = pct(left, containerPx);
+  const rightPct = pct(right, containerPx);
+  return [leftPct, 100 - leftPct - rightPct, rightPct];
+}
+
+/**
+ * The percentage constraints to hand the panels for a window this wide — the
+ * px min/max expressed in the only unit the library takes. Clamped to a band
+ * that stays valid on a very narrow window, where the raw conversions would
+ * otherwise exceed 100% (or leave no room for the center).
+ */
+export function columnConstraints(containerPx: number): {
+  sideMin: number;
+  sideMax: number;
+  centerMin: number;
+} {
+  const sideMin = Math.min(pct(MIN_COLUMN_PX, containerPx), 25);
+  const sideMax = Math.max(
+    sideMin,
+    Math.min(pct(MAX_COLUMN_PX, containerPx), 60),
+  );
+  const centerMin = Math.min(pct(MIN_CENTER_PX, containerPx), 30);
+  return { sideMin, sideMax, centerMin };
+}
+
+/**
+ * The px widths to remember from a layout the user just produced. A collapsed
+ * (zero-width) side keeps the width it had — that's the width it reopens at,
+ * and it's the whole reason closing a panel doesn't forget how wide it was.
+ */
+export function widthsFromLayout(
+  layout: readonly number[],
+  containerPx: number,
+  previous: ColumnWidths,
+): ColumnWidths {
+  const [left, , right] = layout;
+  return {
+    left: left ? clampPx((left / 100) * containerPx) : previous.left,
+    right: right ? clampPx((right / 100) * containerPx) : previous.right,
+  };
+}
+
+function sanitize(value: unknown): ColumnWidths {
+  const w = value as Partial<ColumnWidths> | undefined;
+  return {
+    left: clampPx(
+      typeof w?.left === "number" ? w.left : DEFAULT_COLUMN_WIDTHS.left,
+    ),
+    right: clampPx(
+      typeof w?.right === "number" ? w.right : DEFAULT_COLUMN_WIDTHS.right,
+    ),
+  };
+}
+
+/** Both modes' remembered widths, defaulted and clamped so a hand-edited or
+ * stale entry can't produce an unusable layout. */
+export function readColumnWidths(): ColumnWidthsByMode {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null");
+  } catch {
+    parsed = null;
+  }
+  const stored = parsed as Partial<ColumnWidthsByMode> | null;
+  return {
+    normal: sanitize(stored?.normal),
+    smallScreen: sanitize(stored?.smallScreen),
+  };
+}
+
+export function writeColumnWidths(widths: ColumnWidthsByMode): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(widths));
+  } catch {
+    // A full/blocked localStorage costs us the remembered widths, nothing more.
+  }
+}

--- a/packages/extension-host/src/state/panel-state.test.ts
+++ b/packages/extension-host/src/state/panel-state.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { store } from "./store";
+import { capturePanelState, applyPanelState } from "./panel-state";
+import { DEFAULT_PANEL_STATE } from "./types";
+import type { WorkspaceInternal } from "./types";
+
+function makeWorkspace(id: string): WorkspaceInternal {
+  return {
+    id,
+    name: id,
+    folder: `/ws/${id}`,
+    createdAt: "",
+    lastOpenedAt: "",
+    terminals: [],
+    editors: [],
+    dockLayout: null,
+  };
+}
+
+/** A live store with every panel field set to something distinctive, so a
+ * field dropped from either half of the mapping shows up as a difference. */
+function seedLiveState(): void {
+  store.sidePanelLocations = { explorer: "left" };
+  store.sidePanelOrder = { explorer: 2 };
+  store.activeSidePanelTabs = { left: "explorer" };
+  store.sidePanelScrollPositions = { explorer: 12 };
+  store.sidePanelVisibility = { themes: false };
+  store.extensionState = { "silo.explorer": { expanded: ["/a"] } };
+  store.leftPanelCollapsed = true;
+  store.rightPanelCollapsed = false;
+}
+
+beforeEach(() => {
+  Object.assign(store, structuredClone(DEFAULT_PANEL_STATE));
+  store.leftPanelCollapsed = false;
+  store.rightPanelCollapsed = false;
+  store.smallScreenActive = false;
+  store.inactiveModeCollapsed = null;
+});
+
+describe("capturePanelState / applyPanelState", () => {
+  it("round-trips every field — capture, apply, capture is identity", () => {
+    // The assertion that catches a field missing from *either* function: drop
+    // one from capture and the first snapshot loses it; drop one from apply
+    // and the second does.
+    seedLiveState();
+    const first = capturePanelState();
+
+    applyPanelState({ ...makeWorkspace("a"), ...first });
+    expect(capturePanelState()).toEqual(first);
+  });
+
+  it("round-trips the small-screen layout too", () => {
+    seedLiveState();
+    store.smallScreenActive = true;
+    store.inactiveModeCollapsed = { left: false, right: true };
+    const first = capturePanelState();
+    expect(first.smallScreenCollapsed).toEqual({ left: true, right: false });
+
+    applyPanelState({ ...makeWorkspace("a"), ...first });
+    expect(capturePanelState()).toEqual(first);
+  });
+
+  it("omits the small-screen layout for a workspace that has never been narrow", () => {
+    seedLiveState();
+    expect("smallScreenCollapsed" in capturePanelState()).toBe(false);
+  });
+
+  it("copies out of the live store, so a saved record can't be rewritten by later edits", () => {
+    seedLiveState();
+    const snapshot = capturePanelState();
+
+    store.sidePanelVisibility.explorer = false;
+    store.extensionState["silo.new"] = { added: true };
+    store.extensionState["silo.explorer"].expanded = ["/b"];
+
+    expect(snapshot.sidePanelVisibility).toEqual({ themes: false });
+    expect(snapshot.extensionState).toEqual({
+      "silo.explorer": { expanded: ["/a"] },
+    });
+  });
+
+  it("copies out of the record, so the live store isn't aliased to it", () => {
+    const ws = { ...makeWorkspace("a"), ...capturePanelState() };
+    seedLiveState();
+    applyPanelState(ws);
+
+    store.sidePanelVisibility.themes = false;
+    store.extensionState["silo.new"] = { added: true };
+
+    expect(ws.sidePanelVisibility).toEqual({});
+    expect(ws.extensionState).toEqual({});
+  });
+
+  it("hydrates an older record with no panel fields to empty defaults", () => {
+    seedLiveState();
+    applyPanelState(makeWorkspace("older"));
+
+    expect(store.sidePanelLocations).toEqual({});
+    expect(store.sidePanelVisibility).toEqual({});
+    expect(store.extensionState).toEqual({});
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.inactiveModeCollapsed).toBeNull();
+  });
+});

--- a/packages/extension-host/src/state/panel-state.ts
+++ b/packages/extension-host/src/state/panel-state.ts
@@ -1,0 +1,87 @@
+// The one mapping between a workspace's panel state and the live store.
+//
+// Two callers need it and used to carry a copy each: switching workspaces
+// (`workspaces.ts`, which swaps the live fields) and saving to disk
+// (`persistence.ts`, which merges them onto the record). Two hand-kept copies
+// of the same field list drift — so both now come through `capturePanelState`
+// / `applyPanelState`, and adding a per-workspace field means editing the
+// shape in `types.ts` (which both `AppState` and `WorkspaceInternal` derive
+// from) and the two functions here. Nothing else.
+//
+// Everything is copied on the way through: the record must never alias the
+// live store's containers, or a later edit to a panel's state would silently
+// rewrite the workspace we last saved.
+
+import { store, collapseStateByMode } from "./store";
+import { DEFAULT_SMALL_SCREEN_COLLAPSE } from "./types";
+import type { PanelStateSnapshot, WorkspaceInternal } from "./types";
+
+/** Deep-clone the two-level extension-state bag (the one field that isn't flat). */
+function cloneExtensionState(
+  src: Record<string, Record<string, unknown>>,
+): Record<string, Record<string, unknown>> {
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const k of Object.keys(src)) out[k] = { ...src[k] };
+  return out;
+}
+
+/**
+ * The live panel state, in the shape a workspace record stores it.
+ *
+ * The collapse fields are the one place the two shapes differ: the store holds
+ * the *live* pair plus the parked one, keyed by which layout mode is on screen,
+ * while a record holds one pair per mode (see `collapseStateByMode` and
+ * `extension-host/small-screen-mode.ts`).
+ */
+export function capturePanelState(): PanelStateSnapshot {
+  const collapse = collapseStateByMode();
+  return {
+    sidePanelLocations: { ...store.sidePanelLocations },
+    sidePanelOrder: { ...store.sidePanelOrder },
+    activeSidePanelTabs: { ...store.activeSidePanelTabs },
+    sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
+    sidePanelVisibility: { ...store.sidePanelVisibility },
+    extensionState: cloneExtensionState(store.extensionState),
+    leftPanelCollapsed: collapse.normal.left,
+    rightPanelCollapsed: collapse.normal.right,
+    // Absent, not null, while this workspace has never been narrow — that's
+    // what keeps the record merge a plain spread.
+    ...(collapse.smallScreen
+      ? { smallScreenCollapsed: { ...collapse.smallScreen } }
+      : {}),
+  };
+}
+
+/**
+ * The reverse: make `ws`'s panel state the live one. Fields absent from an
+ * older record fall back to empty.
+ *
+ * Which layout mode becomes live depends on the window: on a narrow one the
+ * workspace's small-screen layout is on screen and its normal-width layout
+ * waits in `inactiveModeCollapsed`, and vice versa. A workspace that has never
+ * been narrow has no small-screen layout yet, so small-screen mode's default
+ * (both collapsed) stands in — which is what it would have done to this
+ * workspace on arrival anyway.
+ */
+export function applyPanelState(ws: WorkspaceInternal): void {
+  store.sidePanelLocations = { ...(ws.sidePanelLocations ?? {}) };
+  store.sidePanelOrder = { ...(ws.sidePanelOrder ?? {}) };
+  store.activeSidePanelTabs = { ...(ws.activeSidePanelTabs ?? {}) };
+  store.sidePanelScrollPositions = { ...(ws.sidePanelScrollPositions ?? {}) };
+  store.sidePanelVisibility = { ...(ws.sidePanelVisibility ?? {}) };
+  store.extensionState = cloneExtensionState(ws.extensionState ?? {});
+
+  const normal = {
+    left: ws.leftPanelCollapsed ?? false,
+    right: ws.rightPanelCollapsed ?? false,
+  };
+  const smallScreen = ws.smallScreenCollapsed
+    ? { ...ws.smallScreenCollapsed }
+    : null;
+  const live = store.smallScreenActive
+    ? (smallScreen ?? { ...DEFAULT_SMALL_SCREEN_COLLAPSE })
+    : normal;
+  store.leftPanelCollapsed = live.left;
+  store.rightPanelCollapsed = live.right;
+  store.inactiveModeCollapsed = store.smallScreenActive ? normal : smallScreen;
+}

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -124,23 +124,16 @@ describe("withActivePanelState", () => {
     expect(merged.rightPanelCollapsed).toBe(false);
   });
 
-  it("isolates the visibility bag from the source panel state", () => {
-    const merged = withActivePanelState(makeWorkspace("a"), PANEL);
-    merged.sidePanelVisibility!.explorer = false;
-    expect(PANEL.sidePanelVisibility.explorer).toBeUndefined();
+  it("does not mutate the source workspace", () => {
+    const ws = makeWorkspace("a");
+    withActivePanelState(ws, PANEL);
+    expect(ws.sidePanelLocations).toBeUndefined();
   });
 
-  it("does not mutate the source workspace and isolates the extension-state bag", () => {
-    const ws = makeWorkspace("a");
-    const merged = withActivePanelState(ws, PANEL);
-    expect(ws.sidePanelLocations).toBeUndefined();
-    // Two-level isolation: adding/replacing entries in the merged bag (or a
-    // per-extension object) must not bleed back into PANEL's bag.
-    merged.extensionState!["silo.new"] = { added: true };
-    merged.extensionState!["silo.explorer"] = { replaced: true };
-    expect(PANEL.extensionState["silo.new"]).toBeUndefined();
-    expect(PANEL.extensionState["silo.explorer"]).toEqual({ expanded: ["/a"] });
-  });
+  // Isolation from the *live store* — the property that actually protects a
+  // saved record — is `capturePanelState`'s, and is covered in
+  // panel-state.test.ts. The merge itself is a spread of an already-copied
+  // snapshot, so there is nothing left here to alias.
 });
 
 describe("diffWorkspaceWrites", () => {

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -10,7 +10,7 @@
 
 import type {
   EditorSettings,
-  SideCollapseState,
+  PanelStateSnapshot,
   SidePanelSlot,
   TerminalSettings,
   WorkspaceInternal,
@@ -73,21 +73,9 @@ export interface LegacyPersisted {
 }
 
 /** The active-workspace panel-state snapshot merged in at save time (the live
- * global store fields, which aren't mirrored onto the workspace until then). */
-export interface PanelState {
-  sidePanelLocations: Record<string, SidePanelSlot>;
-  sidePanelOrder: Record<string, number>;
-  activeSidePanelTabs: Record<string, string>;
-  sidePanelScrollPositions: Record<string, number>;
-  sidePanelVisibility: Record<string, boolean>;
-  extensionState: Record<string, Record<string, unknown>>;
-  /** The normal-width layout's collapse state... */
-  leftPanelCollapsed: boolean;
-  rightPanelCollapsed: boolean;
-  /** ...and small-screen mode's own, `null` until that mode has applied to
-   * this workspace. See `small-screen-mode.ts`. */
-  smallScreenCollapsed: SideCollapseState | null;
-}
+ * global store fields, which aren't mirrored onto the workspace until then).
+ * Declared with the store shape it's captured from — see `state/types.ts`. */
+export type PanelState = PanelStateSnapshot;
 
 /** Deep-clone the two-level extension-state bag so a stored snapshot can't alias
  * (and later mutate via) the live store. */
@@ -235,22 +223,11 @@ export function withActivePanelState(
   ws: WorkspaceInternal,
   panel: PanelState,
 ): WorkspaceInternal {
-  return {
-    ...ws,
-    sidePanelLocations: { ...panel.sidePanelLocations },
-    sidePanelOrder: { ...panel.sidePanelOrder },
-    activeSidePanelTabs: { ...panel.activeSidePanelTabs },
-    sidePanelScrollPositions: { ...panel.sidePanelScrollPositions },
-    sidePanelVisibility: { ...panel.sidePanelVisibility },
-    extensionState: cloneExtensionState(panel.extensionState),
-    leftPanelCollapsed: panel.leftPanelCollapsed,
-    rightPanelCollapsed: panel.rightPanelCollapsed,
-    // Keep the key absent (rather than null) while the workspace has never
-    // been narrow, matching how the rest of the record omits unset state.
-    ...(panel.smallScreenCollapsed
-      ? { smallScreenCollapsed: { ...panel.smallScreenCollapsed } }
-      : {}),
-  };
+  // `PanelState` is by definition the record's panel fields, so the merge is
+  // the spread — no field list to keep in step. The containers are already
+  // copies (`capturePanelState` clones them off the live store), so the result
+  // can't alias state anyone still mutates.
+  return { ...ws, ...panel };
 }
 
 /**

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -10,6 +10,7 @@
 
 import type {
   EditorSettings,
+  SideCollapseState,
   SidePanelSlot,
   TerminalSettings,
   WorkspaceInternal,
@@ -30,8 +31,8 @@ export interface PersistedIndex {
   // `small-screen-mode.ts`. Absent in older indexes: defaults applied at hydrate.
   smallScreenModeEnabled?: boolean;
   smallScreenThresholdPx?: number;
-  // Small-screen peek overlay width — also global, independent of the
-  // panel's normal (large-screen) width. See `small-screen-mode.ts`.
+  // Peek overlay width — also global, independent of either layout mode's
+  // column width. See `small-screen-mode.ts`.
   smallScreenPeekWidthLeftPx?: number;
   smallScreenPeekWidthRightPx?: number;
   // Per-extension global storage (`ctx.storage.global`), keyed by extension id.
@@ -80,8 +81,12 @@ export interface PanelState {
   sidePanelScrollPositions: Record<string, number>;
   sidePanelVisibility: Record<string, boolean>;
   extensionState: Record<string, Record<string, unknown>>;
+  /** The normal-width layout's collapse state... */
   leftPanelCollapsed: boolean;
   rightPanelCollapsed: boolean;
+  /** ...and small-screen mode's own, `null` until that mode has applied to
+   * this workspace. See `small-screen-mode.ts`. */
+  smallScreenCollapsed: SideCollapseState | null;
 }
 
 /** Deep-clone the two-level extension-state bag so a stored snapshot can't alias
@@ -240,6 +245,11 @@ export function withActivePanelState(
     extensionState: cloneExtensionState(panel.extensionState),
     leftPanelCollapsed: panel.leftPanelCollapsed,
     rightPanelCollapsed: panel.rightPanelCollapsed,
+    // Keep the key absent (rather than null) while the workspace has never
+    // been narrow, matching how the rest of the record omits unset state.
+    ...(panel.smallScreenCollapsed
+      ? { smallScreenCollapsed: { ...panel.smallScreenCollapsed } }
+      : {}),
   };
 }
 

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -1,7 +1,7 @@
 import { load, Store } from "@tauri-apps/plugin-store";
 import { invoke } from "@tauri-apps/api/core";
 import { subscribe } from "valtio";
-import { store } from "./store";
+import { store, collapseStateByMode } from "./store";
 import {
   DEFAULT_UI_FONT_SIZE,
   DEFAULT_EDITOR_SETTINGS,
@@ -207,18 +207,19 @@ export async function hydrate(configDir: string): Promise<void> {
     Object.entries(workspaces).map(([id, ws]) => [id, JSON.stringify(ws)]),
   );
 
-  // Hydrate the global panel-state fields from the active workspace.
+  // Hydrate the global panel-state fields from the active workspace. Side-dock
+  // collapse state is per-workspace; back-fill it from the index first for a
+  // one-time migration carry-over from installs that stored it globally, so
+  // the load below (which picks the live layout mode — small-screen mode may
+  // already be active by now) sees a complete record.
   const activeWs = store.activeWorkspaceId
     ? workspaces[store.activeWorkspaceId]
     : null;
-  if (activeWs) loadPanelStateFromWorkspace(activeWs);
-
-  // Side-dock collapse state is per-workspace. Fall back to the index for a
-  // one-time migration carry-over from installs that stored it globally.
-  store.leftPanelCollapsed =
-    activeWs?.leftPanelCollapsed ?? index?.leftPanelCollapsed ?? false;
-  store.rightPanelCollapsed =
-    activeWs?.rightPanelCollapsed ?? index?.rightPanelCollapsed ?? false;
+  if (activeWs) {
+    activeWs.leftPanelCollapsed ??= index?.leftPanelCollapsed ?? false;
+    activeWs.rightPanelCollapsed ??= index?.rightPanelCollapsed ?? false;
+    loadPanelStateFromWorkspace(activeWs);
+  }
 
   // Side-panel visibility is per-workspace, restored from the active workspace
   // by loadPanelStateFromWorkspace above (defaults to all-visible when absent).
@@ -228,6 +229,7 @@ export async function hydrate(configDir: string): Promise<void> {
 }
 
 function snapshotPanelState(): PanelState {
+  const collapse = collapseStateByMode();
   return {
     sidePanelLocations: { ...store.sidePanelLocations },
     sidePanelOrder: { ...store.sidePanelOrder },
@@ -235,8 +237,9 @@ function snapshotPanelState(): PanelState {
     sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
     sidePanelVisibility: { ...store.sidePanelVisibility },
     extensionState: cloneExtensionState(store.extensionState),
-    leftPanelCollapsed: store.leftPanelCollapsed,
-    rightPanelCollapsed: store.rightPanelCollapsed,
+    leftPanelCollapsed: collapse.normal.left,
+    rightPanelCollapsed: collapse.normal.right,
+    smallScreenCollapsed: collapse.smallScreen,
   };
 }
 

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -1,7 +1,7 @@
 import { load, Store } from "@tauri-apps/plugin-store";
 import { invoke } from "@tauri-apps/api/core";
 import { subscribe } from "valtio";
-import { store, collapseStateByMode } from "./store";
+import { store } from "./store";
 import {
   DEFAULT_UI_FONT_SIZE,
   DEFAULT_EDITOR_SETTINGS,
@@ -11,6 +11,7 @@ import {
 } from "./types";
 import type { WorkspaceInternal } from "./types";
 import { loadPanelStateFromWorkspace } from "./workspaces";
+import { capturePanelState } from "./panel-state";
 import { setBackupDir, sweepEditorBackups } from "./editor-backups";
 import {
   buildIndex,
@@ -22,7 +23,6 @@ import {
   splitPersistedState,
   withActivePanelState,
   type LegacyPersisted,
-  type PanelState,
   type PersistedIndex,
 } from "./persistence-model";
 
@@ -228,28 +228,13 @@ export async function hydrate(configDir: string): Promise<void> {
   subscribe(store, schedulePersist);
 }
 
-function snapshotPanelState(): PanelState {
-  const collapse = collapseStateByMode();
-  return {
-    sidePanelLocations: { ...store.sidePanelLocations },
-    sidePanelOrder: { ...store.sidePanelOrder },
-    activeSidePanelTabs: { ...store.activeSidePanelTabs },
-    sidePanelScrollPositions: { ...store.sidePanelScrollPositions },
-    sidePanelVisibility: { ...store.sidePanelVisibility },
-    extensionState: cloneExtensionState(store.extensionState),
-    leftPanelCollapsed: collapse.normal.left,
-    rightPanelCollapsed: collapse.normal.right,
-    smallScreenCollapsed: collapse.smallScreen,
-  };
-}
-
 async function doPersist(): Promise<void> {
   if (!indexStore) return;
 
   // Build each workspace's record, merging the active workspace's live panel
   // state (it isn't mirrored onto the workspace object until save time).
   const activeId = store.activeWorkspaceId;
-  const panel = snapshotPanelState();
+  const panel = capturePanelState();
   const records = new Map<string, WorkspaceInternal>();
   const next = new Map<string, string>();
   for (const [id, ws] of Object.entries(store.workspaces)) {

--- a/packages/extension-host/src/state/store.test.ts
+++ b/packages/extension-host/src/state/store.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { store, isSidePanelVisible, toggleSidePanelVisibility } from "./store";
+import {
+  store,
+  isSidePanelVisible,
+  toggleSidePanelVisibility,
+  collapseStateByMode,
+  swapCollapseMode,
+} from "./store";
 
 describe("side-panel visibility", () => {
   beforeEach(() => {
@@ -32,5 +38,53 @@ describe("side-panel visibility", () => {
     toggleSidePanelVisibility("a");
     toggleSidePanelVisibility("a");
     expect(store.sidePanelVisibility).toEqual({});
+  });
+});
+
+describe("the two side-column layout modes", () => {
+  beforeEach(() => {
+    store.leftPanelCollapsed = false;
+    store.rightPanelCollapsed = false;
+    store.smallScreenActive = false;
+    store.inactiveModeCollapsed = null;
+  });
+
+  it("sorts the live pair into the normal slot off a small screen", () => {
+    store.leftPanelCollapsed = true;
+    expect(collapseStateByMode()).toEqual({
+      normal: { left: true, right: false },
+      smallScreen: null,
+    });
+  });
+
+  it("sorts the live pair into the small-screen slot while narrow", () => {
+    store.smallScreenActive = true;
+    store.inactiveModeCollapsed = { left: true, right: false };
+    store.rightPanelCollapsed = true;
+    expect(collapseStateByMode()).toEqual({
+      normal: { left: true, right: false },
+      smallScreen: { left: false, right: true },
+    });
+  });
+
+  it("swaps the live and parked modes, so a round trip is a no-op", () => {
+    store.leftPanelCollapsed = true; // the normal-width layout
+    store.inactiveModeCollapsed = { left: false, right: true };
+
+    swapCollapseMode({ left: true, right: true });
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.rightPanelCollapsed).toBe(true);
+    expect(store.inactiveModeCollapsed).toEqual({ left: true, right: false });
+
+    swapCollapseMode({ left: false, right: false });
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.rightPanelCollapsed).toBe(false);
+  });
+
+  it("falls back to the given layout when the mode being entered has none", () => {
+    swapCollapseMode({ left: true, right: true });
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.rightPanelCollapsed).toBe(true);
+    expect(store.inactiveModeCollapsed).toEqual({ left: false, right: false });
   });
 });

--- a/packages/extension-host/src/state/store.ts
+++ b/packages/extension-host/src/state/store.ts
@@ -6,6 +6,7 @@ import {
   MAX_UI_FONT_SIZE,
   DEFAULT_EDITOR_SETTINGS,
   DEFAULT_TERMINAL_SETTINGS,
+  DEFAULT_PANEL_STATE,
   DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
   MIN_SMALL_SCREEN_THRESHOLD_PX,
   DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
@@ -25,11 +26,9 @@ export const store = proxy<AppState>({
   editorSettings: { ...DEFAULT_EDITOR_SETTINGS },
   terminalSettings: { ...DEFAULT_TERMINAL_SETTINGS },
   customThemes: [],
-  sidePanelLocations: {},
-  sidePanelOrder: {},
-  activeSidePanelTabs: {},
-  sidePanelScrollPositions: {},
-  extensionState: {},
+  // Every per-workspace panel field, from its one declaration — a new one
+  // needs no edit here (see `SharedPanelState` in types.ts).
+  ...structuredClone(DEFAULT_PANEL_STATE),
   globalExtensionState: {},
   agentState: {},
   leftPanelCollapsed: false,
@@ -44,7 +43,6 @@ export const store = proxy<AppState>({
   rightPanelPeekDragging: false,
   smallScreenPeekWidthLeftPx: DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
   smallScreenPeekWidthRightPx: DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
-  sidePanelVisibility: {},
   groups: {},
   panelOrder: [],
 });

--- a/packages/extension-host/src/state/store.ts
+++ b/packages/extension-host/src/state/store.ts
@@ -1,5 +1,5 @@
 import { proxy } from "valtio";
-import type { AppState, SidePanelSlot } from "./types";
+import type { AppState, SideCollapseState, SidePanelSlot } from "./types";
 import {
   DEFAULT_UI_FONT_SIZE,
   MIN_UI_FONT_SIZE,
@@ -36,8 +36,8 @@ export const store = proxy<AppState>({
   rightPanelCollapsed: false,
   smallScreenModeEnabled: true,
   smallScreenThresholdPx: DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
-  leftPanelAutoHidden: false,
-  rightPanelAutoHidden: false,
+  smallScreenActive: false,
+  inactiveModeCollapsed: null,
   leftPanelPeeking: false,
   rightPanelPeeking: false,
   leftPanelPeekDragging: false,
@@ -76,22 +76,18 @@ export function reorderSidePanels(orderedIds: string[]) {
 }
 
 /**
- * Explicit collapse setters for the manual/public path (commands, the status
- * bar, `ctx.layout`). Always clear the corresponding `*PanelAutoHidden` flag —
- * an explicit call is by definition not small-screen mode's doing, so it
- * "promotes" the panel to a manual state that auto-hide/auto-restore leaves
- * alone until the next full large→small→large round-trip. Small-screen mode
- * itself (`small-screen-mode.ts`) bypasses these and mutates the collapsed +
- * autoHidden fields together directly.
+ * Collapse setters for the manual/public path (commands, the status bar,
+ * `ctx.layout`). They write the *live* layout mode's state — on a narrow
+ * window that's small-screen mode's own layout, which is remembered for the
+ * next narrow window rather than folded into the normal-width one (see
+ * `small-screen-mode.ts`).
  */
 export function setLeftPanelCollapsed(collapsed: boolean) {
   store.leftPanelCollapsed = collapsed;
-  store.leftPanelAutoHidden = false;
 }
 
 export function setRightPanelCollapsed(collapsed: boolean) {
   store.rightPanelCollapsed = collapsed;
-  store.rightPanelAutoHidden = false;
 }
 
 export function toggleLeftPanel() {
@@ -100,6 +96,39 @@ export function toggleLeftPanel() {
 
 export function toggleRightPanel() {
   setRightPanelCollapsed(!store.rightPanelCollapsed);
+}
+
+/** The live (on-screen) collapse pair, as one value. */
+export function liveCollapseState(): SideCollapseState {
+  return { left: store.leftPanelCollapsed, right: store.rightPanelCollapsed };
+}
+
+/**
+ * Both layout modes' collapse state, sorted into the slots a workspace record
+ * stores them in. Which one is live depends on `smallScreenActive`, so every
+ * writer (workspace switch, persist) goes through this rather than reading the
+ * live fields and guessing.
+ */
+export function collapseStateByMode(): {
+  normal: SideCollapseState;
+  smallScreen: SideCollapseState | null;
+} {
+  const live = liveCollapseState();
+  return store.smallScreenActive
+    ? { normal: store.inactiveModeCollapsed ?? live, smallScreen: live }
+    : { normal: live, smallScreen: store.inactiveModeCollapsed };
+}
+
+/**
+ * Swap the live layout mode with the inactive one — the single move that both
+ * entering and leaving small-screen mode are made of. `fallback` is the layout
+ * to switch *to* when the mode being entered has nothing recorded yet.
+ */
+export function swapCollapseMode(fallback: SideCollapseState): void {
+  const incoming = store.inactiveModeCollapsed ?? fallback;
+  store.inactiveModeCollapsed = liveCollapseState();
+  store.leftPanelCollapsed = incoming.left;
+  store.rightPanelCollapsed = incoming.right;
 }
 
 export function setSmallScreenModeEnabled(enabled: boolean) {
@@ -113,10 +142,9 @@ export function setSmallScreenThresholdPx(px: number) {
   );
 }
 
-/** Set the small-screen peek overlay's width for one side — global (not
- * per-workspace) and independent of the panel's normal (large-screen) width.
- * Clamped to a sane, usable range regardless of caller (a drag gesture or a
- * future settings-page field). */
+/** Set the peek overlay's width for one side — global (not per-workspace) and
+ * independent of either layout mode's column width. Clamped to a sane, usable
+ * range regardless of caller (a drag gesture or a future settings-page field). */
 export function setSmallScreenPeekWidthPx(side: SideLocation, px: number) {
   const clamped = Math.max(
     MIN_SMALL_SCREEN_PEEK_WIDTH_PX,

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -30,7 +30,8 @@ import type {
  *
  * Not exported from `@silo-code/sdk` — host-only.
  */
-export interface WorkspaceInternal extends Workspace {
+export interface WorkspaceInternal
+  extends Workspace, Partial<PanelStateSnapshot> {
   terminals: TerminalRecord[];
   editors: EditorRecord[];
   dockLayout: unknown | null;
@@ -38,24 +39,7 @@ export interface WorkspaceInternal extends Workspace {
   editorViewStates?: Record<string, unknown>;
   /** Per-tab word-wrap/minimap overrides, toggled from the editor's context menu. */
   editorSettingsOverrides?: Record<string, EditorSettingsOverride>;
-  sidePanelLocations?: Record<string, SidePanelSlot>;
-  sidePanelOrder?: Record<string, number>;
-  activeSidePanelTabs?: Record<string, string>;
-  sidePanelScrollPositions?: Record<string, number>;
-  /** Absent key = visible (default); only explicit `false` is stored. */
-  sidePanelVisibility?: Record<string, boolean>;
-  extensionState?: Record<string, Record<string, unknown>>;
   previewEditorId?: string | null;
-  /** The side columns' collapse state on a **normal-width** window. */
-  leftPanelCollapsed?: boolean;
-  rightPanelCollapsed?: boolean;
-  /**
-   * The same, for **small-screen (Laptop) mode** — a second, independent layout
-   * this workspace returns to whenever the window is narrow (see
-   * `small-screen-mode.ts`). Absent until small-screen mode has applied to this
-   * workspace, in which case it starts from "both collapsed".
-   */
-  smallScreenCollapsed?: SideCollapseState;
 }
 
 /** Collapse state of the two side columns, as one value — the unit both layout
@@ -63,6 +47,81 @@ export interface WorkspaceInternal extends Workspace {
 export interface SideCollapseState {
   left: boolean;
   right: boolean;
+}
+
+/**
+ * The per-workspace panel fields the live store and a workspace record hold
+ * **under the same name and shape** — declared once here so adding one adds it
+ * to both {@link AppState} (required, always present) and
+ * {@link WorkspaceInternal} (optional, absent in older records).
+ *
+ * The mapping between the two lives in `state/panel-state.ts`. Anything whose
+ * live shape *differs* from its stored shape stays out of here and is handled
+ * explicitly there — today that's the collapse state, which the store keys by
+ * which layout mode is on screen and the record keys by which mode it is (see
+ * `extension-host/small-screen-mode.ts`).
+ */
+export interface SharedPanelState {
+  /**
+   * User-chosen slot overrides, keyed by side-panel id.
+   * Possible values: "left" | "right" | "left-bottom" | "right-bottom".
+   * If a key is absent the panel renders at its registered default location.
+   */
+  sidePanelLocations: Record<string, SidePanelSlot>;
+  /**
+   * Sort order within each slot, keyed by side-panel id.
+   * Lower numbers appear first. Missing entries sort as 0.
+   */
+  sidePanelOrder: Record<string, number>;
+  /**
+   * Last-active panel id per slot, keyed by SidePanelSlot string.
+   * Restored on reload so the same tab is visible after restart.
+   */
+  activeSidePanelTabs: Record<string, string>;
+  /**
+   * Scroll positions for side panels, keyed by panel id.
+   * Stores the scrollTop of the panel's content area.
+   */
+  sidePanelScrollPositions: Record<string, number>;
+  /**
+   * Side-panel visibility, keyed by panel id. Absent = visible (default); only
+   * an explicit `false` (hidden) is stored.
+   */
+  sidePanelVisibility: Record<string, boolean>;
+  /**
+   * Per-extension/side-panel namespaced state, keyed first by panel id then
+   * by key. This is the **workspace** scope: it is snapshotted into the active
+   * workspace and swapped when the active workspace changes. Backs
+   * `SidePanelProps.storage` (keyed by panel id) and `ctx.storage.workspace`
+   * (keyed by extension id).
+   */
+  extensionState: Record<string, Record<string, unknown>>;
+}
+
+/** What every {@link SharedPanelState} field starts as — spread into the store's
+ * initial value, so a new field needs no separate edit there. */
+export const DEFAULT_PANEL_STATE: SharedPanelState = {
+  sidePanelLocations: {},
+  sidePanelOrder: {},
+  activeSidePanelTabs: {},
+  sidePanelScrollPositions: {},
+  sidePanelVisibility: {},
+  extensionState: {},
+};
+
+/**
+ * A workspace's complete panel state: the shared fields plus both layout
+ * modes' collapse state. This is exactly the set of panel fields a workspace
+ * record carries, which is what lets the record merge be a plain spread (see
+ * `withActivePanelState`).
+ */
+export interface PanelStateSnapshot extends SharedPanelState {
+  /** The normal-width layout's collapse state... */
+  leftPanelCollapsed: boolean;
+  rightPanelCollapsed: boolean;
+  /** ...and small-screen mode's own. Absent until that mode has applied to
+   * this workspace. */
+  smallScreenCollapsed?: SideCollapseState;
 }
 
 // ── Host-only state types (not part of the public surface) ──
@@ -120,7 +179,7 @@ export interface PersistedAgentInfo {
   lastLiveAt: string;
 }
 
-export interface AppState {
+export interface AppState extends SharedPanelState {
   workspaces: Record<string, WorkspaceInternal>;
   workspaceOrder: string[];
   activeWorkspaceId: string | null;
@@ -133,35 +192,6 @@ export interface AppState {
   terminalSettings: TerminalSettings;
   /** Loaded from disk at startup; not persisted in the Tauri store. */
   customThemes: CustomTheme[];
-  /**
-   * User-chosen slot overrides, keyed by side-panel id.
-   * Possible values: "left" | "right" | "left-bottom" | "right-bottom".
-   * If a key is absent the panel renders at its registered default location.
-   */
-  sidePanelLocations: Record<string, SidePanelSlot>;
-  /**
-   * Sort order within each slot, keyed by side-panel id.
-   * Lower numbers appear first. Missing entries sort as 0.
-   */
-  sidePanelOrder: Record<string, number>;
-  /**
-   * Last-active panel id per slot, keyed by SidePanelSlot string.
-   * Restored on reload so the same tab is visible after restart.
-   */
-  activeSidePanelTabs: Record<string, string>;
-  /**
-   * Scroll positions for side panels, keyed by panel id.
-   * Stores the scrollTop of the panel's content area.
-   */
-  sidePanelScrollPositions: Record<string, number>;
-  /**
-   * Per-extension/side-panel namespaced state, keyed first by panel id then
-   * by key. This is the **workspace** scope: it is snapshotted into the active
-   * workspace and swapped when the active workspace changes. Backs
-   * `SidePanelProps.storage` (keyed by panel id) and `ctx.storage.workspace`
-   * (keyed by extension id).
-   */
-  extensionState: Record<string, Record<string, unknown>>;
   /**
    * Per-extension namespaced state shared across **all** workspaces. This is
    * the **global** scope (`ctx.storage.global`), keyed first by extension id
@@ -176,6 +206,13 @@ export interface AppState {
    * each `PersistedAgentInfo` carries its own `workspaceId`.
    */
   agentState: Record<string, PersistedAgentInfo>;
+  /**
+   * The **live** (on-screen) collapse state — small-screen mode's own layout
+   * while it's active, the normal-width one otherwise. Which is which is
+   * `smallScreenActive` below; the other mode's pair sits in
+   * `inactiveModeCollapsed`. (A workspace record keys the same two pairs by
+   * *mode* instead — see `PanelStateSnapshot`.)
+   */
   leftPanelCollapsed: boolean;
   rightPanelCollapsed: boolean;
   /**
@@ -233,13 +270,6 @@ export interface AppState {
    */
   smallScreenPeekWidthLeftPx: number;
   smallScreenPeekWidthRightPx: number;
-  /**
-   * Side-panel visibility, keyed by panel id. Per-workspace: snapshotted into
-   * the active workspace and swapped when the active workspace changes (like
-   * the other panel-state fields). Absent = visible (default); only an explicit
-   * `false` (hidden) is stored.
-   */
-  sidePanelVisibility: Record<string, boolean>;
   /**
    * Named collapsible groups in the Workspaces panel, keyed by group id. A
    * group's `workspaceOrder` is the single source of truth for membership — a

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -46,8 +46,23 @@ export interface WorkspaceInternal extends Workspace {
   sidePanelVisibility?: Record<string, boolean>;
   extensionState?: Record<string, Record<string, unknown>>;
   previewEditorId?: string | null;
+  /** The side columns' collapse state on a **normal-width** window. */
   leftPanelCollapsed?: boolean;
   rightPanelCollapsed?: boolean;
+  /**
+   * The same, for **small-screen (Laptop) mode** — a second, independent layout
+   * this workspace returns to whenever the window is narrow (see
+   * `small-screen-mode.ts`). Absent until small-screen mode has applied to this
+   * workspace, in which case it starts from "both collapsed".
+   */
+  smallScreenCollapsed?: SideCollapseState;
+}
+
+/** Collapse state of the two side columns, as one value — the unit both layout
+ * modes (normal / small-screen) are remembered in. */
+export interface SideCollapseState {
+  left: boolean;
+  right: boolean;
 }
 
 // ── Host-only state types (not part of the public surface) ──
@@ -172,15 +187,30 @@ export interface AppState {
   smallScreenModeEnabled: boolean;
   smallScreenThresholdPx: number;
   /**
-   * True while the respective side panel is collapsed *because* small-screen
-   * mode hid it, as opposed to a manual collapse. Drives auto-restore on a
-   * large screen, edge-hover peek eligibility, and Tab-order exclusion.
-   * Ephemeral — recomputed on launch/resize, never persisted.
+   * True while small-screen mode is actually applying — the feature is on *and*
+   * the window is inside the small band. Ephemeral (re-derived from the window
+   * width on launch), never persisted.
+   *
+   * It selects which of the **two layout modes** is on screen. Each side of the
+   * app keeps both: `leftPanelCollapsed`/`rightPanelCollapsed` above are the
+   * *live* pair and `inactiveModeCollapsed` below is the other one; the column
+   * *widths* work the same way (`layout/column-widths.ts`). Switching
+   * modes swaps them, so what the user does to the side columns on a narrow
+   * window is remembered for the next narrow window and never disturbs the
+   * normal-width layout.
    */
-  leftPanelAutoHidden: boolean;
-  rightPanelAutoHidden: boolean;
+  smallScreenActive: boolean;
   /**
-   * True while an auto-hidden panel is temporarily revealed by an edge-hover
+   * The collapse state of the layout mode that is *not* on screen: the
+   * normal-width one while small-screen mode is active, the small-screen one
+   * while it isn't. `null` when that mode has nothing recorded yet (a workspace
+   * that has never been narrow). Swapped in on every mode change, loaded and
+   * saved per-workspace alongside the live pair. Ephemeral itself — the
+   * *persisted* copy is `WorkspaceInternal.smallScreenCollapsed`.
+   */
+  inactiveModeCollapsed: SideCollapseState | null;
+  /**
+   * True while a collapsed side panel is temporarily revealed by an edge-hover
    * peek. Ephemeral UI state, never persisted.
    */
   leftPanelPeeking: boolean;
@@ -195,9 +225,11 @@ export interface AppState {
   rightPanelPeekDragging: boolean;
   /**
    * The peek overlay's width — global (not per-workspace) and independent of
-   * the panel's normal (large-screen) width, since it's a separate, small-
-   * screen-only sizing the user tunes by dragging the peek's own resize
-   * handle. Persisted in the global index, like `smallScreenThresholdPx`.
+   * either layout mode's column width, since it's a separate sizing the user
+   * tunes by dragging the peek's own resize handle. Persisted in the global
+   * index, like `smallScreenThresholdPx`. (The `smallScreen` prefix is
+   * historical: peek started out small-screen-only and now works at any window
+   * size — see `small-screen-mode.ts`.)
    */
   smallScreenPeekWidthLeftPx: number;
   smallScreenPeekWidthRightPx: number;
@@ -247,6 +279,14 @@ export const MIN_SMALL_SCREEN_THRESHOLD_PX = 200;
 /** Width above `threshold` a panel must regain before small-screen mode exits
  * — prevents hide/show flicker right at the boundary. */
 export const SMALL_SCREEN_HYSTERESIS_PX = 80;
+
+/** What a workspace's small-screen layout starts as, the first time the window
+ * is narrow: both side columns out of the way. From then on the workspace
+ * remembers whatever the user leaves it in on a narrow window. */
+export const DEFAULT_SMALL_SCREEN_COLLAPSE: SideCollapseState = {
+  left: true,
+  right: true,
+};
 
 /** Default width for the small-screen peek overlay — independent of, and
  * usually narrower than, the panel's normal (large-screen) width. Drag the

--- a/packages/extension-host/src/state/workspaces.test.ts
+++ b/packages/extension-host/src/state/workspaces.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import type { WorkspaceInternal } from "./types";
 
 // removeEditor fire-and-forgets a backup clear; mock the backup module so the
@@ -99,6 +99,87 @@ describe("side-panel visibility is per-workspace", () => {
     // And w2 kept its own.
     activateWorkspace("w2");
     expect(store.sidePanelVisibility).toEqual({ git: false });
+  });
+});
+
+describe("the two side-column layout modes are per-workspace", () => {
+  beforeEach(() => {
+    store.leftPanelCollapsed = false;
+    store.rightPanelCollapsed = false;
+    store.smallScreenActive = false;
+    store.inactiveModeCollapsed = null;
+  });
+
+  afterEach(() => {
+    store.smallScreenActive = false;
+    store.inactiveModeCollapsed = null;
+  });
+
+  it("saves the live state as the normal-width layout on a normal-width window", () => {
+    store.leftPanelCollapsed = true;
+    savePanelStateToWorkspace("w");
+    expect(store.workspaces.w.leftPanelCollapsed).toBe(true);
+    expect(store.workspaces.w.rightPanelCollapsed).toBe(false);
+    // Nothing recorded for small-screen mode yet — the key stays absent.
+    expect(store.workspaces.w.smallScreenCollapsed).toBeUndefined();
+  });
+
+  it("saves the live state as the small-screen layout while narrow, leaving the other alone", () => {
+    store.smallScreenActive = true;
+    store.inactiveModeCollapsed = { left: false, right: false };
+    store.leftPanelCollapsed = false;
+    store.rightPanelCollapsed = true;
+
+    savePanelStateToWorkspace("w");
+    expect(store.workspaces.w.leftPanelCollapsed).toBe(false);
+    expect(store.workspaces.w.rightPanelCollapsed).toBe(false);
+    expect(store.workspaces.w.smallScreenCollapsed).toEqual({
+      left: false,
+      right: true,
+    });
+  });
+
+  it("loads the live mode's layout and parks the other one", () => {
+    store.workspaces.w.leftPanelCollapsed = true;
+    store.workspaces.w.rightPanelCollapsed = false;
+    store.workspaces.w.smallScreenCollapsed = { left: false, right: true };
+
+    loadPanelStateFromWorkspace(store.workspaces.w);
+    expect(store.leftPanelCollapsed).toBe(true); // normal-width layout
+    expect(store.inactiveModeCollapsed).toEqual({ left: false, right: true });
+
+    store.smallScreenActive = true;
+    loadPanelStateFromWorkspace(store.workspaces.w);
+    expect(store.leftPanelCollapsed).toBe(false); // small-screen layout
+    expect(store.rightPanelCollapsed).toBe(true);
+    expect(store.inactiveModeCollapsed).toEqual({ left: true, right: false });
+  });
+
+  it("starts a workspace that has never been narrow with both columns hidden", () => {
+    store.smallScreenActive = true;
+    loadPanelStateFromWorkspace(store.workspaces.w);
+    expect(store.leftPanelCollapsed).toBe(true);
+    expect(store.rightPanelCollapsed).toBe(true);
+  });
+
+  it("keeps each workspace's small-screen layout across a switch and back", () => {
+    store.workspaces = { w: makeWorkspace("w"), w2: makeWorkspace("w2") };
+    store.workspaceOrder = ["w", "w2"];
+    store.activeWorkspaceId = "w";
+    store.smallScreenActive = true;
+    store.inactiveModeCollapsed = { left: false, right: false };
+    store.leftPanelCollapsed = true;
+    store.rightPanelCollapsed = true;
+
+    // Open the left column on the narrow window, then go look at w2...
+    store.leftPanelCollapsed = false;
+    activateWorkspace("w2");
+    expect(store.leftPanelCollapsed).toBe(true); // w2's own (fresh) layout
+
+    // ...and back: w's narrow-window layout is exactly as it was left.
+    activateWorkspace("w");
+    expect(store.leftPanelCollapsed).toBe(false);
+    expect(store.rightPanelCollapsed).toBe(true);
   });
 });
 

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -1,8 +1,9 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { basename } from "@tauri-apps/api/path";
 import { path } from "@silo-code/sdk";
-import { store } from "./store";
+import { store, collapseStateByMode } from "./store";
 import { clearEditorBackup } from "./editor-backups";
+import { DEFAULT_SMALL_SCREEN_COLLAPSE } from "./types";
 import type {
   EditorRecord,
   EditorSettingsOverride,
@@ -65,8 +66,13 @@ export function savePanelStateToWorkspace(wsId: string): void {
   ws.activeSidePanelTabs = { ...store.activeSidePanelTabs };
   ws.sidePanelScrollPositions = { ...store.sidePanelScrollPositions };
   ws.sidePanelVisibility = { ...store.sidePanelVisibility };
-  ws.leftPanelCollapsed = store.leftPanelCollapsed;
-  ws.rightPanelCollapsed = store.rightPanelCollapsed;
+  // Both layout modes travel with the workspace — the live one plus the one
+  // waiting off screen (see `small-screen-mode.ts`).
+  const collapse = collapseStateByMode();
+  ws.leftPanelCollapsed = collapse.normal.left;
+  ws.rightPanelCollapsed = collapse.normal.right;
+  if (collapse.smallScreen)
+    ws.smallScreenCollapsed = { ...collapse.smallScreen };
   const ext: Record<string, Record<string, unknown>> = {};
   for (const k of Object.keys(store.extensionState))
     ext[k] = { ...store.extensionState[k] };
@@ -80,8 +86,24 @@ export function loadPanelStateFromWorkspace(ws: WorkspaceInternal): void {
   store.activeSidePanelTabs = { ...(ws.activeSidePanelTabs ?? {}) };
   store.sidePanelScrollPositions = { ...(ws.sidePanelScrollPositions ?? {}) };
   store.sidePanelVisibility = { ...(ws.sidePanelVisibility ?? {}) };
-  store.leftPanelCollapsed = ws.leftPanelCollapsed ?? false;
-  store.rightPanelCollapsed = ws.rightPanelCollapsed ?? false;
+  // Whichever layout mode is on screen becomes live; the other one waits in
+  // `inactiveModeCollapsed` for the next mode switch. A workspace that has
+  // never been narrow has no small-screen layout yet — small-screen mode's
+  // default (both collapsed) stands in, which is what it would have done to
+  // this workspace on arrival anyway.
+  const normal = {
+    left: ws.leftPanelCollapsed ?? false,
+    right: ws.rightPanelCollapsed ?? false,
+  };
+  const smallScreen = ws.smallScreenCollapsed
+    ? { ...ws.smallScreenCollapsed }
+    : null;
+  const live = store.smallScreenActive
+    ? (smallScreen ?? { ...DEFAULT_SMALL_SCREEN_COLLAPSE })
+    : normal;
+  store.leftPanelCollapsed = live.left;
+  store.rightPanelCollapsed = live.right;
+  store.inactiveModeCollapsed = store.smallScreenActive ? normal : smallScreen;
   const ext: Record<string, Record<string, unknown>> = {};
   for (const k of Object.keys(ws.extensionState ?? {}))
     ext[k] = { ...ws.extensionState![k] };

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -1,9 +1,9 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { basename } from "@tauri-apps/api/path";
 import { path } from "@silo-code/sdk";
-import { store, collapseStateByMode } from "./store";
+import { store } from "./store";
 import { clearEditorBackup } from "./editor-backups";
-import { DEFAULT_SMALL_SCREEN_COLLAPSE } from "./types";
+import { applyPanelState, capturePanelState } from "./panel-state";
 import type {
   EditorRecord,
   EditorSettingsOverride,
@@ -61,53 +61,12 @@ export function createWorkspace(input: {
 export function savePanelStateToWorkspace(wsId: string): void {
   const ws = store.workspaces[wsId];
   if (!ws) return;
-  ws.sidePanelLocations = { ...store.sidePanelLocations };
-  ws.sidePanelOrder = { ...store.sidePanelOrder };
-  ws.activeSidePanelTabs = { ...store.activeSidePanelTabs };
-  ws.sidePanelScrollPositions = { ...store.sidePanelScrollPositions };
-  ws.sidePanelVisibility = { ...store.sidePanelVisibility };
-  // Both layout modes travel with the workspace — the live one plus the one
-  // waiting off screen (see `small-screen-mode.ts`).
-  const collapse = collapseStateByMode();
-  ws.leftPanelCollapsed = collapse.normal.left;
-  ws.rightPanelCollapsed = collapse.normal.right;
-  if (collapse.smallScreen)
-    ws.smallScreenCollapsed = { ...collapse.smallScreen };
-  const ext: Record<string, Record<string, unknown>> = {};
-  for (const k of Object.keys(store.extensionState))
-    ext[k] = { ...store.extensionState[k] };
-  ws.extensionState = ext;
+  Object.assign(ws, capturePanelState());
 }
 
 /** Restore the global panel state from a workspace object. */
 export function loadPanelStateFromWorkspace(ws: WorkspaceInternal): void {
-  store.sidePanelLocations = { ...(ws.sidePanelLocations ?? {}) };
-  store.sidePanelOrder = { ...(ws.sidePanelOrder ?? {}) };
-  store.activeSidePanelTabs = { ...(ws.activeSidePanelTabs ?? {}) };
-  store.sidePanelScrollPositions = { ...(ws.sidePanelScrollPositions ?? {}) };
-  store.sidePanelVisibility = { ...(ws.sidePanelVisibility ?? {}) };
-  // Whichever layout mode is on screen becomes live; the other one waits in
-  // `inactiveModeCollapsed` for the next mode switch. A workspace that has
-  // never been narrow has no small-screen layout yet — small-screen mode's
-  // default (both collapsed) stands in, which is what it would have done to
-  // this workspace on arrival anyway.
-  const normal = {
-    left: ws.leftPanelCollapsed ?? false,
-    right: ws.rightPanelCollapsed ?? false,
-  };
-  const smallScreen = ws.smallScreenCollapsed
-    ? { ...ws.smallScreenCollapsed }
-    : null;
-  const live = store.smallScreenActive
-    ? (smallScreen ?? { ...DEFAULT_SMALL_SCREEN_COLLAPSE })
-    : normal;
-  store.leftPanelCollapsed = live.left;
-  store.rightPanelCollapsed = live.right;
-  store.inactiveModeCollapsed = store.smallScreenActive ? normal : smallScreen;
-  const ext: Record<string, Record<string, unknown>> = {};
-  for (const k of Object.keys(ws.extensionState ?? {}))
-    ext[k] = { ...ws.extensionState![k] };
-  store.extensionState = ext;
+  applyPanelState(ws);
 }
 
 export function activateWorkspace(id: string): void {

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
@@ -42,7 +42,7 @@ export function LayoutSettingsPage() {
         <Section label="Laptop Mode">
           <SettingRow
             label="Enable Laptop Mode"
-            hint="Auto-hide side panels when the window narrows past the threshold below, and peek a hidden panel by hovering the window's edge."
+            hint="Give a narrow window its own layout: side panels hide when the window narrows past the threshold below, and each workspace remembers what you show, hide, and resize while it's narrow. Your full-size layout is untouched, and comes back with the wider window. (Hovering the window's edge peeks a collapsed panel at any size.)"
           >
             <Switch
               checked={snap.smallScreenModeEnabled}


### PR DESCRIPTION
## What & why

Two changes to how the side columns behave, plus a refactor the first one earned.

**Laptop Mode is now a second layout, not a temporary tweak of the one layout.** It used to fold whatever you did on a narrow window back into the single saved layout, so a panel opened to cope with a small screen followed you to the big one — and a workspace switch threw the narrow-window arrangement away entirely. Each workspace now remembers both: the normal-width pair in `leftPanelCollapsed`/`rightPanelCollapsed`, the narrow-window pair in `smallScreenCollapsed` (absent until the mode has applied). The mode that isn't on screen sits in `inactiveModeCollapsed`, so a mode change is one swap, and `applyPanelState` picks the live one on a workspace switch.

**Side columns are sized in pixels** — min 200, max 800, with a 240px floor for the center. react-resizable-panels only takes percentages, which is why the columns used to rescale with the window; the layout is now derived from two px numbers against the live window width, so the sides stay put on resize and the center absorbs the difference. Widths live per mode in localStorage, read synchronously so the first paint is already right (an async read of the app-state index can't do that). This replaces the library's `autoSaveId`: its stored percentages were the thing being replaced, and its storage key hashes the panel constraints, which are now window-dependent. Dragging a column below the minimum still collapses it.

**Peek is no longer Laptop Mode's alone.** Any collapsed side panel is one edge-hover away, at any window size — which retires `*PanelAutoHidden` entirely, since peek eligibility and Tab-order exclusion are both just "is this column collapsed".

**`refactor(state)`, second commit.** Adding the one per-workspace field above meant editing it in two hand-kept copies of the same mapping. The shape is now declared once (`SharedPanelState`) with `AppState` and `WorkspaceInternal` derived from it, and `capturePanelState`/`applyPanelState` in the new `state/panel-state.ts` are the only mapping — `withActivePanelState` collapses to `{ ...ws, ...panel }`. A new per-workspace field now costs two files instead of five. The global-index half of the same problem is written up in #322 and deliberately left alone.

## How to test

Verified by hand in the dev app (resizing across the threshold, workspace switches in both modes, drag-to-collapse, edge-hover peek at full size) plus:

- `packages/extension-host/src/layout/column-widths.test.ts` — px↔% math, size held across window widths, clamping, the narrow-window fallback, storage round-trip
- `packages/extension-host/src/extension-host/small-screen-mode.test.ts` — mode entry/exit, changes staying in their own mode, the narrow layout coming back, peek eligibility
- `packages/extension-host/src/state/panel-state.test.ts` — capture → apply → capture round-trip (fails if either half of the mapping drops a field) and store/record isolation
- `packages/extension-host/src/state/workspaces.test.ts` — both modes surviving a workspace switch and back

**No format change and nothing to migrate.** Two things do move on first run: column widths reset once (they left the library's percentage entry for `silo:main-column-widths`), and workspace records gain an additive `smallScreenCollapsed` key that stays absent until a workspace has been narrow.

## Checklist

- [x] PR title is a valid Conventional Commit
- [x] `pnpm lint`, `pnpm format:check`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm test` pass (967 tests; `format:check`'s only warnings are gitignored `crates/pty-host/target` build artifacts, untouched here)
- [x] No new architecture-boundary violations
- [x] Docs/`ctx` reference updated if the public extension surface changed — n/a, no public surface change; the Settings → Layout copy is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX5aXcB3zmXrzuWbC7T5rT