### PR TITLE
fix(pty-host): stop the maintenance sweep's timer from firing during CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,8 +48,16 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Start the dev app (with automation RPC)
+        # SILO_DISABLE_MAINTENANCE_SWEEP: the PTY session-maintenance sweep's
+        # automatic timer fires on its own schedule (first tick 90s after
+        # startup) with no way to know a test suite is mid-run against this
+        # same app instance — a sweep firing at an unpredictable moment can
+        # reap a test's in-flight, not-yet-persisted session out from under
+        # it. Seen here: it disrupted keyboard-nav.it.test.ts on an earlier
+        # run. Tests that want a sweep call the triggerMaintenanceSweep RPC
+        # op explicitly instead (see session-maintenance.it.test.ts).
         run: |
-          nohup pnpm dev > dev-app.log 2>&1 &
+          SILO_DISABLE_MAINTENANCE_SWEEP=1 nohup pnpm dev > dev-app.log 2>&1 &
           echo $! > dev-app.pid
 
       - name: Wait for the automation port

--- a/apps/desktop/src-tauri/src/commands/session_maintenance.rs
+++ b/apps/desktop/src-tauri/src/commands/session_maintenance.rs
@@ -214,8 +214,27 @@ fn sweep_delay(tick: usize) -> Duration {
     }
 }
 
-/// Spawn the maintenance sweep. Call once, at app startup.
+/// Pure: should the automatic timer be disabled? Factored out from
+/// `spawn_maintenance_sweep` so the "empty string doesn't count as set"
+/// nuance (a shell `export FOO=` some CI step forgot to unset) is unit
+/// testable without spawning a real thread.
+fn auto_sweep_disabled(env_value: Option<String>) -> bool {
+    env_value.is_some_and(|v| !v.is_empty())
+}
+
+/// Spawn the maintenance sweep. Call once, at app startup. A no-op when
+/// `SILO_DISABLE_MAINTENANCE_SWEEP` is set: the automatic timer's first tick
+/// (90s after startup, by default) has no way to know a test suite is mid-run
+/// against the same app instance, and a sweep firing at an unpredictable
+/// moment can reap a test's in-flight, not-yet-persisted session out from
+/// under it — found in CI when it disrupted an unrelated integration test.
+/// Set by `integration.yml`'s app-launch step; `triggerMaintenanceSweep`
+/// (the automation RPC op) stays fully available regardless, so tests that
+/// want a sweep still get one, deterministically, on their own terms.
 pub fn spawn_maintenance_sweep() {
+    if auto_sweep_disabled(std::env::var("SILO_DISABLE_MAINTENANCE_SWEEP").ok()) {
+        return;
+    }
     std::thread::spawn(|| {
         let mut tick = 0usize;
         loop {
@@ -270,6 +289,16 @@ mod tests {
             Some(v) => std::env::set_var("SILO_TEST_MAINT_SWEEP_MS", v),
             None => std::env::remove_var("SILO_TEST_MAINT_SWEEP_MS"),
         }
+    }
+
+    #[test]
+    fn auto_sweep_disabled_only_when_set_and_non_empty() {
+        assert!(!auto_sweep_disabled(None), "unset must not disable it");
+        assert!(
+            !auto_sweep_disabled(Some(String::new())),
+            "an empty value (e.g. a forgotten `export FOO=`) must not disable it either"
+        );
+        assert!(auto_sweep_disabled(Some("1".to_string())));
     }
 
     #[test]

--- a/apps/desktop/src/automation/session-maintenance.it.test.ts
+++ b/apps/desktop/src/automation/session-maintenance.it.test.ts
@@ -111,12 +111,40 @@ async function forgetSession(
   }
 }
 
+/**
+ * Does the *persisted* workspace file (not the in-memory state `listTerminals`
+ * reads) reference this session yet? The sweep reads straight off disk, and
+ * the frontend persists on a 250ms debounce — `listTerminals` can see a
+ * terminal's sessionId well before its workspace file is flushed. Triggering
+ * a sweep inside that gap would see the session as unreferenced, exactly the
+ * race the two-strike rule exists to guard against — so a test that wants to
+ * assert "sweeps never touch this" has to wait on the same signal the sweep
+ * itself reads, not a faster in-memory proxy for it.
+ */
+async function workspaceFileReferences(
+  configRoot: string,
+  workspaceId: string,
+  sessionId: string,
+): Promise<boolean> {
+  const raw = await readFile(
+    join(configRoot, "workspaces", `${workspaceId}.json`),
+    "utf8",
+  ).catch(() => null);
+  if (raw === null) return false;
+  const terminals = JSON.parse(raw)?.workspace?.terminals as
+    | { sessionId?: string }[]
+    | undefined;
+  return (terminals ?? []).some((t) => t.sessionId === sessionId);
+}
+
 describe.skipIf(!available)("PTY session maintenance sweep", () => {
   let dataDir: string;
+  let configRoot: string;
 
   beforeAll(async () => {
     const paths = await silo.debugPaths();
     dataDir = paths.dataDir;
+    configRoot = paths.configRoot;
   });
 
   it(
@@ -181,6 +209,18 @@ describe.skipIf(!available)("PTY session maintenance sweep", () => {
           .not.toBe("");
 
         expect((await silo.processAlive(sessionId)).alive).toBe(true);
+
+        // Wait for the workspace file itself (not just in-memory state) to
+        // carry this session before sweeping — otherwise both triggers below
+        // could land inside the persistence debounce and see it as
+        // unreferenced, which is a test-timing bug, not the sweep's.
+        await expect
+          .poll(() => workspaceFileReferences(configRoot, wsId, sessionId), {
+            timeout: 5000,
+            interval: 50,
+          })
+          .toBe(true);
+
         await silo.triggerMaintenanceSweep();
         await silo.triggerMaintenanceSweep();
         expect((await silo.processAlive(sessionId)).alive).toBe(true);


### PR DESCRIPTION
## Summary

Follow-up to #336 — a manually-triggered run of the integration workflow (workflow_dispatch, run [31408441279](https://github.com/silo-code/silo/actions/runs/31408441279)) surfaced two real problems:

1. **`session-maintenance.it.test.ts` itself** — a race in the test, not the sweep. It called `triggerMaintenanceSweep()` twice back-to-back with no delay. The frontend persists workspace state on a 250ms debounce, so both triggers could land inside that window and see a legitimately-referenced session as unreferenced — defeating the exact two-strike guard the test was meant to prove holds. It happened to pass locally (real network round-trip latency was enough slack) and lost the race on the CI runner.

   Fix: poll the actual on-disk workspace file — the same source `session_maintenance.rs` reads — before triggering, instead of the faster in-memory `listTerminals` proxy.

2. **`keyboard-nav.it.test.ts`**, unrelated to #336 and previously green on the last nightly run — the maintenance sweep's automatic timer fires its first tick 90s after app startup, with no way to know a test suite is running against that same app instance. App boot time in that CI job put the 90s mark right in the middle of the test run, and it most likely reaped an in-flight session `keyboard-nav.it` depended on, cascading into 8 failures clustered in that one file (all timeouts / a "no active workspace" error, consistent with shared state breaking mid-file).

   Fix: `SILO_DISABLE_MAINTENANCE_SWEEP`, set only by `integration.yml`'s app-launch step. The automatic timer never starts under that flag, but `triggerMaintenanceSweep` (the RPC op) stays fully available — tests that want a sweep still get one, deterministically, on their own terms. Normal `pnpm dev` usage is untouched.

## Test plan

- [x] `cargo test` on both crates — 23 + 36 passing (2 new: the env-flag predicate, `auto_sweep_disabled`)
- [x] `cargo clippy --features automation --all-targets` clean
- [x] `pnpm --filter silo exec tsc --noEmit` clean
- [x] Full pre-commit suite (boundary lint, format, all 21 packages) green
- [x] Verified live: launched the dev app with `SILO_DISABLE_MAINTENANCE_SWEEP=1` (matching the CI step exactly) — both `session-maintenance.it.test.ts` cases pass, and confirmed via the app's own log that zero automatic sweep activity occurred in a 170s+ window that would previously have included the 90s auto-tick, while the test's own explicit `triggerMaintenanceSweep()` calls still worked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011epKaPkDhYfREjX4VpnLQA