### PR TITLE
feat(docs): show app and SDK changelogs on the docs site

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,3 +1,9 @@
 # VitePress build artifacts (the generated API markdown under api/ IS committed)
 .vitepress/cache/
 .vitepress/dist/
+
+# Changelog pages copied from CHANGELOG.md at build time (scripts/copy-changelog.mjs).
+# Unlike the API reference, Context7 doesn't need these indexed and a committed
+# copy would go stale between releases, so they're regenerated fresh each build.
+changelog.md
+api/sdk-changelog.md

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -108,6 +108,7 @@ const apiSidebar = [
   },
   { text: "Design tokens", link: "/api/theming" },
   { text: "Stability & versioning", link: "/reference/stability" },
+  { text: "SDK changelog", link: "/api/sdk-changelog" },
   { text: "Type reference", collapsed: true, items: typeReference },
 ];
 
@@ -193,6 +194,7 @@ export default withMermaid(
           text: "Download",
           link: "https://github.com/silo-code/silo/releases/latest",
         },
+        { text: "Changelog", link: "/changelog" },
         { text: "Guides", link: "/guide/" },
         { text: "Design", link: "/design/" },
         { text: "API Reference", link: "/api/" },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "docs:api": "typedoc",
-    "dev": "pnpm docs:api && vitepress dev",
-    "build": "pnpm docs:api && vitepress build",
+    "docs:changelog": "node scripts/copy-changelog.mjs",
+    "dev": "pnpm docs:api && pnpm docs:changelog && vitepress dev",
+    "build": "pnpm docs:api && pnpm docs:changelog && vitepress build",
     "preview": "vitepress preview"
   },
   "dependencies": {

--- a/apps/docs/reference/stability.md
+++ b/apps/docs/reference/stability.md
@@ -78,3 +78,4 @@ against the SDK version your `engine` range allows.
 - [Roadmap](/roadmap) — what's stable, what's planned.
 - [Publishing an extension](/guide/publishing-an-extension) — the manifest,
   including `engine`.
+- [SDK changelog](/api/sdk-changelog) — what changed, release by release.

--- a/apps/docs/scripts/copy-changelog.mjs
+++ b/apps/docs/scripts/copy-changelog.mjs
@@ -1,0 +1,28 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Surfaces the release-please-generated CHANGELOG.md files as VitePress
+// pages. Not committed (see apps/docs/.gitignore) — regenerated on every
+// docs build so it's always current with the source of truth.
+const docsRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const repoRoot = path.resolve(docsRoot, "../..");
+
+const pages = [
+  {
+    source: path.join(repoRoot, "apps/desktop/CHANGELOG.md"),
+    dest: path.join(docsRoot, "changelog.md"),
+  },
+  {
+    source: path.join(repoRoot, "packages/sdk/CHANGELOG.md"),
+    dest: path.join(docsRoot, "api/sdk-changelog.md"),
+  },
+];
+
+for (const { source, dest } of pages) {
+  const body = readFileSync(source, "utf8");
+  writeFileSync(dest, `---\noutline: false\n---\n\n${body}`);
+}

--- a/packages/extension-host/src/extension-host/agent-catalog.test.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.test.ts
@@ -183,7 +183,11 @@ describe("buildTrackSessionScript", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+    // Three sequential script runs, each forking ~8 short-lived processes
+    // (sh, ps, and their command-substitution subshells) — past vitest's
+    // default 5s under the full-monorepo parallel test load the pre-commit
+    // hook runs under (confirmed flaky there, not on the logic).
+  }, 20000);
 
   it("resolves the real agent's pgid past a setpgrp worker that only references it (Cursor regression)", () => {
     // Confirmed live: a fresh Cursor session runs the hook from a worker that


### PR DESCRIPTION
## Summary
- Surfaces `apps/desktop/CHANGELOG.md` and `packages/sdk/CHANGELOG.md` as VitePress pages on getsilo.dev (`/changelog`, `/api/sdk-changelog`) instead of leaving changelogs GitHub-only
- Both pages are regenerated from source on every docs build (`apps/docs/scripts/copy-changelog.mjs`, wired into `docs:dev`/`docs:build`) and gitignored, so they stay current with every release-please merge automatically
- Also includes an unrelated but necessary fix: bumped the timeout on `agent-catalog.test.ts`'s "hostile cwd" test (`buildTrackSessionScript`), which was flaking under the pre-commit hook's full-monorepo parallel test load — the test forks ~24 short-lived processes across three script runs, which reliably clears vitest's 5s default in isolation but not under contention

## Test plan
- [x] `pnpm docs:build` succeeds end to end (typedoc → changelog copy → vitepress build, no dead-link failures)
- [x] `pnpm docs:dev` / preview: `/changelog` and `/api/sdk-changelog` render with correct titles, nav "Changelog" link and API sidebar "SDK changelog" entry both resolve
- [x] `git status` after a build shows no untracked changes under the generated changelog pages (gitignore is effective)
- [x] `agent-catalog.test.ts` passes in isolation and the full pre-commit test suite passed on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011epKaPkDhYfREjX4VpnLQA