### PR TITLE
feat(layout): add global side panel layout option

### DIFF
--- a/docs/decisions/0033-laptop-mode-independent-layout.md
+++ b/docs/decisions/0033-laptop-mode-independent-layout.md
@@ -46,8 +46,6 @@ available whenever a side is collapsed, not only in Laptop Mode.
 
 - **One layout, temporarily collapsed on narrow windows** — rejected: the
   narrow choices leak into the wide layout and are lost on workspace switch.
-- **Global (not per-workspace) Laptop Mode layout** — rejected: workspaces
-  already own panel layout; a second mode should follow the same ownership.
 - **Keep percentage column widths** — rejected: sides rescale with the
   window instead of holding the px size the user set.
 
@@ -55,3 +53,10 @@ available whenever a side is collapsed, not only in Laptop Mode.
 
 - Glossary: `CONTEXT.md` (Laptop Mode, Peek).
 - Related: [0022](./0022-on-disk-storage-layout.md) (where layout prefs live).
+- Related: [0035](./0035-global-side-panel-layout.md) — an opt-in, off-by-default
+  flag that shares side-panel arrangement (including both of this ADR's layout
+  modes) across every workspace. An earlier version of this ADR rejected a
+  _global_ Laptop Mode layout outright; 0035 supersedes that specific point —
+  per-workspace remains the default, but sharing is now available as a
+  deliberate opt-in built for that purpose, which the original alternative
+  never considered.

--- a/docs/decisions/0035-global-side-panel-layout.md
+++ b/docs/decisions/0035-global-side-panel-layout.md
@@ -1,0 +1,143 @@
+---
+status: accepted
+date: 2026-08-08
+---
+
+# 0035. Global Side Panel Layout is an opt-in shared arrangement
+
+## Context
+
+Side-panel arrangement — which panels show, where they sit (`sidePanelLocations`),
+their order (`sidePanelOrder`), visibility (`sidePanelVisibility`), and side-column
+collapse — is per-workspace: `activateWorkspace()` captures the outgoing
+workspace's arrangement and applies the incoming one on every switch
+(`capturePanelState()`/`applyPanelState()` in `state/panel-state.ts`). That's a
+deliberate choice ([0033](./0033-laptop-mode-independent-layout.md)) — but some
+users want the opposite for this one dimension: resize, hide, or reorder a side
+panel once and have it apply everywhere, since they think of the side dock as
+one arrangement they're configuring for the app, not per-project.
+
+Column width already does something like this — it's global unconditionally,
+stored outside the per-workspace system entirely (`layout/column-widths.ts`,
+for first-paint reasons unrelated to this feature). This ADR is about the
+remaining arrangement fields, which don't share that constraint and can be
+made global _conditionally_, without giving up each workspace's own
+arrangement for users who don't want to share it.
+
+## Decision
+
+**Global Side Panel Layout** is an opt-in, **off-by-default** setting
+(`globalPanelLayoutEnabled`, in Settings → Layout). While off, everything
+behaves exactly as before. While on:
+
+- `sidePanelLocations`, `sidePanelOrder`, `sidePanelVisibility`, and side-column
+  collapse (both the normal-width and Laptop Mode variants — see below) are
+  shared across every workspace, live, through one new record
+  (`store.globalPanelLayout`, shape `GlobalPanelLayout` in `state/types.ts`).
+- `extensionState` (a panel's own instance data), `sidePanelScrollPositions`,
+  and `activeSidePanelTabs` are **not** included in the main flag — they're
+  either always per-workspace (the first two) or gated behind their own
+  dependent sub-setting (`globalActiveTabEnabled`, also off by default,
+  disabled in the UI until the main flag is on).
+- **Frozen dual-state, not merge-on-write**: each workspace's own arrangement
+  fields are left untouched on disk while the flag is on — captured/applied
+  as normal only for the fields that stay per-workspace. Turning the flag off
+  restores each workspace's own arrangement exactly as it was frozen. This
+  mirrors 0033's own normal/Laptop-Mode dual-state pattern
+  (`swapCollapseMode`/`collapseStateByMode`), generalized to the arrangement
+  fields and applied across workspaces instead of across layout modes.
+- **Applies to Laptop Mode too**: `GlobalPanelLayout` carries both collapse
+  variants (`leftPanelCollapsed`/`rightPanelCollapsed` +
+  `smallScreenCollapsed?`), the same normal/small-screen split a workspace's
+  own `PanelStateSnapshot` already has. Treating Laptop Mode differently from
+  normal-width under this flag — global for one, per-workspace for the
+  other — would be a second, harder-to-explain rule layered on top of the
+  first; a single flag covering both is simpler to reason about, and 0033's
+  reasoning for keeping Laptop Mode per-workspace _by default_ doesn't argue
+  against a user deliberately opting both modes into sharing at once.
+- **Seeding**: enabling the main flag (or the sub-setting) seeds the shared
+  record from whatever's currently live — the active workspace's current
+  arrangement — so opting in never wipes out a layout the user just set.
+  Disabling seeds any workspace that has _no_ frozen arrangement of its own
+  (created while the flag was on) from the shared record at that moment,
+  rather than snapping it to bare defaults.
+- **Confirming the main flag's "on" transition**: enabling it unconditionally
+  seeds from the active workspace (see above) — which, on a _second_ or later
+  enable, silently discards whatever shared layout was frozen the last time
+  it was turned off. The settings page confirms this first via
+  `ctx.ui.showModal` (`GlobalPanelLayoutConfirm.tsx`): one line explaining
+  that this overrides every workspace's layout with the active workspace's
+  current one, an OK/Cancel footer, and — only when a previously-saved shared
+  layout exists (`hasSavedGlobalPanelLayout()`) — a checkbox to restore that
+  instead of overwriting it (`enableGlobalPanelLayout("previous")`, which
+  applies the saved record to live without re-capturing it; unchecked is
+  `enableGlobalPanelLayout("current")`, today's default). Cancelling leaves
+  the flag off either way. The sub-setting has no equivalent prompt — its own
+  stored value is always low-stakes enough to just overwrite (see
+  "Alternatives considered").
+
+## Postscript (2026-08-08 update)
+
+Dave noticed enabling the flag a second time silently overwrote a shared
+layout he'd built up previously, with no warning — the confirmation above was
+added the same day to fix that gap. `setGlobalPanelLayoutEnabled(true)`
+remains as a plain-boolean convenience (equivalent to
+`enableGlobalPanelLayout("current")`, no prompt) for callers that don't need
+the choice, e.g. tests.
+
+## Consequences
+
+- Users who want one side-dock arrangement across every workspace get it
+  without losing their per-workspace history — turning the flag back off is
+  non-destructive.
+- The live store gains one more thing to reason about: while the flag is on,
+  `savePanelStateToWorkspace`/`loadPanelStateFromWorkspace` (state/workspaces.ts)
+  branch to skip the arrangement fields for per-workspace capture/apply, and
+  `doPersist()` (state/persistence.ts) must avoid merging the _live_ shared
+  arrangement into the active workspace's own persisted record — that would
+  silently overwrite its frozen snapshot on every autosave.
+  `withActiveNonGlobalPanelState` (state/persistence-model.ts) exists
+  specifically to prevent that leak.
+- `store.globalPanelLayout` is deliberately **not** kept continuously
+  synchronized with live edits — it's only (re)captured from live state when
+  the flag is turned off (to freeze the final value) and at persist time (to
+  write it to disk). An ordinary workspace switch while the flag is on
+  doesn't touch the arrangement fields at all, since they already show the
+  correct shared arrangement; applying the (possibly stale) global record on
+  every switch was tried and rejected during implementation — it clobbered
+  live edits made since the last sync.
+- 0033's original rejection of a "global Laptop Mode layout" no longer holds
+  as stated; that ADR has been updated to point here instead of standing
+  uncorrected next to code that does exactly what it once rejected.
+
+## Alternatives considered
+
+- **Merge-on-write instead of frozen dual-state** — rejected: every live edit
+  while the flag is on would immediately overwrite the active (or every)
+  workspace's own stored arrangement, so turning the flag back off would
+  leave no memory of what each workspace looked like beforehand. Frozen
+  dual-state keeps that reversible.
+- **Exclude Laptop Mode from the flag's scope** (global for normal-width
+  only) — rejected: treating the two modes differently under one flag is a
+  second rule to learn on top of the first, for no benefit users asked for.
+- **A single combined setting instead of a main flag + dependent sub-setting**
+  for `activeSidePanelTabs` — rejected: which side-panel tab is frontmost is
+  a much more visible, opinionated thing to force-share than arrangement: a
+  user might want the _panels_ shared but still want to be looking at
+  different tabs in different workspaces. Splitting it into its own opt-in
+  keeps the main flag's blast radius smaller by default.
+- **Always silently overwriting the shared record on enable, no confirmation**
+  (the original shape of this ADR) — rejected after real use: a second enable
+  discarding a previously-built shared layout with no warning was surprising
+  enough to file as a bug the same day.
+- **Prompting for the sub-setting too** — rejected: `activeSidePanelTabs` is
+  one flat map, not worth a second confirmation dialog for; overwriting it is
+  cheap to notice and cheap to redo.
+
+## References
+
+- Supersedes part of [0033](./0033-laptop-mode-independent-layout.md)'s
+  "Alternatives considered" (the global-Laptop-Mode rejection).
+- Related: [0022](./0022-on-disk-storage-layout.md) (where global vs.
+  per-workspace state is persisted — this feature's shared record lives in
+  the same `app-state.json` index as `smallScreenModeEnabled`).

--- a/packages/extension-host/src/components/SettingsDialog.css
+++ b/packages/extension-host/src/components/SettingsDialog.css
@@ -82,24 +82,29 @@
   cursor: pointer;
   font: inherit;
 }
+
 .settings-rail-item-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
 .settings-rail-item:hover {
   background: var(--silo-color-bg-hover);
   color: var(--silo-color-text-hi);
 }
+
 .settings-rail-item.active {
   background: var(--silo-color-bg-active);
   color: var(--silo-color-text-hi);
   font-weight: 600;
 }
+
 .settings-rail-item.group-start {
   margin-top: 9px;
   position: relative;
 }
+
 /* A divider line marks each group boundary, centered in the gap above the
    group's first item. */
 .settings-rail-item.group-start::before {
@@ -113,6 +118,7 @@
   border-top: 1px solid var(--silo-modal-border);
   opacity: 0.5;
 }
+
 /* …except the very first group, which sits directly under the rail title. */
 .settings-rail-item.group-start:first-of-type::before {
   content: none;
@@ -164,6 +170,7 @@
   color: var(--silo-color-text-lo);
   cursor: pointer;
 }
+
 /* Scoped under .settings-dialog (specificity 0,3,0) so it beats the global
    `button:hover` rule (0,2,1) — otherwise the close would pick up the darker
    filled-button hover mix instead of this subtle ghost highlight. This is the
@@ -183,7 +190,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  gap: 12px;
+  gap: 20px;
 }
 
 .es-header {
@@ -193,6 +200,7 @@
   gap: 12px;
   min-height: var(--settings-header-height);
 }
+
 .es-header h2 {
   margin: 0;
   font-size: 1.1em;
@@ -209,7 +217,7 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 26px;
 }
 
 /* Font family picker (Terminal) — bespoke; out of scope for the SDK kit. */
@@ -236,6 +244,7 @@
   width: 100%;
   padding-right: 30px;
 }
+
 .es-font-picker--has-value .es-font-picker-input {
   padding-right: 54px;
 }
@@ -256,6 +265,7 @@
   padding: 0;
   font-size: 15px;
 }
+
 .es-font-picker-clear:hover {
   color: var(--silo-color-text-hi);
 }
@@ -278,6 +288,7 @@
   font-size: 20px;
   border-radius: 0 var(--silo-radius-sm) var(--silo-radius-sm) 0;
 }
+
 .es-font-picker-arrow:hover {
   color: var(--silo-color-text-hi);
   background: var(--silo-color-bg-active);
@@ -306,6 +317,7 @@
   color: var(--silo-color-text-hi);
   font-size: var(--settings-font);
 }
+
 .es-font-picker-item:hover,
 .es-font-picker-item--selected {
   background: var(--silo-color-bg-active);

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -394,3 +394,16 @@ export {
   DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
   MIN_SMALL_SCREEN_THRESHOLD_PX,
 } from "../state/types";
+
+// "Global Side Panel Layout" settings (ADR 0035) — same seam as above, for
+// the `core.layout` settings page's two switches. `hasSavedGlobalPanelLayout`
+// / `enableGlobalPanelLayout` back the settings page's confirmation dialog
+// (whether to reuse or overwrite a previously-saved shared layout);
+// `setGlobalPanelLayoutEnabled` covers the plain on/off case (disabling, and
+// enabling for callers that don't need that choice).
+export {
+  setGlobalPanelLayoutEnabled,
+  setGlobalActiveTabEnabled,
+  hasSavedGlobalPanelLayout,
+  enableGlobalPanelLayout,
+} from "../state/workspaces";

--- a/packages/extension-host/src/layout/components.css
+++ b/packages/extension-host/src/layout/components.css
@@ -641,6 +641,7 @@
     opacity: 1;
     transform: scale(1);
   }
+
   50% {
     opacity: 0.55;
     transform: scale(1.2);
@@ -653,6 +654,7 @@
     opacity: 1;
     transform: scale(1);
   }
+
   50% {
     opacity: 0.65;
     transform: scale(1.25);
@@ -664,6 +666,7 @@
     opacity: 0.7;
     transform: scale(1);
   }
+
   100% {
     opacity: 0;
     transform: scale(3.4);
@@ -826,7 +829,7 @@
 .silo-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   width: 100%;
 }
 

--- a/packages/extension-host/src/state/panel-state.test.ts
+++ b/packages/extension-host/src/state/panel-state.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { store } from "./store";
-import { capturePanelState, applyPanelState } from "./panel-state";
+import {
+  capturePanelState,
+  applyPanelState,
+  captureGlobalPanelLayout,
+  applyGlobalPanelLayout,
+} from "./panel-state";
 import { DEFAULT_PANEL_STATE } from "./types";
 import type { WorkspaceInternal } from "./types";
 
@@ -101,5 +106,55 @@ describe("capturePanelState / applyPanelState", () => {
     expect(store.extensionState).toEqual({});
     expect(store.leftPanelCollapsed).toBe(false);
     expect(store.inactiveModeCollapsed).toBeNull();
+  });
+});
+
+describe("captureGlobalPanelLayout / applyGlobalPanelLayout", () => {
+  it("round-trips every arrangement field — capture, apply, capture is identity", () => {
+    seedLiveState();
+    const first = captureGlobalPanelLayout();
+
+    applyGlobalPanelLayout(first);
+    expect(captureGlobalPanelLayout()).toEqual(first);
+  });
+
+  it("does not carry activeSidePanelTabs, sidePanelScrollPositions, or extensionState", () => {
+    seedLiveState();
+    const g = captureGlobalPanelLayout();
+    expect(g).not.toHaveProperty("activeSidePanelTabs");
+    expect(g).not.toHaveProperty("sidePanelScrollPositions");
+    expect(g).not.toHaveProperty("extensionState");
+  });
+
+  it("round-trips the small-screen layout too", () => {
+    seedLiveState();
+    store.smallScreenActive = true;
+    store.inactiveModeCollapsed = { left: false, right: true };
+    const first = captureGlobalPanelLayout();
+    expect(first.smallScreenCollapsed).toEqual({ left: true, right: false });
+
+    applyGlobalPanelLayout(first);
+    expect(captureGlobalPanelLayout()).toEqual(first);
+  });
+
+  it("copies out of the live store, so a captured record can't be rewritten by later edits", () => {
+    seedLiveState();
+    const snapshot = captureGlobalPanelLayout();
+
+    store.sidePanelVisibility.explorer = false;
+    store.sidePanelLocations.explorer = "right";
+
+    expect(snapshot.sidePanelVisibility).toEqual({ themes: false });
+    expect(snapshot.sidePanelLocations).toEqual({ explorer: "left" });
+  });
+
+  it("copies out of the record, so the live store isn't aliased to it", () => {
+    const g = captureGlobalPanelLayout(); // empty, pre-seed
+    seedLiveState();
+    applyGlobalPanelLayout(g); // overwrites live back to empty
+
+    store.sidePanelVisibility.themes = false;
+
+    expect(g.sidePanelVisibility).toEqual({});
   });
 });

--- a/packages/extension-host/src/state/panel-state.ts
+++ b/packages/extension-host/src/state/panel-state.ts
@@ -14,10 +14,17 @@
 
 import { store, collapseStateByMode } from "./store";
 import { DEFAULT_SMALL_SCREEN_COLLAPSE } from "./types";
-import type { PanelStateSnapshot, WorkspaceInternal } from "./types";
+import type {
+  GlobalPanelLayout,
+  PanelStateSnapshot,
+  WorkspaceInternal,
+} from "./types";
 
-/** Deep-clone the two-level extension-state bag (the one field that isn't flat). */
-function cloneExtensionState(
+/** Deep-clone the two-level extension-state bag (the one field that isn't
+ * flat). Exported: also used by `workspaces.ts` when the global panel layout
+ * is enabled, since `loadPanelStateFromWorkspace` then applies extensionState
+ * from the workspace record without going through the full `applyPanelState`. */
+export function cloneExtensionState(
   src: Record<string, Record<string, unknown>>,
 ): Record<string, Record<string, unknown>> {
   const out: Record<string, Record<string, unknown>> = {};
@@ -77,6 +84,48 @@ export function applyPanelState(ws: WorkspaceInternal): void {
   };
   const smallScreen = ws.smallScreenCollapsed
     ? { ...ws.smallScreenCollapsed }
+    : null;
+  const live = store.smallScreenActive
+    ? (smallScreen ?? { ...DEFAULT_SMALL_SCREEN_COLLAPSE })
+    : normal;
+  store.leftPanelCollapsed = live.left;
+  store.rightPanelCollapsed = live.right;
+  store.inactiveModeCollapsed = store.smallScreenActive ? normal : smallScreen;
+}
+
+/**
+ * The live arrangement, in the shape the shared "Global Side Panel Layout"
+ * record stores it (ADR 0035) — the same fields as {@link capturePanelState},
+ * minus `activeSidePanelTabs`/`sidePanelScrollPositions`/`extensionState`,
+ * which stay per-workspace even when the global flag is on.
+ */
+export function captureGlobalPanelLayout(): GlobalPanelLayout {
+  const collapse = collapseStateByMode();
+  return {
+    sidePanelLocations: { ...store.sidePanelLocations },
+    sidePanelOrder: { ...store.sidePanelOrder },
+    sidePanelVisibility: { ...store.sidePanelVisibility },
+    leftPanelCollapsed: collapse.normal.left,
+    rightPanelCollapsed: collapse.normal.right,
+    ...(collapse.smallScreen
+      ? { smallScreenCollapsed: { ...collapse.smallScreen } }
+      : {}),
+  };
+}
+
+/** The reverse: make `g` the live arrangement. Mirrors `applyPanelState`'s
+ * collapse resolution against the currently-live layout mode. */
+export function applyGlobalPanelLayout(g: GlobalPanelLayout): void {
+  store.sidePanelLocations = { ...g.sidePanelLocations };
+  store.sidePanelOrder = { ...g.sidePanelOrder };
+  store.sidePanelVisibility = { ...g.sidePanelVisibility };
+
+  const normal = {
+    left: g.leftPanelCollapsed,
+    right: g.rightPanelCollapsed,
+  };
+  const smallScreen = g.smallScreenCollapsed
+    ? { ...g.smallScreenCollapsed }
     : null;
   const live = store.smallScreenActive
     ? (smallScreen ?? { ...DEFAULT_SMALL_SCREEN_COLLAPSE })

--- a/packages/extension-host/src/state/persistence-model.test.ts
+++ b/packages/extension-host/src/state/persistence-model.test.ts
@@ -7,6 +7,7 @@ import {
   reconcileWorkspaceListing,
   splitPersistedState,
   withActivePanelState,
+  withActiveNonGlobalPanelState,
   type LegacyPersisted,
   type PanelState,
   type PersistedIndex,
@@ -136,6 +137,41 @@ describe("withActivePanelState", () => {
   // snapshot, so there is nothing left here to alias.
 });
 
+describe("withActiveNonGlobalPanelState", () => {
+  it("merges only extensionState/sidePanelScrollPositions/activeSidePanelTabs, leaving arrangement fields alone", () => {
+    const ws = makeWorkspace("a", {
+      sidePanelLocations: { explorer: "right" },
+      sidePanelOrder: { explorer: 3 },
+      sidePanelVisibility: { themes: true },
+      leftPanelCollapsed: false,
+      rightPanelCollapsed: true,
+    });
+    const merged = withActiveNonGlobalPanelState(ws, PANEL, false);
+
+    // Arrangement fields are untouched — they stay whatever `ws` already had.
+    expect(merged.sidePanelLocations).toEqual({ explorer: "right" });
+    expect(merged.sidePanelOrder).toEqual({ explorer: 3 });
+    expect(merged.sidePanelVisibility).toEqual({ themes: true });
+    expect(merged.leftPanelCollapsed).toBe(false);
+    expect(merged.rightPanelCollapsed).toBe(true);
+
+    // These three merge in from the live panel snapshot.
+    expect(merged.extensionState).toEqual({
+      "silo.explorer": { expanded: ["/a"] },
+    });
+    expect(merged.sidePanelScrollPositions).toEqual({ explorer: 12 });
+    expect(merged.activeSidePanelTabs).toEqual({ left: "explorer" });
+  });
+
+  it("omits activeSidePanelTabs from the merge when it's global too", () => {
+    const ws = makeWorkspace("a", {
+      activeSidePanelTabs: { left: "search" },
+    });
+    const merged = withActiveNonGlobalPanelState(ws, PANEL, true);
+    expect(merged.activeSidePanelTabs).toEqual({ left: "search" }); // ws's own, untouched
+  });
+});
+
 describe("diffWorkspaceWrites", () => {
   it("flags new and changed ids to write, removed ids to delete, leaves unchanged", () => {
     const prev = new Map([
@@ -251,6 +287,10 @@ describe("buildIndex", () => {
     expect(index.uiFontSize).toBeUndefined();
     expect(index.smallScreenModeEnabled).toBeUndefined();
     expect(index.smallScreenThresholdPx).toBeUndefined();
+    expect(index.globalPanelLayoutEnabled).toBeUndefined();
+    expect(index.globalActiveTabEnabled).toBeUndefined();
+    expect(index.globalPanelLayout).toBeUndefined();
+    expect(index.globalActiveSidePanelTabs).toBeUndefined();
   });
 
   it("round-trips small-screen-mode settings when provided", () => {
@@ -266,6 +306,34 @@ describe("buildIndex", () => {
     expect(index.smallScreenThresholdPx).toBe(1600);
     expect(index.smallScreenPeekWidthLeftPx).toBe(320);
     expect(index.smallScreenPeekWidthRightPx).toBe(260);
+  });
+
+  it("round-trips global panel layout settings when provided, copying the layout container", () => {
+    const globalPanelLayout = {
+      sidePanelLocations: { explorer: "left" as const },
+      sidePanelOrder: { explorer: 0 },
+      sidePanelVisibility: { themes: false },
+      leftPanelCollapsed: true,
+      rightPanelCollapsed: false,
+    };
+    const index = buildIndex({
+      workspaceOrder: [],
+      activeWorkspaceId: null,
+      globalPanelLayoutEnabled: true,
+      globalActiveTabEnabled: true,
+      globalPanelLayout,
+      globalActiveSidePanelTabs: { left: "explorer" },
+    });
+    expect(index.globalPanelLayoutEnabled).toBe(true);
+    expect(index.globalActiveTabEnabled).toBe(true);
+    expect(index.globalPanelLayout).toEqual(globalPanelLayout);
+    expect(index.globalPanelLayout).not.toBe(globalPanelLayout);
+    expect(index.globalActiveSidePanelTabs).toEqual({ left: "explorer" });
+
+    globalPanelLayout.sidePanelVisibility.themes = true;
+    expect(index.globalPanelLayout!.sidePanelVisibility).toEqual({
+      themes: false,
+    });
   });
 
   it("round-trips group fields when provided", () => {

--- a/packages/extension-host/src/state/persistence-model.ts
+++ b/packages/extension-host/src/state/persistence-model.ts
@@ -10,6 +10,7 @@
 
 import type {
   EditorSettings,
+  GlobalPanelLayout,
   PanelStateSnapshot,
   SidePanelSlot,
   TerminalSettings,
@@ -52,6 +53,13 @@ export interface PersistedIndex {
   // top-level list (ungrouped workspace ids + group ids).
   groups?: Record<string, WorkspaceGroup>;
   panelOrder?: string[];
+  // "Global Side Panel Layout" (ADR 0035) — global (not per-workspace), so it
+  // lives in the index like `smallScreenModeEnabled`. Absent in older
+  // indexes: defaults (both off, empty layout) applied at hydrate.
+  globalPanelLayoutEnabled?: boolean;
+  globalActiveTabEnabled?: boolean;
+  globalPanelLayout?: GlobalPanelLayout;
+  globalActiveSidePanelTabs?: Record<string, string>;
 }
 
 /** The legacy monolithic blob (one `"state"` key in the app-data store) we
@@ -169,6 +177,32 @@ export function buildIndex(snapshot: PersistedIndex): PersistedIndex {
       : undefined,
     groups: snapshot.groups ? cloneGroups(snapshot.groups) : undefined,
     panelOrder: snapshot.panelOrder ? [...snapshot.panelOrder] : undefined,
+    globalPanelLayoutEnabled: snapshot.globalPanelLayoutEnabled,
+    globalActiveTabEnabled: snapshot.globalActiveTabEnabled,
+    globalPanelLayout: snapshot.globalPanelLayout
+      ? cloneGlobalPanelLayout(snapshot.globalPanelLayout)
+      : undefined,
+    globalActiveSidePanelTabs: snapshot.globalActiveSidePanelTabs
+      ? { ...snapshot.globalActiveSidePanelTabs }
+      : undefined,
+  };
+}
+
+/** Deep-clone a {@link GlobalPanelLayout} record so a stored snapshot can't
+ * alias (and later mutate via) the live store. Exported: also used by
+ * `persistence.ts` to hydrate `store.globalPanelLayout` from the index. */
+export function cloneGlobalPanelLayout(
+  g: GlobalPanelLayout,
+): GlobalPanelLayout {
+  return {
+    sidePanelLocations: { ...g.sidePanelLocations },
+    sidePanelOrder: { ...g.sidePanelOrder },
+    sidePanelVisibility: { ...g.sidePanelVisibility },
+    leftPanelCollapsed: g.leftPanelCollapsed,
+    rightPanelCollapsed: g.rightPanelCollapsed,
+    ...(g.smallScreenCollapsed
+      ? { smallScreenCollapsed: { ...g.smallScreenCollapsed } }
+      : {}),
   };
 }
 
@@ -228,6 +262,30 @@ export function withActivePanelState(
   // copies (`capturePanelState` clones them off the live store), so the result
   // can't alias state anyone still mutates.
   return { ...ws, ...panel };
+}
+
+/**
+ * Like {@link withActivePanelState}, but for when "Global Side Panel Layout"
+ * (ADR 0035) is on: merges only the fields that stay per-workspace even
+ * then — `extensionState`, `sidePanelScrollPositions`, and
+ * `activeSidePanelTabs` (unless its own sub-flag is also global). The
+ * workspace's arrangement fields (locations/order/visibility/collapse) are
+ * left exactly as they are on disk — the frozen snapshot from before the
+ * flag was enabled — since `store.globalPanelLayout` governs them instead.
+ */
+export function withActiveNonGlobalPanelState(
+  ws: WorkspaceInternal,
+  panel: PanelState,
+  activeTabIsGlobal: boolean,
+): WorkspaceInternal {
+  return {
+    ...ws,
+    extensionState: panel.extensionState,
+    sidePanelScrollPositions: panel.sidePanelScrollPositions,
+    ...(activeTabIsGlobal
+      ? {}
+      : { activeSidePanelTabs: panel.activeSidePanelTabs }),
+  };
 }
 
 /**

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -8,21 +8,28 @@ import {
   DEFAULT_TERMINAL_SETTINGS,
   DEFAULT_SMALL_SCREEN_THRESHOLD_PX,
   DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
+  DEFAULT_GLOBAL_PANEL_LAYOUT,
 } from "./types";
 import type { WorkspaceInternal } from "./types";
 import { migratePanelIds } from "./panel-id-migration";
 import { loadPanelStateFromWorkspace } from "./workspaces";
-import { capturePanelState } from "./panel-state";
+import {
+  capturePanelState,
+  captureGlobalPanelLayout,
+  applyGlobalPanelLayout,
+} from "./panel-state";
 import { setBackupDir, sweepEditorBackups } from "./editor-backups";
 import {
   buildIndex,
   cloneExtensionState,
   cloneAgentState,
+  cloneGlobalPanelLayout,
   diffWorkspaceWrites,
   reconcilePanelOrder,
   reconcileWorkspaceListing,
   splitPersistedState,
   withActivePanelState,
+  withActiveNonGlobalPanelState,
   type LegacyPersisted,
   type PersistedIndex,
 } from "./persistence-model";
@@ -151,6 +158,14 @@ export async function hydrate(configDir: string): Promise<void> {
     store.agentState = index.agentState
       ? cloneAgentState(index.agentState)
       : {};
+    store.globalPanelLayoutEnabled = index.globalPanelLayoutEnabled ?? false;
+    store.globalActiveTabEnabled = index.globalActiveTabEnabled ?? false;
+    store.globalPanelLayout = index.globalPanelLayout
+      ? cloneGlobalPanelLayout(index.globalPanelLayout)
+      : structuredClone(DEFAULT_GLOBAL_PANEL_LAYOUT);
+    store.globalActiveSidePanelTabs = index.globalActiveSidePanelTabs
+      ? { ...index.globalActiveSidePanelTabs }
+      : {};
   }
 
   // One file per workspace. Invalid files are skipped (like the theme loader),
@@ -225,6 +240,15 @@ export async function hydrate(configDir: string): Promise<void> {
   // Side-panel visibility is per-workspace, restored from the active workspace
   // by loadPanelStateFromWorkspace above (defaults to all-visible when absent).
 
+  // Global Side Panel Layout (ADR 0035): loadPanelStateFromWorkspace above
+  // deliberately leaves arrangement fields alone when the flag is on (an
+  // ordinary switch mustn't clobber a live edit against a stale snapshot —
+  // see its doc comment), so seed them once here, at startup, from the
+  // record just read out of the index.
+  if (store.globalPanelLayoutEnabled) {
+    applyGlobalPanelLayout(store.globalPanelLayout);
+  }
+
   store.hydrated = true;
   subscribe(store, schedulePersist);
 }
@@ -239,7 +263,19 @@ async function doPersist(): Promise<void> {
   const records = new Map<string, WorkspaceInternal>();
   const next = new Map<string, string>();
   for (const [id, ws] of Object.entries(store.workspaces)) {
-    const rec = id === activeId ? withActivePanelState(ws, panel) : { ...ws };
+    // While the global panel layout is on, the active workspace's own
+    // arrangement fields must stay exactly as they are on disk (frozen) —
+    // only merge in the fields that stay per-workspace regardless.
+    const rec =
+      id === activeId
+        ? store.globalPanelLayoutEnabled
+          ? withActiveNonGlobalPanelState(
+              ws,
+              panel,
+              store.globalActiveTabEnabled,
+            )
+          : withActivePanelState(ws, panel)
+        : { ...ws };
     records.set(id, rec);
     next.set(id, JSON.stringify(rec));
   }
@@ -288,6 +324,17 @@ async function doPersist(): Promise<void> {
       agentState: store.agentState,
       groups: store.groups,
       panelOrder: [...store.panelOrder],
+      globalPanelLayoutEnabled: store.globalPanelLayoutEnabled,
+      globalActiveTabEnabled: store.globalActiveTabEnabled,
+      // While the flag is on, live state is the source of truth; while off,
+      // `store.globalPanelLayout`/`globalActiveSidePanelTabs` already hold
+      // the frozen value from when it was last turned off.
+      globalPanelLayout: store.globalPanelLayoutEnabled
+        ? captureGlobalPanelLayout()
+        : store.globalPanelLayout,
+      globalActiveSidePanelTabs: store.globalActiveTabEnabled
+        ? { ...store.activeSidePanelTabs }
+        : store.globalActiveSidePanelTabs,
     }),
   );
   await indexStore.save();

--- a/packages/extension-host/src/state/store.ts
+++ b/packages/extension-host/src/state/store.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
   MIN_SMALL_SCREEN_PEEK_WIDTH_PX,
   MAX_SMALL_SCREEN_PEEK_WIDTH_PX,
+  DEFAULT_GLOBAL_PANEL_LAYOUT,
 } from "./types";
 import type { SideLocation } from "@silo-code/sdk";
 
@@ -43,6 +44,10 @@ export const store = proxy<AppState>({
   rightPanelPeekDragging: false,
   smallScreenPeekWidthLeftPx: DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
   smallScreenPeekWidthRightPx: DEFAULT_SMALL_SCREEN_PEEK_WIDTH_PX,
+  globalPanelLayoutEnabled: false,
+  globalActiveTabEnabled: false,
+  globalPanelLayout: structuredClone(DEFAULT_GLOBAL_PANEL_LAYOUT),
+  globalActiveSidePanelTabs: {},
   groups: {},
   panelOrder: [],
 });

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -124,6 +124,35 @@ export interface PanelStateSnapshot extends SharedPanelState {
   smallScreenCollapsed?: SideCollapseState;
 }
 
+/**
+ * The shared "Global Side Panel Layout" record — the same arrangement fields
+ * a workspace normally owns for itself (`PanelStateSnapshot`), minus the
+ * fields that stay per-workspace even when the flag is on:
+ * `activeSidePanelTabs` (has its own dependent opt-in, see
+ * `globalActiveTabEnabled`), `sidePanelScrollPositions`, and `extensionState`
+ * (a panel's own instance data, not its arrangement). Applies to both layout
+ * modes, mirroring `PanelStateSnapshot`'s own normal/small-screen split — see
+ * ADR 0035.
+ */
+export interface GlobalPanelLayout {
+  sidePanelLocations: Record<string, SidePanelSlot>;
+  sidePanelOrder: Record<string, number>;
+  sidePanelVisibility: Record<string, boolean>;
+  leftPanelCollapsed: boolean;
+  rightPanelCollapsed: boolean;
+  smallScreenCollapsed?: SideCollapseState;
+}
+
+/** What {@link GlobalPanelLayout} starts as before the flag has ever been
+ * enabled. */
+export const DEFAULT_GLOBAL_PANEL_LAYOUT: GlobalPanelLayout = {
+  sidePanelLocations: {},
+  sidePanelOrder: {},
+  sidePanelVisibility: {},
+  leftPanelCollapsed: false,
+  rightPanelCollapsed: false,
+};
+
 // ── Host-only state types (not part of the public surface) ──
 
 /**
@@ -270,6 +299,32 @@ export interface AppState extends SharedPanelState {
    */
   smallScreenPeekWidthLeftPx: number;
   smallScreenPeekWidthRightPx: number;
+  /**
+   * "Global Side Panel Layout" (ADR 0035): opt-in, off by default. When true,
+   * side-panel arrangement (`sidePanelLocations`/`sidePanelOrder`/
+   * `sidePanelVisibility`/collapse, for both layout modes) is shared across
+   * every workspace instead of per-workspace — the live fields above read
+   * from and write to {@link globalPanelLayout} rather than being
+   * captured/applied per workspace. Each workspace's own arrangement is
+   * frozen (untouched) while this is on, and restored exactly when it's
+   * turned back off. See `setGlobalPanelLayoutEnabled` in `workspaces.ts`.
+   */
+  globalPanelLayoutEnabled: boolean;
+  /**
+   * Dependent sub-setting of {@link globalPanelLayoutEnabled}: also share
+   * `activeSidePanelTabs` globally (via {@link globalActiveSidePanelTabs}).
+   * Meaningless while the main flag is off — the settings page disables its
+   * control in that state — but its own stored value survives the main flag
+   * being toggled off, so re-enabling brings it back as the user left it.
+   * Off by default.
+   */
+  globalActiveTabEnabled: boolean;
+  /** The shared arrangement itself, live while {@link globalPanelLayoutEnabled}
+   * is on. Frozen (last known value) while it's off. */
+  globalPanelLayout: GlobalPanelLayout;
+  /** The shared active-tab-per-slot map, live while
+   * {@link globalActiveTabEnabled} is on. */
+  globalActiveSidePanelTabs: Record<string, string>;
   /**
    * Named collapsible groups in the Workspaces panel, keyed by group id. A
    * group's `workspaceOrder` is the single source of truth for membership — a

--- a/packages/extension-host/src/state/workspaces.test.ts
+++ b/packages/extension-host/src/state/workspaces.test.ts
@@ -18,8 +18,13 @@ import {
   getEditorSettingOverride,
   addExtraFolder,
   removeExtraFolder,
+  setGlobalPanelLayoutEnabled,
+  setGlobalActiveTabEnabled,
+  hasSavedGlobalPanelLayout,
+  enableGlobalPanelLayout,
 } from "./workspaces";
 import { clearEditorBackup } from "./editor-backups";
+import { DEFAULT_GLOBAL_PANEL_LAYOUT } from "./types";
 
 function makeWorkspace(id: string): WorkspaceInternal {
   return {
@@ -234,6 +239,173 @@ describe("extra folders", () => {
   it("no-ops for an unknown workspace", () => {
     expect(() => addExtraFolder("nope", "/x")).not.toThrow();
     expect(() => removeExtraFolder("nope", "/x")).not.toThrow();
+  });
+});
+
+describe("global side panel layout (ADR 0035)", () => {
+  beforeEach(() => {
+    store.sidePanelLocations = {};
+    store.sidePanelVisibility = {};
+    store.activeSidePanelTabs = {};
+    store.leftPanelCollapsed = false;
+    store.rightPanelCollapsed = false;
+    store.globalPanelLayoutEnabled = false;
+    store.globalActiveTabEnabled = false;
+    store.globalPanelLayout = structuredClone(DEFAULT_GLOBAL_PANEL_LAYOUT);
+    store.globalActiveSidePanelTabs = {};
+  });
+
+  it("enabling seeds the global layout from what's currently live", () => {
+    store.sidePanelLocations = { explorer: "left" };
+    store.sidePanelVisibility = { themes: false };
+    store.leftPanelCollapsed = true;
+
+    setGlobalPanelLayoutEnabled(true);
+
+    expect(store.globalPanelLayout.sidePanelLocations).toEqual({
+      explorer: "left",
+    });
+    expect(store.globalPanelLayout.sidePanelVisibility).toEqual({
+      themes: false,
+    });
+    expect(store.globalPanelLayout.leftPanelCollapsed).toBe(true);
+  });
+
+  it("disabling restores the active workspace's own frozen arrangement, unaffected by edits made while global was on", () => {
+    store.sidePanelLocations = { explorer: "left" };
+    savePanelStateToWorkspace("w"); // freeze w's arrangement before enabling
+
+    setGlobalPanelLayoutEnabled(true);
+    store.sidePanelLocations = { explorer: "right" }; // live edit while shared
+
+    setGlobalPanelLayoutEnabled(false);
+    expect(store.sidePanelLocations).toEqual({ explorer: "left" });
+    expect(store.workspaces.w.sidePanelLocations).toEqual({
+      explorer: "left",
+    });
+  });
+
+  it("disabling seeds a workspace created while the flag was on from the global record", () => {
+    setGlobalPanelLayoutEnabled(true);
+    store.sidePanelLocations = { explorer: "right" };
+
+    // A workspace created while global mode is on has no arrangement yet.
+    store.workspaces.w2 = makeWorkspace("w2");
+    store.workspaceOrder.push("w2");
+    expect(store.workspaces.w2.sidePanelLocations).toBeUndefined();
+
+    setGlobalPanelLayoutEnabled(false);
+
+    expect(store.workspaces.w2.sidePanelLocations).toEqual({
+      explorer: "right",
+    });
+  });
+
+  it("shares live arrangement edits across every workspace while enabled", () => {
+    store.workspaces = { w: makeWorkspace("w"), w2: makeWorkspace("w2") };
+    store.workspaceOrder = ["w", "w2"];
+    store.activeWorkspaceId = "w";
+    store.workspaces.w.sidePanelLocations = { explorer: "left" };
+    store.workspaces.w2.sidePanelLocations = { explorer: "right" };
+
+    setGlobalPanelLayoutEnabled(true);
+    store.sidePanelLocations = { explorer: "right" }; // a live edit
+
+    activateWorkspace("w2");
+    // w2 shows the shared edit, not its own (now-frozen, unused) arrangement.
+    expect(store.sidePanelLocations).toEqual({ explorer: "right" });
+  });
+
+  it("the active-tab sub-setting only takes effect while the main flag is on, and keeps its stored value when the main flag is disabled", () => {
+    store.activeSidePanelTabs = { left: "explorer" };
+    setGlobalPanelLayoutEnabled(true);
+    setGlobalActiveTabEnabled(true);
+    expect(store.globalActiveSidePanelTabs).toEqual({ left: "explorer" });
+
+    setGlobalPanelLayoutEnabled(false);
+    expect(store.globalActiveTabEnabled).toBe(true); // preserved, just inert
+
+    setGlobalPanelLayoutEnabled(true);
+    expect(store.globalActiveTabEnabled).toBe(true); // re-takes effect, no re-opt-in
+  });
+
+  it("shares activeSidePanelTabs across workspaces only when its sub-setting is also on", () => {
+    store.workspaces = { w: makeWorkspace("w"), w2: makeWorkspace("w2") };
+    store.workspaceOrder = ["w", "w2"];
+    store.activeWorkspaceId = "w";
+    store.workspaces.w.activeSidePanelTabs = { left: "explorer" };
+    store.workspaces.w2.activeSidePanelTabs = { left: "search" };
+
+    setGlobalPanelLayoutEnabled(true);
+    // Not shared yet — each workspace keeps its own active tab.
+    loadPanelStateFromWorkspace(store.workspaces.w);
+    expect(store.activeSidePanelTabs).toEqual({ left: "explorer" });
+    loadPanelStateFromWorkspace(store.workspaces.w2);
+    expect(store.activeSidePanelTabs).toEqual({ left: "search" });
+
+    setGlobalActiveTabEnabled(true); // seeds from what's currently live (w2's)
+    loadPanelStateFromWorkspace(store.workspaces.w);
+    expect(store.activeSidePanelTabs).toEqual({ left: "search" });
+  });
+
+  describe("hasSavedGlobalPanelLayout", () => {
+    it("is false for a fresh/default record", () => {
+      expect(hasSavedGlobalPanelLayout()).toBe(false);
+    });
+
+    it("is true once a previous enable/disable cycle has left something behind", () => {
+      store.sidePanelLocations = { explorer: "left" };
+      setGlobalPanelLayoutEnabled(true);
+      setGlobalPanelLayoutEnabled(false);
+      expect(hasSavedGlobalPanelLayout()).toBe(true);
+    });
+  });
+
+  describe("enableGlobalPanelLayout", () => {
+    it('"current" captures fresh from live, discarding any previously-saved layout', () => {
+      store.sidePanelLocations = { explorer: "left" };
+      setGlobalPanelLayoutEnabled(true);
+      setGlobalPanelLayoutEnabled(false); // saves { explorer: "left" } as the shared record
+
+      store.sidePanelLocations = { explorer: "right" }; // a different arrangement now
+      enableGlobalPanelLayout("current");
+      expect(store.globalPanelLayout.sidePanelLocations).toEqual({
+        explorer: "right",
+      });
+      expect(store.sidePanelLocations).toEqual({ explorer: "right" });
+    });
+
+    it('"previous" applies the saved record to live without re-capturing it', () => {
+      store.sidePanelLocations = { explorer: "left" };
+      setGlobalPanelLayoutEnabled(true);
+      setGlobalPanelLayoutEnabled(false); // saves { explorer: "left" }
+
+      store.sidePanelLocations = { explorer: "right" }; // live has since changed
+      enableGlobalPanelLayout("previous");
+      expect(store.sidePanelLocations).toEqual({ explorer: "left" });
+      expect(store.globalPanelLayout.sidePanelLocations).toEqual({
+        explorer: "left",
+      });
+    });
+
+    it('"previous" also restores the saved active-tab map when the sub-setting is on', () => {
+      store.sidePanelLocations = { explorer: "left" };
+      store.activeSidePanelTabs = { left: "explorer" };
+      setGlobalActiveTabEnabled(true);
+      setGlobalPanelLayoutEnabled(true);
+      setGlobalPanelLayoutEnabled(false); // saves globalActiveSidePanelTabs too
+
+      store.activeSidePanelTabs = { left: "search" }; // live has since changed
+      enableGlobalPanelLayout("previous");
+      expect(store.activeSidePanelTabs).toEqual({ left: "explorer" });
+    });
+
+    it("is a no-op if already enabled", () => {
+      setGlobalPanelLayoutEnabled(true);
+      store.sidePanelLocations = { explorer: "left" };
+      enableGlobalPanelLayout("current"); // should not re-seed while already on
+      expect(store.globalPanelLayout.sidePanelLocations).toEqual({});
+    });
   });
 });
 

--- a/packages/extension-host/src/state/workspaces.ts
+++ b/packages/extension-host/src/state/workspaces.ts
@@ -3,7 +3,13 @@ import { basename } from "@tauri-apps/api/path";
 import { path } from "@silo-code/sdk";
 import { store } from "./store";
 import { clearEditorBackup } from "./editor-backups";
-import { applyPanelState, capturePanelState } from "./panel-state";
+import {
+  applyPanelState,
+  capturePanelState,
+  applyGlobalPanelLayout,
+  captureGlobalPanelLayout,
+  cloneExtensionState,
+} from "./panel-state";
 import type {
   EditorRecord,
   EditorSettingsOverride,
@@ -57,16 +63,158 @@ export function createWorkspace(input: {
   return ws;
 }
 
-/** Copy the global panel state into a workspace object. */
+/**
+ * Copy the live panel state into a workspace object. When "Global Side Panel
+ * Layout" (ADR 0035) is on, the workspace's own arrangement fields
+ * (locations/order/visibility/collapse) are left untouched — frozen — since
+ * they're governed by `store.globalPanelLayout` instead; only the fields that
+ * stay per-workspace regardless (`extensionState`, `sidePanelScrollPositions`,
+ * and `activeSidePanelTabs` unless its own sub-flag is also on) get captured.
+ */
 export function savePanelStateToWorkspace(wsId: string): void {
   const ws = store.workspaces[wsId];
   if (!ws) return;
-  Object.assign(ws, capturePanelState());
+  if (store.globalPanelLayoutEnabled) {
+    const full = capturePanelState();
+    ws.extensionState = full.extensionState;
+    ws.sidePanelScrollPositions = full.sidePanelScrollPositions;
+    if (!store.globalActiveTabEnabled) {
+      ws.activeSidePanelTabs = full.activeSidePanelTabs;
+    }
+  } else {
+    Object.assign(ws, capturePanelState());
+  }
 }
 
-/** Restore the global panel state from a workspace object. */
+/**
+ * Restore the live panel state from a workspace object — the reverse of
+ * {@link savePanelStateToWorkspace}. When the global flag is on, the
+ * arrangement fields are left untouched: they already show the current
+ * shared layout, and nothing workspace-specific should reset them on an
+ * ordinary switch (`store.globalPanelLayout` itself is only synced from live
+ * state at hydrate, disable, and persist time — applying it here on every
+ * switch would clobber a live edit made since the last sync). Only the
+ * fields that stay per-workspace regardless get restored from `ws`.
+ */
 export function loadPanelStateFromWorkspace(ws: WorkspaceInternal): void {
-  applyPanelState(ws);
+  if (store.globalPanelLayoutEnabled) {
+    store.extensionState = cloneExtensionState(ws.extensionState ?? {});
+    store.sidePanelScrollPositions = { ...(ws.sidePanelScrollPositions ?? {}) };
+    store.activeSidePanelTabs = store.globalActiveTabEnabled
+      ? { ...store.globalActiveSidePanelTabs }
+      : { ...(ws.activeSidePanelTabs ?? {}) };
+  } else {
+    applyPanelState(ws);
+  }
+}
+
+/**
+ * Whether there's a previously-saved shared layout worth asking the user
+ * about before overwriting it (ADR 0035). "Saved" means the flag has been
+ * enabled at least once before and left something behind in
+ * `store.globalPanelLayout` — an empty/default record (never used, or a
+ * fresh install) isn't worth warning about.
+ */
+export function hasSavedGlobalPanelLayout(): boolean {
+  const g = store.globalPanelLayout;
+  return (
+    Object.keys(g.sidePanelLocations).length > 0 ||
+    Object.keys(g.sidePanelOrder).length > 0 ||
+    Object.keys(g.sidePanelVisibility).length > 0 ||
+    g.leftPanelCollapsed ||
+    g.rightPanelCollapsed ||
+    !!g.smallScreenCollapsed
+  );
+}
+
+/**
+ * Turn "Global Side Panel Layout" on, choosing how to seed the shared
+ * record: `"current"` captures it fresh from what's currently live (the
+ * active workspace's arrangement, discarding any previously-saved shared
+ * layout); `"previous"` instead re-applies whatever was last frozen in
+ * `store.globalPanelLayout` (from an earlier enable/disable cycle) to live
+ * state, leaving the saved record itself untouched. The settings page
+ * confirms this choice with the user first — see
+ * `hasSavedGlobalPanelLayout`/`confirmEnableGlobalPanelLayout`. No-op if
+ * already on.
+ */
+export function enableGlobalPanelLayout(mode: "current" | "previous"): void {
+  if (store.globalPanelLayoutEnabled) return;
+  if (mode === "current") {
+    store.globalPanelLayout = captureGlobalPanelLayout();
+    if (store.globalActiveTabEnabled) {
+      store.globalActiveSidePanelTabs = { ...store.activeSidePanelTabs };
+    }
+  } else {
+    applyGlobalPanelLayout(store.globalPanelLayout);
+    if (store.globalActiveTabEnabled) {
+      store.activeSidePanelTabs = { ...store.globalActiveSidePanelTabs };
+    }
+  }
+  store.globalPanelLayoutEnabled = true;
+}
+
+/**
+ * Turn "Global Side Panel Layout" on or off (ADR 0035). Enabling always
+ * seeds from what's currently live — equivalent to
+ * `enableGlobalPanelLayout("current")` — for callers that don't need the
+ * "reuse the previous saved layout" choice (e.g. tests, programmatic use).
+ * The settings page instead calls `enableGlobalPanelLayout` directly once
+ * the user has picked "current" or "previous" from the confirmation dialog.
+ * Disabling freezes the final shared value, seeds any workspace created
+ * while the flag was on (never captured, so it has no arrangement of its
+ * own) from it, then restores the active workspace's own arrangement as
+ * live.
+ */
+export function setGlobalPanelLayoutEnabled(enabled: boolean): void {
+  if (enabled === store.globalPanelLayoutEnabled) return;
+  if (enabled) {
+    enableGlobalPanelLayout("current");
+    return;
+  }
+  const activeId = store.activeWorkspaceId;
+  // Fresh-capture the active workspace's non-global fields before flipping
+  // the flag, so no live edit made since its last switch is lost.
+  if (activeId) savePanelStateToWorkspace(activeId);
+  store.globalPanelLayout = captureGlobalPanelLayout();
+  for (const ws of Object.values(store.workspaces)) {
+    if (ws.sidePanelLocations === undefined) {
+      // Created while the flag was on — give it the shared arrangement as
+      // its own starting point rather than snapping to bare defaults.
+      Object.assign(ws, {
+        sidePanelLocations: { ...store.globalPanelLayout.sidePanelLocations },
+        sidePanelOrder: { ...store.globalPanelLayout.sidePanelOrder },
+        sidePanelVisibility: { ...store.globalPanelLayout.sidePanelVisibility },
+        leftPanelCollapsed: store.globalPanelLayout.leftPanelCollapsed,
+        rightPanelCollapsed: store.globalPanelLayout.rightPanelCollapsed,
+        ...(store.globalPanelLayout.smallScreenCollapsed
+          ? {
+              smallScreenCollapsed: {
+                ...store.globalPanelLayout.smallScreenCollapsed,
+              },
+            }
+          : {}),
+      });
+    }
+  }
+  store.globalPanelLayoutEnabled = false;
+  const activeWs = activeId ? store.workspaces[activeId] : null;
+  if (activeWs) applyPanelState(activeWs);
+}
+
+/**
+ * Turn the "also share the active tab" sub-setting on or off — dependent on
+ * {@link setGlobalPanelLayoutEnabled}, meaningless while the main flag is
+ * off. Enabling seeds the shared record from what's currently live; on
+ * disable there's nothing to freeze or seed, since `activeSidePanelTabs`
+ * simply resumes being captured/applied per-workspace like it always was.
+ */
+export function setGlobalActiveTabEnabled(enabled: boolean): void {
+  if (enabled === store.globalActiveTabEnabled) return;
+  if (enabled) {
+    store.globalActiveSidePanelTabs = { ...store.activeSidePanelTabs };
+  }
+  store.globalActiveTabEnabled = enabled;
 }
 
 export function activateWorkspace(id: string): void {

--- a/packages/extensions-core/src/keybindings/KeybindingsPage.css
+++ b/packages/extensions-core/src/keybindings/KeybindingsPage.css
@@ -1,37 +1,8 @@
-.kb-page {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  gap: 12px;
-}
-
-.kb-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: var(--settings-header-height);
-}
-.kb-header h2 {
-  margin: 0;
-  font-size: 1.1em;
-  color: var(--silo-color-text-hi);
-}
-
-/* SearchInput (SDK) spans the page width. */
-.kb-page > .silo-search-input {
-  width: 100%;
-}
-
-.kb-list {
-  flex: 1 1 auto;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  /* Space between groups; the gap itself separates each Section from the one
-     before it, so no group needs its own top margin. */
-  gap: 20px;
-}
+/* Page chrome (header, search width, scroll/group gap) is the shared
+   `.es-page`/`.es-header`/`.es-scroll` from SettingsDialog.css — this page
+   used to carry its own duplicate copy (`.kb-page`/`.kb-header`/`.kb-list`),
+   which is why its spacing drifted out of sync with every other settings
+   page. Only what's genuinely bespoke to a keybinding row lives here. */
 
 .kb-row {
   display: flex;

--- a/packages/extensions-core/src/keybindings/index.tsx
+++ b/packages/extensions-core/src/keybindings/index.tsx
@@ -253,8 +253,8 @@ function makePage(ctx: ExtensionContext) {
     const sortedGroups = groupCommands(rows, menuFor);
 
     return (
-      <div className="kb-page">
-        <div className="kb-header">
+      <div className="es-page">
+        <div className="es-header">
           <h2>Keyboard Shortcuts</h2>
           <Tooltip content="More options">
             <IconButton
@@ -271,7 +271,7 @@ function makePage(ctx: ExtensionContext) {
           placeholder="Search commands or keys…"
           autoFocus
         />
-        <div className="kb-list silo-scroll">
+        <div className="es-scroll silo-scroll">
           {sortedGroups.map(([group, cmds]) => (
             <Section key={group} label={group}>
               {cmds.map((c) => {

--- a/packages/extensions-core/src/layout/GlobalPanelLayoutConfirm.tsx
+++ b/packages/extensions-core/src/layout/GlobalPanelLayoutConfirm.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { Button, ModalActions } from "@silo-code/sdk";
+import type { UiService } from "@silo-code/sdk";
+
+// Confirmation for turning "Global Side Panel Layout" on (ADR 0035), via
+// `ctx.ui.showModal` — plain `ctx.ui.confirm` has no room for the optional
+// checkbox. Enabling always overrides every workspace's layout with the
+// active workspace's current one *unless* a previously-saved shared layout
+// exists and the user checks the box to restore that instead. Cancel backs
+// out without changing anything, e.g. to switch to a different workspace
+// first.
+
+export type GlobalPanelLayoutChoice = "current" | "previous" | "cancel";
+
+function GlobalPanelLayoutConfirmContent({
+  hasSaved,
+  close,
+}: {
+  hasSaved: boolean;
+  close: (result?: GlobalPanelLayoutChoice) => void;
+}) {
+  const [restorePrevious, setRestorePrevious] = useState(false);
+
+  return (
+    <>
+      <div className="silo-modal-body">
+        This overrides every workspace&apos;s side panel layout with the active
+        workspace&apos;s layout.
+      </div>
+      {hasSaved && (
+        <label className="silo-modal-checkbox-row">
+          <input
+            type="checkbox"
+            checked={restorePrevious}
+            onChange={(e) => setRestorePrevious(e.target.checked)}
+          />
+          Restore my previous shared layout instead
+        </label>
+      )}
+      <ModalActions>
+        <Button type="button" onClick={() => close("cancel")}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          onClick={() => close(restorePrevious ? "previous" : "current")}
+          autoFocus
+        >
+          OK
+        </Button>
+      </ModalActions>
+    </>
+  );
+}
+
+/**
+ * Show the confirmation and resolve to the user's choice. Dismissing
+ * (Escape/backdrop) resolves to `"cancel"`, same as clicking Cancel.
+ */
+export async function confirmEnableGlobalPanelLayout(
+  ui: UiService,
+  hasSaved: boolean,
+): Promise<GlobalPanelLayoutChoice> {
+  const result = await ui.showModal<GlobalPanelLayoutChoice>(
+    (close) => (
+      <GlobalPanelLayoutConfirmContent hasSaved={hasSaved} close={close} />
+    ),
+    {
+      title: "Share Side Panel Layout",
+      size: "sm",
+      ariaLabel: "Share Side Panel Layout",
+      dismissible: true,
+    },
+  );
+  return result ?? "cancel";
+}

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
@@ -1,80 +1,148 @@
 import { useEffect, useState } from "react";
 import { useSnapshot } from "valtio";
-import { Button, Input, Section, SettingRow, Switch } from "@silo-code/sdk";
+import { Crosshair } from "@phosphor-icons/react";
+import type { ExtensionContext } from "@silo-code/sdk";
+import {
+  CheckboxRow,
+  IconButton,
+  Input,
+  Section,
+  SettingRow,
+  Switch,
+  Tooltip,
+} from "@silo-code/sdk";
 import {
   store,
   setSmallScreenModeEnabled,
   setSmallScreenThresholdPx,
   MIN_SMALL_SCREEN_THRESHOLD_PX,
+  setGlobalPanelLayoutEnabled,
+  setGlobalActiveTabEnabled,
+  hasSavedGlobalPanelLayout,
+  enableGlobalPanelLayout,
 } from "@silo-code/extension-host/internal";
+import { confirmEnableGlobalPanelLayout } from "./GlobalPanelLayoutConfirm";
 
 // A module of the core.layout extension — small-screen mode's on/off switch
-// and width threshold. The auto-hide/auto-restore/peek behavior itself is
-// host-internal (extension-host/small-screen-mode.ts); this page only edits
-// the two preferences it reads.
-export function LayoutSettingsPage() {
-  const snap = useSnapshot(store);
-  const [thresholdInput, setThresholdInput] = useState(
-    String(snap.smallScreenThresholdPx),
-  );
+// and width threshold, plus Global Side Panel Layout's two settings. The
+// auto-hide/auto-restore behavior and the panel-state mechanics themselves
+// are host-internal (extension-host/small-screen-mode.ts,
+// state/workspaces.ts); this page only edits the preferences they read.
+//
+// Factory (not a bare component) because enabling Global Side Panel Layout
+// needs `ctx.ui.showModal` to confirm what to do about a previously-saved
+// shared layout before committing — see `GlobalPanelLayoutConfirm.tsx`.
+export function makeLayoutSettingsPage(ctx: ExtensionContext) {
+  return function LayoutSettingsPage() {
+    const snap = useSnapshot(store);
+    const [thresholdInput, setThresholdInput] = useState(
+      String(snap.smallScreenThresholdPx),
+    );
 
-  // Keep the text field in sync when the stored value changes from elsewhere
-  // (the "use current width" button below, or a future second surface).
-  useEffect(() => {
-    setThresholdInput(String(snap.smallScreenThresholdPx));
-  }, [snap.smallScreenThresholdPx]);
-
-  function commitThreshold(raw: string): void {
-    const n = Number(raw);
-    if (Number.isFinite(n) && n >= MIN_SMALL_SCREEN_THRESHOLD_PX) {
-      setSmallScreenThresholdPx(n);
-    } else {
+    // Keep the text field in sync when the stored value changes from elsewhere
+    // (the capture-width icon button below, or a future second surface).
+    useEffect(() => {
       setThresholdInput(String(snap.smallScreenThresholdPx));
-    }
-  }
+    }, [snap.smallScreenThresholdPx]);
 
-  return (
-    <div className="es-page">
-      <div className="es-header">
-        <h2>Layout</h2>
-      </div>
-      <div className="es-scroll silo-scroll">
-        <Section label="Laptop Mode">
-          <SettingRow
-            label="Enable Laptop Mode"
-            hint="Give a narrow window its own layout: side panels hide when the window narrows past the threshold below, and each workspace remembers what you show, hide, and resize while it's narrow. Your full-size layout is untouched, and comes back with the wider window. (Hovering the window's edge peeks a collapsed panel at any size.)"
-          >
-            <Switch
-              checked={snap.smallScreenModeEnabled}
-              onChange={setSmallScreenModeEnabled}
-              aria-label="Enable Laptop Mode"
-            />
-          </SettingRow>
-          <SettingRow
-            label="Threshold width"
-            hint="Below this window width (in pixels), side panels auto-hide."
-          >
-            <Input
-              type="number"
-              min={MIN_SMALL_SCREEN_THRESHOLD_PX}
-              value={thresholdInput}
-              onChange={(e) => setThresholdInput(e.target.value)}
-              onBlur={(e) => commitThreshold(e.target.value)}
-            />
-          </SettingRow>
-          <SettingRow
-            label="Capture current width"
-            hint="Resize the Silo window to whatever you consider too small, then use this to set the threshold to that exact width."
-          >
-            <Button
-              size="sm"
-              onClick={() => setSmallScreenThresholdPx(window.innerWidth)}
+    function commitThreshold(raw: string): void {
+      const n = Number(raw);
+      if (Number.isFinite(n) && n >= MIN_SMALL_SCREEN_THRESHOLD_PX) {
+        setSmallScreenThresholdPx(n);
+      } else {
+        setThresholdInput(String(snap.smallScreenThresholdPx));
+      }
+    }
+
+    async function toggleGlobalPanelLayout(next: boolean): Promise<void> {
+      if (!next) {
+        setGlobalPanelLayoutEnabled(false);
+        return;
+      }
+      const choice = await confirmEnableGlobalPanelLayout(
+        ctx.ui,
+        hasSavedGlobalPanelLayout(),
+      );
+      if (choice === "cancel") return;
+      enableGlobalPanelLayout(choice);
+    }
+
+    return (
+      <div className="es-page">
+        <div className="es-header">
+          <h2>Layout</h2>
+        </div>
+        <div className="es-scroll silo-scroll">
+          <Section label="Side Panel Layout">
+            {/* Hand-rolled instead of <SettingRow> (whose `hint` is a plain
+                string) so the sub-setting checkbox can sit inside the same
+                row's text column, directly under the hint, rather than as
+                its own separate row below. */}
+            <div className="silo-setting-row">
+              <div className="silo-setting-row-text">
+                <div className="silo-setting-row-label">
+                  Share side panel layout across workspaces
+                </div>
+                <div className="silo-setting-row-hint">
+                  Enable this setting to use the same side panel layout
+                  (position, visibility, collapse) across workspaces.
+                </div>
+                <div style={{ marginTop: "8px", marginBottom: "12px" }}>
+                  <CheckboxRow
+                    label="Also maintain active tab"
+                    checked={snap.globalActiveTabEnabled}
+                    onChange={setGlobalActiveTabEnabled}
+                    disabled={!snap.globalPanelLayoutEnabled}
+                  />
+                </div>
+              </div>
+              <div className="silo-setting-row-control">
+                <Switch
+                  checked={snap.globalPanelLayoutEnabled}
+                  onChange={(next) => void toggleGlobalPanelLayout(next)}
+                  aria-label="Share side panel layout across workspaces"
+                />
+              </div>
+            </div>
+          </Section>
+          <Section label="Laptop Mode">
+            <SettingRow
+              label="Enable Laptop Mode"
+              hint="Enable this setting to automatically hide the side panels when using Silo on a laptop (determined by threshold below)."
             >
-              Use current window width
-            </Button>
-          </SettingRow>
-        </Section>
+              <Switch
+                checked={snap.smallScreenModeEnabled}
+                onChange={setSmallScreenModeEnabled}
+                aria-label="Enable Laptop Mode"
+              />
+            </SettingRow>
+            <SettingRow
+              label="Threshold width"
+              hint="Below this window width (in pixels), side panels auto-hide."
+            >
+              <div
+                style={{ display: "flex", alignItems: "center", gap: "6px" }}
+              >
+                <Input
+                  type="number"
+                  min={MIN_SMALL_SCREEN_THRESHOLD_PX}
+                  value={thresholdInput}
+                  onChange={(e) => setThresholdInput(e.target.value)}
+                  onBlur={(e) => commitThreshold(e.target.value)}
+                />
+                <Tooltip content="Capture current width">
+                  <IconButton
+                    aria-label="Capture current width"
+                    onClick={() => setSmallScreenThresholdPx(window.innerWidth)}
+                  >
+                    <Crosshair size={16} weight="bold" />
+                  </IconButton>
+                </Tooltip>
+              </div>
+            </SettingRow>
+          </Section>
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 }

--- a/packages/extensions-core/src/layout/index.tsx
+++ b/packages/extensions-core/src/layout/index.tsx
@@ -1,12 +1,13 @@
 import type { Extension } from "@silo-code/sdk";
-import { LayoutSettingsPage } from "./LayoutSettingsPage";
+import { makeLayoutSettingsPage } from "./LayoutSettingsPage";
 
 // `core.layout` — the "Layout" settings page (small-screen mode's on/off
-// switch + width threshold). The auto-hide/peek behavior itself is
-// host-internal (extension-host/small-screen-mode.ts, always wired into
-// AppShell); this extension only owns the user-facing settings surface, same
-// division as core.editor/core.terminal owning their settings pages over a
-// host-internal core.
+// switch + width threshold, plus Global Side Panel Layout). The auto-hide/
+// peek behavior and panel-state mechanics themselves are host-internal
+// (extension-host/small-screen-mode.ts, state/workspaces.ts, always wired
+// into AppShell); this extension only owns the user-facing settings surface,
+// same division as core.editor/core.terminal owning their settings pages
+// over a host-internal core.
 export const extension: Extension = {
   id: "core.layout",
   activate(ctx) {
@@ -16,7 +17,7 @@ export const extension: Extension = {
       group: "1_general",
       // After Keyboard Shortcuts (0), Editor (1), Terminal (2).
       order: 3,
-      component: LayoutSettingsPage,
+      component: makeLayoutSettingsPage(ctx),
     });
   },
 };


### PR DESCRIPTION
## Summary
- Adds an opt-in "Global Side Panel Layout" setting (Settings → Layout) that shares side-panel arrangement — position, visibility, and collapse state (including Laptop Mode's own layout) — across every workspace instead of per-workspace.
- Frozen dual-state model: each workspace's own arrangement stays untouched on disk while the flag is on, and comes back exactly as it was when turned back off — never destructive.
- A dependent sub-setting additionally shares which side-panel tab is active across workspaces.
- Enabling the flag confirms via a dialog when a previously-saved shared layout already exists, letting the user reuse it instead of silently overwriting it with the active workspace's current arrangement.
- New ADR 0035 records the design; ADR 0033 is updated since this supersedes its prior rejection of a global Laptop Mode layout.

## Test plan
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `pnpm test` (full suite, including new unit coverage for the enable/disable/seed lifecycle and persistence round-trip)
- [x] Manually verified in the dev app: enabling/disabling the flag, a workspace created while it's on, the confirm-dialog's reuse-vs-overwrite choice, and the active-tab sub-setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKwuPCiZGrxQwZTnXmeabu