### PR TITLE
fix(docs): disambiguate homepage title and add sameAs for branded search

### DIFF
--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -15,7 +15,8 @@ navbar: false
 sidebar: false
 footer: false
 aside: false
-title: Silo
+title: Silo — One window — every project, every agent
+titleTemplate: false
 description: One window — every project, every agent. Terminals, agents, and layout stay intact — switch between them instantly. 100% open source, free forever.
 ---
 

--- a/apps/website/src/homepage-seo.test.ts
+++ b/apps/website/src/homepage-seo.test.ts
@@ -45,6 +45,11 @@ describe("homepage SEO helpers", () => {
       price: "0",
       priceCurrency: "USD",
     });
+    expect(ld.sameAs).toEqual([
+      "https://github.com/silo-code/silo",
+      "https://x.com/silo_code",
+      "https://extensions.getsilo.dev",
+    ]);
   });
 
   it("includes canonical, OG/Twitter image tags, and both JSON-LD scripts", () => {

--- a/apps/website/src/homepage-seo.ts
+++ b/apps/website/src/homepage-seo.ts
@@ -63,6 +63,11 @@ export function buildSoftwareApplicationJsonLd() {
     downloadUrl: "https://github.com/silo-code/silo/releases/latest",
     license: "https://github.com/silo-code/silo/blob/main/LICENSE",
     image: OG_IMAGE_URL,
+    sameAs: [
+      "https://github.com/silo-code/silo",
+      "https://x.com/silo_code",
+      "https://extensions.getsilo.dev",
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary
- Homepage `<title>` was collapsing to a bare `Silo` (VitePress drops the site-title suffix when frontmatter `title` matches it exactly) — the single highest-leverage on-page signal for disambiguating from unrelated "Silo"-named products (NameSilo, Sentilo, the Apple TV+ series, etc.) was undifferentiated. Now `Silo — One window — every project, every agent`, reusing the site's existing vetted headline copy.
- Added `sameAs` to the `SoftwareApplication` JSON-LD (GitHub, X, extensions.getsilo.dev) so Google consolidates these as one entity.

## Test plan
- [x] `pnpm --filter @silo-code/website test` — includes new assertion on `sameAs`
- [x] Local `pnpm docs:build`, confirmed `<title>` and `sameAs` render correctly in the built output
- [ ] After merge: re-request indexing on the homepage in Search Console so Google picks up the new title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J54G3Q7apW5D3HmTqpMKTE