### PR TITLE
fix(extension-host): fix cross-workspace, split-dock, and window-refocus tab-focus bugs

### DIFF
--- a/apps/desktop/src/automation/bridge.ts
+++ b/apps/desktop/src/automation/bridge.ts
@@ -18,6 +18,7 @@ import {
   splitActivePanel,
   getActiveDockApi,
   getOutputLogs,
+  restoreRegionFocus,
 } from "@silo-code/extension-host";
 
 // --- Monaco introspection (source of truth, not DOM scraping) ---------------
@@ -401,9 +402,15 @@ async function handleOp(
 
     case "openTerminal": {
       // Drive the real ctx.terminals.create path (not addTerminal directly), so
-      // the bridge exercises the same public API the menu does.
+      // the bridge exercises the same public API the menu does. workspaceId
+      // defaults to the active workspace, but a test can pass another one
+      // explicitly to add a terminal to a *backgrounded* workspace — e.g.
+      // simulating an agent spawning a terminal in a workspace the user isn't
+      // looking at.
       const rec = getTerminalService().create({
-        workspaceId: requireActiveWorkspace(),
+        workspaceId: args.workspaceId
+          ? String(args.workspaceId)
+          : requireActiveWorkspace(),
         cwd: args.cwd ? String(args.cwd) : undefined,
       });
       if (!rec) throw new Error("openTerminal: no active workspace");
@@ -501,11 +508,37 @@ async function handleOp(
       return { focused: terminalId };
     }
 
+    // Reproduces the exact call shape agent-inspector's openAndFocus() (and,
+    // per RFC 0023, the closed-source agent-monitor extension's Navigator row
+    // click) makes: activate the target workspace, THEN focus a terminal
+    // inside it, back to back in one tick — without needing that extension
+    // built/installed. See ADR 0034 / terminal-service.ts's focus().
+    case "activateThenFocusTerminal": {
+      const workspaceId = String(args.workspaceId ?? "");
+      const terminalId = String(args.terminalId ?? "");
+      activateWorkspace(workspaceId);
+      getTerminalService().focus(terminalId);
+      return { focused: terminalId };
+    }
+
     // Which tab the visible center dock is actually showing. Read from
     // dockview's own api (not the DOM), so a test can watch the active tab
     // settle — or catch it flipping away a moment after it was set.
     case "activePanel": {
       return { panelId: getActiveDockApi()?.activePanel?.id ?? null };
+    }
+
+    // Simulate the window regaining OS focus by calling the same
+    // restoreRegionFocus() Tauri's real onFocusChanged handler calls
+    // (AppShell.tsx), at a moment the test controls. Returns what focus
+    // landed on afterward plus which panel the active dock now shows, so a
+    // test can catch it dragging the active TAB along with DOM focus.
+    case "restoreRegionFocus": {
+      restoreRegionFocus();
+      return {
+        ...describeActiveElement(),
+        activePanelId: getActiveDockApi()?.activePanel?.id ?? null,
+      };
     }
 
     // Bring a registered side panel into view: expand its slot, then activate
@@ -739,5 +772,9 @@ function describeActiveElement() {
     isTextarea: el instanceof HTMLTextAreaElement,
     inMonaco: !!el.closest(".monaco-editor"),
     inXterm: !!el.closest(".xterm"),
+    // False when focus landed on content belonging to a backgrounded
+    // workspace's dock — CenterDock.tsx keeps every visited workspace's dock
+    // mounted as a sibling `.dock-host`, toggling `data-active`.
+    inActiveDockHost: !!el.closest('.dock-host[data-active="true"]'),
   };
 }

--- a/apps/desktop/src/automation/client.ts
+++ b/apps/desktop/src/automation/client.ts
@@ -57,6 +57,8 @@ export interface ActiveElement {
   isTextarea: boolean;
   inMonaco: boolean;
   inXterm: boolean;
+  /** False when focus is on a backgrounded workspace's (hidden) dock content. */
+  inActiveDockHost: boolean;
 }
 
 /** A single serialisable log entry from the `outputLogs` op. */
@@ -240,8 +242,16 @@ export class SiloAutomation {
     return this.call("openDiff", spec);
   }
 
-  openTerminal(cwd?: string): Promise<{ terminalId: string; panelId: string }> {
-    return this.call("openTerminal", { cwd });
+  /**
+   * `workspaceId` defaults to the active workspace; pass another one to add a
+   * terminal to a *backgrounded* workspace (e.g. simulating an agent spawning
+   * a terminal in a workspace the user isn't looking at).
+   */
+  openTerminal(
+    cwd?: string,
+    workspaceId?: string,
+  ): Promise<{ terminalId: string; panelId: string }> {
+    return this.call("openTerminal", { cwd, workspaceId });
   }
 
   /**
@@ -318,12 +328,39 @@ export class SiloAutomation {
   }
 
   /**
+   * Reproduce an extension calling `ctx.workspaces.activate(workspaceId)`
+   * immediately followed by `ctx.terminals.focus(terminalId)` — the ordering
+   * agent-inspector's Navigator row click (and, per RFC 0023, the real
+   * agent-monitor extension) uses. This is the shape that drops the
+   * cross-workspace activation request when the two calls race with
+   * `WorkspaceDock`'s own dock-mount commit. See ADR 0034.
+   */
+  activateThenFocusTerminal(
+    workspaceId: string,
+    terminalId: string,
+  ): Promise<{ focused: string }> {
+    return this.call("activateThenFocusTerminal", { workspaceId, terminalId });
+  }
+
+  /**
    * The panel id the visible center dock is showing, straight from dockview —
    * the ground truth for "which tab am I on", and for watching whether it stays
    * put.
    */
   activePanel(): Promise<{ panelId: string | null }> {
     return this.call("activePanel");
+  }
+
+  /**
+   * Simulate the window regaining OS focus by calling the same
+   * `restoreRegionFocus()` Tauri's real `onFocusChanged` handler calls.
+   * Returns what focus landed on afterward plus which panel the active dock
+   * now shows, so a test can catch it dragging the active tab along with it.
+   */
+  restoreRegionFocus(): Promise<
+    (ActiveElement & { activePanelId: string | null }) | null
+  > {
+    return this.call("restoreRegionFocus");
   }
 
   /**

--- a/apps/desktop/src/automation/cross-workspace-activate-then-focus.it.test.ts
+++ b/apps/desktop/src/automation/cross-workspace-activate-then-focus.it.test.ts
@@ -1,0 +1,117 @@
+// Integration test (Layer 2): a caller that calls ctx.workspaces.activate()
+// immediately followed by ctx.terminals.focus() — the exact shape
+// agent-inspector's Navigator row click uses (see AgentInspectorPanel.tsx's
+// openAndFocus()), and per RFC 0023 the shape the real (closed-source, not in
+// this repo) agent-monitor extension's Navigator agent list uses too — must
+// still land on the requested tab.
+//
+// Sibling to cross-workspace-terminal-focus.it.test.ts, which only ever drives
+// the jump through silo.focusTerminal() alone. That test passing is not
+// evidence this one does: ctx.terminals.focus()'s cross-workspace branch is
+// gated on `store.activeWorkspaceId !== wsId`. A caller that already flipped
+// store.activeWorkspaceId itself (via ctx.workspaces.activate()) one line
+// earlier makes that check false — before WorkspaceDock's authority effect has
+// actually committed the new dock as live — so focus() silently takes the
+// "same workspace, dock already up" fast path, finds no panel on the (still
+// stale) active dock API, and no-ops. requestPanelActivation() — the only
+// sanctioned way to register a cross-workspace intent — never gets called, so
+// there's no race to "flash and flip back" from: the destination workspace's
+// dock just falls through to whatever it already remembers. Unlike the
+// existing file's race, this is a pure ordering bug with no timing
+// component — expect it to fail on essentially every round pre-fix, not
+// intermittently.
+//
+// Runs the jump several times and alternates which tab is requested, so a
+// stale "remembered tab" can't accidentally be the right answer.
+//
+// No DOM focus involved (dockview's active panel is the ground truth), so
+// unlike new-terminal-focus.it this doesn't need the window frontmost.
+//
+// Requires the dev app running (`pnpm dev`); skips otherwise.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[cross-workspace-activate-then-focus.it] no dev app reachable on :7878 — " +
+      "skipping. Run `pnpm dev` to exercise this suite.",
+  );
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!available)(
+  "cross-workspace activate() immediately followed by terminals.focus()",
+  () => {
+    let folderA: string;
+    let folderB: string;
+    let priorActive: string | null;
+    let wsA: string;
+    let wsB: string;
+    let termB1: string;
+    let termB2: string;
+
+    beforeAll(async () => {
+      priorActive = (await silo.listWorkspaces()).active;
+      folderA = await mkdtemp(join(tmpdir(), "silo-it-actf-a-"));
+      folderB = await mkdtemp(join(tmpdir(), "silo-it-actf-b-"));
+      wsA = (await silo.openWorkspace(folderA, "it-actf-a")).id;
+      wsB = (await silo.openWorkspace(folderB, "it-actf-b")).id;
+
+      // Two terminals in B, so B has a "remembered" tab that can win by
+      // default when the request is silently dropped. The second one is
+      // active when we leave B.
+      await silo.activateWorkspace(wsB);
+      termB1 = (await silo.openTerminal(folderB)).terminalId;
+      termB2 = (await silo.openTerminal(folderB)).terminalId;
+
+      // And one in A, so leaving A is a realistic "I was working over here" state.
+      await silo.activateWorkspace(wsA);
+      await silo.openTerminal(folderA);
+    }, 60000);
+
+    afterAll(async () => {
+      if (wsA) await silo.deleteWorkspace(wsA);
+      if (wsB) await silo.deleteWorkspace(wsB);
+      if (priorActive) await silo.activateWorkspace(priorActive);
+      await rm(folderA, { recursive: true, force: true });
+      await rm(folderB, { recursive: true, force: true });
+    });
+
+    it(
+      "activates the requested tab even when the caller pre-activates the workspace",
+      { timeout: 60000 },
+      async () => {
+        for (let round = 0; round < 4; round++) {
+          const target = round % 2 === 0 ? termB1 : termB2;
+          const wanted = `terminal:${target}`;
+
+          await silo.activateWorkspace(wsA);
+          await sleep(400); // let workspace A settle before timing the jump
+
+          await silo.activateThenFocusTerminal(wsB, target);
+
+          // Same generous settle window as the sibling test — give every
+          // deferred actor (dock mount, onDidAddPanel, relayoutAndRefit) its
+          // full budget before checking where things landed.
+          await sleep(500);
+          const { panelId } = await silo.activePanel();
+
+          expect(
+            panelId,
+            `round ${round}: expected ${wanted}, got ${panelId} — the ` +
+              `pre-activate call likely dropped the cross-workspace request`,
+          ).toBe(wanted);
+        }
+      },
+    );
+  },
+);

--- a/apps/desktop/src/automation/window-focus-restore.it.test.ts
+++ b/apps/desktop/src/automation/window-focus-restore.it.test.ts
@@ -1,0 +1,171 @@
+// Integration test (Layer 2): the window regaining OS focus (alt-tabbing back
+// from another app — Tauri's onFocusChanged) must never change which tab is
+// active. It's allowed to restore DOM keyboard focus (that's the whole point
+// of focus-restore.ts — macOS eats the click that reactivates an inactive
+// window), but it must restore focus to something in the CURRENTLY ACTIVE
+// workspace's dock, never a backgrounded one.
+//
+// Regression guard for symptom 3: focus-restore.ts's record() blindly
+// remembers the last `focusin` anywhere under ".side-pane, .center-body,
+// .status-bar" — and CenterDock.tsx keeps every visited workspace's dock
+// mounted as a sibling `.dock-host` inside that same shared `.center-body`
+// container, only toggling `data-active`. record()'s region selector doesn't
+// discriminate between them, so a stray/deferred focusin from a backgrounded
+// dock (there are several async focus-retry chains around workspace
+// switches — WorkspaceDock's 3-RAF fallback, relayoutAndRefit's 2-RAF
+// setActive(), focusPanelContent's retryFocus polling) can end up as
+// `lastFocused`. restoreRegionFocus() then calls .focus() on it directly when
+// the window regains focus — bypassing the whole panel-activation-request /
+// WorkspaceDock-authority system — and because dockview treats a focusin
+// landing in a panel's content as "make this panel active", that raw .focus()
+// call can drag the active TAB along with it.
+//
+// Two variants:
+//   1. Timing race — switches workspaces and calls the window-regain
+//      simulation with no settle delay, maximizing the chance a deferred
+//      retry from the workspace just left is still in flight when it fires.
+//      10 rounds: this is inherently timing-sensitive, so more samples both
+//      prove reproducibility pre-fix and later prove it's solid post-fix,
+//      rather than one lucky/unlucky round reading as the whole story.
+//   2. Deterministic — switches to an EMPTY workspace (no terminals/editors,
+//      so nothing generates a fresh focusin there at all) and force-blurs, so
+//      lastFocused is guaranteed to still be whatever it was in the
+//      originating workspace. Isolates "does a stale cross-dock lastFocused
+//      get restored at all" from timing luck. Diagnostic regardless of
+//      pass/fail — report which variant actually reproduces; that tells us
+//      whether the fix needs dock-scoping, focusGen-staleness, or both.
+//
+// Focus-sensitive: only runs with the window visible + frontmost (can't be
+// guaranteed headless/CI — see client.foreground()). Skips otherwise.
+//
+// Requires the dev app running (`pnpm dev`); skips otherwise.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+const canFocus = available && (await silo.foreground());
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[window-focus-restore.it] no dev app reachable on :7878 — skipping. " +
+      "Run `pnpm dev` to exercise this suite.",
+  );
+} else if (!canFocus) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[window-focus-restore.it] app window not foregrounded — skipping focus " +
+      "assertions. Bring the Silo window to the front and keep it frontmost.",
+  );
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!canFocus)(
+  "window regaining OS focus keeps the active tab",
+  () => {
+    let folderA: string;
+    let folderB: string;
+    let folderC: string;
+    let priorActive: string | null;
+    let wsA: string;
+    let wsB: string;
+    let wsC: string;
+    let termA: string;
+    let termB: string;
+
+    beforeAll(async () => {
+      priorActive = (await silo.listWorkspaces()).active;
+      folderA = await mkdtemp(join(tmpdir(), "silo-it-wfr-a-"));
+      folderB = await mkdtemp(join(tmpdir(), "silo-it-wfr-b-"));
+      folderC = await mkdtemp(join(tmpdir(), "silo-it-wfr-c-"));
+      wsA = (await silo.openWorkspace(folderA, "it-wfr-a")).id;
+      wsB = (await silo.openWorkspace(folderB, "it-wfr-b")).id;
+      // C stays empty on purpose — no terminals/editors, so switching to it
+      // drives no fresh focusin anywhere (variant 2).
+      wsC = (await silo.openWorkspace(folderC, "it-wfr-c")).id;
+
+      await silo.activateWorkspace(wsA);
+      termA = (await silo.openTerminal(folderA)).terminalId;
+
+      await silo.activateWorkspace(wsB);
+      termB = (await silo.openTerminal(folderB)).terminalId;
+    }, 60000);
+
+    afterAll(async () => {
+      if (wsA) await silo.deleteWorkspace(wsA);
+      if (wsB) await silo.deleteWorkspace(wsB);
+      if (wsC) await silo.deleteWorkspace(wsC);
+      if (priorActive) await silo.activateWorkspace(priorActive);
+      await rm(folderA, { recursive: true, force: true });
+      await rm(folderB, { recursive: true, force: true });
+      await rm(folderC, { recursive: true, force: true });
+    });
+
+    it(
+      "variant 1: window-regain right after a workspace switch doesn't restore the old workspace's tab",
+      { timeout: 60000 },
+      async () => {
+        let failures = 0;
+        for (let round = 0; round < 10; round++) {
+          await silo.activateWorkspace(wsA);
+          await silo.focusTerminal(termA);
+          await sleep(300); // let A's focus fully settle — real lastFocused = A's terminal
+
+          await silo.activateWorkspace(wsB);
+          await silo.focusTerminal(termB);
+          // No settle sleep here on purpose — call the regain-focus simulation
+          // as close as possible to the switch, while B's own deferred focus
+          // retries (and any straggler from A) may still be in flight.
+          await silo.restoreRegionFocus();
+
+          // Give every deferred actor its full budget, then check where things
+          // actually settled — the assertion that matters, not the immediate
+          // sample.
+          await sleep(500);
+          const finalPanel = await silo.activePanel();
+          const finalEl = await silo.activeElement();
+          if (
+            finalPanel.panelId !== `terminal:${termB}` ||
+            finalEl?.inActiveDockHost === false
+          ) {
+            failures++;
+          }
+        }
+        expect(
+          failures,
+          `${failures}/10 rounds settled on the wrong workspace's tab after ` +
+            `a window-regain race`,
+        ).toBe(0);
+      },
+    );
+
+    it(
+      "variant 2: window-regain after switching to an empty workspace doesn't restore the backgrounded one",
+      { timeout: 60000 },
+      async () => {
+        for (let round = 0; round < 4; round++) {
+          await silo.activateWorkspace(wsA);
+          await silo.focusTerminal(termA);
+          await sleep(300);
+
+          await silo.activateWorkspace(wsC); // empty — nothing to focus here
+          await sleep(200);
+          await silo.eval("document.activeElement?.blur()"); // simulate real OS blur
+
+          const result = await silo.restoreRegionFocus();
+
+          expect(
+            result?.inActiveDockHost,
+            `round ${round}: window-regain restored focus into backgrounded workspace A`,
+          ).not.toBe(false);
+        }
+      },
+    );
+  },
+);

--- a/apps/desktop/src/automation/workspace-revisit-active-tab.it.test.ts
+++ b/apps/desktop/src/automation/workspace-revisit-active-tab.it.test.ts
@@ -1,0 +1,150 @@
+// Integration test (Layer 2): revisiting a workspace (switch away, then back)
+// must land on the tab that was active when you left it — no explicit request
+// in play, just the dock's own "remembered panel" precedence.
+//
+// Two scenarios, isolating whether the bug needs something to have happened in
+// the backgrounded workspace while you were away, or reproduces on a bare,
+// activity-free revisit:
+//
+//   (a) bare revisit — switch A -> B -> A repeatedly, nothing else happens.
+//       WorkspaceDock's authority effect (packages/extension-host/src/panels/
+//       WorkspaceDock.tsx) re-asserts lastActivePanelRef on return via
+//       resolveActivationTarget, so this is expected to hold even before any
+//       fix — it's the control. If this scenario ever fails, the bug is
+//       broader than the leading hypothesis and needs re-investigation before
+//       shipping a fix.
+//
+//   (b) revisit after a terminal is added to A while it's backgrounded —
+//       simulating an agent spawning a terminal in a workspace you're not
+//       looking at. WorkspaceDock's panel-reconciliation effect (same file,
+//       the terminal/editor sync effect) force-activates a newly-added panel
+//       via panel.api.setActive() and is NOT gated on the `active` prop, so it
+//       can silently commandeer a backgrounded workspace's active tab without
+//       going through the authority effect or updating lastActivePanelRef.
+//       This is the scenario expected to fail pre-fix if that's the real
+//       trigger for symptom 1.
+//
+// 6 rounds each (more than the usual 4) — this is the least-confirmed root
+// cause of the three symptoms, so a clean negative result needs more samples
+// to be trustworthy, and a positive one needs to show it's not a one-off.
+//
+// No DOM focus involved (dockview's active panel is the ground truth), so
+// unlike new-terminal-focus.it this doesn't need the window frontmost.
+//
+// Requires the dev app running (`pnpm dev`); skips otherwise.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[workspace-revisit-active-tab.it] no dev app reachable on :7878 — " +
+      "skipping. Run `pnpm dev` to exercise this suite.",
+  );
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!available)(
+  "revisiting a workspace keeps its active tab",
+  () => {
+    let folderA: string;
+    let folderB: string;
+    let priorActive: string | null;
+    let wsA: string;
+    let wsB: string;
+    let termA2: string;
+
+    beforeAll(async () => {
+      priorActive = (await silo.listWorkspaces()).active;
+      folderA = await mkdtemp(join(tmpdir(), "silo-it-revisit-a-"));
+      folderB = await mkdtemp(join(tmpdir(), "silo-it-revisit-b-"));
+      wsA = (await silo.openWorkspace(folderA, "it-revisit-a")).id;
+      wsB = (await silo.openWorkspace(folderB, "it-revisit-b")).id;
+
+      // Two terminals in A — the second one is active when we leave, so a
+      // reversion to "whatever dockview happens to remember" is distinguishable
+      // from a reversion to the correct (second) tab.
+      await silo.activateWorkspace(wsA);
+      await silo.openTerminal(folderA);
+      termA2 = (await silo.openTerminal(folderA)).terminalId;
+
+      await silo.activateWorkspace(wsB);
+      await silo.openTerminal(folderB);
+
+      await silo.activateWorkspace(wsA);
+      await sleep(400);
+    }, 60000);
+
+    afterAll(async () => {
+      if (wsA) await silo.deleteWorkspace(wsA);
+      if (wsB) await silo.deleteWorkspace(wsB);
+      if (priorActive) await silo.activateWorkspace(priorActive);
+      await rm(folderA, { recursive: true, force: true });
+      await rm(folderB, { recursive: true, force: true });
+    });
+
+    it(
+      "(a) bare revisit — no activity while away",
+      { timeout: 60000 },
+      async () => {
+        for (let round = 0; round < 6; round++) {
+          await silo.activateWorkspace(wsA);
+          await silo.activatePanel(`terminal:${termA2}`);
+          await sleep(300);
+
+          await silo.activateWorkspace(wsB);
+          await sleep(300);
+
+          await silo.activateWorkspace(wsA);
+          await sleep(300);
+
+          const { panelId } = await silo.activePanel();
+          expect(
+            panelId,
+            `round ${round}: bare revisit lost the remembered tab`,
+          ).toBe(`terminal:${termA2}`);
+        }
+      },
+    );
+
+    it(
+      "(b) revisit after a terminal is added to A while backgrounded",
+      { timeout: 60000 },
+      async () => {
+        for (let round = 0; round < 6; round++) {
+          await silo.activateWorkspace(wsA);
+          await silo.activatePanel(`terminal:${termA2}`);
+          await sleep(300);
+
+          await silo.activateWorkspace(wsB);
+          await sleep(200);
+
+          // Simulate an agent spawning a terminal in A while the user is in B.
+          // Left open for the rest of the run (no close-terminal op exists on
+          // the automation bridge) — afterAll's deleteWorkspace(wsA) reaps
+          // everything, and a growing terminal count in A doesn't affect
+          // whether termA2 stays the remembered/active tab.
+          await silo.openTerminal(folderA, wsA);
+          await sleep(300); // let A's panel-reconciliation effect run
+
+          await silo.activateWorkspace(wsA);
+          await sleep(300);
+
+          const { panelId } = await silo.activePanel();
+          expect(
+            panelId,
+            `round ${round}: background terminal add hijacked A's remembered tab`,
+          ).toBe(`terminal:${termA2}`);
+        }
+      },
+    );
+  },
+);

--- a/apps/desktop/src/automation/workspace-revisit-split-dock.it.test.ts
+++ b/apps/desktop/src/automation/workspace-revisit-split-dock.it.test.ts
@@ -1,28 +1,30 @@
-// Integration test (Layer 2): end-to-end coverage of the layout symptom 1 was
-// reported against (ADR 0034) — a center dock split into two groups, terminals
-// on the left, editors on the right. Focus a terminal in the LEFT group,
-// switch workspaces and back, and the terminal must still be the active tab
-// rather than the right group's editor.
+// Integration test (Layer 2): live regression guard for symptom 1 (ADR 0034)
+// — a center dock split into two groups, terminals on the left, editors on
+// the right. Focus a terminal in the LEFT group, switch workspaces and back,
+// and the terminal must still be the active tab rather than the right
+// group's editor.
 //
-// HONESTY NOTE about what this does and does not guard. This test never
-// reproduced the bug: driving the jump through the automation API doesn't
-// re-mount a *background* editor panel the way real interaction does, and the
-// re-mount is what triggered it (see below). It passed against the broken
-// build. Keep it as end-to-end coverage of the reported layout, but do NOT
-// treat it as the regression guard.
-//
-// The real regression guard is a unit test —
-// `use-focus-retry.test.ts` → "never grabs on mount when the panel is not the
-// active tab" — which encodes the actual invariant deterministically, plus
-// `retryFocus`'s now-required `stillWanted` parameter, which makes omitting
-// the guard a compile error rather than a silent focus steal.
-//
-// Root cause, for the record: re-entering a workspace re-mounts every panel in
-// its dock, and TextViewer/DiffPanel's mount-time `retryFocus` passed no
-// `stillWanted` guard — so a background editor grabbed DOM focus on re-mount.
-// Because dockview marks a panel's group active when focus lands inside it
+// Root cause: re-entering a workspace re-mounts every panel in its dock, and
+// TextViewer/DiffPanel's mount-time `retryFocus` passed no `stillWanted`
+// guard — so a background editor grabbed DOM focus on re-mount. Because
+// dockview marks a panel's group active when focus lands inside it
 // (`contentContainer.onDidFocus → doSetGroupActive`), that steal also flipped
 // the visible active tab.
+//
+// TIMING MATTERS HERE, and it isn't cosmetic. Earlier drafts of this exact
+// scenario, run with 200-300ms settle delays between actions, passed cleanly
+// even against the broken (pre-fix) build — 0 failures across dozens of
+// rounds — and were wrongly read as "scripted automation can't reproduce this
+// bug, only real interaction can." That conclusion was wrong. Reverting the
+// fix locally and widening these delays to match the cadence actually
+// observed in a real manual reproduction (roughly 1-2s between actions, not
+// 200-300ms) reproduced it immediately: 3 of 4 rounds failed. The original
+// short-delay version wasn't measuring "can automation trigger this" — it was
+// running faster than whatever real settle time (Monaco/`@monaco-editor/react`
+// layout and mount work) the race actually depends on. Keep these delays as
+// wide as they are; shortening them for speed silently turns this back into a
+// test that can't fail. If you need to add more scenarios, prefer more rounds
+// over shorter sleeps.
 //
 // Requires the dev app running (`pnpm dev`); skips otherwise.
 
@@ -59,7 +61,6 @@ describe.skipIf(!available)(
       folderA = await mkdtemp(join(tmpdir(), "silo-it-split-a-"));
       folderB = await mkdtemp(join(tmpdir(), "silo-it-split-b-"));
       await writeFile(join(folderA, "one.txt"), "one\n");
-      await writeFile(join(folderA, "two.txt"), "two\n");
       wsA = (await silo.openWorkspace(folderA, "it-split-a")).id;
       wsB = (await silo.openWorkspace(folderB, "it-split-b")).id;
 
@@ -80,69 +81,44 @@ describe.skipIf(!available)(
       { timeout: 120000 },
       async () => {
         let failures = 0;
-        const totalCycles = 5 * 3; // 5 rounds x 3 switch-away/back cycles each
-        for (let round = 0; round < 5; round++) {
+        const rounds = 4;
+        for (let round = 0; round < rounds; round++) {
           await silo.activateWorkspace(wsA);
-          await sleep(200);
+          await sleep(1500); // let the workspace fully settle, like a real session
 
-          // Three terminals in the left group (matches the tab-dense left
-          // group in the report, not just a single lonely tab). One file
-          // opens as a tab alongside them (no group shows a file yet), then
-          // splitActivePanel moves it (the now-active panel) to a new right
-          // group. A second file opens AFTER the split, once the right group
-          // is both active and already showing a file — findEditorTargetGroup
-          // then targets that group, landing the second file there too
-          // instead of back with the terminals. Order matters: opening both
-          // files before splitting only moves whichever was active at split
-          // time, stranding the other one in the left group.
-          const t1 = await silo.openTerminal(folderA);
-          await silo.openTerminal(folderA);
-          await silo.openTerminal(folderA);
+          const term = await silo.openTerminal(folderA);
+          const termA = term.terminalId;
+          await sleep(1000);
           await silo.openFile(join(folderA, "one.txt"));
+          await sleep(1000);
           const { groups } = await silo.splitActivePanel("right");
           expect(
             groups,
             `round ${round}: split didn't produce two groups`,
           ).toBe(2);
-          await silo.openFile(join(folderA, "two.txt"));
+          await sleep(1500); // let the split settle — real editor layout/mount time
 
-          const termA = t1.terminalId;
-
-          // Simulate actually working across the left group's tabs — not
-          // just landing on T1 once — before settling on it: focus a
-          // different terminal, then focus T1, matching "I was on another
-          // agent tab, then focused this one" rather than a bare first-touch.
-          const t2 = await silo.listTerminals(wsA);
-          const other = t2.terminals.find((t) => t.id !== termA)?.id;
-          if (other) {
-            await silo.focusTerminal(other);
-            await sleep(150);
-          }
           await silo.focusTerminal(termA);
-          await sleep(300);
+          await sleep(1200); // let the focus fully settle before leaving
           const before = await silo.activePanel();
           expect(
             before.panelId,
             `round ${round}: setup didn't leave the terminal focused`,
           ).toBe(`terminal:${termA}`);
 
-          // Multiple switch-away/switch-back cycles within the same round —
-          // in case the first revisit is clean but a later one isn't.
-          for (let cycle = 0; cycle < 3; cycle++) {
-            await silo.activateWorkspace(wsB);
-            await sleep(300);
+          await silo.activateWorkspace(wsB);
+          await sleep(1600); // matches the ~1.6s gap observed in a real manual repro
 
-            await silo.activateWorkspace(wsA);
-            await sleep(300);
+          await silo.activateWorkspace(wsA);
+          await sleep(1200); // matches the ~1.2s settle gap observed in a real manual repro
 
-            const after = await silo.activePanel();
-            if (after.panelId !== `terminal:${termA}`) {
-              failures++;
-              // eslint-disable-next-line no-console
-              console.warn(
-                `round ${round} cycle ${cycle}: expected terminal:${termA}, got ${after.panelId}`,
-              );
-            }
+          const after = await silo.activePanel();
+          if (after.panelId !== `terminal:${termA}`) {
+            failures++;
+            // eslint-disable-next-line no-console
+            console.warn(
+              `round ${round}: expected terminal:${termA}, got ${after.panelId}`,
+            );
           }
 
           // Reset to a clean single-panel state for the next round (close
@@ -152,8 +128,8 @@ describe.skipIf(!available)(
         }
         expect(
           failures,
-          `${failures}/${totalCycles} switch-away/back cycles landed on the ` +
-            `wrong (right-group editor) tab after revisiting a split dock`,
+          `${failures}/${rounds} rounds landed on the wrong (right-group ` +
+            `editor) tab after revisiting a split dock`,
         ).toBe(0);
       },
     );

--- a/apps/desktop/src/automation/workspace-revisit-split-dock.it.test.ts
+++ b/apps/desktop/src/automation/workspace-revisit-split-dock.it.test.ts
@@ -1,0 +1,161 @@
+// Integration test (Layer 2): end-to-end coverage of the layout symptom 1 was
+// reported against (ADR 0034) — a center dock split into two groups, terminals
+// on the left, editors on the right. Focus a terminal in the LEFT group,
+// switch workspaces and back, and the terminal must still be the active tab
+// rather than the right group's editor.
+//
+// HONESTY NOTE about what this does and does not guard. This test never
+// reproduced the bug: driving the jump through the automation API doesn't
+// re-mount a *background* editor panel the way real interaction does, and the
+// re-mount is what triggered it (see below). It passed against the broken
+// build. Keep it as end-to-end coverage of the reported layout, but do NOT
+// treat it as the regression guard.
+//
+// The real regression guard is a unit test —
+// `use-focus-retry.test.ts` → "never grabs on mount when the panel is not the
+// active tab" — which encodes the actual invariant deterministically, plus
+// `retryFocus`'s now-required `stillWanted` parameter, which makes omitting
+// the guard a compile error rather than a silent focus steal.
+//
+// Root cause, for the record: re-entering a workspace re-mounts every panel in
+// its dock, and TextViewer/DiffPanel's mount-time `retryFocus` passed no
+// `stillWanted` guard — so a background editor grabbed DOM focus on re-mount.
+// Because dockview marks a panel's group active when focus lands inside it
+// (`contentContainer.onDidFocus → doSetGroupActive`), that steal also flipped
+// the visible active tab.
+//
+// Requires the dev app running (`pnpm dev`); skips otherwise.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[workspace-revisit-split-dock.it] no dev app reachable on :7878 — " +
+      "skipping. Run `pnpm dev` to exercise this suite.",
+  );
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!available)(
+  "revisiting a workspace with a split dock keeps the focused group's tab",
+  () => {
+    let folderA: string;
+    let folderB: string;
+    let priorActive: string | null;
+    let wsA: string;
+    let wsB: string;
+
+    beforeAll(async () => {
+      priorActive = (await silo.listWorkspaces()).active;
+      folderA = await mkdtemp(join(tmpdir(), "silo-it-split-a-"));
+      folderB = await mkdtemp(join(tmpdir(), "silo-it-split-b-"));
+      await writeFile(join(folderA, "one.txt"), "one\n");
+      await writeFile(join(folderA, "two.txt"), "two\n");
+      wsA = (await silo.openWorkspace(folderA, "it-split-a")).id;
+      wsB = (await silo.openWorkspace(folderB, "it-split-b")).id;
+
+      await silo.activateWorkspace(wsB);
+      await silo.openTerminal(folderB);
+    }, 60000);
+
+    afterAll(async () => {
+      if (wsA) await silo.deleteWorkspace(wsA);
+      if (wsB) await silo.deleteWorkspace(wsB);
+      if (priorActive) await silo.activateWorkspace(priorActive);
+      await rm(folderA, { recursive: true, force: true });
+      await rm(folderB, { recursive: true, force: true });
+    });
+
+    it(
+      "focused left-group terminal survives a revisit — doesn't fall back to the right group's editor",
+      { timeout: 120000 },
+      async () => {
+        let failures = 0;
+        const totalCycles = 5 * 3; // 5 rounds x 3 switch-away/back cycles each
+        for (let round = 0; round < 5; round++) {
+          await silo.activateWorkspace(wsA);
+          await sleep(200);
+
+          // Three terminals in the left group (matches the tab-dense left
+          // group in the report, not just a single lonely tab). One file
+          // opens as a tab alongside them (no group shows a file yet), then
+          // splitActivePanel moves it (the now-active panel) to a new right
+          // group. A second file opens AFTER the split, once the right group
+          // is both active and already showing a file — findEditorTargetGroup
+          // then targets that group, landing the second file there too
+          // instead of back with the terminals. Order matters: opening both
+          // files before splitting only moves whichever was active at split
+          // time, stranding the other one in the left group.
+          const t1 = await silo.openTerminal(folderA);
+          await silo.openTerminal(folderA);
+          await silo.openTerminal(folderA);
+          await silo.openFile(join(folderA, "one.txt"));
+          const { groups } = await silo.splitActivePanel("right");
+          expect(
+            groups,
+            `round ${round}: split didn't produce two groups`,
+          ).toBe(2);
+          await silo.openFile(join(folderA, "two.txt"));
+
+          const termA = t1.terminalId;
+
+          // Simulate actually working across the left group's tabs — not
+          // just landing on T1 once — before settling on it: focus a
+          // different terminal, then focus T1, matching "I was on another
+          // agent tab, then focused this one" rather than a bare first-touch.
+          const t2 = await silo.listTerminals(wsA);
+          const other = t2.terminals.find((t) => t.id !== termA)?.id;
+          if (other) {
+            await silo.focusTerminal(other);
+            await sleep(150);
+          }
+          await silo.focusTerminal(termA);
+          await sleep(300);
+          const before = await silo.activePanel();
+          expect(
+            before.panelId,
+            `round ${round}: setup didn't leave the terminal focused`,
+          ).toBe(`terminal:${termA}`);
+
+          // Multiple switch-away/switch-back cycles within the same round —
+          // in case the first revisit is clean but a later one isn't.
+          for (let cycle = 0; cycle < 3; cycle++) {
+            await silo.activateWorkspace(wsB);
+            await sleep(300);
+
+            await silo.activateWorkspace(wsA);
+            await sleep(300);
+
+            const after = await silo.activePanel();
+            if (after.panelId !== `terminal:${termA}`) {
+              failures++;
+              // eslint-disable-next-line no-console
+              console.warn(
+                `round ${round} cycle ${cycle}: expected terminal:${termA}, got ${after.panelId}`,
+              );
+            }
+          }
+
+          // Reset to a clean single-panel state for the next round (close
+          // everything in A so the next round's split starts fresh).
+          await silo.deleteWorkspace(wsA);
+          wsA = (await silo.openWorkspace(folderA, "it-split-a")).id;
+        }
+        expect(
+          failures,
+          `${failures}/${totalCycles} switch-away/back cycles landed on the ` +
+            `wrong (right-group editor) tab after revisiting a split dock`,
+        ).toBe(0);
+      },
+    );
+  },
+);

--- a/docs/decisions/0034-dock-authority-is-the-live-dock-not-store-state.md
+++ b/docs/decisions/0034-dock-authority-is-the-live-dock-not-store-state.md
@@ -1,0 +1,139 @@
+---
+status: proposed
+date: 2026-08-07
+---
+
+# 0034. The dock authority is the live dock, not `store.activeWorkspaceId`
+
+## Context
+
+ADR [0032](./0032-dock-active-panel-authority.md) made `WorkspaceDock` the
+single authority over its own active panel: nothing outside it calls
+`panel.api.setActive()` on a workspace switch, callers record a request via
+`panel-activation-requests.ts`, and `WorkspaceDock`'s authority effect applies
+it once its dock is live.
+
+That fix shipped with a regression test
+(`cross-workspace-terminal-focus.it.test.ts`) that always drives the jump
+through `ctx.terminals.focus()` alone. It never covered a caller that first
+calls `ctx.workspaces.activate()` and then, in the same tick, calls
+`ctx.terminals.focus()` — exactly the shape `agent-inspector`'s Navigator row
+click uses (`openAndFocus()`), and per RFC 0023 the shape the real
+(closed-source, not in this repo) agent-monitor extension's Navigator agent
+list uses too. The bug came back in three reported flavors:
+
+1. Switch workspace A → B → A: A's remembered tab is no longer active.
+2. Click an agent running in a backgrounded workspace from the Navigator: the
+   correct terminal tab never actually activates (not even a flash — it
+   silently no-ops).
+3. Alt-tab to another macOS app and back: a different tab ends up focused than
+   the one active before switching away.
+
+A test harness was built to reproduce each of these against current code
+before any fix landed
+(`cross-workspace-activate-then-focus.it.test.ts`,
+`workspace-revisit-active-tab.it.test.ts`, `window-focus-restore.it.test.ts`).
+Results:
+
+- **Symptom 2 reproduced deterministically** — every round, no timing luck.
+  Root cause: `terminal-service.ts`'s `focus()` gated its cross-workspace
+  branch on `store.activeWorkspaceId !== wsId`. A caller that already flipped
+  `store.activeWorkspaceId` itself (`ctx.workspaces.activate()`, one line
+  earlier) makes that check `false` before React has actually committed the
+  new dock as live (`WorkspaceDock`'s authority effect calls
+  `setActiveDockApi()` only after that commit). `focus()` then takes the
+  "same workspace, dock already up" fast path, finds no panel on the still-old
+  dock API, and no-ops — `requestPanelActivation()`, the only sanctioned way
+  to register a cross-workspace intent, is never called. The request isn't
+  raced and lost, as ADR 0032's bug was; it's dropped entirely.
+- **Symptom 1 did NOT reproduce** — 5 runs × 6 rounds × 2 scenarios (bare
+  A→B→A revisit, and revisit after a terminal is added to A while
+  backgrounded) = 60/60 passed. The leading hypothesis (an un-gated
+  `setActive()` in `WorkspaceDock`'s panel-reconciliation effect force-
+  activating a newly-added panel in a backgrounded dock) doesn't hold up
+  empirically. No fix shipped for this; noted below as investigated but
+  unconfirmed.
+- **Symptom 3's mechanism is confirmed by reading the source**, but live
+  numeric reproduction wasn't obtainable in the environment this was built in
+  — the dev app window couldn't hold OS focus for even a few hundred
+  milliseconds across 8 automated attempts (unexplained; possibly something
+  specific to that machine/session). `focus-restore.ts`'s `record()` recorded
+  the last `focusin` anywhere under `.side-pane, .center-body, .status-bar` —
+  and `CenterDock.tsx` keeps every visited workspace mounted as a sibling
+  `.dock-host` inside that same shared `.center-body`, only toggling
+  `data-active`, so that selector can't tell a backgrounded dock's element
+  from the foreground one's. `restoreRegionFocus()` then called `.focus()` on
+  whatever `lastFocused` held directly, bypassing the authority/request system
+  entirely.
+
+## Decision
+
+**The dock authority a caller must check is the live dock, not
+`store.activeWorkspaceId`.** Concretely:
+
+1. `dock-api-registry.ts` now tracks which workspace id the live `DockviewApi`
+   actually belongs to (`getActiveDockWorkspaceId()`), set only from
+   `WorkspaceDock`'s own authority effect at the moment it commits
+   `setActiveDockApi()`. `terminal-service.ts`'s `focus()` checks this instead
+   of `store.activeWorkspaceId`, so it's correct regardless of caller
+   ordering — a caller can pre-activate the workspace itself and `focus()`
+   still takes the cross-workspace (request-registry) path until the real
+   dock is confirmed live. `agent-inspector`'s `openAndFocus()` was simplified
+   to drop its now-fully-redundant `ctx.workspaces.activate()` pre-call, but
+   that's cleanup, not the fix — the real agent-monitor extension has the
+   identical shape and isn't in this repo, so `ctx.terminals.focus()` had to
+   be correct standing alone.
+2. `focus-restore.ts`'s `record()`/`restoreTarget()` now scope to the live
+   dock: an element inside a `.dock-host[data-active="false"]` is never
+   recorded as `lastFocused`, and `restoreTarget` re-checks scope as defense
+   in depth. `restoreTarget` keeps its pure-function shape with an injectable
+   scope predicate, so its unit tests stay jsdom-only.
+3. Symptom 1 is left **unfixed** — investigated via the same harness, not
+   reproduced. If it recurs with a concrete trigger, that trigger is the next
+   thing to capture in a test before touching code again.
+
+## Consequences
+
+- `ctx.terminals.focus()` — and by extension any future cross-workspace
+  "activate this panel" API — is now robust to being called immediately after
+  a separate `ctx.workspaces.activate()` call, closing a footgun every
+  extension with this jump-to-a-terminal-in-another-workspace shape (not just
+  `agent-inspector`) was exposed to.
+- Window-focus restoration can no longer silently drag the active tab into a
+  backgrounded workspace — a `.dock-host`'s `data-active` attribute (already
+  set by `CenterDock.tsx` for other reasons) is now load-bearing for a second,
+  independent purpose.
+- Symptom 3's fix shipped without a pre-fix live numeric baseline — the
+  mechanism is source-confirmed and unit-tested, but the "how often did it
+  actually flip the tab" number wasn't captured. Re-run
+  `window-focus-restore.it.test.ts` with the window genuinely frontmost when
+  that's practical, to get the post-fix consistency number the original plan
+  called for.
+- Symptom 1 stays open. Three symptoms were reported; two had confirmed,
+  fixable root causes. The harness exists (`workspace-revisit-active-tab.it.test.ts`)
+  for whoever picks this back up.
+
+## Alternatives considered
+
+- **For Fix A**: promote the desired active panel into the store
+  (`ws.activePanelId`) instead of adding a second module-level "which
+  workspace is live" tracker. ADR 0032 already considered and deferred this
+  for the same reason it would apply here: `layout(force=true)` produces
+  spurious active-panel changes a store write-back would need to filter,
+  reintroducing the ordering assumptions this whole area keeps tripping on.
+- **For symptom 1**: ship the panel-reconciliation `active`-gating fix
+  speculatively anyway, on the theory the harness just didn't hit the right
+  trigger. Rejected — shipping an unconfirmed fix for an unconfirmed cause
+  risks masking the real one; better to leave it open and documented.
+
+## References
+
+- ADR [0032](./0032-dock-active-panel-authority.md) — the authority model this
+  extends.
+- `apps/desktop/src/automation/cross-workspace-activate-then-focus.it.test.ts`,
+  `workspace-revisit-active-tab.it.test.ts`, `window-focus-restore.it.test.ts`
+  — the reproduction harness.
+- `packages/extension-host/src/extension-host/terminal-service.ts` (`focus()`),
+  `packages/extension-host/src/docked/dock-api-registry.ts`
+  (`getActiveDockWorkspaceId`), `packages/extension-host/src/extension-host/focus-restore.ts`
+  (`record`/`restoreTarget`).

--- a/docs/decisions/0034-focus-and-activation-authority.md
+++ b/docs/decisions/0034-focus-and-activation-authority.md
@@ -72,9 +72,29 @@ Results:
   terminal) landing first, then the unguarded mount grab overriding it 33ms
   later.
 
-  This is why it only surfaced with a split dock and only under real
-  interaction: automation drives `ctx.terminals.focus()` without re-mounting a
-  background editor alongside an active terminal.
+  A wrong conclusion was drawn at this point and later corrected: the split-dock
+  scenario, scripted with 200-300ms settle delays between actions, still passed
+  cleanly against the (confirmed, via source-reading and a live manual repro)
+  broken build — 0 failures across dozens of rounds. That read as "scripted
+  automation structurally can't reproduce this, only real interaction can,"
+  which is false. Reverting the fix locally and widening the delays to match the
+  cadence of an actual manual reproduction (~1-2s between actions, not 200-300ms)
+  reproduced it immediately — 3 of 4 rounds failed — and passed clean again once
+  the fix was restored. The short-delay version wasn't measuring "can automation
+  trigger this behavior"; it was running faster than the real settle time
+  (Monaco's own layout/mount work) the race depends on. `workspace-revisit-split-dock.it.test.ts`
+  now uses the realistic delays and is a working live regression guard, not just
+  end-to-end scenario coverage.
+
+  The generalizable lesson, corrected: this codebase's automation bridge calls
+  the same underlying functions a real user interaction reaches (confirmed
+  separately for symptom 2 — `activateWorkspace()` + `terminals.focus()` are
+  exactly what a real click's SDK calls resolve to), so it is not structurally
+  blind to this class of bug. What matters is whether the _timing_ between
+  scripted actions matches the real timing the race depends on — an automated
+  scenario that "can't reproduce" a mount/timing-sensitive bug should be
+  suspected of running too fast before being trusted as evidence the bug
+  doesn't reproduce under automation at all.
 
 - **Symptom 3's mechanism is confirmed by reading the source**, but live
   numeric reproduction wasn't obtainable in the environment this was built in
@@ -155,14 +175,18 @@ Concretely:
   stole my tab" bugs. The tradeoff: a panel that legitimately wants focus on
   mount while _not_ active can no longer get it — correct by construction
   here, but it means new panel kinds must activate first and focus second.
-- Scripted UI automation could not reproduce symptom 1 at all (three separate
-  harnesses, ~75 rounds). The generalizable lesson: automation that drives
-  behavior through service APIs bypasses React mount/unmount cycles that real
-  interaction triggers, so it is blind to mount-effect bugs. When a
-  user-reported bug resists scripted reproduction, instrument the primitive
-  itself (here, patching `HTMLElement.prototype.focus` to capture calling
-  stacks) rather than adding more scenarios — three hypotheses were disproved
-  by reading source, and the fourth was found in one traced reproduction.
+- Scripted UI automation initially seemed unable to reproduce symptom 1 (three
+  separate harnesses, ~75 rounds, all with 200-300ms settle delays). That was a
+  false negative from running faster than the real settle time the race
+  depends on, not a structural limit of the automation approach — see the
+  timing note under symptom 1 above. The generalizable lesson: when a
+  user-reported, timing-sensitive bug resists scripted reproduction, suspect
+  the _pacing_ of the script before concluding automation can't reach it, and
+  instrument the primitive itself (here, patching `HTMLElement.prototype.focus`
+  to capture calling stacks) to find the actual mechanism — three hypotheses
+  were disproved by reading source, and the fourth was found in one traced
+  reproduction and then confirmed reproducible under automation once the
+  timing matched reality.
 
 ## Alternatives considered
 
@@ -191,13 +215,24 @@ Concretely:
 - `apps/desktop/src/automation/cross-workspace-activate-then-focus.it.test.ts`
   — the live regression guard for the confirmed, deterministic symptom 2.
 - `packages/extension-host/src/extension-host/use-focus-retry.test.ts` →
-  "never grabs on mount when the panel is not the active tab" — the real
-  regression guard for symptom 1 (deterministic; the integration harnesses
-  never reproduced it).
-- `apps/desktop/src/automation/workspace-revisit-active-tab.it.test.ts`,
-  `workspace-revisit-split-dock.it.test.ts`, `window-focus-restore.it.test.ts`
-  — end-to-end coverage of the reported scenarios. Useful, but each passed
-  against the broken build; see the honesty note in the split-dock file.
+  "never grabs on mount when the panel is not the active tab" — the
+  deterministic unit-level regression guard for symptom 1, independent of
+  timing.
+- `apps/desktop/src/automation/workspace-revisit-split-dock.it.test.ts` — the
+  live regression guard for symptom 1's reported scenario (a split dock).
+  Confirmed to actually catch it: fails 3/4 rounds against a locally-reverted
+  pre-fix build, passes clean against the fix. Its settle delays (~1-2s) are
+  load-bearing — see the timing note in the file's own header before touching
+  them.
+- `apps/desktop/src/automation/workspace-revisit-active-tab.it.test.ts` — the
+  bare-revisit and background-terminal-add hypotheses, both disproved. Unlike
+  the split-dock scenario these were never re-tested with widened timing after
+  the real root cause was found — not expected to be timing-sensitive, since
+  neither scenario opens an editor panel at all (the confirmed bug is specific
+  to `TextViewer`/`DiffPanel`'s mount-time focus, and `TerminalPanel` already
+  had the guard), but that's an inference, not something re-verified live.
+- `window-focus-restore.it.test.ts` — symptom 3's live numeric baseline,
+  blocked on window focus in this environment (see Consequences above).
 - `packages/extension-host/src/extension-host/terminal-service.ts` (`focus()`),
   `packages/extension-host/src/docked/dock-api-registry.ts`
   (`getActiveDockWorkspaceId`), `packages/extension-host/src/extension-host/focus-restore.ts`

--- a/docs/decisions/0034-focus-and-activation-authority.md
+++ b/docs/decisions/0034-focus-and-activation-authority.md
@@ -3,7 +3,7 @@ status: proposed
 date: 2026-08-07
 ---
 
-# 0034. The dock authority is the live dock, not `store.activeWorkspaceId`
+# 0034. Focus and activation authority: the live dock, and only the active panel
 
 ## Context
 
@@ -46,13 +46,36 @@ Results:
   dock API, and no-ops — `requestPanelActivation()`, the only sanctioned way
   to register a cross-workspace intent, is never called. The request isn't
   raced and lost, as ADR 0032's bug was; it's dropped entirely.
-- **Symptom 1 did NOT reproduce** — 5 runs × 6 rounds × 2 scenarios (bare
-  A→B→A revisit, and revisit after a terminal is added to A while
-  backgrounded) = 60/60 passed. The leading hypothesis (an un-gated
-  `setActive()` in `WorkspaceDock`'s panel-reconciliation effect force-
-  activating a newly-added panel in a backgrounded dock) doesn't hold up
-  empirically. No fix shipped for this; noted below as investigated but
-  unconfirmed.
+- **Symptom 1 resisted every scripted reproduction** — 60/60 rounds passed
+  across two hypotheses (bare A→B→A revisit; revisit after a terminal is added
+  to a backgrounded workspace), and a later split-dock scenario passed too.
+  Three successive hypotheses were formed and each **disproved by reading the
+  source** rather than shipped: (a) `WorkspaceDock`'s panel-reconciliation
+  effect force-activating a backgrounded panel; (b) `DockPanelApi.isActive`
+  being group-scoped so a lone panel in its own split group never blurs —
+  disproved, `isActive` is `group.api.isActive && isPanelVisible`; (c) a
+  stale-Monaco focus tracker surviving a workspace switch — disproved,
+  `DockviewGroupPanelModel.setActive()` ends in `updateContainer()` →
+  `panel.runEvents()`, which does propagate the deactivation.
+
+  It was finally caught by instrumenting `HTMLElement.prototype.focus` at
+  runtime to capture the **calling stack** of every focus grab. That named the
+  culprit outright: `onMount` in `TextViewer.tsx`, via React's
+  `commitHookPassiveMountEffects`. **Re-entering a workspace re-mounts every
+  panel in its dock**, and the mount-time `retryFocus` in `TextViewer` /
+  `DiffPanel` passed no `stillWanted` guard — so it defaulted to `() => true`
+  and grabbed focus unconditionally, including for panels that are not the
+  active tab. Because dockview marks a panel's group active whenever DOM focus
+  lands inside it (`contentContainer.onDidFocus → doSetGroupActive`), that
+  steal did not merely move keyboard focus — it changed the visible active tab.
+  The trace showed the _correct_ guarded grab (WorkspaceDock's fallback →
+  terminal) landing first, then the unguarded mount grab overriding it 33ms
+  later.
+
+  This is why it only surfaced with a split dock and only under real
+  interaction: automation drives `ctx.terminals.focus()` without re-mounting a
+  background editor alongside an active terminal.
+
 - **Symptom 3's mechanism is confirmed by reading the source**, but live
   numeric reproduction wasn't obtainable in the environment this was built in
   — the dev app window couldn't hold OS focus for even a few hundred
@@ -68,8 +91,14 @@ Results:
 
 ## Decision
 
-**The dock authority a caller must check is the live dock, not
-`store.activeWorkspaceId`.** Concretely:
+Two invariants, one per half of the problem. **(i) The dock authority a caller
+must check is the live dock, not `store.activeWorkspaceId`** — store state can
+be flipped synchronously by a caller before React has committed the dock it
+names. **(ii) Only the currently active panel may take focus** — and because
+dockview makes a panel's group active whenever DOM focus lands inside it
+(`contentContainer.onDidFocus → doSetGroupActive`), an unguarded focus grab is
+never "just" a focus grab; it silently changes the user's visible tab.
+Concretely:
 
 1. `dock-api-registry.ts` now tracks which workspace id the live `DockviewApi`
    actually belongs to (`getActiveDockWorkspaceId()`), set only from
@@ -88,9 +117,21 @@ Results:
    recorded as `lastFocused`, and `restoreTarget` re-checks scope as defense
    in depth. `restoreTarget` keeps its pure-function shape with an injectable
    scope predicate, so its unit tests stay jsdom-only.
-3. Symptom 1 is left **unfixed** — investigated via the same harness, not
-   reproduced. If it recurs with a concrete trigger, that trigger is the next
-   thing to capture in a test before touching code again.
+3. **Only the active panel may take focus, and `retryFocus` enforces it.**
+   `stillWanted` is now a **required** parameter rather than defaulting to
+   `() => true`. Every correct call site already passed one (`() => api.isActive`,
+   or the center dock's `focusGen` token); the permissive default was the
+   footgun that let two mount-time sites silently omit it. Making it required
+   turns a recurrence into a compile error instead of a silent focus steal.
+   `TextViewer` and `DiffPanel` now gate their mount-time focus on
+   `dockApi.isActive` both up front and for the life of the retry — matching
+   `TerminalPanel`, which already did this correctly and served as the
+   exemplar.
+
+   The corollary worth internalizing: **mount is not "the user just created
+   this panel."** Re-entering a workspace re-mounts every panel in its dock, so
+   any mount-time side effect that touches focus must ask whether it is the
+   active tab first.
 
 ## Consequences
 
@@ -109,9 +150,19 @@ Results:
   `window-focus-restore.it.test.ts` with the window genuinely frontmost when
   that's practical, to get the post-fix consistency number the original plan
   called for.
-- Symptom 1 stays open. Three symptoms were reported; two had confirmed,
-  fixable root causes. The harness exists (`workspace-revisit-active-tab.it.test.ts`)
-  for whoever picks this back up.
+- Mount-time focus is now a guarded operation everywhere, which costs one
+  `isActive` check per panel mount and removes a whole class of "something
+  stole my tab" bugs. The tradeoff: a panel that legitimately wants focus on
+  mount while _not_ active can no longer get it — correct by construction
+  here, but it means new panel kinds must activate first and focus second.
+- Scripted UI automation could not reproduce symptom 1 at all (three separate
+  harnesses, ~75 rounds). The generalizable lesson: automation that drives
+  behavior through service APIs bypasses React mount/unmount cycles that real
+  interaction triggers, so it is blind to mount-effect bugs. When a
+  user-reported bug resists scripted reproduction, instrument the primitive
+  itself (here, patching `HTMLElement.prototype.focus` to capture calling
+  stacks) rather than adding more scenarios — three hypotheses were disproved
+  by reading source, and the fourth was found in one traced reproduction.
 
 ## Alternatives considered
 
@@ -121,18 +172,32 @@ Results:
   for the same reason it would apply here: `layout(force=true)` produces
   spurious active-panel changes a store write-back would need to filter,
   reintroducing the ordering assumptions this whole area keeps tripping on.
-- **For symptom 1**: ship the panel-reconciliation `active`-gating fix
-  speculatively anyway, on the theory the harness just didn't hit the right
-  trigger. Rejected — shipping an unconfirmed fix for an unconfirmed cause
-  risks masking the real one; better to leave it open and documented.
+- **For symptom 1**: ship one of the three unproven hypotheses (the
+  panel-reconciliation `active` gate; a dock-wide blur-on-tab-switch; re-blurring
+  backgrounded panels after every forced relayout). Two of these were actually
+  built and tested live — both failed to fix it, because none addressed the real
+  cause. Rejected on principle as well as evidence: an unconfirmed fix for an
+  unconfirmed cause masks the real one and leaves dead defensive code behind.
+- **For symptom 1**: fix only the two offending call sites, leaving
+  `retryFocus`'s `stillWanted` optional. Rejected — the permissive default is
+  what allowed the omission in the first place, and nothing would stop the next
+  mount-time focus call from repeating it. Making the parameter required moves
+  the guarantee from review-time vigilance to compile time.
 
 ## References
 
 - ADR [0032](./0032-dock-active-panel-authority.md) — the authority model this
   extends.
-- `apps/desktop/src/automation/cross-workspace-activate-then-focus.it.test.ts`,
-  `workspace-revisit-active-tab.it.test.ts`, `window-focus-restore.it.test.ts`
-  — the reproduction harness.
+- `apps/desktop/src/automation/cross-workspace-activate-then-focus.it.test.ts`
+  — the live regression guard for the confirmed, deterministic symptom 2.
+- `packages/extension-host/src/extension-host/use-focus-retry.test.ts` →
+  "never grabs on mount when the panel is not the active tab" — the real
+  regression guard for symptom 1 (deterministic; the integration harnesses
+  never reproduced it).
+- `apps/desktop/src/automation/workspace-revisit-active-tab.it.test.ts`,
+  `workspace-revisit-split-dock.it.test.ts`, `window-focus-restore.it.test.ts`
+  — end-to-end coverage of the reported scenarios. Useful, but each passed
+  against the broken build; see the honesty note in the split-dock file.
 - `packages/extension-host/src/extension-host/terminal-service.ts` (`focus()`),
   `packages/extension-host/src/docked/dock-api-registry.ts`
   (`getActiveDockWorkspaceId`), `packages/extension-host/src/extension-host/focus-restore.ts`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -33,39 +33,39 @@ A small, obvious choice needs neither.
 
 ## Index
 
-| ADR                                                               | Title                                                | Date       | Status   |
-| ----------------------------------------------------------------- | ---------------------------------------------------- | ---------- | -------- |
-| [0001](./0001-in-process-extension-architecture.md)               | In-process, registry-based extension architecture    | 2026-05-23 | accepted |
-| [0002](./0002-imperative-registration-no-manifest.md)             | Imperative registration; no static manifest (v1)     | 2026-05-23 | accepted |
-| [0003](./0003-monorepo-pnpm.md)                                   | Monorepo with pnpm workspaces                        | 2026-05-29 | accepted |
-| [0004](./0004-sdk-types-first.md)                                 | Public `@silo-code/sdk` is types-first               | 2026-05-29 | accepted |
-| [0005](./0005-ui-library-internal.md)                             | Component library (`@silo-code/ui`) stays internal   | 2026-05-29 | accepted |
-| [0006](./0006-open-platform-licensing.md)                         | Open-platform MIT licensing                          | 2026-05-30 | accepted |
-| [0007](./0007-core-primitive-vs-extension-test.md)                | Core-primitive vs extension-feature test             | 2026-05-31 | accepted |
-| [0008](./0008-extension-decomposition-provider-view.md)           | Extension decomposition; provider/view split         | 2026-05-31 | accepted |
-| [0009](./0009-extension-communication-and-events.md)              | Extension communication: typed APIs + domain events  | 2026-05-31 | accepted |
-| [0010](./0010-persistent-process-sessions.md)                     | Persistent process sessions as a core primitive      | 2026-05-31 | accepted |
-| [0011](./0011-editor-and-terminal-are-core.md)                    | Editor and terminal are core surfaces                | 2026-05-31 | accepted |
-| [0012](./0012-dev-automation-rpc.md)                              | Dev-only automation RPC                              | 2026-06-01 | accepted |
-| [0013](./0013-trust-tiers-two-barrel-sdk.md)                      | Extension trust tiers + two-barrel SDK               | 2026-06-02 | accepted |
-| [0014](./0014-per-extension-enablement.md)                        | Per-extension enablement config (Obsidian-style)     | 2026-06-02 | accepted |
-| [0015](./0015-phased-security-model.md)                           | Phased security model for privileged primitives      | 2026-06-02 | accepted |
-| [0016](./0016-ctx-dnd-primitive.md)                               | First-class drag-and-drop primitive (`ctx.dnd`)      | 2026-06-02 | accepted |
-| [0017](./0017-css-theming-contract.md)                            | CSS theming contract (`--silo-*` token tiers)        | 2026-06-02 | accepted |
-| [0018](./0018-host-owned-chrome.md)                               | Host-owned UI chrome: modals + unified menu          | 2026-06-03 | accepted |
-| [0019](./0019-runtime-extension-loading.md)                       | Runtime extension loading + manifest validation      | 2026-06-04 | accepted |
-| [0020](./0020-silo-extensions-bundled.md)                         | Ship `silo.*` bundled, surfaced as disable-able      | 2026-06-04 | accepted |
-| [0021](./0021-keyboard-navigation-architecture.md)                | Keyboard nav: headless focus-group + region model    | 2026-06-08 | accepted |
-| [0022](./0022-on-disk-storage-layout.md)                          | On-disk storage layout: config / app-state / runtime | 2026-06-10 | accepted |
-| [0023](./0023-workspace-groups-host-internal.md)                  | Workspace panel groups are host-internal             | 2026-06-30 | accepted |
-| [0024](./0024-release-channels.md)                                | Two release channels: stable and nightly             | 2026-07-01 | accepted |
-| [0025](./0025-pending-remove-worktree.md)                         | Pending remove worktree: close folder on start       | 2026-07-17 | accepted |
-| [0026](./0026-sdk-component-set.md)                               | A curated presentational component set joins the SDK | 2026-07-18 | accepted |
-| [0027](./0027-terminal-link-policy.md)                            | Unified terminal link policy: modifier-click to open | 2026-07-21 | accepted |
-| [0028](./0028-sealed-agent-detection.md)                          | Sealed agent detection and honest resume             | 2026-07-29 | accepted |
-| [0029](./0029-adornments-vs-registration.md)                      | Adornments vs registration                           | 2026-07-31 | accepted |
-| [0030](./0030-activity-chrome.md)                                 | Activity as first-class chrome                       | 2026-07-31 | accepted |
-| [0031](./0031-update-check-analytics.md)                          | Update-check analytics via a Cloudflare Worker proxy | 2026-08-01 | accepted |
-| [0032](./0032-dock-active-panel-authority.md)                     | One authority decides a dock's active panel          | 2026-08-04 | accepted |
-| [0033](./0033-laptop-mode-independent-layout.md)                  | Laptop Mode is a second independent layout           | 2026-08-06 | accepted |
-| [0034](./0034-dock-authority-is-the-live-dock-not-store-state.md) | The dock authority is the live dock, not store state | 2026-08-07 | proposed |
+| ADR                                                     | Title                                                      | Date       | Status   |
+| ------------------------------------------------------- | ---------------------------------------------------------- | ---------- | -------- |
+| [0001](./0001-in-process-extension-architecture.md)     | In-process, registry-based extension architecture          | 2026-05-23 | accepted |
+| [0002](./0002-imperative-registration-no-manifest.md)   | Imperative registration; no static manifest (v1)           | 2026-05-23 | accepted |
+| [0003](./0003-monorepo-pnpm.md)                         | Monorepo with pnpm workspaces                              | 2026-05-29 | accepted |
+| [0004](./0004-sdk-types-first.md)                       | Public `@silo-code/sdk` is types-first                     | 2026-05-29 | accepted |
+| [0005](./0005-ui-library-internal.md)                   | Component library (`@silo-code/ui`) stays internal         | 2026-05-29 | accepted |
+| [0006](./0006-open-platform-licensing.md)               | Open-platform MIT licensing                                | 2026-05-30 | accepted |
+| [0007](./0007-core-primitive-vs-extension-test.md)      | Core-primitive vs extension-feature test                   | 2026-05-31 | accepted |
+| [0008](./0008-extension-decomposition-provider-view.md) | Extension decomposition; provider/view split               | 2026-05-31 | accepted |
+| [0009](./0009-extension-communication-and-events.md)    | Extension communication: typed APIs + domain events        | 2026-05-31 | accepted |
+| [0010](./0010-persistent-process-sessions.md)           | Persistent process sessions as a core primitive            | 2026-05-31 | accepted |
+| [0011](./0011-editor-and-terminal-are-core.md)          | Editor and terminal are core surfaces                      | 2026-05-31 | accepted |
+| [0012](./0012-dev-automation-rpc.md)                    | Dev-only automation RPC                                    | 2026-06-01 | accepted |
+| [0013](./0013-trust-tiers-two-barrel-sdk.md)            | Extension trust tiers + two-barrel SDK                     | 2026-06-02 | accepted |
+| [0014](./0014-per-extension-enablement.md)              | Per-extension enablement config (Obsidian-style)           | 2026-06-02 | accepted |
+| [0015](./0015-phased-security-model.md)                 | Phased security model for privileged primitives            | 2026-06-02 | accepted |
+| [0016](./0016-ctx-dnd-primitive.md)                     | First-class drag-and-drop primitive (`ctx.dnd`)            | 2026-06-02 | accepted |
+| [0017](./0017-css-theming-contract.md)                  | CSS theming contract (`--silo-*` token tiers)              | 2026-06-02 | accepted |
+| [0018](./0018-host-owned-chrome.md)                     | Host-owned UI chrome: modals + unified menu                | 2026-06-03 | accepted |
+| [0019](./0019-runtime-extension-loading.md)             | Runtime extension loading + manifest validation            | 2026-06-04 | accepted |
+| [0020](./0020-silo-extensions-bundled.md)               | Ship `silo.*` bundled, surfaced as disable-able            | 2026-06-04 | accepted |
+| [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model          | 2026-06-08 | accepted |
+| [0022](./0022-on-disk-storage-layout.md)                | On-disk storage layout: config / app-state / runtime       | 2026-06-10 | accepted |
+| [0023](./0023-workspace-groups-host-internal.md)        | Workspace panel groups are host-internal                   | 2026-06-30 | accepted |
+| [0024](./0024-release-channels.md)                      | Two release channels: stable and nightly                   | 2026-07-01 | accepted |
+| [0025](./0025-pending-remove-worktree.md)               | Pending remove worktree: close folder on start             | 2026-07-17 | accepted |
+| [0026](./0026-sdk-component-set.md)                     | A curated presentational component set joins the SDK       | 2026-07-18 | accepted |
+| [0027](./0027-terminal-link-policy.md)                  | Unified terminal link policy: modifier-click to open       | 2026-07-21 | accepted |
+| [0028](./0028-sealed-agent-detection.md)                | Sealed agent detection and honest resume                   | 2026-07-29 | accepted |
+| [0029](./0029-adornments-vs-registration.md)            | Adornments vs registration                                 | 2026-07-31 | accepted |
+| [0030](./0030-activity-chrome.md)                       | Activity as first-class chrome                             | 2026-07-31 | accepted |
+| [0031](./0031-update-check-analytics.md)                | Update-check analytics via a Cloudflare Worker proxy       | 2026-08-01 | accepted |
+| [0032](./0032-dock-active-panel-authority.md)           | One authority decides a dock's active panel                | 2026-08-04 | accepted |
+| [0033](./0033-laptop-mode-independent-layout.md)        | Laptop Mode is a second independent layout                 | 2026-08-06 | accepted |
+| [0034](./0034-focus-and-activation-authority.md)        | Focus/activation: the live dock, and only the active panel | 2026-08-07 | proposed |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -33,38 +33,39 @@ A small, obvious choice needs neither.
 
 ## Index
 
-| ADR                                                     | Title                                                | Date       | Status   |
-| ------------------------------------------------------- | ---------------------------------------------------- | ---------- | -------- |
-| [0001](./0001-in-process-extension-architecture.md)     | In-process, registry-based extension architecture    | 2026-05-23 | accepted |
-| [0002](./0002-imperative-registration-no-manifest.md)   | Imperative registration; no static manifest (v1)     | 2026-05-23 | accepted |
-| [0003](./0003-monorepo-pnpm.md)                         | Monorepo with pnpm workspaces                        | 2026-05-29 | accepted |
-| [0004](./0004-sdk-types-first.md)                       | Public `@silo-code/sdk` is types-first               | 2026-05-29 | accepted |
-| [0005](./0005-ui-library-internal.md)                   | Component library (`@silo-code/ui`) stays internal   | 2026-05-29 | accepted |
-| [0006](./0006-open-platform-licensing.md)               | Open-platform MIT licensing                          | 2026-05-30 | accepted |
-| [0007](./0007-core-primitive-vs-extension-test.md)      | Core-primitive vs extension-feature test             | 2026-05-31 | accepted |
-| [0008](./0008-extension-decomposition-provider-view.md) | Extension decomposition; provider/view split         | 2026-05-31 | accepted |
-| [0009](./0009-extension-communication-and-events.md)    | Extension communication: typed APIs + domain events  | 2026-05-31 | accepted |
-| [0010](./0010-persistent-process-sessions.md)           | Persistent process sessions as a core primitive      | 2026-05-31 | accepted |
-| [0011](./0011-editor-and-terminal-are-core.md)          | Editor and terminal are core surfaces                | 2026-05-31 | accepted |
-| [0012](./0012-dev-automation-rpc.md)                    | Dev-only automation RPC                              | 2026-06-01 | accepted |
-| [0013](./0013-trust-tiers-two-barrel-sdk.md)            | Extension trust tiers + two-barrel SDK               | 2026-06-02 | accepted |
-| [0014](./0014-per-extension-enablement.md)              | Per-extension enablement config (Obsidian-style)     | 2026-06-02 | accepted |
-| [0015](./0015-phased-security-model.md)                 | Phased security model for privileged primitives      | 2026-06-02 | accepted |
-| [0016](./0016-ctx-dnd-primitive.md)                     | First-class drag-and-drop primitive (`ctx.dnd`)      | 2026-06-02 | accepted |
-| [0017](./0017-css-theming-contract.md)                  | CSS theming contract (`--silo-*` token tiers)        | 2026-06-02 | accepted |
-| [0018](./0018-host-owned-chrome.md)                     | Host-owned UI chrome: modals + unified menu          | 2026-06-03 | accepted |
-| [0019](./0019-runtime-extension-loading.md)             | Runtime extension loading + manifest validation      | 2026-06-04 | accepted |
-| [0020](./0020-silo-extensions-bundled.md)               | Ship `silo.*` bundled, surfaced as disable-able      | 2026-06-04 | accepted |
-| [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model    | 2026-06-08 | accepted |
-| [0022](./0022-on-disk-storage-layout.md)                | On-disk storage layout: config / app-state / runtime | 2026-06-10 | accepted |
-| [0023](./0023-workspace-groups-host-internal.md)        | Workspace panel groups are host-internal             | 2026-06-30 | accepted |
-| [0024](./0024-release-channels.md)                      | Two release channels: stable and nightly             | 2026-07-01 | accepted |
-| [0025](./0025-pending-remove-worktree.md)               | Pending remove worktree: close folder on start       | 2026-07-17 | accepted |
-| [0026](./0026-sdk-component-set.md)                     | A curated presentational component set joins the SDK | 2026-07-18 | accepted |
-| [0027](./0027-terminal-link-policy.md)                  | Unified terminal link policy: modifier-click to open | 2026-07-21 | accepted |
-| [0028](./0028-sealed-agent-detection.md)                | Sealed agent detection and honest resume             | 2026-07-29 | accepted |
-| [0029](./0029-adornments-vs-registration.md)            | Adornments vs registration                           | 2026-07-31 | accepted |
-| [0030](./0030-activity-chrome.md)                       | Activity as first-class chrome                       | 2026-07-31 | accepted |
-| [0031](./0031-update-check-analytics.md)                | Update-check analytics via a Cloudflare Worker proxy | 2026-08-01 | accepted |
-| [0032](./0032-dock-active-panel-authority.md)           | One authority decides a dock's active panel          | 2026-08-04 | accepted |
-| [0033](./0033-laptop-mode-independent-layout.md)        | Laptop Mode is a second independent layout           | 2026-08-06 | accepted |
+| ADR                                                               | Title                                                | Date       | Status   |
+| ----------------------------------------------------------------- | ---------------------------------------------------- | ---------- | -------- |
+| [0001](./0001-in-process-extension-architecture.md)               | In-process, registry-based extension architecture    | 2026-05-23 | accepted |
+| [0002](./0002-imperative-registration-no-manifest.md)             | Imperative registration; no static manifest (v1)     | 2026-05-23 | accepted |
+| [0003](./0003-monorepo-pnpm.md)                                   | Monorepo with pnpm workspaces                        | 2026-05-29 | accepted |
+| [0004](./0004-sdk-types-first.md)                                 | Public `@silo-code/sdk` is types-first               | 2026-05-29 | accepted |
+| [0005](./0005-ui-library-internal.md)                             | Component library (`@silo-code/ui`) stays internal   | 2026-05-29 | accepted |
+| [0006](./0006-open-platform-licensing.md)                         | Open-platform MIT licensing                          | 2026-05-30 | accepted |
+| [0007](./0007-core-primitive-vs-extension-test.md)                | Core-primitive vs extension-feature test             | 2026-05-31 | accepted |
+| [0008](./0008-extension-decomposition-provider-view.md)           | Extension decomposition; provider/view split         | 2026-05-31 | accepted |
+| [0009](./0009-extension-communication-and-events.md)              | Extension communication: typed APIs + domain events  | 2026-05-31 | accepted |
+| [0010](./0010-persistent-process-sessions.md)                     | Persistent process sessions as a core primitive      | 2026-05-31 | accepted |
+| [0011](./0011-editor-and-terminal-are-core.md)                    | Editor and terminal are core surfaces                | 2026-05-31 | accepted |
+| [0012](./0012-dev-automation-rpc.md)                              | Dev-only automation RPC                              | 2026-06-01 | accepted |
+| [0013](./0013-trust-tiers-two-barrel-sdk.md)                      | Extension trust tiers + two-barrel SDK               | 2026-06-02 | accepted |
+| [0014](./0014-per-extension-enablement.md)                        | Per-extension enablement config (Obsidian-style)     | 2026-06-02 | accepted |
+| [0015](./0015-phased-security-model.md)                           | Phased security model for privileged primitives      | 2026-06-02 | accepted |
+| [0016](./0016-ctx-dnd-primitive.md)                               | First-class drag-and-drop primitive (`ctx.dnd`)      | 2026-06-02 | accepted |
+| [0017](./0017-css-theming-contract.md)                            | CSS theming contract (`--silo-*` token tiers)        | 2026-06-02 | accepted |
+| [0018](./0018-host-owned-chrome.md)                               | Host-owned UI chrome: modals + unified menu          | 2026-06-03 | accepted |
+| [0019](./0019-runtime-extension-loading.md)                       | Runtime extension loading + manifest validation      | 2026-06-04 | accepted |
+| [0020](./0020-silo-extensions-bundled.md)                         | Ship `silo.*` bundled, surfaced as disable-able      | 2026-06-04 | accepted |
+| [0021](./0021-keyboard-navigation-architecture.md)                | Keyboard nav: headless focus-group + region model    | 2026-06-08 | accepted |
+| [0022](./0022-on-disk-storage-layout.md)                          | On-disk storage layout: config / app-state / runtime | 2026-06-10 | accepted |
+| [0023](./0023-workspace-groups-host-internal.md)                  | Workspace panel groups are host-internal             | 2026-06-30 | accepted |
+| [0024](./0024-release-channels.md)                                | Two release channels: stable and nightly             | 2026-07-01 | accepted |
+| [0025](./0025-pending-remove-worktree.md)                         | Pending remove worktree: close folder on start       | 2026-07-17 | accepted |
+| [0026](./0026-sdk-component-set.md)                               | A curated presentational component set joins the SDK | 2026-07-18 | accepted |
+| [0027](./0027-terminal-link-policy.md)                            | Unified terminal link policy: modifier-click to open | 2026-07-21 | accepted |
+| [0028](./0028-sealed-agent-detection.md)                          | Sealed agent detection and honest resume             | 2026-07-29 | accepted |
+| [0029](./0029-adornments-vs-registration.md)                      | Adornments vs registration                           | 2026-07-31 | accepted |
+| [0030](./0030-activity-chrome.md)                                 | Activity as first-class chrome                       | 2026-07-31 | accepted |
+| [0031](./0031-update-check-analytics.md)                          | Update-check analytics via a Cloudflare Worker proxy | 2026-08-01 | accepted |
+| [0032](./0032-dock-active-panel-authority.md)                     | One authority decides a dock's active panel          | 2026-08-04 | accepted |
+| [0033](./0033-laptop-mode-independent-layout.md)                  | Laptop Mode is a second independent layout           | 2026-08-06 | accepted |
+| [0034](./0034-dock-authority-is-the-live-dock-not-store-state.md) | The dock authority is the live dock, not store state | 2026-08-07 | proposed |

--- a/examples/extensions/agent-inspector/src/AgentInspectorPanel.tsx
+++ b/examples/extensions/agent-inspector/src/AgentInspectorPanel.tsx
@@ -176,15 +176,15 @@ function AgentRow({
     agent.terminalId,
   )?.sessionId;
 
-  // ctx.workspaces.activate reopens a closed workspace too (its own doc
-  // comment: "Activate (and reopen if closed)"), so this works uniformly
-  // regardless of which scope filter found this row — including the
-  // "Closed workspaces" case. ctx.terminals.focus then switches to that
-  // workspace *and* activates the terminal's own tab in one call; calling
-  // activate() first just makes the reopen-if-closed step explicit rather
-  // than relying on focus() to also handle it.
+  // ctx.terminals.focus reopens a closed workspace, switches to it, and
+  // activates the terminal's own tab, all in one call — its cross-workspace
+  // path calls the same activate() (reopen-if-closed included) internally, so
+  // a separate pre-call here is redundant. It used to be load-bearing for a
+  // different reason: calling activate() first, then focus() in the same
+  // tick, raced WorkspaceDock's dock-mount commit and silently dropped the
+  // cross-workspace activation request (see ADR 0034) — the fix there means
+  // this single call is both simpler and correct regardless of ordering.
   function openAndFocus() {
-    ctx.workspaces.activate(agent.workspaceId);
     ctx.terminals.focus(agent.terminalId);
   }
 

--- a/packages/extension-host/src/docked/dock-api-registry.ts
+++ b/packages/extension-host/src/docked/dock-api-registry.ts
@@ -237,7 +237,11 @@ export function splitActivePanel(
 ): number {
   const panel = activeApi?.activePanel;
   if (!activeApi || !panel) return 0;
-  panel.api.moveTo({ position });
+  // dockview's moveTo forces `position` to "center" (a no-op move within the
+  // same group) whenever `group` is omitted — only an explicit `group`
+  // (here, the panel's own current group) makes it honor `position` and
+  // actually split off a new one beside it. See DockviewPanelApiImpl.moveTo.
+  panel.api.moveTo({ group: panel.group, position });
   return activeApi.groups.length;
 }
 

--- a/packages/extension-host/src/docked/dock-api-registry.ts
+++ b/packages/extension-host/src/docked/dock-api-registry.ts
@@ -4,6 +4,7 @@ import { retryFocus } from "../extension-host/use-focus-retry";
 import { TABBABLE, focusFirstOrContainer } from "../extension-host/focus-dom";
 
 let activeApi: DockviewApi | null = null;
+let activeApiWorkspaceId: string | null = null;
 
 // Monotonic "focus intent" counter. Every region/group/tab focus bumps it; the
 // center dock's async retry (focusContentIn) captures the current value and
@@ -12,12 +13,29 @@ let activeApi: DockviewApi | null = null;
 // "skips" the side dock when chording quickly through the center.
 let focusGen = 0;
 
-export function setActiveDockApi(api: DockviewApi | null) {
+export function setActiveDockApi(
+  api: DockviewApi | null,
+  workspaceId: string | null = null,
+) {
   activeApi = api;
+  activeApiWorkspaceId = api ? workspaceId : null;
 }
 
 export function getActiveDockApi(): DockviewApi | null {
   return activeApi;
+}
+
+/**
+ * The workspace id whose dock is currently the live authority — i.e. whose
+ * `WorkspaceDock` authority effect has actually committed `setActiveDockApi`.
+ * NOT the same as `store.activeWorkspaceId`: a caller can flip that store flag
+ * synchronously (`ctx.workspaces.activate()`) before React has committed the
+ * new dock as live. Callers that need to know "is the dock actually up for
+ * this workspace" (`ctx.terminals.focus()`) should check dock identity here
+ * instead of trusting store state alone. See ADR 0034.
+ */
+export function getActiveDockWorkspaceId(): string | null {
+  return activeApiWorkspaceId;
 }
 
 export function closeActivePanel(): boolean {

--- a/packages/extension-host/src/extension-host/focus-restore.test.ts
+++ b/packages/extension-host/src/extension-host/focus-restore.test.ts
@@ -43,3 +43,41 @@ describe("restoreTarget", () => {
     expect(restoreTarget(document.body, null)).toBeNull();
   });
 });
+
+// Build a `.dock-host` (as CenterDock.tsx renders one per visited workspace,
+// toggling `data-active`) with a focusable button inside it, nested in a
+// shared `.center-body` the way every dock-host actually is.
+function dockHostButton(active: boolean): HTMLButtonElement {
+  const centerBody = document.createElement("div");
+  centerBody.className = "center-body";
+  const host = document.createElement("div");
+  host.className = "dock-host";
+  host.dataset.active = String(active);
+  const btn = document.createElement("button");
+  host.appendChild(btn);
+  centerBody.appendChild(host);
+  document.body.appendChild(centerBody);
+  return btn;
+}
+
+describe("restoreTarget — dock-host scoping", () => {
+  it("does not restore an element inside a backgrounded dock-host", () => {
+    const last = dockHostButton(false);
+    expect(restoreTarget(document.body, last)).toBeNull();
+  });
+
+  it("restores an element inside the active dock-host", () => {
+    const last = dockHostButton(true);
+    expect(restoreTarget(document.body, last)).toBe(last);
+  });
+
+  it("restores a side-pane element unaffected by dock-host scoping", () => {
+    const last = regionButton(); // not inside any .dock-host
+    expect(restoreTarget(document.body, last)).toBe(last);
+  });
+
+  it("honors an injected scope predicate over the real dock-liveness check", () => {
+    const last = dockHostButton(true); // live per the real DOM check
+    expect(restoreTarget(document.body, last, () => false)).toBeNull();
+  });
+});

--- a/packages/extension-host/src/extension-host/focus-restore.ts
+++ b/packages/extension-host/src/extension-host/focus-restore.ts
@@ -15,9 +15,21 @@ function inRegion(el: Element | null): el is HTMLElement {
   return el instanceof HTMLElement && el.closest(REGION) !== null;
 }
 
+// True when `el` isn't inside a workspace dock at all (side-pane, status-bar —
+// always "live"), or is inside the currently-foreground one. False for an
+// element belonging to a backgrounded workspace's (hidden) dock — CenterDock
+// keeps every visited workspace mounted as a sibling `.dock-host` inside the
+// same shared `.center-body`, only toggling `data-active`, so REGION's own
+// selector can't tell them apart on its own. See ADR 0034.
+function inLiveDockScope(el: Element): boolean {
+  const host = el.closest(".dock-host");
+  return !host || host.getAttribute("data-active") === "true";
+}
+
 function record(): void {
-  if (inRegion(document.activeElement)) {
-    lastFocused = document.activeElement as HTMLElement;
+  const el = document.activeElement;
+  if (inRegion(el) && inLiveDockScope(el)) {
+    lastFocused = el;
   }
 }
 
@@ -26,14 +38,19 @@ function record(): void {
  * focus as-is. Returns `null` when focus already sits on a real region element
  * (the activating click landed somewhere — don't override the user), and
  * otherwise the last region element focused before the app lost focus, if it's
- * still in the DOM. Pure, for testing.
+ * still in the DOM and still inside the live (foreground) dock. Pure, for
+ * testing — `inLiveScope` defaults to the real dock-liveness check and is
+ * injectable so unit tests don't need a real dockview DOM.
  */
 export function restoreTarget(
   active: Element | null,
   last: HTMLElement | null,
+  inLiveScope: (el: Element) => boolean = inLiveDockScope,
 ): HTMLElement | null {
   if (inRegion(active)) return null;
-  if (last && last.isConnected && inRegion(last)) return last;
+  if (last && last.isConnected && inRegion(last) && inLiveScope(last)) {
+    return last;
+  }
   return null;
 }
 

--- a/packages/extension-host/src/extension-host/terminal-service.test.ts
+++ b/packages/extension-host/src/extension-host/terminal-service.test.ts
@@ -15,16 +15,22 @@ vi.mock("./process-service", () => ({
 
 // Mock dockview's own registry so `focus()`'s call sequence/timing is
 // observable without a real dockview instance.
-const { setActive, getPanel, getActiveDockApi, focusPanelContent } = vi.hoisted(
-  () => ({
-    setActive: vi.fn(),
-    getPanel: vi.fn(),
-    getActiveDockApi: vi.fn(),
-    focusPanelContent: vi.fn(),
-  }),
-);
+const {
+  setActive,
+  getPanel,
+  getActiveDockApi,
+  getActiveDockWorkspaceId,
+  focusPanelContent,
+} = vi.hoisted(() => ({
+  setActive: vi.fn(),
+  getPanel: vi.fn(),
+  getActiveDockApi: vi.fn(),
+  getActiveDockWorkspaceId: vi.fn(),
+  focusPanelContent: vi.fn(),
+}));
 vi.mock("../docked/dock-api-registry", () => ({
   getActiveDockApi,
+  getActiveDockWorkspaceId,
   focusPanelContent,
 }));
 
@@ -79,6 +85,11 @@ beforeEach(() => {
     view: { content: { element: PANEL_CONTENT_ELEMENT } },
   });
   getActiveDockApi.mockReset().mockReturnValue({ getPanel });
+  // Default: the live dock is workspace "w" — matches store.activeWorkspaceId
+  // below for the common "same workspace, dock already up" case. Tests that
+  // exercise the cross-workspace path don't need to touch this — "w" simply
+  // isn't the target workspace id they focus into.
+  getActiveDockWorkspaceId.mockReset().mockReturnValue("w");
   focusPanelContent.mockReset();
   rafCallbacks = [];
   vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {

--- a/packages/extension-host/src/extension-host/terminal-service.ts
+++ b/packages/extension-host/src/extension-host/terminal-service.ts
@@ -27,6 +27,7 @@ import {
 import {
   focusPanelContent,
   getActiveDockApi,
+  getActiveDockWorkspaceId,
 } from "../docked/dock-api-registry";
 import { requestPanelActivation } from "../docked/panel-activation-requests";
 import { createHostChannel } from "./output-store";
@@ -296,21 +297,35 @@ export function getTerminalService(): TerminalService {
 
       const panelId = `terminal:${terminalId}`;
 
-      if (store.activeWorkspaceId !== wsId) {
-        // Cross-workspace: do NOT reach for the dock from here. The target
-        // workspace's dock may not be mounted yet, and the moment it becomes
-        // active it runs its own active-panel restore — a setActive() fired on
-        // a timer here is racing that restore, and whichever call lands last
-        // wins (the requested tab flashes active, then flips back). Record the
-        // intent instead and let WorkspaceDock, the single authority over its
-        // own active panel, apply it — and drive focus — once its dock is up.
+      if (getActiveDockWorkspaceId() !== wsId) {
+        // Cross-workspace — or same-workspace-on-paper-but-not-live-yet: check
+        // dock identity, not store.activeWorkspaceId. A caller that already
+        // flipped store.activeWorkspaceId itself (e.g. ctx.workspaces.activate()
+        // immediately followed by this call — see agent-inspector's
+        // openAndFocus(), and per RFC 0023 the real agent-monitor extension's
+        // Navigator row click) can win the store check before WorkspaceDock's
+        // authority effect has actually committed the new dock as live,
+        // making `store.activeWorkspaceId === wsId` true while the dock behind
+        // it is still the old one. Trusting that would silently no-op here
+        // (the old dock has no panel for this terminal) and drop the request
+        // entirely — the tab never activates at all, not even a flash. Do NOT
+        // reach for the dock from here either way: the target workspace's dock
+        // may not be mounted yet, and the moment it becomes active it runs its
+        // own active-panel restore — a setActive() fired on a timer here is
+        // racing that restore, and whichever call lands last wins (the
+        // requested tab flashes active, then flips back). Record the intent
+        // instead and let WorkspaceDock, the single authority over its own
+        // active panel, apply it — and drive focus — once its dock is up.
+        // activateWorkspace() is a no-op if wsId is already store.activeWorkspaceId
+        // (see state/workspaces.ts), so this is safe to call unconditionally.
+        // See ADR 0034.
         requestPanelActivation(wsId, panelId);
         activateWorkspace(wsId);
         return;
       }
 
-      // Same workspace — the dock is already up and nothing else is deciding
-      // its active panel right now, so activate the tab directly.
+      // Same workspace, dock confirmed live — nothing else is deciding its
+      // active panel right now, so activate the tab directly.
       const panel = getActiveDockApi()?.getPanel(panelId);
       panel?.api.setActive();
       if (!panel) return;

--- a/packages/extension-host/src/extension-host/use-focus-retry.test.ts
+++ b/packages/extension-host/src/extension-host/use-focus-retry.test.ts
@@ -45,7 +45,11 @@ describe("retryFocus", () => {
   it("re-grabs each frame until focus lands, then stops grabbing", () => {
     const focus = vi.fn();
     let focused = false;
-    retryFocus(focus, () => focused);
+    retryFocus(
+      focus,
+      () => focused,
+      () => true,
+    );
 
     flushFrame(); // not focused → grab
     flushFrame(); // still not focused → grab
@@ -54,6 +58,32 @@ describe("retryFocus", () => {
     focused = true;
     flushFrame(); // landed → no further grab
     expect(focus).toHaveBeenCalledTimes(2);
+  });
+
+  // Regression guard for symptom 1 (ADR 0034): a panel that merely re-mounts
+  // in the background — which happens to every panel of a workspace whose dock
+  // becomes visible again — must not grab focus from the tab the user actually
+  // left active. `stillWanted` is required precisely so a mount-time caller
+  // can't silently omit it and grab unconditionally.
+  it("never grabs on mount when the panel is not the active tab", () => {
+    const focus = vi.fn();
+    let isActive = false; // this panel re-mounted in the background
+    retryFocus(
+      focus,
+      () => false, // never reports focused → would grab every frame if unguarded
+      () => isActive,
+    );
+
+    flushFrame();
+    flushFrame();
+    expect(focus).not.toHaveBeenCalled();
+
+    // …and it stays bailed even if the panel becomes active later: the loop
+    // ended, so activation focus is the active tab's own concern, not a
+    // stale mount-time retry's.
+    isActive = true;
+    flushFrame();
+    expect(focus).not.toHaveBeenCalled();
   });
 
   it("never grabs when superseded before the first frame", () => {

--- a/packages/extension-host/src/extension-host/use-focus-retry.ts
+++ b/packages/extension-host/src/extension-host/use-focus-retry.ts
@@ -33,15 +33,27 @@ function focusInMenu(active: Element | null): boolean {
  * Repeatedly call `focus()` on successive animation frames until `isFocused()`
  * returns true, `stillWanted()` returns false, or `cap` frames have elapsed.
  *
- * Use directly for one-shot focus (e.g. on editor mount). For focusing a panel
- * whenever its dock tab becomes active, prefer {@link useFocusOnActive}.
+ * `stillWanted` is **required**, and must express "this panel is still the one
+ * that should hold focus" — normally `() => api.isActive`, or the center
+ * dock's focus-intent token (`focusGen`). It is deliberately not optional: a
+ * retry loop without it keeps grabbing focus for its entire frame budget no
+ * matter what else happened meanwhile. That matters most on *mount*, because
+ * re-entering a workspace re-mounts its panels — so an unguarded mount-time
+ * grab in a background tab yanks focus away from the tab the user actually
+ * left active. And because DOM focus landing inside a dockview panel makes
+ * dockview mark that panel's group active
+ * (`contentContainer.onDidFocus → doSetGroupActive`), stealing focus silently
+ * changes the visible active tab too. That was symptom 1 in ADR 0034.
+ *
+ * For focusing a panel whenever its dock tab becomes active, prefer
+ * {@link useFocusOnActive}, which supplies the guard for you.
  *
  * @internal
  */
 export function retryFocus(
   focus: () => void,
   isFocused: () => boolean,
-  stillWanted: () => boolean = () => true,
+  stillWanted: () => boolean,
   cap = DEFAULT_CAP,
 ): void {
   let attempts = 0;

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -53,6 +53,10 @@ export { ensureMonaco } from "./docked/monaco-setup";
 // Test-driver only (the dev automation bridge uses it to set up a center split,
 // and to read which tab the center dock is actually showing).
 export { splitActivePanel, getActiveDockApi } from "./docked/dock-api-registry";
+// Test-driver only — lets the automation bridge simulate "window regained OS
+// focus" (Tauri's onFocusChanged) without a real window blur/refocus, which
+// automation can't drive.
+export { restoreRegionFocus } from "./extension-host/focus-restore";
 // Output log query — lets the automation bridge surface logs to external tools.
 export {
   getOutputLogs,

--- a/packages/extension-host/src/panels/WorkspaceDock.tsx
+++ b/packages/extension-host/src/panels/WorkspaceDock.tsx
@@ -207,7 +207,7 @@ export function WorkspaceDock({
   useEffect(() => {
     if (!active || !api) return;
     const liveApi = api;
-    setActiveDockApi(liveApi);
+    setActiveDockApi(liveApi, workspaceId);
     const root =
       (liveApi as unknown as { element?: HTMLElement }).element ?? null;
 

--- a/packages/extensions-core/src/editor/DiffPanel.tsx
+++ b/packages/extensions-core/src/editor/DiffPanel.tsx
@@ -137,9 +137,17 @@ export function DiffViewer({
       diffEditor.getModifiedEditor(),
     ]);
 
+    // Gated on this panel actually being the active tab — mount is not only
+    // "the user just opened this diff": re-entering a workspace re-mounts
+    // every panel in its dock, and an unguarded grab would steal focus from
+    // the tab the user actually left active (and, via dockview's
+    // focus-follows-active wiring, change the visible tab). Mirrors
+    // TextViewer's text-mode guard. See ADR 0034.
+    if (!dockApi.isActive) return;
     retryFocus(
       () => diffEditor.focus(),
       () => isTextareaFocusedWithin(diffEditor.getContainerDomNode()),
+      () => dockApi.isActive,
     );
   };
 

--- a/packages/extensions-core/src/editor/TextViewer.tsx
+++ b/packages/extensions-core/src/editor/TextViewer.tsx
@@ -544,9 +544,19 @@ export function TextViewer({
     //
     // `editor.focus()` only takes effect after Monaco's internal textarea is
     // laid out with non-zero dimensions, so retry across frames until it lands.
+    //
+    // Gated on this panel actually being the active tab, both up front and for
+    // the life of the retry: mount is NOT only "the user just created this
+    // editor". Re-entering a workspace re-mounts every panel in its dock, so
+    // an unguarded grab here fires for background editors too and yanks focus
+    // off the tab the user actually left active — which dockview then treats
+    // as a real focus, flipping the visible active tab to this editor. Same
+    // guard TerminalPanel uses for its own post-spawn focus. See ADR 0034.
+    if (!dockApi.isActive) return;
     retryFocus(
       () => editor.focus(),
       () => isTextareaFocusedWithin(editor.getDomNode()),
+      () => dockApi.isActive,
     );
   };
 


### PR DESCRIPTION
## Summary

Three separate active-tab focus bugs that all present as "the wrong tab is focused after switching workspaces" — reported after ADR 0032's earlier fix in this area:

1. **Navigator agent click lands on the wrong tab.** `ctx.terminals.focus()` trusted `store.activeWorkspaceId` to know whether the destination dock was already live. A caller that pre-activates the workspace itself (agent-inspector's `openAndFocus()`, and per RFC 0023 the real agent-monitor extension's Navigator row click) wins that check before React commits the new dock as live, so the cross-workspace activation request is silently dropped. Fixed by checking dock identity (`getActiveDockWorkspaceId()`) instead of store state.
2. **Alt-tabbing away and back changes the focused tab.** `focus-restore.ts` couldn't tell a backgrounded workspace's dock from the foreground one, so window-refocus could restore DOM focus into a hidden dock — which flips the active tab as a side effect. Fixed by scoping to the live `.dock-host`.
3. **Focusing a terminal in a split dock, switching workspaces, and coming back lands on an editor instead.** Root cause: re-entering a workspace re-mounts every panel in its dock, and `TextViewer`/`DiffPanel`'s mount-time `retryFocus` call had no `stillWanted` guard, so it grabbed DOM focus unconditionally — including for backgrounded panels. Because dockview marks a panel's group active whenever focus lands inside it, that steal silently changed the visible tab. Fixed by making `retryFocus`'s guard **required** (every other call site already passed one) and gating `TextViewer`/`DiffPanel` on `dockApi.isActive`, matching `TerminalPanel`'s existing correct pattern.

Also fixes `splitActivePanel` (the automation test-driver helper), which never actually split — dockview's `moveTo` forces `position` to `"center"` unless an explicit `group` is passed.

Full writeup, including three disproven hypotheses and how bug #3 was actually found (instrumenting `HTMLElement.prototype.focus` to capture calling stacks after scripted reproduction repeatedly failed): [ADR 0034](docs/decisions/0034-focus-and-activation-authority.md).

## Test plan

- [x] `pnpm test` — full monorepo suite green (1020+ unit tests), including new regression coverage:
  - `use-focus-retry.test.ts` — "never grabs on mount when the panel is not the active tab" (the real guard for bug #3)
  - `focus-restore.test.ts` — dock-host scoping cases (bug #2)
  - `terminal-service.test.ts` — updated for dock-identity check (bug #1)
- [x] `pnpm lint` clean, `tsc --noEmit` clean
- [x] Live integration tests against the running dev app: `cross-workspace-activate-then-focus.it.test.ts` (new, bug #1) — 10/10 passes pre/post-fix comparison; existing `cross-workspace-terminal-focus.it.test.ts` unaffected (no regression)
- [x] Bug #3 manually reproduced and confirmed fixed live by Dave, multiple times, in both directions (workspace A and B)
- [ ] Bug #2 (window-refocus) has a source-confirmed mechanism and a unit test, but no live pre/post-fix numeric baseline was obtainable in this environment (documented in the ADR) — worth a live spot-check when convenient

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_01HKwuPCiZGrxQwZTnXmeabu