### PR TITLE
fix(updates): re-check for stale handle before installing

### DIFF
--- a/packages/extension-host/src/extension-host/update-service.test.ts
+++ b/packages/extension-host/src/extension-host/update-service.test.ts
@@ -165,6 +165,59 @@ describe("UpdateService.installAndRelaunch", () => {
     await svc.installAndRelaunch();
     expect(seam.installUpdate).toHaveBeenCalledTimes(2);
   });
+
+  it("re-checks before downloading and installs the freshest handle, not the cached one", async () => {
+    // A stale `pending` from an earlier check shouldn't be trusted blindly —
+    // the status-bar link can sit actionable for a long time before it's
+    // clicked, so the handle it captured may no longer be good.
+    const stale = { version: "9.9.9" };
+    const fresh = { version: "9.9.9" };
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(fresh);
+    seam.installUpdate.mockResolvedValue(undefined);
+    const svc = await freshService();
+
+    await svc.check(); // caches `stale`
+    await svc.installAndRelaunch(); // re-checks -> `fresh`, installs that
+
+    expect(seam.checkForUpdate).toHaveBeenCalledTimes(2);
+    expect(seam.installUpdate).toHaveBeenCalledWith(fresh);
+  });
+
+  it("treats a fresh re-check finding no release as up to date, without installing", async () => {
+    const stale = { version: "9.9.9" };
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(null);
+    const svc = await freshService();
+
+    await svc.check();
+    await svc.installAndRelaunch();
+
+    expect(seam.installUpdate).not.toHaveBeenCalled();
+    expect(svc.getState()).toEqual({ phase: "upToDate", version: null });
+  });
+
+  it("logs install failures to the Output panel", async () => {
+    seam.isStableApp.mockResolvedValue(true);
+    seam.checkForUpdate.mockResolvedValue({ version: "9.9.9" });
+    seam.installUpdate.mockRejectedValue(new Error("download failed"));
+    const svc = await freshService();
+    const { outputStore } = await import("./output-store");
+
+    await svc.check();
+    await expect(svc.installAndRelaunch()).rejects.toThrow("download failed");
+
+    const entries = outputStore.channels["silo:updates"]?.entries ?? [];
+    expect(
+      entries.some(
+        (e) => e.level === "warn" && e.message.includes("install failed"),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("UpdateService.getChangelog", () => {

--- a/packages/extension-host/src/extension-host/update-service.ts
+++ b/packages/extension-host/src/extension-host/update-service.ts
@@ -15,6 +15,9 @@ import {
   fetchChangelog,
   type ChangelogEntry,
 } from "./changelog-client";
+import { createHostChannel } from "./output-store";
+
+const channel = createHostChannel("silo:updates", "Updates");
 
 export type { ChangelogEntry };
 
@@ -82,12 +85,18 @@ export interface UpdateService {
    */
   check(): Promise<void>;
   /**
-   * Download + install the release found by the last {@link UpdateService.check}
-   * and relaunch into it. No-op when no update is pending or an install is
-   * already in flight (guards against a double-click). Moves `phase` to
-   * `"installing"` for the duration; on failure it reverts to `"available"` and
-   * re-throws so the caller can report it (a successful install never returns —
-   * the app relaunches).
+   * Download + install the newest release and relaunch into it. No-op when no
+   * update is pending or an install is already in flight (guards against a
+   * double-click). Moves `phase` to `"installing"` for the duration.
+   *
+   * Re-checks immediately before downloading rather than trusting the release
+   * found by the last {@link UpdateService.check} — that check can be
+   * significantly stale (e.g. the status-bar link stays actionable across a
+   * long background re-check interval, so a click can fire against an
+   * `Update` handle that's hours old). If the re-check finds nothing newer,
+   * the state reverts to `"upToDate"` without installing. On any other
+   * failure it reverts to `"available"` and re-throws so the caller can
+   * report it (a successful install never returns — the app relaunches).
    */
   installAndRelaunch(): Promise<void>;
   /**
@@ -155,7 +164,7 @@ export function getUpdateService(): UpdateService {
           state.phase = "upToDate";
         }
       } catch (err) {
-        console.warn("[updater] check failed", err);
+        channel.warn("[updater] check failed", err);
         state.phase = "error";
       }
     },
@@ -167,11 +176,23 @@ export function getUpdateService(): UpdateService {
       // returns (the app relaunches), so this is the only chance to report it.
       if (state.version) void reportUpdateAction("installed", state.version);
       try {
-        await installUpdate(pending);
+        // `pending` may be from a background check up to RECHECK_INTERVAL_MS
+        // old — re-check right before downloading so we never install a
+        // stale `Update` handle (see the interface doc above).
+        const fresh = await checkForUpdate();
+        if (!fresh) {
+          pending = null;
+          state.version = null;
+          state.phase = "upToDate";
+          return;
+        }
+        pending = fresh;
+        state.version = fresh.version;
+        await installUpdate(fresh);
         // On success the app relaunches into the new version — control never
         // returns here.
       } catch (err) {
-        console.warn("[updater] install failed", err);
+        channel.warn("[updater] install failed", err);
         // Revert so the link reappears and the user can retry.
         state.phase = "available";
         throw err;
@@ -186,7 +207,7 @@ export function getUpdateService(): UpdateService {
         const range = changelogRange(all, installed, available);
         if (range.length > 0) return range;
       } catch (err) {
-        console.warn("[updater] changelog fetch failed", err);
+        channel.warn("[updater] changelog fetch failed", err);
       }
       // Fall back to the manifest's own single-version notes, if present.
       return pending.body


### PR DESCRIPTION
## Summary
- The status-bar "Update Silo" link installed whatever `Update` handle a prior background check had cached — potentially hours old by the time it's clicked — while the app-menu "Check for Updates" path always re-checks immediately before install. `installAndRelaunch()` now re-checks right before downloading, so both entry points install a fresh handle instead of a possibly-stale one.
- Routed the three swallowed `console.warn` calls in the update service through a new `"silo:updates"` Output panel channel instead, so a future install/check/changelog failure is diagnosable in-app rather than console-only.

## Test plan
- [x] `pnpm test` — full suite green, including 3 new unit tests covering: re-check installs the freshest handle (not the stale cached one), a fresh re-check finding no release reverts to "up to date" without installing, and install failures are logged to the Output panel
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)