### PR TITLE
fix(pty-host): reap PTY sessions whose workspace no longer exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,17 @@ jobs:
           components: clippy
       - uses: swatinem/rust-cache@v2
         with:
-          workspaces: "./apps/desktop/src-tauri -> target"
+          workspaces: |
+            ./apps/desktop/src-tauri -> target
+            ./crates/pty-host -> target
       - run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
       # Informational for now — pre-existing warnings are cleaned in the
       # module-decomposition pass. Not `-D warnings` yet.
       - run: cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets
+      # crates/pty-host is a standalone crate (own Cargo.lock, no root
+      # workspace), so it needs its own test/clippy invocation.
+      - run: cargo test --manifest-path crates/pty-host/Cargo.toml
+      - run: cargo clippy --manifest-path crates/pty-host/Cargo.toml --all-targets
 
   pr-title:
     if: github.event_name == 'pull_request'

--- a/apps/desktop/src-tauri/src/commands/automation.rs
+++ b/apps/desktop/src-tauri/src/commands/automation.rs
@@ -218,6 +218,31 @@ fn dispatch<R: Runtime>(app: &AppHandle<R>, body: Value) -> Value {
         return json!({ "ok": true, "result": "pong" });
     }
 
+    // Run one PTY-session maintenance pass immediately, bypassing the real
+    // hourly timer. Pure Rust (`commands::session_maintenance`) — no webview
+    // involved. Exists so integration tests can exercise the real
+    // membership-based reap deterministically instead of waiting out the
+    // real cadence.
+    #[cfg(unix)]
+    if op == "triggerMaintenanceSweep" {
+        crate::commands::session_maintenance::trigger_sweep_now();
+        return json!({ "ok": true, "result": { "triggered": true } });
+    }
+
+    // The already-resolved SILO_DATA_DIR / SILO_CONFIG_ROOT env vars this
+    // process is using (see lib.rs::run()) — lets a test locate the session
+    // registry / workspace files on disk without re-deriving the identity ->
+    // folder mapping a third time in TypeScript.
+    if op == "debugPaths" {
+        return json!({
+            "ok": true,
+            "result": {
+                "dataDir": std::env::var("SILO_DATA_DIR").unwrap_or_default(),
+                "configRoot": std::env::var("SILO_CONFIG_ROOT").unwrap_or_default(),
+            }
+        });
+    }
+
     // Host-side: the webview can't rasterize itself, so we grab the OS window.
     // Returns a base64 PNG the caller can decode and view.
     if op == "screenshot" {

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -16,6 +16,9 @@ pub mod session_backend;
 // Self-owned PTY session host backend (RFC 0010). Unix-only.
 #[cfg(unix)]
 pub mod session_host;
+// Membership-based orphan reaping for PTY session daemons. Unix-only.
+#[cfg(unix)]
+pub mod session_maintenance;
 // ConPTY daemon backend. Windows-only.
 #[cfg(windows)]
 pub mod session_windows;

--- a/apps/desktop/src-tauri/src/commands/session_host.rs
+++ b/apps/desktop/src-tauri/src/commands/session_host.rs
@@ -37,6 +37,19 @@ const KILL_TIMEOUT: Duration = Duration::from_millis(1000);
 // from this build's view, unreachable — i.e. effectively gone.
 const SESSION_GONE: &str = "SESSION_GONE";
 
+// Well above realistic legitimate usage (a handful to a couple dozen tabs
+// across workspaces), well below the 84-113 the leaked-daemon investigation
+// found. A backstop signal, not a real limit — see `should_warn_concurrency_cap`.
+const CONCURRENCY_WARN_THRESHOLD: usize = 40;
+
+/// Should a concurrency-cap warning fire for a spawn, given the count of live
+/// sessions *before* this one is added? Warn-only: a runaway caller (e.g. a
+/// leaky test harness) surfaces immediately in the log instead of silently
+/// piling up for days, but legitimate heavy usage is never blocked.
+fn should_warn_concurrency_cap(live_count: usize, threshold: usize) -> bool {
+    live_count >= threshold
+}
+
 pub struct SessionHostBackend;
 
 impl SessionHostBackend {
@@ -49,6 +62,14 @@ impl SessionHostBackend {
         size: PtySize,
         command: Option<&[String]>,
     ) -> Result<(), String> {
+        let live = discovery::list_sessions().len();
+        if should_warn_concurrency_cap(live, CONCURRENCY_WARN_THRESHOLD) {
+            log_event(
+                "host_cap_warning",
+                &format!("live={live} threshold={CONCURRENCY_WARN_THRESHOLD} spawning_handle={handle}"),
+            );
+        }
+
         let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
         let mut cmd = std::process::Command::new(exe);
         cmd.arg("--session-host")
@@ -314,5 +335,17 @@ struct SocketChild(UnixStream);
 impl SessionChild for SocketChild {
     fn kill(&mut self) -> Result<(), String> {
         self.0.shutdown(Shutdown::Both).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warns_at_and_above_threshold_not_below() {
+        assert!(!should_warn_concurrency_cap(39, 40));
+        assert!(should_warn_concurrency_cap(40, 40));
+        assert!(should_warn_concurrency_cap(50, 40));
     }
 }

--- a/apps/desktop/src-tauri/src/commands/session_maintenance.rs
+++ b/apps/desktop/src-tauri/src/commands/session_maintenance.rs
@@ -1,0 +1,316 @@
+// Periodic PTY-session maintenance: reap orphaned session-host daemons by
+// workspace membership, never by time.
+//
+// The contract (the persistent-workspace promise): a session referenced by
+// any existing workspace file — open or closed, idle for months — is never
+// touched. The only death signal is "the workspace that owned this session
+// no longer exists in Silo's workspace list": its sessions should already
+// have been killed when the workspace was deleted, so anything still running
+// is cleanup debt from a missed kill (a crash mid-delete, a killed test
+// harness). This sweep exists so that debt is collected within hours while
+// Silo runs — not only at the next restart, which for a user who keeps Silo
+// up for months may be weeks away.
+//
+// Safety properties, in order of importance:
+// - Sessions not in the session registry are exempt: the registry records
+//   every session this app created (`terminal.rs` saves at create time), so
+//   anything absent from it — e.g. a session made via the standalone
+//   `pty-host` CLI — isn't ours to kill.
+// - Two-strike rule: a candidate must be orphaned across two consecutive
+//   sweeps before it's killed, so one unluckily-timed snapshot (a terminal
+//   created after the workspace files were last flushed — the frontend
+//   persists on a debounce) can never kill anything.
+// - Fail-safe reads: if the workspace store can't be read or any file in it
+//   fails to parse, the whole sweep is skipped — "couldn't determine" is
+//   never treated as "not referenced".
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::session_backend::{active_backend, log_event};
+use super::session_registry;
+use pty_host::discovery;
+
+// First sweep shortly after startup (covers the crash-then-relaunch case),
+// a quick second pass to satisfy the two-strike rule without waiting a full
+// hour, then hourly for as long as the app runs.
+const FIRST_SWEEP_DELAY: Duration = Duration::from_secs(90);
+const SECOND_SWEEP_DELAY: Duration = Duration::from_secs(10 * 60);
+const SWEEP_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Map a bundle identifier to its user-config root folder name under
+/// `~/.config` — must mirror `configRootName` in
+/// `packages/extension-host/src/services/user-config.ts` exactly, since the
+/// workspace files this sweep reads live under the TS-owned config root.
+pub fn config_root_name(identifier: &str) -> String {
+    const STABLE: &str = "com.silo.desktop";
+    if identifier == STABLE {
+        return "silo".to_string();
+    }
+    let suffix = identifier
+        .strip_prefix("com.silo.desktop.")
+        .unwrap_or(identifier);
+    format!("silo-{suffix}")
+}
+
+/// The `workspaces/` dir under the config root exported by `lib.rs::run()`
+/// as `SILO_CONFIG_ROOT` (mirroring the `SILO_DATA_DIR`/`SILO_PTY_NS`
+/// pattern). `None` when unset — the sweep then never runs.
+fn workspaces_dir() -> Option<PathBuf> {
+    std::env::var("SILO_CONFIG_ROOT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|root| PathBuf::from(root).join("workspaces"))
+}
+
+/// Every `sessionId` referenced by one workspace file's terminals. `None` on
+/// parse failure (fail-safe — a half-written file mid-flush must abort the
+/// sweep, not expose its sessions as unreferenced).
+fn extract_session_ids(json: &str) -> Option<Vec<String>> {
+    let v: serde_json::Value = serde_json::from_str(json).ok()?;
+    let terminals = match v.get("workspace").and_then(|w| w.get("terminals")) {
+        Some(t) => t.as_array()?.clone(),
+        // A workspace with no terminals key is valid — it just references
+        // no sessions.
+        None => Vec::new(),
+    };
+    Some(
+        terminals
+            .iter()
+            .filter_map(|t| t.get("sessionId").and_then(|s| s.as_str()))
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+/// Every session id referenced by any existing workspace file. `Err` (with
+/// the reason, for the skip log) if the store can't be read in full — the
+/// caller must skip the sweep entirely. A silent skip would let one corrupt
+/// file disable maintenance forever with no trace; the live verification of
+/// this module found exactly that (a stray 0-byte workspace file).
+fn referenced_session_ids() -> Result<HashSet<String>, String> {
+    let dir = workspaces_dir().ok_or("SILO_CONFIG_ROOT unset")?;
+    let entries =
+        std::fs::read_dir(&dir).map_err(|e| format!("read_dir {}: {e}", dir.display()))?;
+    let mut out = HashSet::new();
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let text =
+            std::fs::read_to_string(&p).map_err(|e| format!("read {}: {e}", p.display()))?;
+        out.extend(
+            extract_session_ids(&text)
+                .ok_or_else(|| format!("unparseable workspace file {}", p.display()))?,
+        );
+    }
+    Ok(out)
+}
+
+/// Pure: which registry-known sessions are live but referenced by no
+/// existing workspace file? Iterates the registry (not the live list), so
+/// sessions the app never created are structurally exempt.
+fn orphan_candidates(
+    live_handles: &HashSet<String>,
+    registry: &HashMap<String, String>,
+    referenced: &HashSet<String>,
+) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = registry
+        .iter()
+        .filter(|(sid, handle)| live_handles.contains(*handle) && !referenced.contains(*sid))
+        .map(|(sid, handle)| (sid.clone(), handle.clone()))
+        .collect();
+    out.sort();
+    out
+}
+
+/// Pure: apply the two-strike rule. Returns the candidates that were already
+/// suspects last sweep (confirmed — kill now) and replaces the suspect set
+/// with this sweep's candidates, so a candidate that disappears between
+/// sweeps (its workspace file flushed late) is forgotten, not accumulated.
+fn confirm_orphans(
+    suspects: &mut HashSet<(String, String)>,
+    candidates: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    let current: HashSet<(String, String)> = candidates.into_iter().collect();
+    let mut confirmed: Vec<(String, String)> =
+        current.intersection(suspects).cloned().collect();
+    confirmed.sort();
+    *suspects = current;
+    confirmed
+}
+
+fn run_sweep(suspects: &mut HashSet<(String, String)>) {
+    // File-level cleanup first: dead sockets and orphaned sidecar files.
+    discovery::reap_stale();
+
+    let referenced = match referenced_session_ids() {
+        Ok(r) => r,
+        Err(reason) => {
+            // Couldn't read the workspace store — skip, and drop any prior
+            // suspicions so a bad read can't count as a strike. Loudly: a
+            // persistent read failure would otherwise disable maintenance
+            // forever with nothing in the log to show for it.
+            log_event("maintenance_skip", &reason);
+            suspects.clear();
+            return;
+        }
+    };
+    let live: HashSet<String> = discovery::list_sessions().into_iter().collect();
+    let registry = session_registry::all();
+
+    let confirmed = confirm_orphans(suspects, orphan_candidates(&live, &registry, &referenced));
+    for (session_id, handle) in confirmed {
+        log_event(
+            "maintenance_reap",
+            &format!("session={session_id} handle={handle} reason=no-workspace-references"),
+        );
+        let _ = active_backend().kill(&handle);
+        session_registry::remove(&session_id);
+    }
+}
+
+/// Test-only seam: `SILO_TEST_MAINT_SWEEP_MS` collapses all three delays to
+/// one fast interval so a live verification doesn't wait out real hours.
+fn sweep_delay(tick: usize) -> Duration {
+    if let Some(ms) = std::env::var("SILO_TEST_MAINT_SWEEP_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+    {
+        return Duration::from_millis(ms);
+    }
+    match tick {
+        0 => FIRST_SWEEP_DELAY,
+        1 => SECOND_SWEEP_DELAY,
+        _ => SWEEP_INTERVAL,
+    }
+}
+
+/// Spawn the maintenance sweep. Call once, at app startup.
+pub fn spawn_maintenance_sweep() {
+    std::thread::spawn(|| {
+        let mut suspects: HashSet<(String, String)> = HashSet::new();
+        let mut tick = 0usize;
+        loop {
+            std::thread::sleep(sweep_delay(tick));
+            tick += 1;
+            run_sweep(&mut suspects);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    // `SILO_TEST_MAINT_SWEEP_MS` is process-global; the two tests below both
+    // touch it and cargo runs tests in parallel by default, so they'd race
+    // each other without this.
+    fn sweep_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn sweep_delay_progresses_first_second_then_hourly() {
+        let _g = sweep_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("SILO_TEST_MAINT_SWEEP_MS").ok();
+        std::env::remove_var("SILO_TEST_MAINT_SWEEP_MS");
+
+        assert_eq!(sweep_delay(0), FIRST_SWEEP_DELAY);
+        assert_eq!(sweep_delay(1), SECOND_SWEEP_DELAY);
+        assert_eq!(sweep_delay(2), SWEEP_INTERVAL);
+        assert_eq!(sweep_delay(100), SWEEP_INTERVAL);
+
+        match prev {
+            Some(v) => std::env::set_var("SILO_TEST_MAINT_SWEEP_MS", v),
+            None => std::env::remove_var("SILO_TEST_MAINT_SWEEP_MS"),
+        }
+    }
+
+    #[test]
+    fn sweep_delay_env_override_wins_at_every_tick() {
+        let _g = sweep_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("SILO_TEST_MAINT_SWEEP_MS").ok();
+        std::env::set_var("SILO_TEST_MAINT_SWEEP_MS", "250");
+
+        assert_eq!(sweep_delay(0), Duration::from_millis(250));
+        assert_eq!(sweep_delay(1), Duration::from_millis(250));
+        assert_eq!(sweep_delay(2), Duration::from_millis(250));
+
+        match prev {
+            Some(v) => std::env::set_var("SILO_TEST_MAINT_SWEEP_MS", v),
+            None => std::env::remove_var("SILO_TEST_MAINT_SWEEP_MS"),
+        }
+    }
+
+    #[test]
+    fn config_root_name_mirrors_ts_mapping() {
+        assert_eq!(config_root_name("com.silo.desktop"), "silo");
+        assert_eq!(config_root_name("com.silo.desktop.dev"), "silo-dev");
+        assert_eq!(config_root_name("com.example.other"), "silo-com.example.other");
+    }
+
+    #[test]
+    fn extract_session_ids_reads_terminals() {
+        let json = r#"{"workspace":{"id":"ws_1","terminals":[
+            {"id":"t1","sessionId":"aaa"},{"id":"t2","sessionId":"bbb"}
+        ]}}"#;
+        assert_eq!(extract_session_ids(json).unwrap(), vec!["aaa", "bbb"]);
+    }
+
+    #[test]
+    fn extract_session_ids_tolerates_missing_terminals_but_not_bad_json() {
+        assert_eq!(
+            extract_session_ids(r#"{"workspace":{"id":"ws_1"}}"#).unwrap(),
+            Vec::<String>::new()
+        );
+        // A half-written file must poison the whole sweep, not read as empty.
+        assert_eq!(extract_session_ids(r#"{"workspace":{"termi"#), None);
+    }
+
+    #[test]
+    fn orphan_candidates_applies_all_three_filters() {
+        let live: HashSet<String> =
+            ["h-orphan", "h-referenced", "h-cli"].map(String::from).into();
+        let registry: HashMap<String, String> = [
+            ("sid-orphan".to_string(), "h-orphan".to_string()),
+            ("sid-referenced".to_string(), "h-referenced".to_string()),
+            ("sid-dead".to_string(), "h-dead".to_string()), // not live
+        ]
+        .into();
+        let referenced: HashSet<String> = ["sid-referenced".to_string()].into();
+
+        // Only the live, registry-known, unreferenced session is a candidate:
+        // the referenced one is protected, the dead one has nothing to kill,
+        // and h-cli (live but not in the registry) is structurally exempt.
+        assert_eq!(
+            orphan_candidates(&live, &registry, &referenced),
+            vec![("sid-orphan".to_string(), "h-orphan".to_string())]
+        );
+    }
+
+    #[test]
+    fn confirm_orphans_requires_two_consecutive_strikes() {
+        let orphan = ("sid-1".to_string(), "h-1".to_string());
+        let transient = ("sid-2".to_string(), "h-2".to_string());
+        let mut suspects = HashSet::new();
+
+        // First sighting: suspect only, nothing confirmed.
+        let killed = confirm_orphans(&mut suspects, vec![orphan.clone(), transient.clone()]);
+        assert!(killed.is_empty());
+
+        // Second sweep: `transient`'s workspace file has since flushed, so it
+        // is no longer a candidate — only the persisting orphan is confirmed.
+        let killed = confirm_orphans(&mut suspects, vec![orphan.clone()]);
+        assert_eq!(killed, vec![orphan.clone()]);
+
+        // `transient` was forgotten, not accumulated: seeing it again later
+        // starts its count over.
+        let killed = confirm_orphans(&mut suspects, vec![transient.clone()]);
+        assert!(killed.is_empty());
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/session_maintenance.rs
+++ b/apps/desktop/src-tauri/src/commands/session_maintenance.rs
@@ -26,6 +26,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use super::session_backend::{active_backend, log_event};
@@ -142,7 +143,23 @@ fn confirm_orphans(
     confirmed
 }
 
-fn run_sweep(suspects: &mut HashSet<(String, String)>) {
+/// The two-strike suspect set, shared between the periodic background sweep
+/// and an on-demand trigger (`trigger_sweep_now`, exposed to the dev-only
+/// automation RPC for integration tests) — both must drive the *same* state,
+/// or a manual trigger interleaved with the timer could see a candidate as
+/// "first time" twice in a row and never confirm it, or double-count it.
+fn suspects_state() -> &'static Mutex<HashSet<(String, String)>> {
+    static STATE: OnceLock<Mutex<HashSet<(String, String)>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Run one sweep pass. Safe to call concurrently (from the background timer
+/// and an on-demand trigger both) — serialized on `suspects_state()`'s lock
+/// for the pass's full duration, so two passes can't interleave and
+/// double-confirm or double-kill the same candidate.
+fn run_sweep() {
+    let mut suspects = suspects_state().lock().unwrap_or_else(|e| e.into_inner());
+
     // File-level cleanup first: dead sockets and orphaned sidecar files.
     discovery::reap_stale();
 
@@ -161,7 +178,8 @@ fn run_sweep(suspects: &mut HashSet<(String, String)>) {
     let live: HashSet<String> = discovery::list_sessions().into_iter().collect();
     let registry = session_registry::all();
 
-    let confirmed = confirm_orphans(suspects, orphan_candidates(&live, &registry, &referenced));
+    let confirmed =
+        confirm_orphans(&mut suspects, orphan_candidates(&live, &registry, &referenced));
     for (session_id, handle) in confirmed {
         log_event(
             "maintenance_reap",
@@ -170,6 +188,14 @@ fn run_sweep(suspects: &mut HashSet<(String, String)>) {
         let _ = active_backend().kill(&handle);
         session_registry::remove(&session_id);
     }
+}
+
+/// Run one sweep pass immediately, outside the normal timer. Exposed to the
+/// dev-only automation RPC (`triggerMaintenanceSweep`) so integration tests
+/// can exercise the real membership-based reap deterministically instead of
+/// waiting out the real hourly cadence.
+pub fn trigger_sweep_now() {
+    run_sweep();
 }
 
 /// Test-only seam: `SILO_TEST_MAINT_SWEEP_MS` collapses all three delays to
@@ -191,12 +217,11 @@ fn sweep_delay(tick: usize) -> Duration {
 /// Spawn the maintenance sweep. Call once, at app startup.
 pub fn spawn_maintenance_sweep() {
     std::thread::spawn(|| {
-        let mut suspects: HashSet<(String, String)> = HashSet::new();
         let mut tick = 0usize;
         loop {
             std::thread::sleep(sweep_delay(tick));
             tick += 1;
-            run_sweep(&mut suspects);
+            run_sweep();
         }
     });
 }

--- a/apps/desktop/src-tauri/src/commands/session_registry.rs
+++ b/apps/desktop/src-tauri/src/commands/session_registry.rs
@@ -75,9 +75,9 @@ pub fn remove(session_id: &str) {
     write_map(&map);
 }
 
-/// All known session_id -> handle mappings. Reconciliation (matching persisted
-/// tabs against live backend sessions) will consume this.
-#[allow(dead_code)]
+/// All known session_id -> handle mappings. Consumed by the maintenance
+/// sweep (`session_maintenance`) to know which sessions this app instance
+/// owns — anything absent from here is not ours to reap.
 pub fn all() -> HashMap<String, String> {
     let _g = guard().lock();
     read_map()

--- a/apps/desktop/src-tauri/src/commands/terminal_buffer.rs
+++ b/apps/desktop/src-tauri/src/commands/terminal_buffer.rs
@@ -39,7 +39,13 @@ pub fn cleanup_stale_buffers() -> Result<(), String> {
         Err(_) => return Ok(()), // Dir doesn't exist yet, nothing to clean
     };
 
-    let seven_days_secs = 7 * 24 * 60 * 60;
+    // 90 days, not a week: these buffers are the only way terminal tabs
+    // restore their scrollback after a reboot (a live daemon replays its own
+    // ring, but a reboot kills every daemon). A workspace parked for a month
+    // must come back with its scrollback intact — that persistence is the
+    // product promise, so retention here has to comfortably outlast any
+    // realistic absence.
+    let max_age_secs = 90 * 24 * 60 * 60;
 
     for entry in fs::read_dir(&dir).map_err(|e| format!("Failed to read dir: {}", e))? {
         let entry = entry.map_err(|e| format!("Dir entry error: {}", e))?;
@@ -52,7 +58,7 @@ pub fn cleanup_stale_buffers() -> Result<(), String> {
             if let Ok(metadata) = fs::metadata(&path) {
                 if let Ok(modified) = metadata.modified() {
                     if let Ok(elapsed) = modified.elapsed() {
-                        if elapsed.as_secs() > seven_days_secs {
+                        if elapsed.as_secs() > max_age_secs {
                             let _ = fs::remove_file(&path);
                         }
                     }
@@ -83,6 +89,78 @@ mod tests {
         save_buffer("s1", "scrollback\x1b[0m").unwrap();
         assert!(root.join("terminal-buffers/s1.term").exists());
         assert_eq!(load_buffer("s1").as_deref(), Ok("scrollback\x1b[0m"));
+
+        std::env::remove_var("SILO_DATA_DIR");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Backdate `path`'s mtime by `ago`. Raw `libc::utimes` rather than a new
+    /// dependency for one call — same approach used elsewhere in this repo
+    /// for exactly this (`crates/pty-host`'s daemon tests).
+    fn backdate_mtime(path: &std::path::Path, ago: std::time::Duration) {
+        let target = std::time::SystemTime::now() - ago;
+        let epoch = target
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let tv = libc::timeval {
+            tv_sec: epoch.as_secs() as libc::time_t,
+            tv_usec: epoch.subsec_micros() as libc::suseconds_t,
+        };
+        let times = [tv, tv];
+        let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+        let rc = unsafe { libc::utimes(c_path.as_ptr(), times.as_ptr()) };
+        assert_eq!(rc, 0, "utimes({path:?})");
+    }
+
+    #[test]
+    fn cleanup_retains_90_days_but_purges_older() {
+        let _g = super::super::app_paths::env_lock();
+        let mut root = std::env::temp_dir();
+        root.push(format!("silo-buffer-cleanup-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        std::env::set_var("SILO_DATA_DIR", &root);
+
+        save_buffer("fresh", "still watching this one").unwrap();
+        save_buffer("month-old", "a month\x1b[0m of\x1b[0m idle").unwrap();
+        save_buffer("ancient", "predates the fix").unwrap();
+        save_buffer("ancient-legacy", "old raw-capture format").unwrap();
+
+        let dir = root.join("terminal-buffers");
+        // Within the 90-day retention (the exact scenario this change exists
+        // for: a workspace parked for a month, not touched).
+        backdate_mtime(
+            &dir.join("month-old.term"),
+            std::time::Duration::from_secs(30 * 24 * 60 * 60),
+        );
+        // Past the new 90-day threshold — must still be purged, not kept
+        // forever just because the threshold grew.
+        backdate_mtime(
+            &dir.join("ancient.term"),
+            std::time::Duration::from_secs(91 * 24 * 60 * 60),
+        );
+        let legacy_bin = dir.join("ancient-legacy.term");
+        let legacy_bin = {
+            let renamed = dir.join("ancient-legacy.bin");
+            fs::rename(&legacy_bin, &renamed).unwrap();
+            renamed
+        };
+        backdate_mtime(&legacy_bin, std::time::Duration::from_secs(91 * 24 * 60 * 60));
+
+        cleanup_stale_buffers().unwrap();
+
+        assert!(dir.join("fresh.term").exists(), "fresh buffer must survive");
+        assert!(
+            dir.join("month-old.term").exists(),
+            "a month-old buffer must survive the new 90-day retention"
+        );
+        assert!(
+            !dir.join("ancient.term").exists(),
+            "a 91-day-old buffer must still be purged"
+        );
+        assert!(
+            !legacy_bin.exists(),
+            "legacy .bin buffers are purged by the same threshold"
+        );
 
         std::env::remove_var("SILO_DATA_DIR");
         let _ = fs::remove_dir_all(&root);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -41,6 +41,30 @@ pub fn run() {
         );
     }
 
+    // The TS-owned user-config root (~/.config/silo[-suffix], or the
+    // SILO_CONFIG_DIR override — same resolution as user-config.ts). The
+    // session-maintenance sweep reads workspace files from here to decide
+    // which PTY sessions are still owned by a known workspace.
+    #[cfg(unix)]
+    {
+        let config_root = std::env::var("SILO_CONFIG_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from)
+            .or_else(|| {
+                dirs::home_dir().map(|h| {
+                    h.join(".config").join(
+                        commands::session_maintenance::config_root_name(
+                            context.config().identifier.as_str(),
+                        ),
+                    )
+                })
+            });
+        if let Some(root) = config_root {
+            std::env::set_var("SILO_CONFIG_ROOT", root);
+        }
+    }
+
     let builder = tauri::Builder::default();
 
     // Single-instance must be the FIRST plugin (per its docs). A second `silo
@@ -124,6 +148,13 @@ pub fn run() {
             std::thread::spawn(|| {
                 let _ = commands::terminal_buffer::cleanup_stale_buffers();
             });
+
+            // Periodic PTY-session maintenance: reaps daemons whose owning
+            // workspace was deleted (membership-based, never time-based —
+            // sessions in existing workspaces, open or closed, are never
+            // touched no matter how long they sit idle).
+            #[cfg(unix)]
+            commands::session_maintenance::spawn_maintenance_sweep();
 
             // The application menu is constructed in JS (src/extensions/menu-items.ts)
             // and installed via setAsAppMenu() after extensions activate. That lets

--- a/apps/desktop/src/automation/client.ts
+++ b/apps/desktop/src/automation/client.ts
@@ -196,6 +196,27 @@ export class SiloAutomation {
     return this.call("processAlive", { sessionId });
   }
 
+  /**
+   * Run one PTY-session maintenance pass immediately, bypassing the real
+   * hourly timer — answered host-side, no webview round-trip. Lets a test
+   * exercise the real membership-based reap (a session with no workspace
+   * referencing it is killed after being seen unreferenced on two
+   * consecutive sweeps) deterministically instead of waiting out the real
+   * cadence.
+   */
+  triggerMaintenanceSweep(): Promise<{ triggered: boolean }> {
+    return this.call("triggerMaintenanceSweep");
+  }
+
+  /**
+   * This process's resolved `SILO_DATA_DIR` / `SILO_CONFIG_ROOT` — answered
+   * host-side. Lets a test locate the session registry / workspace files on
+   * disk without re-deriving the identity → folder mapping itself.
+   */
+  debugPaths(): Promise<{ dataDir: string; configRoot: string }> {
+    return this.call("debugPaths");
+  }
+
   /** Terminal tab records for a workspace (defaults to the active one). */
   listTerminals(workspaceId?: string): Promise<{
     terminals: {

--- a/apps/desktop/src/automation/global-teardown.ts
+++ b/apps/desktop/src/automation/global-teardown.ts
@@ -1,0 +1,88 @@
+// Global backstop for the integration suite (Layer 2).
+//
+// Per-file `afterAll` hooks are the primary cleanup path for the PTY
+// sessions this suite spawns (e.g. `workspace-pty-lifecycle.it.test.ts`'s
+// `deleteWorkspace` calls, which reap PTYs through the real `T_KILL` path).
+// This catches the case a hook never gets to run — a test file that crashes
+// or is interrupted (Ctrl-C) mid-suite.
+//
+// Snapshot-diff, NOT "kill everything in the `dev` namespace": `pnpm dev` is
+// normally running interactively while `pnpm test:it` runs against it, so
+// the `dev` namespace can hold real terminals the developer cares about.
+// Only sessions that are newly live at teardown time — absent from the
+// snapshot taken before this run started — are ever killed.
+//
+// Talks to `pty-host` directly, not the dev-app automation RPC: the RPC
+// needs the app alive and responsive, which can't be assumed in exactly the
+// failure modes this exists to catch (the ownership lease already handles a
+// dead dev app on its own timeline — this backstop targets the surviving-app
+// case, a test-runner crash while `pnpm dev` keeps running).
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ptyHostManifest = resolve(here, "../../../../crates/pty-host/Cargo.toml");
+
+function runPtyHost(args: string[]): string | null {
+  const result = spawnSync(
+    "cargo",
+    [
+      "run",
+      "--quiet",
+      "--manifest-path",
+      ptyHostManifest,
+      "--bin",
+      "pty-host",
+      "--",
+      "-n",
+      "dev",
+      ...args,
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+  return result.stdout;
+}
+
+/**
+ * Live session names in the `dev` namespace, or `null` if it couldn't be
+ * determined — kept distinct from "confirmed zero" so a failed lookup can't
+ * be mistaken for an empty namespace and trigger a sweep it has no business
+ * running.
+ */
+function liveSessionNames(): Set<string> | null {
+  const out = runPtyHost(["list"]);
+  if (out === null) return null;
+  const names = new Set<string>();
+  for (const line of out.split("\n")) {
+    const [name] = line.split("\t");
+    if (name && line.includes("\tlive")) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+export default function setup() {
+  const before = liveSessionNames();
+
+  return function teardown() {
+    // Fail-safe, not fail-open: if we couldn't determine the starting state,
+    // skip the sweep rather than risk treating "unknown" as "empty" and
+    // killing sessions that predate this run.
+    if (before === null) return;
+
+    const after = liveSessionNames();
+    if (after === null) return;
+
+    for (const name of after) {
+      if (!before.has(name)) {
+        runPtyHost(["kill", name]);
+      }
+    }
+  };
+}

--- a/apps/desktop/src/automation/session-maintenance.it.test.ts
+++ b/apps/desktop/src/automation/session-maintenance.it.test.ts
@@ -1,0 +1,195 @@
+// Integration test (Layer 2): the membership-based PTY maintenance sweep.
+//
+// Regression guard for the core promise of the orphan-reaping redesign: a
+// session is reaped only when it's absent from BOTH the session registry
+// AND every existing workspace file's terminal list — never by time alone,
+// and never while a workspace still references it, open or closed, no
+// matter how long it's been idle.
+//
+// Drives the real sweep via `triggerMaintenanceSweep` (bypasses the real
+// hourly timer, see `session_maintenance.rs`) rather than waiting out real
+// time — the whole point of exposing that op. Requires the dev app running
+// (`pnpm dev`); skips otherwise.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[session-maintenance.it] no dev app reachable on :7878 — skipping. " +
+      "Run `pnpm dev` to exercise this suite.",
+  );
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ptyHostManifest = resolve(here, "../../../../crates/pty-host/Cargo.toml");
+
+function runPtyHost(args: string[]): void {
+  spawnSync(
+    "cargo",
+    [
+      "run",
+      "--quiet",
+      "--manifest-path",
+      ptyHostManifest,
+      "--bin",
+      "pty-host",
+      "--",
+      "-n",
+      "dev",
+      ...args,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+/**
+ * Spawn an independent daemon via the standalone `pty-host` CLI — deliberately
+ * outside the app entirely, so it's registered nowhere and referenced by no
+ * workspace until the test says so. `new ... -- sleep 600` both creates and
+ * (briefly) attaches; with no stdin piped in, the attach sees immediate EOF
+ * and detaches on its own, leaving the daemon running in the background.
+ */
+function spawnStandaloneDaemon(name: string): void {
+  runPtyHost(["new", name, "--", "sleep", "600"]);
+}
+
+function killStandaloneDaemon(name: string): void {
+  runPtyHost(["kill", name]);
+}
+
+async function readRegistry(dataDir: string): Promise<Record<string, string>> {
+  const raw = await readFile(
+    join(dataDir, "terminal-sessions.json"),
+    "utf8",
+  ).catch(() => "{}");
+  return JSON.parse(raw) as Record<string, string>;
+}
+
+async function writeRegistry(
+  dataDir: string,
+  map: Record<string, string>,
+): Promise<void> {
+  await writeFile(
+    join(dataDir, "terminal-sessions.json"),
+    JSON.stringify(map, null, 2),
+  );
+}
+
+/** Directly register a session_id -> handle mapping, bypassing the app's own
+ * `terminal_create` — simulates a session the app knows about (it's in the
+ * registry, the same signal `processAlive`/reattach use) but that no
+ * workspace's terminal list has ever referenced. */
+async function registerOrphanSession(
+  dataDir: string,
+  sessionId: string,
+  handle: string,
+): Promise<void> {
+  const map = await readRegistry(dataDir);
+  map[sessionId] = handle;
+  await writeRegistry(dataDir, map);
+}
+
+async function forgetSession(
+  dataDir: string,
+  sessionId: string,
+): Promise<void> {
+  const map = await readRegistry(dataDir);
+  if (sessionId in map) {
+    delete map[sessionId];
+    await writeRegistry(dataDir, map);
+  }
+}
+
+describe.skipIf(!available)("PTY session maintenance sweep", () => {
+  let dataDir: string;
+
+  beforeAll(async () => {
+    const paths = await silo.debugPaths();
+    dataDir = paths.dataDir;
+  });
+
+  it(
+    "reaps a registered session referenced by no workspace, after two consecutive sweeps",
+    { timeout: 30000 },
+    async () => {
+      const handle = `silo-${randomUUID().slice(0, 8)}`;
+      const sessionId = randomUUID();
+      spawnStandaloneDaemon(handle);
+      await registerOrphanSession(dataDir, sessionId, handle);
+
+      try {
+        expect((await silo.processAlive(sessionId)).alive).toBe(true);
+
+        // First sweep: seen unreferenced for the first time — suspected, not
+        // yet killed (the two-strike guard against a just-flushed workspace
+        // file this session actually belongs to).
+        await silo.triggerMaintenanceSweep();
+        expect((await silo.processAlive(sessionId)).alive).toBe(true);
+
+        // Second consecutive sweep: still unreferenced — confirmed, reaped.
+        await silo.triggerMaintenanceSweep();
+        expect((await silo.processAlive(sessionId)).alive).toBe(false);
+      } finally {
+        // Best-effort: the assertions above should have it dead already:
+        // this only matters if this test fails partway through.
+        killStandaloneDaemon(handle);
+        await forgetSession(dataDir, sessionId);
+      }
+    },
+  );
+
+  it(
+    "never reaps a session an open workspace still references, even under repeated triggers",
+    { timeout: 30000 },
+    async () => {
+      const folder = await mkdtemp(join(tmpdir(), "silo-it-maint-"));
+      const wsId = (await silo.openWorkspace(folder, "it-maint")).id;
+      await silo.activateWorkspace(wsId);
+
+      try {
+        const { terminalId, panelId } = await silo.openTerminal(folder);
+        try {
+          await silo.activatePanel(panelId);
+        } catch {
+          // Panel may not be in the dock yet — sendText force-spawns regardless.
+        }
+        await silo.sendText(terminalId, "", false);
+
+        let sessionId = "";
+        await expect
+          .poll(
+            async () => {
+              const list = await silo.listTerminals(wsId);
+              sessionId =
+                list.terminals.find((t) => t.id === terminalId)?.sessionId ??
+                "";
+              return sessionId;
+            },
+            { timeout: 15000, interval: 100 },
+          )
+          .not.toBe("");
+
+        expect((await silo.processAlive(sessionId)).alive).toBe(true);
+        await silo.triggerMaintenanceSweep();
+        await silo.triggerMaintenanceSweep();
+        expect((await silo.processAlive(sessionId)).alive).toBe(true);
+      } finally {
+        await silo.deleteWorkspace(wsId).catch(() => {
+          /* already gone */
+        });
+        await rm(folder, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -44,6 +44,9 @@ export default defineConfig({
           // must not run in parallel — concurrent files would step on each
           // other's workspaces and focus. One file at a time.
           fileParallelism: false,
+          // Backstop for PTY sessions a crashed/interrupted test file never
+          // got to clean up in its own afterAll — see global-teardown.ts.
+          globalSetup: ["./src/automation/global-teardown.ts"],
         },
       },
     ],

--- a/crates/pty-host/src/daemon.rs
+++ b/crates/pty-host/src/daemon.rs
@@ -4,7 +4,8 @@
 
 use std::collections::VecDeque;
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::sync::{Arc, Mutex};
+use std::path::Path;
+use std::sync::{Arc, Mutex, Once};
 use std::time::Duration;
 
 use crate::foreground;
@@ -111,6 +112,7 @@ fn run_daemon(name: &str, cmd: &[String], cwd: &str, cols: u16, rows: u16) -> Re
         let clients = clients.clone();
         let ring = ring.clone();
         let path = path.clone();
+        let name = name.to_string();
         std::thread::spawn(move || {
             let mut buf = [0u8; 8192];
             loop {
@@ -135,9 +137,7 @@ fn run_daemon(name: &str, cmd: &[String], cwd: &str, cols: u16, rows: u16) -> Re
                 });
             }
             // Shell gone: tear the session down.
-            log("shell exited; removing socket and exiting");
-            let _ = std::fs::remove_file(&path);
-            unsafe { libc::_exit(0) };
+            teardown_and_exit(&name, &path, "shell exited");
         });
     }
 
@@ -277,6 +277,16 @@ fn run_daemon(name: &str, cmd: &[String], cwd: &str, cols: u16, rows: u16) -> Re
                     Ok(_) => {}
                     Err(_) => {
                         log("client detached");
+                        // Actively prune this client rather than relying on
+                        // the master-reader thread's write-triggered retain
+                        // (daemon.rs's other pruning path): a session with no
+                        // PTY output — the common case, a shell idle at a
+                        // prompt — would otherwise never see that write path
+                        // run at all, so dead entries (and their socket fds)
+                        // would accumulate in `clients` for the session's
+                        // whole life, one per detach, unbounded.
+                        clients_r.lock().unwrap().retain(|c| !Arc::ptr_eq(c, &wh));
+                        fg_clients_r.lock().unwrap().retain(|c| !Arc::ptr_eq(c, &wh));
                         break; // disconnected (detach) — session lives on
                     }
                 }
@@ -376,6 +386,20 @@ mod transitional_leader_tests {
     }
 }
 
+/// Tear the session down: remove its socket and log files and terminate the
+/// process. Guarded by `Once` so any future second exit path shares the same
+/// exactly-once cleanup; `_exit` itself terminates the whole process
+/// atomically. Never returns.
+fn teardown_and_exit(name: &str, sock_path: &Path, reason: &str) -> ! {
+    static TEARDOWN: Once = Once::new();
+    TEARDOWN.call_once(|| {
+        log(&format!("{reason}; removing socket and log"));
+        let _ = std::fs::remove_file(sock_path);
+        let _ = std::fs::remove_file(paths::log_path(name));
+    });
+    unsafe { libc::_exit(0) };
+}
+
 /// Force-terminate the session even mid-foreground-program (Proof 1, P5).
 /// Signals the shell's process group, escalating TERM -> KILL.
 fn kill_group(shell_pid: i32) {
@@ -386,4 +410,171 @@ fn kill_group(shell_pid: i32) {
     unsafe {
         libc::kill(-shell_pid, libc::SIGKILL);
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery;
+    use std::path::{Path, PathBuf};
+    use std::time::Instant;
+
+    // `spawn_detached` double-forks the calling process without an
+    // intervening exec (unlike production, which always calls it from a
+    // freshly re-exec'd, still-single-threaded binary — see main.rs's
+    // `--session-host` branch). Forking a multithreaded process is only
+    // safe if the child sticks to async-signal-safe work until it execs,
+    // which `redirect_std_to_log`/`run_daemon` don't (they touch `std::fs`,
+    // allocate, etc.). Cargo's test harness runs `#[test]`s on multiple
+    // threads by default, so two of *our own* forks racing each other is an
+    // avoidable extra source of exactly that hazard — serialize them here.
+    // Every wait below still has an explicit deadline, so even a genuinely
+    // wedged child fails the test instead of hanging the run.
+    static SPAWN_GUARD: Mutex<()> = Mutex::new(());
+
+    /// Connect to `sock`, retrying briefly — mirrors `client.rs`'s connect
+    /// helper (the daemon may still be finishing its `UnixListener::bind`).
+    fn connect_retry(sock: &Path) -> UnixStream {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            match UnixStream::connect(sock) {
+                Ok(s) => return s,
+                Err(_) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(e) => panic!("connect {sock:?}: {e}"),
+            }
+        }
+    }
+
+    /// Consume the daemon's initial `T_HELLO`, then request and read back the
+    /// live foreground pgid. For a bare `sleep` test command (no shell
+    /// wrapping it) this is the command's own pid — `forkpty`'s child is
+    /// always a fresh session/group leader.
+    fn query_pgid(s: &mut UnixStream) -> i32 {
+        let (tag, _) = read_frame(s).expect("hello frame");
+        assert_eq!(tag, T_HELLO, "daemon's first frame must be T_HELLO");
+        write_frame(s, T_FG_REQ, &[]).expect("send fg req");
+        loop {
+            let (tag, payload) = read_frame(s).expect("fg reply");
+            if tag == T_FG_REP {
+                return foreground::decode(&payload).expect("decode fg").pgid;
+            }
+        }
+    }
+
+    /// Spawns a real detached daemon via the actual `spawn_detached`
+    /// production path, and force-kills it on drop so a panicking assertion
+    /// still can't leak the exact kind of process this project exists to
+    /// stop leaking.
+    struct TestDaemon {
+        sock: PathBuf,
+    }
+
+    impl TestDaemon {
+        fn spawn(name: &str, cmd: Vec<String>) -> Self {
+            let _g = SPAWN_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+            spawn_detached(name, cmd, "/tmp".to_string(), 80, 24).expect("spawn_detached");
+            let sock = paths::sock_path(name);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < deadline && !discovery::is_live(&sock) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(discovery::is_live(&sock), "daemon did not come up in time");
+            TestDaemon { sock }
+        }
+    }
+
+    impl Drop for TestDaemon {
+        fn drop(&mut self) {
+            // Best-effort: if it's already gone (e.g. the test itself killed
+            // the shell), connect fails and there's nothing to do.
+            if let Ok(mut s) = UnixStream::connect(&self.sock) {
+                let _ = write_frame(&mut s, T_KILL, &[]);
+            }
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while Instant::now() < deadline && discovery::is_live(&self.sock) {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+    }
+
+    /// Resolves RFC 0010 §3.7 (an unverified open question, not an assumed
+    /// fact): does the daemon's only production exit path actually work?
+    /// If this fails, that is a P0 bug ahead of anything else — the daemon's
+    /// sole self-exit mechanism would be broken, and nothing later in this
+    /// plan should be built on top of it blind.
+    #[test]
+    fn shell_death_triggers_daemon_self_exit_and_removes_socket() {
+        crate::test_support::with_temp_dir("shell-death", |_dir| {
+            let daemon = TestDaemon::spawn("t-shell-death", vec!["sleep".into(), "600".into()]);
+            let mut s = connect_retry(&daemon.sock);
+            let pgid = query_pgid(&mut s);
+            drop(s);
+
+            unsafe {
+                libc::kill(pgid, libc::SIGKILL);
+            }
+
+            let deadline = Instant::now() + Duration::from_secs(3);
+            while Instant::now() < deadline && discovery::is_live(&daemon.sock) {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            assert!(
+                !discovery::is_live(&daemon.sock),
+                "daemon should self-exit once its shell dies"
+            );
+            assert!(
+                !daemon.sock.exists(),
+                "daemon should remove its socket file on exit"
+            );
+        });
+    }
+
+    /// Pins the deliberate `daemon.rs` contract (see the accept loop's
+    /// `Err(_) => { ... break; }` arm): a client disconnecting must NOT tear
+    /// the session down. Detached survival is the feature this whole crate
+    /// exists to provide — this guards it against regressing while Phase 3
+    /// adds a second, legitimate exit path alongside it.
+    #[test]
+    fn client_detach_does_not_kill_daemon_or_shell() {
+        crate::test_support::with_temp_dir("client-detach", |_dir| {
+            let daemon = TestDaemon::spawn("t-client-detach", vec!["sleep".into(), "600".into()]);
+            let mut s = connect_retry(&daemon.sock);
+            let pgid = query_pgid(&mut s);
+            drop(s); // detach: no T_KILL sent
+
+            std::thread::sleep(Duration::from_millis(300));
+            assert!(
+                discovery::is_live(&daemon.sock),
+                "daemon must survive a client detach"
+            );
+            assert_eq!(
+                unsafe { libc::kill(pgid, 0) },
+                0,
+                "shell must still be alive after a mere detach"
+            );
+        });
+    }
+
+    #[test]
+    fn t_kill_from_a_connected_client_exits_the_daemon() {
+        crate::test_support::with_temp_dir("t-kill", |_dir| {
+            let daemon = TestDaemon::spawn("t-t-kill", vec!["sleep".into(), "600".into()]);
+            let mut s = connect_retry(&daemon.sock);
+            let (tag, _) = read_frame(&mut s).expect("hello frame");
+            assert_eq!(tag, T_HELLO);
+            write_frame(&mut s, T_KILL, &[]).expect("send kill");
+
+            let deadline = Instant::now() + Duration::from_secs(3);
+            while Instant::now() < deadline && discovery::is_live(&daemon.sock) {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            assert!(
+                !discovery::is_live(&daemon.sock),
+                "T_KILL from a connected client should terminate the daemon"
+            );
+        });
+    }
+
 }

--- a/crates/pty-host/src/discovery.rs
+++ b/crates/pty-host/src/discovery.rs
@@ -30,13 +30,24 @@ pub fn list_sessions() -> Vec<String> {
     out
 }
 
-/// Remove socket files whose daemon is gone. Returns how many were reaped.
+/// Remove socket files whose daemon is gone, plus any `.log`/`.lease`
+/// sidecar files left behind with no matching live socket. Returns how many
+/// files were reaped. Normally a daemon removes its own sidecars on exit
+/// (`teardown_and_exit`); this catches the case it never got the chance to
+/// (`SIGKILL`, a crash) — the exact mirror of a daemon's socket outliving it.
+/// (`.lease` files were written by interim builds of the abandonment-lease
+/// design; nothing writes them anymore, this just sweeps the leftovers.)
 pub fn reap_stale() -> usize {
     let mut reaped = 0;
     if let Ok(entries) = std::fs::read_dir(paths::sock_dir()) {
         for e in entries.flatten() {
             let p = e.path();
-            if is_session_socket(&p) && !is_live(&p) && std::fs::remove_file(&p).is_ok() {
+            let sock = match p.extension().and_then(|s| s.to_str()) {
+                Some("sock") => p.clone(),
+                Some("log") | Some("lease") => p.with_extension("sock"),
+                _ => continue,
+            };
+            if !is_live(&sock) && std::fs::remove_file(&p).is_ok() {
                 reaped += 1;
             }
         }
@@ -51,40 +62,8 @@ fn is_session_socket(p: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_temp_dir;
     use std::os::unix::net::UnixListener;
-    use std::path::PathBuf;
-
-    // These tests bind real sockets but in a private temp dir, overriding the
-    // session dir via XDG_RUNTIME_DIR. They serialize on a guard, recovering
-    // from a poisoned lock so one failure doesn't cascade into the others. We
-    // also neutralize SILO_PTY_NS for the duration: if it's set in the ambient
-    // environment (e.g. a dev shell exports SILO_PTY_NS=prod), `sock_dir()`
-    // would append that namespace subdir and miss the sockets these tests write
-    // at the un-namespaced base.
-    fn with_temp_dir<T>(tag: &str, f: impl FnOnce(&Path) -> T) -> T {
-        use std::sync::Mutex;
-        static GUARD: Mutex<()> = Mutex::new(());
-        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
-        // Short base under /tmp — Unix socket paths are capped (~104 bytes on
-        // macOS), so the deeper `std::env::temp_dir()` can overflow `sun_path`.
-        let dir = PathBuf::from("/tmp").join(format!("ph-{}-{}", std::process::id(), tag));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(dir.join("silo-pty")).unwrap();
-        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
-        let prev_ns = std::env::var("SILO_PTY_NS").ok();
-        std::env::set_var("XDG_RUNTIME_DIR", &dir);
-        std::env::remove_var("SILO_PTY_NS");
-        let out = f(&dir.join("silo-pty"));
-        match prev_xdg {
-            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
-            None => std::env::remove_var("XDG_RUNTIME_DIR"),
-        }
-        if let Some(v) = prev_ns {
-            std::env::set_var("SILO_PTY_NS", v);
-        }
-        let _ = std::fs::remove_dir_all(&dir);
-        out
-    }
 
     #[test]
     fn is_live_true_for_bound_socket_false_for_missing() {
@@ -114,6 +93,37 @@ mod tests {
             assert_eq!(reap_stale(), 1);
             assert!(dir.join("live.sock").exists());
             assert!(!dir.join("dead.sock").exists());
+        });
+    }
+
+    #[test]
+    fn reap_stale_removes_orphaned_log_with_no_socket() {
+        with_temp_dir("reap-log", |dir| {
+            std::fs::write(dir.join("dead.log"), b"").unwrap();
+            assert_eq!(reap_stale(), 1);
+            assert!(!dir.join("dead.log").exists());
+        });
+    }
+
+    #[test]
+    fn reap_stale_removes_orphaned_lease_with_no_socket() {
+        with_temp_dir("reap-lease", |dir| {
+            std::fs::write(dir.join("dead.lease"), b"").unwrap();
+            assert_eq!(reap_stale(), 1);
+            assert!(!dir.join("dead.lease").exists());
+        });
+    }
+
+    #[test]
+    fn reap_stale_keeps_sidecars_for_a_live_socket() {
+        with_temp_dir("reap-keep", |dir| {
+            let _live = UnixListener::bind(dir.join("live.sock")).unwrap();
+            std::fs::write(dir.join("live.log"), b"").unwrap();
+            std::fs::write(dir.join("live.lease"), b"").unwrap();
+            assert_eq!(reap_stale(), 0);
+            assert!(dir.join("live.sock").exists());
+            assert!(dir.join("live.log").exists());
+            assert!(dir.join("live.lease").exists());
         });
     }
 }

--- a/crates/pty-host/src/lib.rs
+++ b/crates/pty-host/src/lib.rs
@@ -18,6 +18,9 @@ pub mod paths;
 pub mod proto;
 pub mod pty;
 
+#[cfg(test)]
+mod test_support;
+
 /// Daemonize and serve a session host for `name`, running `cmd` in `cwd` at the
 /// given size. Forks the long-lived daemon (reparented to init) and returns in
 /// the spawning process — which should then exit. The Silo app calls this when

--- a/crates/pty-host/src/test_support.rs
+++ b/crates/pty-host/src/test_support.rs
@@ -1,0 +1,40 @@
+//! Shared test-only helpers for `crates/pty-host`. `discovery.rs` and
+//! `daemon.rs` both need a private, namespace-neutral socket dir to test
+//! against — this is the one place that guard lives, so their tests can't
+//! race each other over the process-global `XDG_RUNTIME_DIR`/`SILO_PTY_NS`
+//! env vars (cargo runs `#[test]`s in parallel threads within one binary).
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+static GUARD: Mutex<()> = Mutex::new(());
+
+/// Run `f` with `XDG_RUNTIME_DIR` redirected to a private temp dir and
+/// `SILO_PTY_NS` neutralized (unset for the duration, restored after), so
+/// `paths::sock_dir()` resolves to `<dir>/silo-pty` regardless of the ambient
+/// environment (e.g. a dev shell exporting `SILO_PTY_NS=prod`). Serializes on
+/// a shared guard, recovering from a poisoned lock so one failing test
+/// doesn't cascade into the rest.
+///
+/// Short base under `/tmp` — Unix socket paths are capped (~104 bytes on
+/// macOS via `sun_path`), so the deeper `std::env::temp_dir()` can overflow.
+pub(crate) fn with_temp_dir<T>(tag: &str, f: impl FnOnce(&Path) -> T) -> T {
+    let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = PathBuf::from("/tmp").join(format!("ph-{}-{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("silo-pty")).unwrap();
+    let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+    let prev_ns = std::env::var("SILO_PTY_NS").ok();
+    std::env::set_var("XDG_RUNTIME_DIR", &dir);
+    std::env::remove_var("SILO_PTY_NS");
+    let out = f(&dir.join("silo-pty"));
+    match prev_xdg {
+        Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+        None => std::env::remove_var("XDG_RUNTIME_DIR"),
+    }
+    if let Some(v) = prev_ns {
+        std::env::set_var("SILO_PTY_NS", v);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+    out
+}


### PR DESCRIPTION
## Summary

Session-host daemons had no exit path for abandonment — only a shell exit or an explicit `T_KILL` from a live client ever terminated one. If the owning app died, crashed, or an integration-test harness tore down without killing its sessions, the daemon and its shell ran forever. 84 such orphans were found accumulated over 5 days of normal use (see the linked investigation).

- Adds a periodic maintenance sweep (hourly, first pass ~90s after startup) that reaps a session only when it's absent from **both** the session registry **and** every existing workspace file's terminal list — membership-based, never time-based. A session in an open or closed workspace is never touched, no matter how long it sits idle; only a genuinely deleted workspace's leftover session is fair game. A two-strike rule protects a just-created terminal whose workspace file hasn't flushed to disk yet.
- Fixes a real unbounded-growth bug found while building this: the daemon's client list was only pruned as a side effect of relaying PTY output, so a disconnected client on an otherwise-silent session (the common case — a shell idle at a prompt) never got cleaned up.
- Sweeps orphaned `.log`/`.sock` sidecar files left by a daemon that never got the chance to clean up after itself (`SIGKILL`, a crash).
- Adds a concurrency-cap warning (log-only) so a runaway spawner surfaces immediately instead of after days.
- Extends scrollback-buffer retention from 7 to 90 days to match the same "come back after a month, everything's where you left it" promise.
- Wires `crates/pty-host` into CI — its test suite never actually ran before (`ci.yml`'s `rust` job only tested `apps/desktop/src-tauri`).

## Test plan

- [x] `cargo test --manifest-path crates/pty-host/Cargo.toml` — 23 passing, including a regression test resolving whether the daemon's original shell-exit path actually worked (it does)
- [x] `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` — 35 passing
- [x] `cargo clippy --all-targets` clean on both crates
- [x] `pnpm --filter silo exec tsc --noEmit` clean
- [x] Full pre-commit suite (boundary lint, format, `turbo run test` across all 21 packages) green
- [x] Verified live against the real compiled dev app across two full rounds: 15+ workspaces, ~25 terminals — multi-workspace/multi-PTY spawn, soft-close survival across many sweep ticks, hard-delete via the real path (immediate, independent of the sweep), workspace reopen, workspace recreation at the same folder path, rapid close/reopen cycling, a corrupt workspace file (full sweep skip + self-heal, nothing falsely killed), simultaneous multi-orphan reap with zero cross-contamination, and both graceful-quit and crash (`SIGKILL`) restarts with precisely-timed two-strike verification — zero interference with a live production Silo.app install throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011epKaPkDhYfREjX4VpnLQA