### PR TITLE
fix(website): resume feature videos on mobile Safari after they stop

### DIFF
--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { AsciiBackdrop } from "./AsciiBackdrop";
 import { DemoWorkspace } from "./DemoWorkspace";
+import { StoryVideo } from "./StoryVideo";
 import { DOWNLOAD_FALLBACK_HREF, fetchLatestDownloadUrl } from "./download-url";
 import {
   EYEBROW,
@@ -301,17 +302,11 @@ export function App() {
                         decoding="async"
                       />
                     ) : visual?.kind === "video" ? (
-                      <video
-                        className="home-story-visual-video"
-                        autoPlay
-                        muted
-                        loop
-                        playsInline
+                      <StoryVideo
+                        webm={visual.webm}
                         poster={visual.poster}
-                        aria-label={section.visualAlt ?? section.title}
-                      >
-                        <source src={visual.webm} type="video/webm" />
-                      </video>
+                        label={section.visualAlt ?? section.title}
+                      />
                     ) : (
                       <span className="home-story-visual-hint">
                         {section.visualHint}

--- a/apps/website/src/StoryVideo.tsx
+++ b/apps/website/src/StoryVideo.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from "react";
+
+interface StoryVideoProps {
+  webm: string;
+  poster: string;
+  label: string;
+}
+
+/**
+ * Mobile Safari silently pauses off-screen/backgrounded `<video>` elements to
+ * save power and memory, and — unlike desktop browsers — does not resume
+ * `autoplay`/`loop` videos on its own once they scroll back into view. With
+ * several feature videos on one long-scrolling page, this shows up as
+ * playback that "stops at some point" while scrolling. Re-asserting `.play()`
+ * via IntersectionObserver whenever a video re-enters the viewport (or the
+ * tab regains visibility) works around it.
+ */
+export function StoryVideo({ webm, poster, label }: StoryVideoProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    let inView = false;
+    const resume = () => {
+      if (inView && video.paused) void video.play().catch(() => {});
+    };
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        inView = entry.isIntersecting;
+        if (inView) resume();
+        else video.pause();
+      },
+      { threshold: 0.25 },
+    );
+    observer.observe(video);
+
+    video.addEventListener("pause", resume);
+    document.addEventListener("visibilitychange", resume);
+    return () => {
+      observer.disconnect();
+      video.removeEventListener("pause", resume);
+      document.removeEventListener("visibilitychange", resume);
+    };
+  }, []);
+
+  return (
+    <video
+      ref={videoRef}
+      className="home-story-visual-video"
+      muted
+      loop
+      playsInline
+      preload="auto"
+      poster={poster}
+      aria-label={label}
+    >
+      <source src={webm} type="video/webm" />
+    </video>
+  );
+}


### PR DESCRIPTION
## Summary
- iOS Safari silently pauses off-screen/backgrounded `<video>` elements and, unlike desktop browsers, never resumes `autoplay`/`loop` videos on its own once they scroll back into view. With four feature videos on the homepage, this showed up as playback that stopped partway through scrolling on mobile Safari.
- New `StoryVideo` component drives playback with an `IntersectionObserver`: plays when a video enters the viewport, pauses when it leaves, and re-asserts `play()` on the video's own `pause` event and on `visibilitychange` (covers the tab-backgrounded case too).

## Test plan
- [x] `pnpm --filter @silo-code/website exec tsc --noEmit` — only pre-existing, unrelated error in `homepage-seo.ts`
- [x] `pnpm --filter @silo-code/website exec eslint src/StoryVideo.tsx src/App.tsx` — clean
- [x] `pnpm --filter @silo-code/website exec vite build` — succeeds
- [x] pre-commit hook: lint + full workspace test suite — green
- [ ] manual check on an actual iPhone in mobile Safari (not verified in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011epKaPkDhYfREjX4VpnLQA