### PR TITLE
ci(integration): run nightly instead of on every PR, drop release gating

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,10 +9,12 @@ name: integration
 # reason, which is the exact failure mode docs/automation.md says this whole
 # RPC-driven layer exists to avoid.
 #
-# Not a required status check (that's a branch-protection setting, not
-# something this file controls) — booting a full Tauri app adds real time on
-# top of tests that already run tens of seconds each, so this starts as
-# informational-on-PR rather than blocking every merge.
+# Nightly, not on-PR: booting a full Tauri app adds real time on top of tests
+# that already run tens of seconds each, and this suite has genuine
+# timing-sensitivity (see ADR 0034 / the split-dock symptom-1 guard's settle
+# delays) — running it on every PR risked noisy, unrelated-looking failures on
+# unrelated changes. Nightly gives a steady signal without that cost; revisit
+# once we've watched it run clean for a while.
 #
 # window-focus-restore.it.test.ts self-gates on real OS window focus
 # (`document.hasFocus()`), which a CI runner has no interactive session to
@@ -21,14 +23,8 @@ name: integration
 # workflow.
 
 on:
-  pull_request:
-    paths:
-      - "apps/desktop/**"
-      - "packages/extension-host/**"
-      - "packages/extensions-core/**"
-      - "packages/extensions-silo/**"
-      - "packages/sdk/**"
-      - ".github/workflows/integration.yml"
+  schedule:
+    - cron: "0 4 * * *" # 4am UTC daily — an hour after release-nightly's 3am build
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Follow-up to #330. Switches the integration workflow from `pull_request` to a nightly schedule (`0 4 * * *` UTC, an hour after `release-nightly.yml`'s 3am build) plus `workflow_dispatch` for manual runs.

Reasoning: this suite has genuine timing-sensitivity even in its fixed state (see ADR 0034 and the split-dock symptom-1 guard's realistic settle delays) — booting a full Tauri app and running tests that take real time is better suited to a steady nightly signal than noisy per-PR runs where a flake looks like it's blocking an unrelated change.

Not wiring this into `release-please`'s build trigger as a gate for now — want to watch how the nightly run behaves for a couple of weeks first before making it part of the release path.

## Test plan

Since this only changes trigger config (no job logic touched — that's already proven out in #330's real runs), there's nothing new to validate mechanically. Will confirm the schedule fires as expected once merged, or can be spot-checked immediately via `gh workflow run integration.yml`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01HKwuPCiZGrxQwZTnXmeabu