### PR TITLE
fix(file-explorer): fix rename arrow-key focus loss and follow renamed file in open editors

### DIFF
--- a/packages/extension-host/src/extension-host/file-service.ts
+++ b/packages/extension-host/src/extension-host/file-service.ts
@@ -13,6 +13,7 @@ import {
   fsCopy,
 } from "../services/tauri-fs";
 import { startWatch, stopWatch, onFileChange } from "../services/tauri-watch";
+import { retargetEditorsForRename } from "../state/workspaces";
 import { resolvePath } from "./security/resolve-path";
 import type { PathScope } from "./security/resolve-path";
 import type {
@@ -64,7 +65,10 @@ export function getFileService(): FileService {
     writeBytes: fsWriteBytes,
     createDir: fsCreateDir,
     copy: fsCopy,
-    rename: fsRename,
+    rename: async (oldPath, newPath) => {
+      await fsRename(oldPath, newPath);
+      retargetEditorsForRename(oldPath, newPath);
+    },
     delete: fsDelete,
     reveal: fsReveal,
     // Subscribe to changes under `path`, sharing one backend watcher per path

--- a/packages/extension-host/src/panels/WorkspaceDock.tsx
+++ b/packages/extension-host/src/panels/WorkspaceDock.tsx
@@ -545,9 +545,8 @@ export function WorkspaceDock({
       const panel = apiRef.current?.getPanel(`editor:${editorId}`);
       if (panel) panel.api.setTitle(title);
     }
-    window.addEventListener("app:update-preview-title", handler);
-    return () =>
-      window.removeEventListener("app:update-preview-title", handler);
+    window.addEventListener("app:update-editor-title", handler);
+    return () => window.removeEventListener("app:update-editor-title", handler);
   }, []);
 
   useEffect(() => {

--- a/packages/extension-host/src/state/workspaces.test.ts
+++ b/packages/extension-host/src/state/workspaces.test.ts
@@ -10,7 +10,9 @@ vi.mock("./editor-backups", () => ({
 import { store } from "./store";
 import {
   openEditor,
+  openDiff,
   removeEditor,
+  retargetEditorsForRename,
   savePanelStateToWorkspace,
   loadPanelStateFromWorkspace,
   activateWorkspace,
@@ -52,6 +54,69 @@ describe("removeEditor", () => {
   it("does nothing for an unknown editor id", () => {
     expect(removeEditor("w", "nope")).toBeNull();
     expect(clearEditorBackup).not.toHaveBeenCalled();
+  });
+});
+
+describe("retargetEditorsForRename", () => {
+  it("repoints an open editor at the renamed file, updating its title", () => {
+    const rec = openEditor("w", "/ws/w/a.ts");
+    retargetEditorsForRename("/ws/w/a.ts", "/ws/w/b.ts");
+    expect(rec.filePath).toBe("/ws/w/b.ts");
+    expect(rec.title).toBe("b.ts");
+  });
+
+  it("repoints every editor nested under a renamed directory", () => {
+    const inner = openEditor("w", "/ws/w/old-dir/nested/c.ts");
+    const direct = openEditor("w", "/ws/w/old-dir/d.ts");
+    retargetEditorsForRename("/ws/w/old-dir", "/ws/w/new-dir");
+    expect(inner.filePath).toBe("/ws/w/new-dir/nested/c.ts");
+    expect(direct.filePath).toBe("/ws/w/new-dir/d.ts");
+  });
+
+  it("leaves editors for unrelated paths untouched", () => {
+    const rec = openEditor("w", "/ws/w/other.ts");
+    retargetEditorsForRename("/ws/w/a.ts", "/ws/w/b.ts");
+    expect(rec.filePath).toBe("/ws/w/other.ts");
+  });
+
+  it("does not retarget a diff-mode editor pinned to the old path", () => {
+    const diffRec = openDiff("w", {
+      filePath: "/ws/w/a.ts",
+      providerId: "silo.git",
+    });
+    retargetEditorsForRename("/ws/w/a.ts", "/ws/w/b.ts");
+    expect(diffRec.filePath).toBe("/ws/w/a.ts");
+  });
+
+  it("fires app:update-editor-title so the dockview tab picks up the new name", () => {
+    const rec = openEditor("w", "/ws/w/a.ts");
+    const seen: { editorId: string; title: string }[] = [];
+    const listener = (e: Event) =>
+      seen.push((e as CustomEvent<{ editorId: string; title: string }>).detail);
+    window.addEventListener("app:update-editor-title", listener);
+    try {
+      retargetEditorsForRename("/ws/w/a.ts", "/ws/w/b.ts");
+    } finally {
+      window.removeEventListener("app:update-editor-title", listener);
+    }
+    expect(seen).toEqual([{ editorId: rec.id, title: "b.ts" }]);
+  });
+
+  it("spans workspaces", () => {
+    store.workspaces = {
+      ...store.workspaces,
+      w2: (() => {
+        const ws = { ...(store.workspaces.w as WorkspaceInternal) };
+        ws.id = "w2";
+        ws.folder = "/ws/w2";
+        ws.editors = [];
+        return ws;
+      })(),
+    };
+    store.workspaceOrder = ["w", "w2"];
+    const rec = openEditor("w2", "/ws/w2/a.ts");
+    retargetEditorsForRename("/ws/w2/a.ts", "/ws/w2/b.ts");
+    expect(rec.filePath).toBe("/ws/w2/b.ts");
   });
 });
 

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -668,6 +668,39 @@ export function setEditorFilePath(
   return rec;
 }
 
+/**
+ * Retarget every open text editor pointed at `oldPath` (or nested under it, for
+ * a renamed/moved directory) to `newPath`, across all workspaces — called after
+ * a successful `ctx.files.rename` so an open tab follows its file instead of
+ * reading as deleted once the old path stops existing on disk. Fires
+ * "app:update-editor-title" per retargeted editor so the dockview tab (whose
+ * title is set once at panel-creation time, not read reactively) picks up the
+ * new name — the record's `title` field alone only updates the breadcrumb.
+ */
+export function retargetEditorsForRename(
+  oldPath: string,
+  newPath: string,
+): void {
+  for (const ws of Object.values(store.workspaces)) {
+    for (const rec of ws.editors) {
+      if (!isTextRecord(rec) || rec.filePath === null) continue;
+      if (rec.filePath === oldPath) {
+        rec.filePath = newPath;
+      } else if (rec.filePath.startsWith(oldPath + "/")) {
+        rec.filePath = newPath + rec.filePath.slice(oldPath.length);
+      } else {
+        continue;
+      }
+      rec.title = baseName(rec.filePath);
+      window.dispatchEvent(
+        new CustomEvent("app:update-editor-title", {
+          detail: { editorId: rec.id, title: rec.title },
+        }),
+      );
+    }
+  }
+}
+
 export function removeEditor(
   workspaceId: string,
   editorId: string,
@@ -808,7 +841,7 @@ export function openPreviewDiff(
     currentPreview.providerId = spec.providerId;
     currentPreview.args = spec.args;
     window.dispatchEvent(
-      new CustomEvent("app:update-preview-title", {
+      new CustomEvent("app:update-editor-title", {
         detail: { editorId: currentPreview.id, title },
       }),
     );
@@ -835,7 +868,7 @@ export function openPreviewDiff(
  * - If the file is already the current preview → just activate it.
  * - If there is an existing preview → reuse its slot (mutate filePath/title in
  *   place so the tab stays in the same position) and fire
- *   "app:update-preview-title" so CenterDock can update the dockview panel
+ *   "app:update-editor-title" so CenterDock can update the dockview panel
  *   title.
  * - Otherwise → create a new preview editor record.
  */
@@ -891,7 +924,7 @@ export function openPreviewEditor(
     if (viewType !== undefined) currentPreview.viewType = viewType;
     else delete currentPreview.viewType;
     window.dispatchEvent(
-      new CustomEvent("app:update-preview-title", {
+      new CustomEvent("app:update-editor-title", {
         detail: { editorId: currentPreview.id, title: currentPreview.title },
       }),
     );

--- a/packages/extensions-silo/src/file-explorer/Tree.tsx
+++ b/packages/extensions-silo/src/file-explorer/Tree.tsx
@@ -59,6 +59,12 @@ export function Tree({
   const [selected, setSelected] = useState<string | null>(
     () => initialSelected ?? null,
   );
+  // Path whose row should take keyboard focus once it (re)appears in the
+  // flattened list — set after a rename commits. The renamed row unmounts and
+  // remounts under its new path when the fs-watch reload refreshes the
+  // listing, which would otherwise strand DOM focus (or leave it wherever the
+  // browser default-focuses on node removal) instead of following the file.
+  const pendingFocusPath = useRef<string | null>(null);
   // Whether `root` is itself a linked git worktree — drives the header badge
   // (mirrors the Git panel's; consumes `silo.git` directly, same as
   // git-explorer does, rather than reaching into that extension's internals).
@@ -112,6 +118,17 @@ export function Tree({
       if (n) openFileMenu(n.path, n.isDir, { anchor });
     },
   });
+
+  // Consume a pending post-rename focus target as soon as its row exists in
+  // the flattened list (see `pendingFocusPath` above and `commitRename` below).
+  useEffect(() => {
+    const path = pendingFocusPath.current;
+    if (!path) return;
+    const idx = indexOfPath.get(path);
+    if (idx === undefined) return;
+    pendingFocusPath.current = null;
+    group.focusItem(idx);
+  }, [indexOfPath, group.focusItem]);
 
   // The tree-specific keys, run before useFocusGroup sees the event. Returns
   // true when it owns the key (the group then skips it); false to defer to the
@@ -487,9 +504,18 @@ export function Tree({
     const dir = dirOf(oldPath);
     const newPath = dir + "/" + trimmed;
     if (newPath === oldPath) return;
-    await files
-      .rename(oldPath, newPath)
-      .catch((e) => console.warn("rename failed", e));
+    try {
+      await files.rename(oldPath, newPath);
+    } catch (e) {
+      console.warn("rename failed", e);
+      return;
+    }
+    // Follow the rename: keep selection on the renamed row, and once the
+    // listing reload remounts it under the new path, restore keyboard focus
+    // there too (see the pendingFocusPath effect above) instead of leaving
+    // focus stranded or moving to whatever row happens to fill the gap.
+    selectPath(newPath);
+    pendingFocusPath.current = newPath;
   }
 
   async function handleDrop(draggedPath: string, targetDir: string) {

--- a/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
+++ b/packages/extensions-silo/src/file-explorer/TreeNodes.tsx
@@ -143,6 +143,11 @@ export function DirNode({
             spellCheck={false}
             onBlur={(e) => onRenameCommit(path, e.target.value)}
             onKeyDown={(e) => {
+              // Stop every key here from bubbling to the row's onKeyDown —
+              // otherwise ArrowLeft/ArrowRight (and ↑/↓) reach handleRowKey /
+              // useFocusGroup and get treated as tree navigation instead of
+              // normal cursor movement inside the input.
+              e.stopPropagation();
               if (e.key === "Enter") {
                 e.currentTarget.blur();
               } else if (e.key === "Escape") {
@@ -395,6 +400,11 @@ export function FileLeaf({
           spellCheck={false}
           onBlur={(e) => onRenameCommit(path, e.target.value)}
           onKeyDown={(e) => {
+            // Stop every key here from bubbling to the row's onKeyDown —
+            // otherwise ArrowLeft/ArrowRight (and ↑/↓) reach handleRowKey /
+            // useFocusGroup and get treated as tree navigation instead of
+            // normal cursor movement inside the input.
+            e.stopPropagation();
             if (e.key === "Enter") {
               e.currentTarget.blur();
             } else if (e.key === "Escape") {


### PR DESCRIPTION
## Summary
- Rename input no longer loses focus on ArrowLeft/ArrowRight (and Up/Down) — the input now stops the keydown from bubbling to the tree row's navigation handler, so arrow keys move the text cursor instead of collapsing/navigating the tree.
- Renaming a file with an open editor tab now follows the rename instead of reading as deleted: the editor's `filePath`/title retarget to the new path (across all workspaces, wired through `ctx.files.rename`), and the dockview tab title updates too (generalized the existing preview-title-sync event into `app:update-editor-title`, since the tab title is set once at panel creation and isn't reactive to the record's `title` field on its own).
- File Explorer selection and keyboard focus now follow the renamed row once the listing reload remounts it under the new path, instead of the focus getting stranded or jumping to an unrelated file.

Fixes #327

## Test plan
- [x] `pnpm test` — 1025/1026 passing; the one failure (`agent-catalog.test.ts`'s hostile-cwd spawn test) is a pre-existing, machine-load-dependent flake unrelated to this change — confirmed it passes in isolation on both `main` and this branch, with and without this diff.
- [x] `pnpm lint` and `pnpm --filter silo exec tsc --noEmit` clean.
- [x] Added unit tests for `retargetEditorsForRename` (exact match, nested directory rename, unrelated paths untouched, diff-mode editors excluded, cross-workspace, `app:update-editor-title` event firing).
- [x] Verified live in the running dev app via the automation bridge: drove an actual rename through the File Explorer UI (focus row → Enter → type new name → Enter) and confirmed the dockview tab title updated immediately and keyboard focus landed on the renamed row once its listing entry remounted.
- [x] Manually confirmed by the reporter that the arrow-key cursor fix works as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011epKaPkDhYfREjX4VpnLQA