### PR TITLE
fix(agents): detect Claude's new circle spinner and hide status glyphs in titles

### DIFF
--- a/apps/docs/api/types/interfaces/CustomTheme.md
+++ b/apps/docs/api/types/interfaces/CustomTheme.md
@@ -1,6 +1,6 @@
 # Interface: CustomTheme
 
-Defined in: [packages/sdk/src/domain-types.ts:234](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L234)
+Defined in: [packages/sdk/src/domain-types.ts:246](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L246)
 
 A persisted custom theme.
 
@@ -12,7 +12,7 @@ A persisted custom theme.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:235](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L235)
+Defined in: [packages/sdk/src/domain-types.ts:247](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L247)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [packages/sdk/src/domain-types.ts:235](https://github.com/silo-code/
 version: 2;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:240](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L240)
+Defined in: [packages/sdk/src/domain-types.ts:252](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L252)
 
 `2` since the `--silo-*` token rename (theming-contract.md › Migration).
 v1 themes used the legacy bare names (`--bg`, `--text-hi`, …).
@@ -35,7 +35,7 @@ v1 themes used the legacy bare names (`--bg`, `--text-hi`, …).
 name: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:241](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L241)
+Defined in: [packages/sdk/src/domain-types.ts:253](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L253)
 
 ***
 
@@ -45,7 +45,7 @@ Defined in: [packages/sdk/src/domain-types.ts:241](https://github.com/silo-code/
 base: ThemeBase;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:242](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L242)
+Defined in: [packages/sdk/src/domain-types.ts:254](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L254)
 
 ***
 
@@ -55,7 +55,7 @@ Defined in: [packages/sdk/src/domain-types.ts:242](https://github.com/silo-code/
 colorScheme: "dark" | "light";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:243](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L243)
+Defined in: [packages/sdk/src/domain-types.ts:255](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L255)
 
 ***
 
@@ -65,4 +65,4 @@ Defined in: [packages/sdk/src/domain-types.ts:243](https://github.com/silo-code/
 vars: Partial<ThemeVars>;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:244](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L244)
+Defined in: [packages/sdk/src/domain-types.ts:256](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L256)

--- a/apps/docs/api/types/interfaces/EditorRecord.md
+++ b/apps/docs/api/types/interfaces/EditorRecord.md
@@ -1,6 +1,6 @@
 # Interface: EditorRecord
 
-Defined in: [packages/sdk/src/domain-types.ts:58](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L58)
+Defined in: [packages/sdk/src/domain-types.ts:70](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L70)
 
 An editor tab record in a workspace — a text editor or a diff.
 
@@ -12,7 +12,7 @@ An editor tab record in a workspace — a text editor or a diff.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:59](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L59)
+Defined in: [packages/sdk/src/domain-types.ts:71](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L71)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [packages/sdk/src/domain-types.ts:59](https://github.com/silo-code/s
 filePath: string | null;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:61](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L61)
+Defined in: [packages/sdk/src/domain-types.ts:73](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L73)
 
 null for an untitled buffer that hasn't been saved yet.
 
@@ -34,7 +34,7 @@ null for an untitled buffer that hasn't been saved yet.
 title: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:62](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L62)
+Defined in: [packages/sdk/src/domain-types.ts:74](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L74)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [packages/sdk/src/domain-types.ts:62](https://github.com/silo-code/s
 optional isPreview?: boolean;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:64](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L64)
+Defined in: [packages/sdk/src/domain-types.ts:76](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L76)
 
 When true, the tab is a temporary preview that gets replaced by the next single-click open.
 
@@ -56,7 +56,7 @@ When true, the tab is a temporary preview that gets replaced by the next single-
 optional mode?: EditorMode;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:70](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L70)
+Defined in: [packages/sdk/src/domain-types.ts:82](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L82)
 
 Which mode this record renders in. Absent ⇒ `"text"`. A `"diff"` record
 additionally carries [EditorRecord.providerId](#providerid)/[EditorRecord.args](#args)
@@ -70,7 +70,7 @@ and always has a non-null `filePath`.
 optional providerId?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:76](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L76)
+Defined in: [packages/sdk/src/domain-types.ts:88](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L88)
 
 Diff mode only: which registered diff-content provider resolves the two
 sides (e.g. "silo.git"). The diff is content-agnostic — the provider owns
@@ -84,7 +84,7 @@ what the two sides contain.
 optional args?: Record<string, unknown>;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:81](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L81)
+Defined in: [packages/sdk/src/domain-types.ts:93](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L93)
 
 Diff mode only: serializable args the provider needs to (re)compute content
 on mount / restart.
@@ -97,7 +97,7 @@ on mount / restart.
 optional viewType?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:92](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L92)
+Defined in: [packages/sdk/src/domain-types.ts:104](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L104)
 
 The chosen editor *view* for this tab, referencing an [Editor.id](Editor.md#id)
 (e.g. `"text"`, `"silo.markdown-preview"`). Absent ⇒ the host renders the

--- a/apps/docs/api/types/interfaces/TerminalRecord.md
+++ b/apps/docs/api/types/interfaces/TerminalRecord.md
@@ -42,7 +42,18 @@ Defined in: [packages/sdk/src/domain-types.ts:28](https://github.com/silo-code/s
 title: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:29](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L29)
+Defined in: [packages/sdk/src/domain-types.ts:41](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L41)
+
+The auto-derived tab title: the window title the running program pushed via
+an OSC escape sequence, else its process name, else the tmux status line.
+
+Agent **status markers are stripped** from this (Claude's `◐`/`✳`, Codex's
+braille spinner and `[ ! ]`, Cursor's trailing ` - Working …`) unless the
+user turns off "Hide status glyphs in tab titles" in Settings → Agents — the
+status is already available as structured state via `ctx.agents`, so the
+glyph would be redundant here. Don't parse this field to detect agent
+activity; use `ctx.agents`, or `ctx.terminals.subscribeOsc` for the raw
+(never-stripped) sequences.
 
 ***
 
@@ -52,7 +63,7 @@ Defined in: [packages/sdk/src/domain-types.ts:29](https://github.com/silo-code/s
 optional customName?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:36](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L36)
+Defined in: [packages/sdk/src/domain-types.ts:48](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L48)
 
 A user-assigned name (via the tab's "Rename…" menu). When set, it wins over
 the PTY-derived [TerminalRecord.title](#title) and stays put until the user
@@ -67,7 +78,7 @@ string, which hands the title back to PTY auto-derivation.
 optional cwd?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:38](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L38)
+Defined in: [packages/sdk/src/domain-types.ts:50](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L50)
 
 Working directory override. Falls back to ws.folder when absent.
 
@@ -79,6 +90,6 @@ Working directory override. Falls back to ws.folder when absent.
 optional lastActiveAt?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:40](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L40)
+Defined in: [packages/sdk/src/domain-types.ts:52](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L52)
 
 ISO timestamp of the last output we observed; used to pick a workspace's "primary" terminal.

--- a/apps/docs/api/types/interfaces/TerminalService.md
+++ b/apps/docs/api/types/interfaces/TerminalService.md
@@ -865,7 +865,7 @@ Prefer [TerminalService.subscribeTabAdornments](TabAdornmentMethods.md#subscribe
 subscribeOsc(terminalId, handler): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:224](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L224)
+Defined in: [packages/sdk/src/terminal-service.ts:231](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L231)
 
 Subscribe to raw OSC (Operating System Command) escape sequences emitted
 by the terminal identified by `terminalId`. The handler is called once per
@@ -895,16 +895,23 @@ Returns a [Disposable](Disposable.md) that cancels the subscription.
 #### Example
 
 ```ts
-// Detect Claude Code busy/idle state from OSC 0 title sequences.
-const BRAILLE_START = 0x2800;
-const BRAILLE_END   = 0x28FF;
+// Detect Claude Code busy/idle state from OSC 0 title sequences: it
+// prefixes the title with an animated spinner glyph while busy, and with
+// the idle char below when awaiting input. Accept both spinner ranges —
+// current builds animate the half-filled circles ◐/◑, older ones used
+// braille (which Codex CLI still does).
+const SPINNERS = [
+  [0x25d0, 0x25d3], // ◐ ◑ ◒ ◓
+  [0x2800, 0x28ff], // ⠋ ⠙ ⠏ …
+];
 const IDLE_CHAR     = '\u2733'; // ✳
 
 const sub = ctx.terminals.subscribeOsc(terminalId, ({ code, payload }) => {
   if (code !== 0) return;
   const first = payload.charCodeAt(0);
-  if (first >= BRAILLE_START && first <= BRAILLE_END) setStatus('busy');
-  else if (payload.startsWith(IDLE_CHAR))              setStatus('idle');
+  const spinning = SPINNERS.some(([lo, hi]) => first >= lo && first <= hi);
+  if (spinning)                           setStatus('busy');
+  else if (payload.startsWith(IDLE_CHAR)) setStatus('idle');
 });
 ctx.subscriptions.push(sub);
 ```
@@ -917,7 +924,7 @@ ctx.subscriptions.push(sub);
 subscribeOutput(terminalId, handler): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:257](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L257)
+Defined in: [packages/sdk/src/terminal-service.ts:264](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L264)
 
 Subscribe to the raw PTY output stream of the terminal identified by
 `terminalId`. The `handler` is called with every chunk of bytes the PTY
@@ -969,7 +976,7 @@ ctx.subscriptions.push(sub);
 getActive(): string | null;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:269](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L269)
+Defined in: [packages/sdk/src/terminal-service.ts:276](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L276)
 
 The record id of the terminal tab that is currently active in the active
 workspace's center dock, or `null` when an editor tab (or nothing) is
@@ -989,7 +996,7 @@ split does not count.
 subscribeActive(listener): Disposable;
 ```
 
-Defined in: [packages/sdk/src/terminal-service.ts:291](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L291)
+Defined in: [packages/sdk/src/terminal-service.ts:298](https://github.com/silo-code/silo/blob/main/packages/sdk/src/terminal-service.ts#L298)
 
 Subscribe to active-terminal changes. The listener receives the terminal
 record id whenever a terminal tab becomes the active center-dock panel,

--- a/apps/docs/api/types/interfaces/ThemeVars.md
+++ b/apps/docs/api/types/interfaces/ThemeVars.md
@@ -1,6 +1,6 @@
 # Interface: ThemeVars
 
-Defined in: [packages/sdk/src/domain-types.ts:154](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L154)
+Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L166)
 
 The full theme-override surface, in type form: every `--silo-*` token a theme
 preset's `vars` may recolor. Per the theming contract it spans **the design
@@ -21,7 +21,7 @@ docs/architecture-audit/theming-contract.md
 --silo-color-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:156](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L156)
+Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L168)
 
 ***
 
@@ -31,7 +31,7 @@ Defined in: [packages/sdk/src/domain-types.ts:156](https://github.com/silo-code/
 --silo-color-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:157](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L157)
+Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L169)
 
 ***
 
@@ -41,7 +41,7 @@ Defined in: [packages/sdk/src/domain-types.ts:157](https://github.com/silo-code/
 --silo-color-bg-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:158](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L158)
+Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L170)
 
 ***
 
@@ -51,7 +51,7 @@ Defined in: [packages/sdk/src/domain-types.ts:158](https://github.com/silo-code/
 --silo-color-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:159](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L159)
+Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L171)
 
 ***
 
@@ -61,7 +61,7 @@ Defined in: [packages/sdk/src/domain-types.ts:159](https://github.com/silo-code/
 --silo-color-text-hi: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:160](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L160)
+Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L172)
 
 ***
 
@@ -71,7 +71,7 @@ Defined in: [packages/sdk/src/domain-types.ts:160](https://github.com/silo-code/
 --silo-color-text-lo: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:161](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L161)
+Defined in: [packages/sdk/src/domain-types.ts:173](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L173)
 
 ***
 
@@ -81,7 +81,7 @@ Defined in: [packages/sdk/src/domain-types.ts:161](https://github.com/silo-code/
 --silo-color-accent: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:162](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L162)
+Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L174)
 
 ***
 
@@ -91,7 +91,7 @@ Defined in: [packages/sdk/src/domain-types.ts:162](https://github.com/silo-code/
 --silo-color-accent-2: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:163](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L163)
+Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L175)
 
 ***
 
@@ -101,7 +101,7 @@ Defined in: [packages/sdk/src/domain-types.ts:163](https://github.com/silo-code/
 --silo-color-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:164](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L164)
+Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L176)
 
 ***
 
@@ -111,7 +111,7 @@ Defined in: [packages/sdk/src/domain-types.ts:164](https://github.com/silo-code/
 --silo-color-border-strong: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L165)
+Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L177)
 
 ***
 
@@ -121,7 +121,7 @@ Defined in: [packages/sdk/src/domain-types.ts:165](https://github.com/silo-code/
 --silo-color-ok: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L166)
+Defined in: [packages/sdk/src/domain-types.ts:178](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L178)
 
 ***
 
@@ -131,7 +131,7 @@ Defined in: [packages/sdk/src/domain-types.ts:166](https://github.com/silo-code/
 --silo-color-warn: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L167)
+Defined in: [packages/sdk/src/domain-types.ts:179](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L179)
 
 ***
 
@@ -141,7 +141,7 @@ Defined in: [packages/sdk/src/domain-types.ts:167](https://github.com/silo-code/
 --silo-color-err: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L168)
+Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L180)
 
 ***
 
@@ -151,7 +151,7 @@ Defined in: [packages/sdk/src/domain-types.ts:168](https://github.com/silo-code/
 --silo-color-input-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L169)
+Defined in: [packages/sdk/src/domain-types.ts:181](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L181)
 
 ***
 
@@ -161,7 +161,7 @@ Defined in: [packages/sdk/src/domain-types.ts:169](https://github.com/silo-code/
 --silo-color-input-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L170)
+Defined in: [packages/sdk/src/domain-types.ts:182](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L182)
 
 ***
 
@@ -171,7 +171,7 @@ Defined in: [packages/sdk/src/domain-types.ts:170](https://github.com/silo-code/
 --silo-color-button-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L171)
+Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L183)
 
 ***
 
@@ -181,7 +181,7 @@ Defined in: [packages/sdk/src/domain-types.ts:171](https://github.com/silo-code/
 --silo-color-button-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L172)
+Defined in: [packages/sdk/src/domain-types.ts:184](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L184)
 
 ***
 
@@ -191,7 +191,7 @@ Defined in: [packages/sdk/src/domain-types.ts:172](https://github.com/silo-code/
 --silo-color-toolbar-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L174)
+Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L186)
 
 ***
 
@@ -201,7 +201,7 @@ Defined in: [packages/sdk/src/domain-types.ts:174](https://github.com/silo-code/
 --silo-color-toolbar-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L175)
+Defined in: [packages/sdk/src/domain-types.ts:187](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L187)
 
 ***
 
@@ -211,7 +211,7 @@ Defined in: [packages/sdk/src/domain-types.ts:175](https://github.com/silo-code/
 --silo-color-toolbar-text-disabled: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L176)
+Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L188)
 
 ***
 
@@ -221,7 +221,7 @@ Defined in: [packages/sdk/src/domain-types.ts:176](https://github.com/silo-code/
 --silo-color-toolbar-input-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L177)
+Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L189)
 
 ***
 
@@ -231,7 +231,7 @@ Defined in: [packages/sdk/src/domain-types.ts:177](https://github.com/silo-code/
 --silo-color-content-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:179](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L179)
+Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L191)
 
 ***
 
@@ -241,7 +241,7 @@ Defined in: [packages/sdk/src/domain-types.ts:179](https://github.com/silo-code/
 --silo-color-content-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L180)
+Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L192)
 
 ***
 
@@ -251,7 +251,7 @@ Defined in: [packages/sdk/src/domain-types.ts:180](https://github.com/silo-code/
 optional --silo-font-ui?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:182](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L182)
+Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L194)
 
 ***
 
@@ -261,7 +261,7 @@ Defined in: [packages/sdk/src/domain-types.ts:182](https://github.com/silo-code/
 optional --silo-font-mono?: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L183)
+Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L195)
 
 ***
 
@@ -271,7 +271,7 @@ Defined in: [packages/sdk/src/domain-types.ts:183](https://github.com/silo-code/
 --silo-content-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L185)
+Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L197)
 
 ***
 
@@ -281,7 +281,7 @@ Defined in: [packages/sdk/src/domain-types.ts:185](https://github.com/silo-code/
 --silo-content-terminal-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L186)
+Defined in: [packages/sdk/src/domain-types.ts:198](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L198)
 
 ***
 
@@ -291,7 +291,7 @@ Defined in: [packages/sdk/src/domain-types.ts:186](https://github.com/silo-code/
 --silo-content-editor-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:187](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L187)
+Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L199)
 
 ***
 
@@ -301,7 +301,7 @@ Defined in: [packages/sdk/src/domain-types.ts:187](https://github.com/silo-code/
 --silo-content-editor-selection: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L188)
+Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L200)
 
 ***
 
@@ -311,7 +311,7 @@ Defined in: [packages/sdk/src/domain-types.ts:188](https://github.com/silo-code/
 --silo-content-editor-selection-inactive: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L189)
+Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L201)
 
 ***
 
@@ -321,7 +321,7 @@ Defined in: [packages/sdk/src/domain-types.ts:189](https://github.com/silo-code/
 --silo-content-editor-text-dim: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:190](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L190)
+Defined in: [packages/sdk/src/domain-types.ts:202](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L202)
 
 ***
 
@@ -331,7 +331,7 @@ Defined in: [packages/sdk/src/domain-types.ts:190](https://github.com/silo-code/
 --silo-content-editor-text-faint: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L191)
+Defined in: [packages/sdk/src/domain-types.ts:203](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L203)
 
 ***
 
@@ -341,7 +341,7 @@ Defined in: [packages/sdk/src/domain-types.ts:191](https://github.com/silo-code/
 --silo-content-tab-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L192)
+Defined in: [packages/sdk/src/domain-types.ts:204](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L204)
 
 ***
 
@@ -351,7 +351,7 @@ Defined in: [packages/sdk/src/domain-types.ts:192](https://github.com/silo-code/
 --silo-content-tab-tray-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:193](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L193)
+Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L205)
 
 ***
 
@@ -361,7 +361,7 @@ Defined in: [packages/sdk/src/domain-types.ts:193](https://github.com/silo-code/
 --silo-content-tab-tray-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L194)
+Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L206)
 
 ***
 
@@ -371,7 +371,7 @@ Defined in: [packages/sdk/src/domain-types.ts:194](https://github.com/silo-code/
 --silo-content-tab-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L195)
+Defined in: [packages/sdk/src/domain-types.ts:207](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L207)
 
 ***
 
@@ -381,7 +381,7 @@ Defined in: [packages/sdk/src/domain-types.ts:195](https://github.com/silo-code/
 --silo-content-tab-text-inactive: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:196](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L196)
+Defined in: [packages/sdk/src/domain-types.ts:208](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L208)
 
 ***
 
@@ -391,7 +391,7 @@ Defined in: [packages/sdk/src/domain-types.ts:196](https://github.com/silo-code/
 --silo-content-tab-text-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L197)
+Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L209)
 
 ***
 
@@ -401,7 +401,7 @@ Defined in: [packages/sdk/src/domain-types.ts:197](https://github.com/silo-code/
 --silo-statusbar-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L199)
+Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L211)
 
 ***
 
@@ -411,7 +411,7 @@ Defined in: [packages/sdk/src/domain-types.ts:199](https://github.com/silo-code/
 --silo-statusbar-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L200)
+Defined in: [packages/sdk/src/domain-types.ts:212](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L212)
 
 ***
 
@@ -421,7 +421,7 @@ Defined in: [packages/sdk/src/domain-types.ts:200](https://github.com/silo-code/
 --silo-statusbar-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L201)
+Defined in: [packages/sdk/src/domain-types.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L213)
 
 ***
 
@@ -431,7 +431,7 @@ Defined in: [packages/sdk/src/domain-types.ts:201](https://github.com/silo-code/
 --silo-tab-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:203](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L203)
+Defined in: [packages/sdk/src/domain-types.ts:215](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L215)
 
 ***
 
@@ -441,7 +441,7 @@ Defined in: [packages/sdk/src/domain-types.ts:203](https://github.com/silo-code/
 --silo-tab-text-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:204](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L204)
+Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L216)
 
 ***
 
@@ -451,7 +451,7 @@ Defined in: [packages/sdk/src/domain-types.ts:204](https://github.com/silo-code/
 --silo-tab-bg-hover: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L205)
+Defined in: [packages/sdk/src/domain-types.ts:217](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L217)
 
 ***
 
@@ -461,7 +461,7 @@ Defined in: [packages/sdk/src/domain-types.ts:205](https://github.com/silo-code/
 --silo-tab-border-active: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L206)
+Defined in: [packages/sdk/src/domain-types.ts:218](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L218)
 
 ***
 
@@ -471,7 +471,7 @@ Defined in: [packages/sdk/src/domain-types.ts:206](https://github.com/silo-code/
 --silo-menu-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:208](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L208)
+Defined in: [packages/sdk/src/domain-types.ts:220](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L220)
 
 ***
 
@@ -481,7 +481,7 @@ Defined in: [packages/sdk/src/domain-types.ts:208](https://github.com/silo-code/
 --silo-menu-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L209)
+Defined in: [packages/sdk/src/domain-types.ts:221](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L221)
 
 ***
 
@@ -491,7 +491,7 @@ Defined in: [packages/sdk/src/domain-types.ts:209](https://github.com/silo-code/
 --silo-menu-item-hover-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:210](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L210)
+Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L222)
 
 ***
 
@@ -501,7 +501,7 @@ Defined in: [packages/sdk/src/domain-types.ts:210](https://github.com/silo-code/
 --silo-menu-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L211)
+Defined in: [packages/sdk/src/domain-types.ts:223](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L223)
 
 ***
 
@@ -511,7 +511,7 @@ Defined in: [packages/sdk/src/domain-types.ts:211](https://github.com/silo-code/
 --silo-modal-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:213](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L213)
+Defined in: [packages/sdk/src/domain-types.ts:225](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L225)
 
 ***
 
@@ -521,7 +521,7 @@ Defined in: [packages/sdk/src/domain-types.ts:213](https://github.com/silo-code/
 --silo-modal-border: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L214)
+Defined in: [packages/sdk/src/domain-types.ts:226](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L226)
 
 ***
 
@@ -531,7 +531,7 @@ Defined in: [packages/sdk/src/domain-types.ts:214](https://github.com/silo-code/
 --silo-notify-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L216)
+Defined in: [packages/sdk/src/domain-types.ts:228](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L228)
 
 ***
 
@@ -541,7 +541,7 @@ Defined in: [packages/sdk/src/domain-types.ts:216](https://github.com/silo-code/
 --silo-notify-text: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:217](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L217)
+Defined in: [packages/sdk/src/domain-types.ts:229](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L229)
 
 ***
 
@@ -551,7 +551,7 @@ Defined in: [packages/sdk/src/domain-types.ts:217](https://github.com/silo-code/
 --silo-notify-text-hi: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:218](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L218)
+Defined in: [packages/sdk/src/domain-types.ts:230](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L230)
 
 ***
 
@@ -561,7 +561,7 @@ Defined in: [packages/sdk/src/domain-types.ts:218](https://github.com/silo-code/
 --silo-list-radius: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:220](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L220)
+Defined in: [packages/sdk/src/domain-types.ts:232](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L232)
 
 ***
 
@@ -571,7 +571,7 @@ Defined in: [packages/sdk/src/domain-types.ts:220](https://github.com/silo-code/
 --silo-list-inset: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:221](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L221)
+Defined in: [packages/sdk/src/domain-types.ts:233](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L233)
 
 ***
 
@@ -581,7 +581,7 @@ Defined in: [packages/sdk/src/domain-types.ts:221](https://github.com/silo-code/
 --silo-list-hover-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L222)
+Defined in: [packages/sdk/src/domain-types.ts:234](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L234)
 
 ***
 
@@ -591,7 +591,7 @@ Defined in: [packages/sdk/src/domain-types.ts:222](https://github.com/silo-code/
 --silo-list-active-bg: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:223](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L223)
+Defined in: [packages/sdk/src/domain-types.ts:235](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L235)
 
 ***
 
@@ -601,6 +601,6 @@ Defined in: [packages/sdk/src/domain-types.ts:223](https://github.com/silo-code/
 --silo-list-active-outline: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:225](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L225)
+Defined in: [packages/sdk/src/domain-types.ts:237](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L237)
 
 Selected-row outline — use a bordered selection instead of (or with) a fill.

--- a/apps/docs/api/types/interfaces/Workspace.md
+++ b/apps/docs/api/types/interfaces/Workspace.md
@@ -1,6 +1,6 @@
 # Interface: Workspace
 
-Defined in: [packages/sdk/src/domain-types.ts:115](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L115)
+Defined in: [packages/sdk/src/domain-types.ts:127](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L127)
 
 A workspace — the unit Silo switches between, keeping its terminals, editors,
 and layout alive. Read via [WorkspaceService](WorkspaceService.md).
@@ -18,7 +18,7 @@ intentionally absent here.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:116](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L116)
+Defined in: [packages/sdk/src/domain-types.ts:128](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L128)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [packages/sdk/src/domain-types.ts:116](https://github.com/silo-code/
 name: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:117](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L117)
+Defined in: [packages/sdk/src/domain-types.ts:129](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L129)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [packages/sdk/src/domain-types.ts:117](https://github.com/silo-code/
 folder: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:118](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L118)
+Defined in: [packages/sdk/src/domain-types.ts:130](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L130)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [packages/sdk/src/domain-types.ts:118](https://github.com/silo-code/
 optional extraFolders?: string[];
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:120](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L120)
+Defined in: [packages/sdk/src/domain-types.ts:132](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L132)
 
 Additional folders beyond the primary one.
 
@@ -60,7 +60,7 @@ Additional folders beyond the primary one.
 createdAt: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:121](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L121)
+Defined in: [packages/sdk/src/domain-types.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L133)
 
 ***
 
@@ -70,7 +70,7 @@ Defined in: [packages/sdk/src/domain-types.ts:121](https://github.com/silo-code/
 lastOpenedAt: string;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:122](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L122)
+Defined in: [packages/sdk/src/domain-types.ts:134](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L134)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [packages/sdk/src/domain-types.ts:122](https://github.com/silo-code/
 optional closedAt?: string | null;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:128](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L128)
+Defined in: [packages/sdk/src/domain-types.ts:140](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L140)
 
 ISO timestamp of when the workspace was soft-closed, or null/undefined
 if the workspace is open. Closed workspaces are hidden from the main
@@ -94,7 +94,7 @@ list and surfaced in a "reopen" picker.
 terminals: readonly TerminalRecord[];
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:129](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L129)
+Defined in: [packages/sdk/src/domain-types.ts:141](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L141)
 
 ***
 
@@ -104,6 +104,6 @@ Defined in: [packages/sdk/src/domain-types.ts:129](https://github.com/silo-code/
 editors: readonly EditorRecord[];
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:131](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L131)
+Defined in: [packages/sdk/src/domain-types.ts:143](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L143)
 
 Editor tabs — text editors and diffs alike (a diff is a record with `mode: "diff"`).

--- a/apps/docs/api/types/type-aliases/EditorMode.md
+++ b/apps/docs/api/types/type-aliases/EditorMode.md
@@ -4,7 +4,7 @@
 type EditorMode = "text" | "diff";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:50](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L50)
+Defined in: [packages/sdk/src/domain-types.ts:62](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L62)
 
 The two modes of the one editor surface: a read-write text editor, or a
 read-only two-model diff. Absent on a record means `"text"`.

--- a/apps/docs/api/types/type-aliases/SidePanelSlot.md
+++ b/apps/docs/api/types/type-aliases/SidePanelSlot.md
@@ -4,6 +4,6 @@
 type SidePanelSlot = "left" | "right" | "left-bottom" | "right-bottom";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:101](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L101)
+Defined in: [packages/sdk/src/domain-types.ts:113](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L113)
 
 Which slot a side panel renders in.

--- a/apps/docs/api/types/type-aliases/ThemeBase.md
+++ b/apps/docs/api/types/type-aliases/ThemeBase.md
@@ -4,6 +4,6 @@
 type ThemeBase = "dark" | "light";
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:140](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L140)
+Defined in: [packages/sdk/src/domain-types.ts:152](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L152)
 
 Light or dark theme base.

--- a/apps/docs/api/types/type-aliases/ThemeExport.md
+++ b/apps/docs/api/types/type-aliases/ThemeExport.md
@@ -4,7 +4,7 @@
 type ThemeExport = Omit<CustomTheme, "id">;
 ```
 
-Defined in: [packages/sdk/src/domain-types.ts:254](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L254)
+Defined in: [packages/sdk/src/domain-types.ts:266](https://github.com/silo-code/silo/blob/main/packages/sdk/src/domain-types.ts#L266)
 
 A [CustomTheme](../interfaces/CustomTheme.md) without its `id` — the shape exported/imported as a
 shareable theme file.

--- a/examples/extensions/terminal-monitor/src/osc-detectors.test.ts
+++ b/examples/extensions/terminal-monitor/src/osc-detectors.test.ts
@@ -20,6 +20,23 @@ describe("detectClaudeCode", () => {
     }
   });
 
+  it("returns working+schedule for Claude's circle spinner frames", () => {
+    // ◐ U+25D0, ◑ U+25D1 — the frames current Claude Code animates in its
+    // title (2.1.228); ◒/◓ complete the accepted U+25D0–25D3 block.
+    for (const ch of ["◐", "◑", "◒", "◓"]) {
+      expect(detectClaudeCode(0, `${ch} my-project`)).toEqual({
+        status: "working",
+        timer: "schedule",
+      });
+    }
+  });
+
+  it("returns null for circle glyphs outside the spinner block", () => {
+    // ● U+25CF and ◔ U+25D4 bracket the block but are not spinner frames.
+    expect(detectClaudeCode(0, "● my-project")).toBeNull();
+    expect(detectClaudeCode(0, "◔ my-project")).toBeNull();
+  });
+
   it("returns waiting+clear for the ✳ idle char", () => {
     expect(detectClaudeCode(0, "\u2733 waiting…")).toEqual({
       status: "waiting",

--- a/examples/extensions/terminal-monitor/src/osc-detectors.ts
+++ b/examples/extensions/terminal-monitor/src/osc-detectors.ts
@@ -23,23 +23,36 @@ export interface DetectionResult {
 // ---------------------------------------------------------------------------
 // Claude Code  (OSC 0 title encoding)
 // ---------------------------------------------------------------------------
-// Uses braille block characters (U+2800–U+28FF) as a spinner while busy, and
+// Prefixes its OSC 0 title with an animated spinner glyph while busy, and with
 // ✳ (U+2733) as an explicit idle signal when waiting for input.
-// Note: Codex CLI uses the same braille spinner range, so the braille → working
-// branch covers both. The ✳ idle signal and debounce timer handle the difference:
-// Claude emits ✳ immediately; Codex relies on the timer after silence.
+//
+// Two spinner ranges are accepted, because the glyph changed: current Claude
+// Code (confirmed 2.1.228) animates the half-filled circles ◐/◑
+// (U+25D0–U+25D3), while older builds — and Codex CLI, which shares this
+// detector — use braille block characters (U+2800–U+28FF). The ✳ idle signal
+// and debounce timer handle the Claude/Codex difference: Claude emits ✳
+// immediately; Codex relies on the timer after silence.
 const BRAILLE_START = 0x2800;
 const BRAILLE_END = 0x28ff;
+const CIRCLE_SPINNER_START = 0x25d0;
+const CIRCLE_SPINNER_END = 0x25d3;
 const CLAUDE_IDLE_CHAR = "\u2733"; // ✳
+
+function startsWithSpinnerGlyph(payload: string): boolean {
+  const first = payload.charCodeAt(0);
+  return (
+    (first >= BRAILLE_START && first <= BRAILLE_END) ||
+    (first >= CIRCLE_SPINNER_START && first <= CIRCLE_SPINNER_END)
+  );
+}
 
 export function detectClaudeCode(
   code: number,
   payload: string,
 ): DetectionResult | null {
   if (code !== 0) return null;
-  const first = payload.charCodeAt(0);
-  if (first >= BRAILLE_START && first <= BRAILLE_END) {
-    // Braille spinner: agent is busy. Schedule idle timer as a fallback for
+  if (startsWithSpinnerGlyph(payload)) {
+    // Spinner frame: agent is busy. Schedule idle timer as a fallback for
     // Codex (which doesn't emit an explicit done signal).
     return { status: "working", timer: "schedule" };
   }

--- a/packages/extension-host/src/extension-host/agent-catalog.test.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.test.ts
@@ -476,6 +476,20 @@ describe("detectFromOsc", () => {
     });
   });
 
+  it("detects Claude's circle spinner as working through the full dispatch", () => {
+    // Real titles observed from claude-code 2.1.228, which prefixes the
+    // conversation title with ◐/◑ instead of the braille frames above. Asserted
+    // at the dispatch level (not just detectClaudeCode) so a Cursor/Codex/
+    // Copilot detector earlier in catalog order can't quietly swallow them.
+    for (const title of ["◐ Design event bus", "◑ Debug OSC detection"]) {
+      expect(detectFromOsc(0, title)).toEqual({
+        status: "working",
+        source: "agent",
+        timer: "schedule",
+      });
+    }
+  });
+
   it("detects Claude's idle marker as idle", () => {
     const result = detectFromOsc(0, "✳ awaiting");
     expect(result).toEqual({ status: "idle", source: "agent", timer: "clear" });

--- a/packages/extension-host/src/extension-host/agent-catalog.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.ts
@@ -287,24 +287,31 @@ const claude: AgentDefinition = {
     "process and records that process's pgid (used to correlate against the " +
     "terminal's foreground pgid — raw PPID alone misses Cursor workers that " +
     "setpgrp). Activity detection " +
-    "depends on Claude emitting a braille-spinner glyph (U+2800–28FF) while " +
-    "working and a '✳' marker when awaiting input.",
+    "depends on Claude prefixing its OSC 0 title with an animated spinner " +
+    "glyph while working and a '✳' marker when awaiting input. CONFIRMED " +
+    "against claude-code 2.1.228 (2026-08-11): the spinner glyphs are now the " +
+    "half-filled circles ◐/◑ (U+25D0–U+25D3 accepted) — they were braille " +
+    "(U+2800–28FF) in earlier builds, and Silo accepts BOTH ranges so old " +
+    "installs (and Codex/Grok, which still use braille) keep working. The " +
+    "title itself is '<glyph> <conversation title>'; the '✳' idle marker is " +
+    "unchanged. A future glyph change here silently breaks 'working' only — " +
+    "idle detection would keep working, so the symptom is an agent terminal " +
+    "that never lights up as busy.",
   upstreamRefs: [
     "https://docs.claude.com/en/docs/claude-code/hooks",
     "https://docs.claude.com/en/docs/claude-code/settings",
   ],
-  lastVerified: "2026-07-27",
-  // Left undefined until the first audit-skill run pins the current version.
-  verifiedAgainstVersion: undefined,
+  lastVerified: "2026-08-11",
+  verifiedAgainstVersion: "claude-code@2.1.228",
 };
 
 const codex: AgentDefinition = {
   id: "codex",
   displayName: "Codex CLI",
   leaderNames: ["codex"],
-  // "Working" is the shared Claude/Codex braille-spinner detector (Codex uses
-  // the same range); detectCodexCLI covers its own explicit "idle" signals
-  // (empty title, action-required markers, specific OSC 9 notifications).
+  // "Working" is the shared spinner detector in `detectClaudeCode` (Codex uses
+  // the braille range Claude used to); detectCodexCLI covers its own explicit
+  // "idle" signals (empty title, action-required markers, OSC 9 notifications).
   // Neither covers the common case — a normal turn finishing with no
   // approval needed, where Codex just sets a plain project/dir title — so
   // idleAfterWorking below handles that contextually.
@@ -356,8 +363,9 @@ const codex: AgentDefinition = {
     "group (Silo installs without one) fires on both startup and resume once " +
     "trusted — blocked on completing the trust step to test. Activity " +
     "detection (ported from silo-extensions/agent-monitor, 2026-07-28): " +
-    "'working' shares Claude's braille-spinner OSC 0 detector (same glyph " +
-    "range, confirmed shared upstream); 'idle' comes from either an empty " +
+    "'working' shares Claude's spinner OSC 0 detector, on its braille branch " +
+    "(U+2800–28FF — the range Claude itself used until claude-code 2.1.228); " +
+    "'idle' comes from either an empty " +
     "OSC 0 title, '[ ! ]'/'[ . ]' (awaiting approval), specific OSC 9 iTerm " +
     "notifications, OR — the common case, a normal turn finishing with no " +
     "approval needed — a contextual fallback: any other non-empty OSC 0 " +
@@ -489,12 +497,13 @@ const grok: AgentDefinition = {
   id: "grok",
   displayName: "Grok",
   leaderNames: ["grok"],
-  // "Working" shares the braille-spinner OSC 0 detector — Grok's TUI uses the
-  // same U+2800–28FF glyph range as Claude/Codex (confirmed live: Grok shows as
-  // an agent via this shared detector before any Grok-specific entry existed).
-  // Idle is the shared contextual fallback (a non-braille OSC 0 title after an
-  // agent-sourced working phase), reused from Codex — provisional until a
-  // Grok-specific idle signal is observed.
+  // "Working" shares the spinner OSC 0 detector, on its braille branch — Grok's
+  // TUI uses the U+2800–28FF glyph range Claude used until 2.1.228 (confirmed
+  // live: Grok shows as an agent via this shared detector before any
+  // Grok-specific entry existed). Idle is the shared contextual fallback (an
+  // OSC 0 title with no spinner glyph after an agent-sourced working phase),
+  // reused from Codex — provisional until a Grok-specific idle signal is
+  // observed.
   activityDetectors: [detectClaudeCode],
   idleAfterWorking: detectCodexIdleAfterWorking,
   resume: {
@@ -540,9 +549,10 @@ const grok: AgentDefinition = {
     "→ pid to attach the exact session id; (3) `grok --resume <SESSION_ID>` " +
     "resumes by id (UUID-shaped values are always treated as ids, per " +
     "`grok --resume --help`); session ids are UUIDv7. Activity: 'working' " +
-    "shares the Claude/Codex braille-spinner OSC 0 detector (same glyph " +
-    "range, confirmed shared); idle is the shared contextual fallback (a " +
-    "non-braille OSC 0 title after an agent-sourced working phase) — " +
+    "shares the spinner OSC 0 detector on its braille branch (U+2800–28FF — " +
+    "the range Claude itself used until claude-code 2.1.228, confirmed " +
+    "shared); idle is the shared contextual fallback (an OSC 0 title with no " +
+    "spinner glyph after an agent-sourced working phase) — " +
     "PROVISIONAL, pending observation of a Grok-specific idle signal. Note: " +
     "Grok ALSO supports [[hooks.SessionStart]] hooks, but only in TOML " +
     "config.toml (no global JSON hooks dir) and behind a folder-trust step, so " +

--- a/packages/extension-host/src/extension-host/agent-osc-detectors.test.ts
+++ b/packages/extension-host/src/extension-host/agent-osc-detectors.test.ts
@@ -7,6 +7,7 @@ import {
   detectCodexCLI,
   detectCodexIdleAfterWorking,
   detectShellIntegration,
+  stripAgentStatusMarkers,
   CURSOR_SPINNER_FRAMES,
 } from "./agent-osc-detectors";
 
@@ -130,7 +131,9 @@ describe("detectCursorAgentOutput", () => {
 // ---------------------------------------------------------------------------
 describe("detectClaudeCode", () => {
   it("returns working+schedule for braille spinner frames", () => {
-    // ⠋ U+280B, ⠙ U+2819, ⠏ U+280F — sample Codex/Claude spinner frames
+    // ⠋ U+280B, ⠙ U+2819, ⠏ U+280F — Codex/Grok frames, and Claude's own
+    // before claude-code 2.1.228 switched to the circles below. Range ends
+    // (U+2800, U+28FF) included so a regression to a narrower test is caught.
     for (const ch of ["⠋", "⠙", "⠏", "⠀", "⣿"]) {
       expect(detectClaudeCode(0, `${ch} my-project`)).toEqual({
         status: "working",
@@ -138,6 +141,27 @@ describe("detectClaudeCode", () => {
         timer: "schedule",
       });
     }
+  });
+
+  it("returns working+schedule for Claude's circle spinner frames", () => {
+    // Regression: claude-code 2.1.228 replaced the braille title spinner with
+    // ◐/◑ (its own frames), which the braille-only range check missed — the
+    // terminal stayed "never working" while idle detection kept working. The
+    // full U+25D0–25D3 block is accepted, so ◒/◓ are covered too.
+    for (const ch of ["◐", "◑", "◒", "◓"]) {
+      expect(detectClaudeCode(0, `${ch} Design event bus`)).toEqual({
+        status: "working",
+        source: "agent",
+        timer: "schedule",
+      });
+    }
+  });
+
+  it("returns null for circle glyphs just outside the spinner block", () => {
+    // U+25CF ● and U+25D4 ◔ both appear in Claude's glyph table but are not
+    // title spinner frames — the range must not creep.
+    expect(detectClaudeCode(0, "● my-project")).toBeNull();
+    expect(detectClaudeCode(0, "◔ my-project")).toBeNull();
   });
 
   it("returns idle+clear for the ✳ idle char", () => {
@@ -287,8 +311,17 @@ describe("detectCodexIdleAfterWorking", () => {
     expect(detectCodexIdleAfterWorking(0, "my-project", false)).toBeNull();
   });
 
-  it("returns null for braille / Claude idle / empty / action-required (other detectors)", () => {
+  it("returns null for any spinner frame / Claude idle / empty / action-required (other detectors)", () => {
     expect(detectCodexIdleAfterWorking(0, "⠋ my-project", true)).toBeNull();
+    // Circle frames must be excluded for the same reason braille is: this
+    // fallback reads "title with no spinner glyph" as the agent having
+    // finished, so treating a live ◐/◑ frame as idle would flip Claude back to
+    // idle on every 960ms tick of its own spinner.
+    for (const ch of ["◐", "◑", "◒", "◓"]) {
+      expect(
+        detectCodexIdleAfterWorking(0, `${ch} my-project`, true),
+      ).toBeNull();
+    }
     expect(detectCodexIdleAfterWorking(0, "✳ waiting…", true)).toBeNull();
     expect(detectCodexIdleAfterWorking(0, "", true)).toBeNull();
     expect(
@@ -343,5 +376,73 @@ describe("detectShellIntegration", () => {
   it("returns null for non-OSC-133 codes", () => {
     expect(detectShellIntegration(0, "C")).toBeNull();
     expect(detectShellIntegration(9, "C")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stripping markers back out for display
+// ---------------------------------------------------------------------------
+describe("stripAgentStatusMarkers", () => {
+  it("strips Claude's circle spinner frames and the ✳ idle marker", () => {
+    for (const ch of ["◐", "◑", "◒", "◓", "✳"]) {
+      expect(stripAgentStatusMarkers(`${ch} Design event bus`)).toBe(
+        "Design event bus",
+      );
+    }
+  });
+
+  it("strips braille spinner frames (Codex / Grok / older Claude)", () => {
+    for (const ch of ["⠋", "⠙", "⠀", "⣿"]) {
+      expect(stripAgentStatusMarkers(`${ch} my-project`)).toBe("my-project");
+    }
+  });
+
+  it("strips Codex's action-required markers", () => {
+    expect(stripAgentStatusMarkers("[ ! ] Action Required - x")).toBe(
+      "Action Required - x",
+    );
+    expect(stripAgentStatusMarkers("[ . ] my-project")).toBe("my-project");
+  });
+
+  it("strips Cursor's trailing status suffix, with and without emoji", () => {
+    // The emoji cases are the ones a naive emoji character class gets wrong:
+    // 📤 is a surrogate pair and ⌨️ carries a variation selector.
+    expect(stripAgentStatusMarkers("my-chat - ⏳ Working ...")).toBe("my-chat");
+    expect(stripAgentStatusMarkers("my-chat - 📤 Moving to cloud")).toBe(
+      "my-chat",
+    );
+    expect(
+      stripAgentStatusMarkers("Cursor Agent - ⌨️ Running shell command"),
+    ).toBe("Cursor Agent");
+    expect(stripAgentStatusMarkers("my-chat - Working ···")).toBe("my-chat");
+    expect(stripAgentStatusMarkers("my-chat - ✅ Ready (feature)")).toBe(
+      "my-chat",
+    );
+  });
+
+  it('returns "" for a marker-only title so callers can fall back', () => {
+    // Claude emits a bare ✳ before any conversation title exists; the caller
+    // must show the program name, not an empty tab.
+    expect(stripAgentStatusMarkers("✳")).toBe("");
+    expect(stripAgentStatusMarkers("◐ ")).toBe("");
+  });
+
+  it("leaves an ordinary title untouched", () => {
+    expect(stripAgentStatusMarkers("my-project")).toBe("my-project");
+    expect(stripAgentStatusMarkers("~/src/silo — zsh")).toBe(
+      "~/src/silo — zsh",
+    );
+    expect(stripAgentStatusMarkers("")).toBe("");
+  });
+
+  it("does not strip a bare Cursor idle title (no status segment)", () => {
+    expect(stripAgentStatusMarkers("Cursor Agent")).toBe("Cursor Agent");
+  });
+
+  it("does not eat a hyphenated title that isn't a Cursor status", () => {
+    expect(stripAgentStatusMarkers("silo - main")).toBe("silo - main");
+    expect(stripAgentStatusMarkers("notes - Workingham")).toBe(
+      "notes - Workingham",
+    );
   });
 });

--- a/packages/extension-host/src/extension-host/agent-osc-detectors.ts
+++ b/packages/extension-host/src/extension-host/agent-osc-detectors.ts
@@ -35,13 +35,41 @@ export interface DetectionResult {
 
 const BRAILLE_START = 0x2800;
 const BRAILLE_END = 0x28ff;
+/**
+ * Claude Code's *current* title spinner: the half/quarter-filled circles
+ * U+25D0–U+25D3 (`◐ ◑ ◒ ◓`). Confirmed against claude-code 2.1.228, whose
+ * title component animates `["◐", "◑"]` and falls back to the idle marker when
+ * not animating — i.e. the OSC 0 title is `"<glyph> <conversation title>"`.
+ * Claude *used* to use the braille range here; the braille branch stays because
+ * Codex CLI and Grok still emit braille frames (and older Claude builds do
+ * too). The whole U+25D0–U+25D3 block is accepted, not just the two frames
+ * currently in rotation, so another frame added to that set still reads as
+ * working.
+ */
+const CIRCLE_SPINNER_START = 0x25d0;
+const CIRCLE_SPINNER_END = 0x25d3;
 const CLAUDE_IDLE_CHAR = "✳";
 
 /**
- * Claude Code's braille spinner (working) + `✳` idle marker (idle).
- * Note: Codex CLI uses the *same* braille spinner range for "working", so
- * the braille → working branch covers both — that's why this function is
- * also attached to Codex's `activityDetectors` in the catalog, not just
+ * Does this OSC 0 title lead with a known agent spinner frame — i.e. is the
+ * agent mid-turn? Shared by `detectClaudeCode` (spinner → working) and
+ * `detectCodexIdleAfterWorking` (spinner → *not* the "spinner cleared to a
+ * plain title" idle signal), so the two can never disagree about which glyphs
+ * mean "still working". An empty payload yields `NaN` and is correctly false.
+ */
+function startsWithSpinnerGlyph(payload: string): boolean {
+  const first = payload.charCodeAt(0);
+  return (
+    (first >= BRAILLE_START && first <= BRAILLE_END) ||
+    (first >= CIRCLE_SPINNER_START && first <= CIRCLE_SPINNER_END)
+  );
+}
+
+/**
+ * Claude Code's title spinner (working) + `✳` idle marker (idle).
+ * Note: Codex CLI and Grok use the *same* braille spinner range for "working",
+ * so the spinner → working branch covers all three — that's why this function is
+ * also attached to their `activityDetectors` in the catalog, not just
  * Claude's. Codex has no `✳` of its own though; its idle transitions are
  * handled separately by `detectCodexCLI`/`detectCodexIdleAfterWorking`.
  */
@@ -50,8 +78,7 @@ export function detectClaudeCode(
   payload: string,
 ): DetectionResult | null {
   if (code !== 0) return null;
-  const first = payload.charCodeAt(0);
-  if (first >= BRAILLE_START && first <= BRAILLE_END) {
+  if (startsWithSpinnerGlyph(payload)) {
     return { status: "working", source: "agent", timer: "schedule" };
   }
   if (payload.startsWith(CLAUDE_IDLE_CHAR)) {
@@ -208,8 +235,9 @@ export function detectCodexCLI(
 /**
  * Codex idle fallback: while an agent-sourced working phase is active (almost
  * always from the shared Claude/Codex braille spinner), a non-empty OSC 0
- * title that is not Claude's ✳ and not another braille frame means Codex
- * cleared the spinner to its plain project title — treat as idle.
+ * title that is not Claude's ✳ and not another spinner frame (see
+ * `startsWithSpinnerGlyph`) means Codex cleared the spinner to its plain
+ * project title — treat as idle.
  *
  * Gated on `wasAgentWorking` so ordinary programs that set a window title are
  * not promoted to agents. Not used as a silence timer: backgrounded tabs
@@ -225,11 +253,68 @@ export function detectCodexIdleAfterWorking(
   wasAgentWorking: boolean,
 ): DetectionResult | null {
   if (code !== 0 || !wasAgentWorking || payload === "") return null;
-  const first = payload.charCodeAt(0);
-  if (first >= BRAILLE_START && first <= BRAILLE_END) return null;
+  if (startsWithSpinnerGlyph(payload)) return null;
   if (payload.startsWith(CLAUDE_IDLE_CHAR)) return null;
   if (CODEX_ACTION_REQUIRED.some((p) => payload.startsWith(p))) return null;
   return { status: "idle", source: "agent", timer: "clear" };
+}
+
+// ---------------------------------------------------------------------------
+// Presentation: stripping status markers back out of a title
+// ---------------------------------------------------------------------------
+
+/** Leading marker an OSC 0 title may carry: a spinner frame (either range),
+ * Claude's `✳`, or Codex's action-required marker — plus trailing whitespace.
+ * Built from the same constants the detectors match on, so a glyph Silo can
+ * *detect* is always a glyph Silo can *strip*. */
+const LEADING_MARKER_RE = new RegExp(
+  `^(?:[\\u2800-\\u28ff\\u25d0-\\u25d3]|${CLAUDE_IDLE_CHAR}|\\[ [!.] \\])\\s*`,
+);
+
+/** Cursor Agent encodes status as a trailing `" - <emoji?> <status>"` segment
+ * (optionally followed by a `" (worktree)"` suffix) rather than a leading
+ * glyph. Assembled from the detector's own status tables — the whole point of
+ * deriving it here is that adding a status to those tables can't leave this
+ * regex behind.
+ *
+ * The emoji is skipped as `[^A-Za-z]*` rather than an emoji character class,
+ * matching what `cursorStatusMatches` already does. A class would be wrong:
+ * Cursor's status emoji include astral-plane codepoints (`📤` = a surrogate
+ * pair) and one with a variation selector (`⌨️` = U+2328 U+FE0F), and a
+ * character class decomposes both into separate single-unit members — so it
+ * would match half a glyph and then fail to reach the status text. */
+const CURSOR_STATUS_SUFFIX_RE = new RegExp(
+  ` - [^A-Za-z]*` +
+    `(?:${[...CURSOR_WORKING_STATUSES, ...CURSOR_IDLE_STATUSES].join("|")})` +
+    // The status must END here, not merely start here: the trailing `[^)]*`
+    // absorbs Cursor's animated ellipsis ("Working ...", "Working ···"), and
+    // without this lookahead it would just as happily absorb the rest of a real
+    // word — stripping "notes - Workingham" down to "notes".
+    `(?![A-Za-z])[^)]*(?: \\([^)]+\\))?$`,
+);
+
+/**
+ * Strip agent status markers out of a terminal title, for display.
+ *
+ * Agents encode their status *into* the OSC 0 window title — that's what the
+ * detectors above read. Once the host has turned that into real
+ * `ctx.agents` state (rendered as a tab activity dot and a Workspaces status
+ * row), the raw glyph is redundant and visually noisy next to those, so the
+ * tab title and `TerminalRecord.title` show the cleaned text instead. Gated by
+ * the `hideAgentStatusGlyphs` terminal setting (Settings → Agents).
+ *
+ * Detection is unaffected: it reads the raw OSC stream via
+ * `subscribeOsc`, never a title. Stripping is purely presentational.
+ *
+ * Returns `""` when the title was *nothing but* a marker (Claude emits a bare
+ * `✳` before its first conversation title exists) — callers should treat that
+ * as "no title" and fall back rather than showing an empty tab.
+ */
+export function stripAgentStatusMarkers(title: string): string {
+  return title
+    .replace(CURSOR_STATUS_SUFFIX_RE, "")
+    .replace(LEADING_MARKER_RE, "")
+    .trim();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -379,6 +379,12 @@ export type {
   HookInstallStrategy,
 } from "./agent-catalog";
 
+// Presentation-side counterpart to detection: strip the status markers agents
+// encode into their OSC 0 title, so `core.terminal` can show a clean tab title
+// (gated by the `hideAgentStatusGlyphs` setting). Detection itself reads the raw
+// OSC stream, so stripping here can't affect it.
+export { stripAgentStatusMarkers } from "./agent-osc-detectors";
+
 // Tooltip — re-exported here so core.* extensions can still import it from the
 // internal barrel. The component itself is now public (@silo-code/sdk); the
 // host component file re-exports from SDK and owns the CSS load.

--- a/packages/extension-host/src/state/types.ts
+++ b/packages/extension-host/src/state/types.ts
@@ -454,6 +454,19 @@ export const MAX_TERMINAL_FONT_SIZE_OFFSET = 10;
 export interface TerminalSettings {
   /** Show the working-directory breadcrumb bar at the top of terminals. */
   breadcrumbs: boolean;
+  /**
+   * Strip agent status markers (Claude's `◐`/`✳`, Codex's braille spinner and
+   * `[ ! ]`, Cursor's ` - Working …` suffix) out of a terminal's title, so the
+   * tab shows just the conversation name. The status itself is not lost — it's
+   * what drives the tab's activity dot and the Workspaces status row, which is
+   * exactly why repeating it as a glyph is noise. Off shows titles verbatim.
+   *
+   * A terminal-display setting, but surfaced on the **Agents** settings page,
+   * since that's where a user looks for agent presentation. Applies to the tab
+   * title and {@link TerminalRecord.title}; agent *detection* reads the raw OSC
+   * stream and is unaffected either way.
+   */
+  hideAgentStatusGlyphs: boolean;
   /** xterm cursor shape. */
   cursorStyle: TerminalCursorStyle;
   /** Copy the selection to the clipboard as soon as it's made. */
@@ -493,6 +506,7 @@ export const DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY = 5;
 
 export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   breadcrumbs: true,
+  hideAgentStatusGlyphs: true,
   cursorStyle: "block",
   copyOnSelect: false,
   pasteOnRightClick: false,

--- a/packages/extensions-core/src/agents-settings/index.tsx
+++ b/packages/extensions-core/src/agents-settings/index.tsx
@@ -23,13 +23,23 @@
  * self-heal), since a shell hook can neither run nor correlate there.
  */
 import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useSnapshot } from "valtio";
 import type { Extension, ExtensionContext } from "@silo-code/sdk";
-import { Badge, Section, Callout, Button } from "@silo-code/sdk";
+import {
+  Badge,
+  Section,
+  Callout,
+  Button,
+  SettingRow,
+  Switch,
+} from "@silo-code/sdk";
 import {
   hookInstallableAgents,
   sessionFileAgents,
   buildTrackSessionScript,
   TRACK_SCRIPT_REL,
+  store,
+  setTerminalSetting,
   type AgentDefinition,
   type AgentHookResume,
 } from "@silo-code/extension-host/internal";
@@ -157,6 +167,9 @@ function AgentsSettingsPage({ ctx }: { ctx: ExtensionContext }) {
   // correlate against (RFC 0019 / RFC 0010's ConPTY gap) — the toggles are
   // hidden there and the page is detection-only.
   const [windows, setWindows] = useState(false);
+  // A terminal-display setting, surfaced here because this is where a user
+  // looks for how agents present themselves (see TerminalSettings).
+  const hideGlyphs = useSnapshot(store).terminalSettings.hideAgentStatusGlyphs;
 
   const load = useCallback(async () => {
     const agents = hookInstallableAgents();
@@ -275,8 +288,28 @@ function AgentsSettingsPage({ ctx }: { ctx: ExtensionContext }) {
       </div>
 
       <div className="es-scroll silo-scroll">
+        <Section label="Display">
+          <SettingRow
+            label="Hide status glyphs in tab titles"
+            hint="Strips agent status markers (Claude's ◐/✳, Codex's spinner, Cursor's “ - Working…”) from terminal tab titles."
+          >
+            <Switch
+              checked={hideGlyphs}
+              onChange={(checked) =>
+                setTerminalSetting("hideAgentStatusGlyphs", checked)
+              }
+              aria-label="Hide status glyphs in tab titles"
+            />
+          </SettingRow>
+        </Section>
+
+        {/* Both of these scope to session hooks specifically — the WIP caveat is
+            about hook-based exact resume, and the Windows gap is that a
+            POSIX-shell hook can't run there. Kept adjacent to the hooks section
+            rather than at the top of the page, where they read as applying to
+            every agent setting. */}
         <p className="agents-settings-banner">
-          <Badge tone="warn">Work in progress</Badge> Agent detection and exact
+          <Badge tone="warn">Work in progress</Badge> Session hooks and exact
           resume are still evolving. Expect rough edges — feedback welcome.{" "}
           <button
             type="button"

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -32,6 +32,7 @@ import {
   contextMenuEntriesFor,
   notifyTerminalSessionGone,
   notifyTerminalSessionRecreated,
+  stripAgentStatusMarkers,
 } from "@silo-code/extension-host/internal";
 import { xtermThemeFor } from "./xterm-theme";
 import { effectiveFontFamily } from "./terminal-font";
@@ -801,9 +802,20 @@ export function TerminalPanel(
     const { term } = live;
     let lastTitle = "";
     // Most recent title the program pushed via an OSC escape sequence ("" =
-    // none yet). Set by onTitleChange; consulted by read() ahead of the tmux
-    // scrape but behind any user-assigned customName.
+    // none yet), stored RAW. Set by onTitleChange; consulted by read() ahead of
+    // the tmux scrape but behind any user-assigned customName.
     let oscTitle = "";
+
+    // The OSC title with agent status markers removed (see
+    // `stripAgentStatusMarkers`), or verbatim when the user turned the setting
+    // off. Read per-call rather than stripped once at onTitleChange time so
+    // toggling the setting takes effect on the next read() tick instead of
+    // waiting for the agent to push another title. Returns "" when the title
+    // was nothing but a marker, which callers treat as "no title yet".
+    const displayOscTitle = () =>
+      store.terminalSettings.hideAgentStatusGlyphs
+        ? stripAgentStatusMarkers(oscTitle)
+        : oscTitle;
     // Foreground process, from the host (RFC 0010 N1). `fgKnown` stays false
     // until the first update so we fall back to legacy behavior if the signal
     // never arrives. At a prompt, a program's stale OSC title is dropped (N1a);
@@ -836,12 +848,14 @@ export function TerminalPanel(
       // 1. A user-assigned name wins over any auto-derived title for the tab
       // display. We still persist the live OSC title to rec.title so extensions
       // can observe actual activity in custom-named terminals.
+      const shown = displayOscTitle();
+
       if (rec?.customName) {
         if (rec.customName !== lastTitle) {
           lastTitle = rec.customName;
           props.api.setTitle(rec.customName);
         }
-        if (oscTitle && rec.title !== oscTitle) rec.title = oscTitle;
+        if (shown && rec.title !== shown) rec.title = shown;
         return;
       }
 
@@ -850,9 +864,10 @@ export function TerminalPanel(
 
       // 2. A title the program set via an OSC escape sequence (e.g. Claude Code).
       //    Drop it once we KNOW we're back at a prompt (N1a — stale title fix);
-      //    otherwise trust it.
-      if (oscTitle && !knownPrompt) {
-        apply(oscTitle, rec);
+      //    otherwise trust it. A marker-only title strips to "" and falls
+      //    through to the program name below rather than showing "Terminal".
+      if (shown && !knownPrompt) {
+        apply(shown, rec);
         return;
       }
 

--- a/packages/sdk/src/domain-types.ts
+++ b/packages/sdk/src/domain-types.ts
@@ -26,6 +26,18 @@ export interface TerminalRecord {
   id: string;
   sessionId: string;
   kind: TerminalKind;
+  /**
+   * The auto-derived tab title: the window title the running program pushed via
+   * an OSC escape sequence, else its process name, else the tmux status line.
+   *
+   * Agent **status markers are stripped** from this (Claude's `◐`/`✳`, Codex's
+   * braille spinner and `[ ! ]`, Cursor's trailing ` - Working …`) unless the
+   * user turns off "Hide status glyphs in tab titles" in Settings → Agents — the
+   * status is already available as structured state via `ctx.agents`, so the
+   * glyph would be redundant here. Don't parse this field to detect agent
+   * activity; use `ctx.agents`, or `ctx.terminals.subscribeOsc` for the raw
+   * (never-stripped) sequences.
+   */
   title: string;
   /**
    * A user-assigned name (via the tab's "Rename…" menu). When set, it wins over

--- a/packages/sdk/src/terminal-service.ts
+++ b/packages/sdk/src/terminal-service.ts
@@ -207,16 +207,23 @@ export interface TerminalService extends TabAdornmentMethods {
    *
    * @example
    * ```ts
-   * // Detect Claude Code busy/idle state from OSC 0 title sequences.
-   * const BRAILLE_START = 0x2800;
-   * const BRAILLE_END   = 0x28FF;
+   * // Detect Claude Code busy/idle state from OSC 0 title sequences: it
+   * // prefixes the title with an animated spinner glyph while busy, and with
+   * // the idle char below when awaiting input. Accept both spinner ranges —
+   * // current builds animate the half-filled circles ◐/◑, older ones used
+   * // braille (which Codex CLI still does).
+   * const SPINNERS = [
+   *   [0x25d0, 0x25d3], // ◐ ◑ ◒ ◓
+   *   [0x2800, 0x28ff], // ⠋ ⠙ ⠏ …
+   * ];
    * const IDLE_CHAR     = '\u2733'; // ✳
    *
    * const sub = ctx.terminals.subscribeOsc(terminalId, ({ code, payload }) => {
    *   if (code !== 0) return;
    *   const first = payload.charCodeAt(0);
-   *   if (first >= BRAILLE_START && first <= BRAILLE_END) setStatus('busy');
-   *   else if (payload.startsWith(IDLE_CHAR))              setStatus('idle');
+   *   const spinning = SPINNERS.some(([lo, hi]) => first >= lo && first <= hi);
+   *   if (spinning)                           setStatus('busy');
+   *   else if (payload.startsWith(IDLE_CHAR)) setStatus('idle');
    * });
    * ctx.subscriptions.push(sub);
    * ```


### PR DESCRIPTION
## The bug

`claude-code` 2.1.228 changed the glyph it prefixes its OSC 0 title with. The braille spinner (U+2800–28FF) became the half-filled circles `◐`/`◑` (U+25D0/U+25D1). From the shipped binary:

```js
szi = ["◐","◑"]   // ◐ ◑  — frames while working
azi = "✳"              // ✳    — shown when not animating
let NHH = isAnimating ? (szi[frame] ?? azi) : azi;
lnt(`${NHH} ${title}`)      // → OSC 0 (SET_TITLE_AND_ICON: 0)
```

`detectClaudeCode` range-checked braille only, so every working frame fell through to `null` and agent terminals never lit up as busy. Still OSC 0, and `✳` is unchanged — which is why it half-worked: idle was detected, working never fired.

## Detection

Both ranges are now accepted via a shared `startsWithSpinnerGlyph`, also used by `detectCodexIdleAfterWorking`. That second use matters: the fallback reads "title with no spinner glyph" as the agent having finished, so without the shared predicate a live `◐` frame would flip Claude back to idle on every 960ms spinner tick.

Nothing regresses for other agents — the braille branch is an added `||`, not a replacement. Codex CLI and Grok still emit braille (and share this detector), older Claude builds too, and Cursor/Copilot use different detectors entirely.

`agent-catalog.ts` contracts updated to record which range each agent depends on; Claude pinned to `verifiedAgainstVersion: "claude-code@2.1.228"`.

## Glyphs no longer shown in the UI

With the fix in place the `◐` became conspicuous in tab titles and Workspaces rows in a way braille never was. Silo already surfaces agent status as a tab activity dot and a Workspaces status row, so the raw glyph is redundant next to those.

`stripAgentStatusMarkers` is built **from the detectors' own constants** — both spinner ranges, `✳`, Codex's `[ ! ]`/`[ . ]`, Cursor's trailing `" - Working…"` — so a glyph Silo can detect is always a glyph Silo can strip. Applied in `TerminalPanel` where the OSC title becomes the tab title, so both the tab and `TerminalRecord.title` are clean and every consumer benefits at once.

New setting: **Settings → Agents → Display → "Hide status glyphs in tab titles"** (`hideAgentStatusGlyphs`, default on). The raw title is kept in memory and stripped per read, so toggling takes effect within 500ms rather than waiting for the agent to push a new title. A marker-only title (`✳`, before Claude has a conversation name) strips to `""` and falls through to the program name rather than showing "Terminal".

**Detection is unaffected by the stripping.** It reads the raw OSC stream — `parseOscSequences` off the PTY output event → `subscribeOsc` — and never consults a title. `subscribeOutput` (Cursor's raw spinner fallback) likewise.

### Side benefit

Agent tabs were rewriting their title every 960ms as the spinner advanced (`◐ Foo` → `◑ Foo` → …), each one a `setTitle()` plus a valtio store write, per agent terminal. Stripped, consecutive frames collapse to the same string and `apply()` early-returns.

## Also here

- The Agents page's "Work in progress" banner and Windows callout are scoped to the Session hooks section they actually describe, instead of sitting page-wide above every setting.
- `packages/sdk`: `TerminalRecord.title` gained the doc comment it never had, stating markers are stripped and pointing activity detection at `ctx.agents` / `subscribeOsc`. `subscribeOsc`'s `@example` no longer teaches the braille-only check.
- `examples/extensions/terminal-monitor` carries its own copy of these detectors; updated to match.

## Notes for review

Two things found while porting the strip logic:

- The external `agent-monitor` extension has an equivalent `stripStatusMarker` whose emoji character class `[📤…⌨️…]` can never match — a non-`u` regex decomposes `📤` into surrogate halves and `⌨️` into base + variation selector, so it matches half a glyph and then fails to reach the status text. Cursor titles *with* emoji were never being stripped there. This implementation uses `[^A-Za-z]*` instead, mirroring what `cursorStatusMatches` already does, with both cases covered by tests.
- A word-boundary lookahead is needed so the `Working` status doesn't eat `notes - Workingham`.

No changes were needed in `silo-extensions`: the host strips first, so `agent-monitor`'s own braille-only strip becomes a harmless no-op.

## Testing

`pnpm test` (10/10 packages, 1069 extension-host tests), `tsc --noEmit`, `pnpm lint`, and the example's own 23 tests all pass. `pnpm docs:api` regenerated.

New coverage: circle frames → working, both as a unit and through the full `detectFromOsc` dispatch (so no earlier catalog detector can swallow them); `●` U+25CF and `◔` U+25D4 stay null so the range can't creep; the Codex fallback returns null for circle frames; and the strip function across every marker kind, marker-only titles, the emoji surrogate-pair cases, and titles it must leave alone.

Not yet verified in the running app — the setting row and the clean tab title are worth eyeballing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdxASUekKnyXVapUsC35G9