### PR TITLE
fix(docs): eliminate homepage load flicker and defer story WebMs

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -152,6 +152,15 @@ export default withMermaid(
       return buildHomepageSeoHead();
     },
     head: [
+      // First paint: never flash the browser default white while VitePress /
+      // the marketing homepage boot (dev SPA shell is an empty #app).
+      // Also force .dark before theme CSS — vars.css defaults :root to white.
+      ["style", {}, "html,body,#app{background:#11120f;color:#f2f4ea}"],
+      [
+        "script",
+        {},
+        `document.documentElement.classList.add("dark","silo-js")`,
+      ],
       // Favicon set, generated from the shipping app-icon art
       // (apps/desktop/src-tauri/icon-source-square.png).
       ["link", { rel: "icon", href: "/favicon.ico", sizes: "any" }],
@@ -326,7 +335,31 @@ export default withMermaid(
     // React marketing homepage (@silo-code/website) mounts on `/`
     // via theme/Layout.vue. Keep React off the VitePress SSR graph.
     vite: {
-      plugins: [react()],
+      plugins: [
+        react(),
+        // VitePress's config.head is applied late in docs:dev (empty SPA
+        // shell). Inject first-paint dark fill + .silo-js into the HTML
+        // Vite serves so reload never flashes browser-default white, and
+        // below-fold SEO shell stays hidden as soon as home-shell.css loads.
+        {
+          name: "silo-first-paint",
+          transformIndexHtml(html: string) {
+            if (html.includes("silo-first-paint")) return html;
+            // VitePress vars.css sets :root { --vp-c-bg: #fff } and only
+            // switches to dark under html.dark. appearance:force-dark adds
+            // .dark late (client), so body flashes white once theme CSS
+            // loads. Seed .dark + a solid fill in the HTML Vite serves.
+            return html.replace(
+              /<head[^>]*>/i,
+              `<head>
+    <style data-silo-first-paint>
+      html,body,#app{background:#11120f;color:#f2f4ea}
+    </style>
+    <script data-silo-first-paint>document.documentElement.classList.add("dark","silo-js")</script>`,
+            );
+          },
+        },
+      ],
       optimizeDeps: {
         include: [
           "react",

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -2,6 +2,10 @@
 import DefaultTheme from "vitepress/theme";
 import { Content, useRoute } from "vitepress";
 import { computed, nextTick, onBeforeUnmount, onMounted, watch } from "vue";
+import {
+  HOME_FONTS_STYLESHEET,
+  buildHomeFontHead,
+} from "@silo-code/website/seo";
 import GitHubStars from "./GitHubStars.vue";
 import "./home-shell.css";
 
@@ -10,6 +14,33 @@ const route = useRoute();
 
 const isHome = computed(
   () => route.path === "/" || route.path === "/index.html",
+);
+
+/**
+ * transformHead only runs at SSG build time. In `docs:dev` the SPA shell has
+ * an empty <head>, and we removed the styles.css @import — so inject the
+ * homepage font links as soon as we know we're on `/`.
+ */
+function ensureHomeFonts() {
+  if (typeof document === "undefined") return;
+  if (document.querySelector(`link[href="${HOME_FONTS_STYLESHEET}"]`)) return;
+  for (const tuple of buildHomeFontHead()) {
+    const [, attrs] = tuple;
+    const link = document.createElement("link");
+    for (const [key, value] of Object.entries(attrs)) {
+      if (value === "") link.setAttribute(key, "");
+      else link.setAttribute(key, value);
+    }
+    document.head.appendChild(link);
+  }
+}
+
+watch(
+  isHome,
+  (home) => {
+    if (home) ensureHomeFonts();
+  },
+  { immediate: true },
 );
 
 /** @type {null | (() => void)} */
@@ -21,8 +52,10 @@ async function mountHome() {
   await nextTick();
   const el = document.getElementById("silo-home");
   if (!el) return;
-  // Dynamic import keeps React + the demo out of the docs-route graph and
-  // off the VitePress SSR path.
+  // CSS first (hero background + hide below-fold shell), then the React
+  // chunk — keeps first paint styled and avoids bundling React into docs
+  // routes / the VitePress SSR graph.
+  await import("@silo-code/website/styles.css");
   const { mountHomepage } = await import("@silo-code/website");
   unmountHome = mountHomepage(el);
 }

--- a/apps/docs/.vitepress/theme/home-shell.css
+++ b/apps/docs/.vitepress/theme/home-shell.css
@@ -1,12 +1,15 @@
 /**
  * Minimal styles for the SSG SEO shell in apps/docs/index.md — visible
- * before (or without) the React homepage hydrating. Kept intentionally
- * small; the full marketing look lives in @silo-code/website CSS.
+ * before (or without) the React homepage hydrating. Background matches
+ * marketing `.silo-home` so the handoff doesn't flash a different fill.
+ * Full marketing chrome still lives in @silo-code/website CSS (preloaded
+ * on `/` before mount).
  */
 .silo-marketing-home {
   min-height: 100vh;
-  background: #0b0d17;
-  color: #b7bccc;
+  background:
+    radial-gradient(circle at 72% 8%, #242830 0, #11120f 32rem), #11120f;
+  color: #f2f4ea;
 }
 
 .silo-home-shell {
@@ -17,8 +20,24 @@
     sans-serif;
   max-width: 1440px;
   margin: 0 auto;
-  padding: 28px 54px 80px;
+  padding: 0 54px 48px;
   box-sizing: border-box;
+  background:
+    radial-gradient(circle at 72% 8%, #242830 0, #11120f 32rem), #11120f;
+  color: #f2f4ea;
+  min-height: 100vh;
+}
+
+/*
+ * JS path (html.silo-js from a blocking head script): keep the SEO shell to
+ * hero-only until React replaces #silo-home. Without this, below-fold copy
+ * flashes at boot (styles.css still pending) and again if the shell class is
+ * dropped before React commits. No-JS clients never get .silo-js, so they
+ * still see the full shell.
+ */
+html.silo-js .silo-home-shell > footer,
+html.silo-js .silo-home-shell > main > section {
+  display: none;
 }
 
 .silo-home-shell a {
@@ -30,7 +49,8 @@
   flex-wrap: wrap;
   gap: 12px 22px;
   align-items: center;
-  margin-bottom: 48px;
+  height: 84px;
+  margin-bottom: 0;
 }
 
 .silo-home-shell-brand {
@@ -74,25 +94,40 @@
 }
 
 .silo-home-shell h1 {
-  font-size: clamp(40px, 7vw, 72px);
-  line-height: 0.95;
-  letter-spacing: -0.06em;
+  font-size: clamp(40px, 4.8vw, 68px);
+  line-height: 0.88;
+  letter-spacing: -0.09em;
   color: #f2f4ea;
-  margin: 0 0 20px;
+  margin: 22px 0 30px;
+  font-weight: 800;
+}
+
+.silo-home-shell .silo-home-shell-eyebrow {
+  color: #8b909e;
+  font:
+    11px "DM Mono",
+    monospace;
+  letter-spacing: 0.16em;
+  margin: 0;
 }
 
 .silo-home-shell .silo-home-shell-tagline {
-  max-width: 36rem;
-  color: #7a8099;
+  max-width: 415px;
+  color: #9a9d92;
   font-size: 16px;
   line-height: 1.6;
+}
+
+.silo-home-shell-intro {
+  padding: 94px 0 64px;
+  max-width: 700px;
 }
 
 .silo-home-shell-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin: 28px 0 48px;
+  margin: 26px 0 0;
 }
 
 .silo-home-shell-actions a {

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -32,13 +32,15 @@ description: One window — every project, every agent. Terminals, agents, and l
 </nav>
 </header>
 <main>
-<p>FOR DEVELOPERS JUGGLING CODING AGENTS</p>
+<div class="silo-home-shell-intro">
+<p class="silo-home-shell-eyebrow">FOR DEVELOPERS JUGGLING CODING AGENTS</p>
 <h1>One window —<br />every project, every agent</h1>
 <p class="silo-home-shell-tagline">Terminals, agents, and layout stay intact — switch between them instantly. 100% open source, free forever.</p>
 <p class="silo-home-shell-actions">
 <a href="https://github.com/silo-code/silo/releases/latest" data-primary>Download</a>
 <a href="https://github.com/silo-code/silo">Star on GitHub</a>
 </p>
+</div>
 <section aria-label="Product">
 <article>
 <p>Workspaces</p>

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#11120f" />
     <title>Silo — Live workspace prototype</title>
+    <style>
+      html,
+      body {
+        background: #11120f;
+        color: #f2f4ea;
+      }
+    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/website/src/StoryVideo.tsx
+++ b/apps/website/src/StoryVideo.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import {
+  STORY_VIDEO_PRELOAD,
+  STORY_VIDEO_ROOT_MARGIN,
+  nextStoryVideoLoadState,
+  shouldAttachStoryVideoSource,
+  type StoryVideoLoadState,
+} from "./story-video-load";
 
 interface StoryVideoProps {
   webm: string;
@@ -14,26 +21,44 @@ interface StoryVideoProps {
  * playback that "stops at some point" while scrolling. Re-asserting `.play()`
  * via IntersectionObserver whenever a video re-enters the viewport (or the
  * tab regains visibility) works around it.
+ *
+ * WebMs are also gated on near-viewport: `preload="none"` and no `<source>`
+ * until the observer fires, so the homepage doesn't pull ~7MB of video on
+ * first paint.
  */
 export function StoryVideo({ webm, poster, label }: StoryVideoProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const [loadState, setLoadState] = useState<StoryVideoLoadState>("idle");
+  const loadStateRef = useRef(loadState);
+  const inViewRef = useRef(false);
+  loadStateRef.current = loadState;
+
+  const attachSource = shouldAttachStoryVideoSource(loadState);
 
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
 
-    let inView = false;
     const resume = () => {
-      if (inView && video.paused) void video.play().catch(() => {});
+      if (
+        inViewRef.current &&
+        video.paused &&
+        shouldAttachStoryVideoSource(loadStateRef.current)
+      ) {
+        void video.play().catch(() => {});
+      }
     };
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        inView = entry.isIntersecting;
-        if (inView) resume();
+        inViewRef.current = entry.isIntersecting;
+        setLoadState((current) =>
+          nextStoryVideoLoadState(current, entry.isIntersecting),
+        );
+        if (entry.isIntersecting) resume();
         else video.pause();
       },
-      { threshold: 0.25 },
+      { threshold: 0.15, rootMargin: STORY_VIDEO_ROOT_MARGIN },
     );
     observer.observe(video);
 
@@ -46,6 +71,16 @@ export function StoryVideo({ webm, poster, label }: StoryVideoProps) {
     };
   }, []);
 
+  // After the source is attached, kick the element so preload=none still
+  // fetches and autoplay can start once near-viewport.
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || loadState !== "pending") return;
+    video.load();
+    setLoadState("ready");
+    if (inViewRef.current) void video.play().catch(() => {});
+  }, [loadState, webm]);
+
   return (
     <video
       ref={videoRef}
@@ -53,11 +88,11 @@ export function StoryVideo({ webm, poster, label }: StoryVideoProps) {
       muted
       loop
       playsInline
-      preload="auto"
+      preload={STORY_VIDEO_PRELOAD}
       poster={poster}
       aria-label={label}
     >
-      <source src={webm} type="video/webm" />
+      {attachSource ? <source src={webm} type="video/webm" /> : null}
     </video>
   );
 }

--- a/apps/website/src/homepage-mount.test.ts
+++ b/apps/website/src/homepage-mount.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOME_ACCENT,
+  REMOVE_SHELL_CLASS_AFTER_REACT_PAINT,
+  SHELL_BELOW_FOLD_SELECTOR,
+  isMarketingCssApplied,
+  waitForMarketingStyles,
+} from "./homepage-mount";
+
+describe("homepage mount handoff", () => {
+  it("keeps the shell class until after React paints (avoids below-fold flash)", () => {
+    expect(REMOVE_SHELL_CLASS_AFTER_REACT_PAINT).toBe(true);
+  });
+
+  it("detects marketing CSS via --home-accent", () => {
+    expect(isMarketingCssApplied(HOME_ACCENT)).toBe(true);
+    expect(isMarketingCssApplied("  #C5C9D2 ")).toBe(true);
+  });
+
+  it("rejects missing / wrong accent (shell-only CSS)", () => {
+    expect(isMarketingCssApplied("")).toBe(false);
+    expect(isMarketingCssApplied(" ")).toBe(false);
+    expect(isMarketingCssApplied("#11120f")).toBe(false);
+  });
+
+  it("waitForMarketingStyles resolves once the probe flips", async () => {
+    let ready = false;
+    queueMicrotask(() => {
+      ready = true;
+    });
+    const ok = await waitForMarketingStyles(
+      () => ({ homeAccent: ready ? HOME_ACCENT : "" }),
+      { timeoutMs: 500, intervalMs: 5 },
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("waitForMarketingStyles times out when styles never arrive", async () => {
+    const ok = await waitForMarketingStyles(() => ({ homeAccent: "" }), {
+      timeoutMs: 40,
+      intervalMs: 10,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("exports a stable below-fold shell selector for styles.css", () => {
+    expect(SHELL_BELOW_FOLD_SELECTOR).toContain(".silo-home.silo-home-shell");
+    expect(SHELL_BELOW_FOLD_SELECTOR).toContain("footer");
+    expect(SHELL_BELOW_FOLD_SELECTOR).toContain("main > section");
+  });
+});

--- a/apps/website/src/homepage-mount.ts
+++ b/apps/website/src/homepage-mount.ts
@@ -1,0 +1,45 @@
+/**
+ * Homepage mount handoff helpers — keep the SSG SEO shell painted until
+ * marketing CSS has applied, then let React replace it in one step.
+ */
+
+/** Below-fold shell nodes; hidden by styles.css once `.silo-home` rules load. */
+export const SHELL_BELOW_FOLD_SELECTOR =
+  ".silo-home.silo-home-shell > footer, .silo-home.silo-home-shell > main > section";
+
+/**
+ * Keep `silo-home-shell` on the root until after React's first paint.
+ * Removing it first un-hides below-fold SEO HTML for a frame (repro: ~11s flash).
+ */
+export const REMOVE_SHELL_CLASS_AFTER_REACT_PAINT = true;
+
+/** Set on `.silo-home` in styles.css — not present in home-shell.css alone. */
+export const HOME_ACCENT = "#c5c9d2";
+
+/**
+ * True when marketing `styles.css` has applied to the homepage root.
+ * Uses `--home-accent` (marketing-only) rather than background — the SSG
+ * shell already shares the same gradient fill for a seamless first paint.
+ */
+export function isMarketingCssApplied(homeAccent: string): boolean {
+  return homeAccent.trim().toLowerCase() === HOME_ACCENT;
+}
+
+export type StyleProbe = {
+  homeAccent: string;
+};
+
+/** Poll until `probe()` reports marketing styles, or `timeoutMs` elapses. */
+export async function waitForMarketingStyles(
+  probe: () => StyleProbe,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<boolean> {
+  const timeoutMs = opts.timeoutMs ?? 2000;
+  const intervalMs = opts.intervalMs ?? 16;
+  const start = Date.now();
+  for (;;) {
+    if (isMarketingCssApplied(probe().homeAccent)) return true;
+    if (Date.now() - start >= timeoutMs) return false;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}

--- a/apps/website/src/homepage-seo.test.ts
+++ b/apps/website/src/homepage-seo.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import { FAQ_ITEMS, SITE_DESCRIPTION, SITE_NAME } from "./homepage-copy";
 import {
   HOME_CANONICAL,
+  HOME_FONTS_STYLESHEET,
   OG_DESCRIPTION,
   OG_IMAGE_URL,
   buildFaqPageJsonLd,
+  buildHomeFontHead,
   buildHomepageSeoHead,
   buildSoftwareApplicationJsonLd,
   homeHeadline,
@@ -52,6 +54,21 @@ describe("homepage SEO helpers", () => {
     ]);
   });
 
+  it("buildHomeFontHead returns preconnects + Manrope/DM Mono stylesheet", () => {
+    expect(buildHomeFontHead()).toEqual([
+      ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+      [
+        "link",
+        {
+          rel: "preconnect",
+          href: "https://fonts.gstatic.com",
+          crossorigin: "",
+        },
+      ],
+      ["link", { rel: "stylesheet", href: HOME_FONTS_STYLESHEET }],
+    ]);
+  });
+
   it("includes canonical, OG/Twitter image tags, and both JSON-LD scripts", () => {
     const head = buildHomepageSeoHead();
     const metas = Object.fromEntries(
@@ -63,12 +80,30 @@ describe("homepage SEO helpers", () => {
           (t[1] as Record<string, string>).content,
         ]),
     );
-    const canonical = head.find(
-      (t) => t[0] === "link" && (t[1] as { rel?: string }).rel === "canonical",
+    const links = head.filter((t) => t[0] === "link");
+    const canonical = links.find(
+      (t) => (t[1] as { rel?: string }).rel === "canonical",
+    );
+    const fontStylesheet = links.find(
+      (t) =>
+        (t[1] as { rel?: string }).rel === "stylesheet" &&
+        (t[1] as { href?: string }).href === HOME_FONTS_STYLESHEET,
+    );
+    const preconnects = links.filter(
+      (t) => (t[1] as { rel?: string }).rel === "preconnect",
     );
     const scripts = head.filter((t) => t[0] === "script");
 
     expect(canonical?.[1]).toEqual({ rel: "canonical", href: HOME_CANONICAL });
+    expect(preconnects.map((t) => (t[1] as { href: string }).href)).toEqual([
+      "https://fonts.googleapis.com",
+      "https://fonts.gstatic.com",
+    ]);
+    expect(fontStylesheet).toBeDefined();
+    // Fonts precede SEO tags so the browser discovers them first.
+    expect(head.indexOf(fontStylesheet!)).toBeLessThan(
+      head.indexOf(canonical!),
+    );
     expect(metas["og:image"]).toBe(OG_IMAGE_URL);
     expect(metas["og:image"]).toMatch(/^https:\/\//);
     expect(metas["twitter:image"]).toBe(OG_IMAGE_URL);

--- a/apps/website/src/homepage-seo.ts
+++ b/apps/website/src/homepage-seo.ts
@@ -19,6 +19,31 @@ export const OG_IMAGE_URL = `${SITE_ORIGIN}${OG_IMAGE_PATH}`;
 export const OG_IMAGE_WIDTH = 1200;
 export const OG_IMAGE_HEIGHT = 630;
 
+/** VitePress `HeadConfig` tuples for the marketing homepage only. */
+export type SeoHeadTuple =
+  | [string, Record<string, string>]
+  | [string, Record<string, string>, string];
+
+/** Marketing homepage typefaces — linked from `<head>`, not via CSS `@import`. */
+export const HOME_FONTS_STYLESHEET =
+  "https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap";
+
+/** Preconnect + stylesheet tuples shared by SSG head and the VitePress theme. */
+export function buildHomeFontHead(): SeoHeadTuple[] {
+  return [
+    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+    [
+      "link",
+      {
+        rel: "preconnect",
+        href: "https://fonts.gstatic.com",
+        crossorigin: "",
+      },
+    ],
+    ["link", { rel: "stylesheet", href: HOME_FONTS_STYLESHEET }],
+  ];
+}
+
 /** Shorter social blurb — leads with audience, then the product promise. */
 export const OG_DESCRIPTION =
   "For developers juggling coding agents. Terminals, agents, and layout stay intact — switch between them instantly. 100% open source, free forever.";
@@ -71,14 +96,12 @@ export function buildSoftwareApplicationJsonLd() {
   };
 }
 
-/** VitePress `HeadConfig` tuples for the marketing homepage only. */
-export type SeoHeadTuple =
-  | [string, Record<string, string>]
-  | [string, Record<string, string>, string];
-
 export function buildHomepageSeoHead(): SeoHeadTuple[] {
   const ogTitle = homeOgTitle();
   return [
+    // Start font CSS early so the shell + React mount don't FOUT after
+    // styles.css arrives. Keep these on the homepage only (transformHead).
+    ...buildHomeFontHead(),
     ["link", { rel: "canonical", href: HOME_CANONICAL }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:site_name", content: SITE_NAME }],

--- a/apps/website/src/mount.tsx
+++ b/apps/website/src/mount.tsx
@@ -1,15 +1,35 @@
 import { StrictMode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { App } from "./App";
+import {
+  REMOVE_SHELL_CLASS_AFTER_REACT_PAINT,
+  waitForMarketingStyles,
+} from "./homepage-mount";
 import "./styles.css";
 
 const roots = new WeakMap<Element, Root>();
 
+function probeStyles(el: HTMLElement) {
+  return {
+    homeAccent: getComputedStyle(el).getPropertyValue("--home-accent"),
+  };
+}
+
+function dropShellClassAfterPaint(el: HTMLElement, isCancelled: () => boolean) {
+  // Two rAFs: after React's commit + the browser's subsequent paint, so the
+  // SEO below-fold nodes are already gone before `.silo-home-shell` (which
+  // was hiding them) is removed.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      if (isCancelled()) return;
+      el.classList.remove("silo-home-shell");
+    });
+  });
+}
+
 /** Mount the marketing homepage into `el`, replacing any SSG SEO shell children. */
 export function mountHomepage(el: HTMLElement): () => void {
   el.classList.add("silo-home");
-  // Drop the no-JS shell styling once React owns the node.
-  el.classList.remove("silo-home-shell");
 
   const existing = roots.get(el);
   if (existing) {
@@ -17,17 +37,36 @@ export function mountHomepage(el: HTMLElement): () => void {
     roots.delete(el);
   }
 
-  const root = createRoot(el);
-  roots.set(el, root);
-  root.render(
-    <StrictMode>
-      <App />
-    </StrictMode>,
-  );
+  let cancelled = false;
+  let root: Root | null = null;
+
+  void (async () => {
+    // Layout preloads styles.css before this module; still wait so the first
+    // React paint isn't unstyled if the CSS chunk is a frame behind.
+    await waitForMarketingStyles(() => probeStyles(el), { timeoutMs: 2000 });
+    if (cancelled) return;
+
+    root = createRoot(el);
+    roots.set(el, root);
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+
+    // Important: do NOT remove `silo-home-shell` before render — that un-hides
+    // below-fold SEO sections for a paint (the ~11s flash in the repro video).
+    if (REMOVE_SHELL_CLASS_AFTER_REACT_PAINT) {
+      dropShellClassAfterPaint(el, () => cancelled);
+    } else {
+      el.classList.remove("silo-home-shell");
+    }
+  })();
 
   return () => {
+    cancelled = true;
     const current = roots.get(el);
-    if (current === root) {
+    if (current) {
       current.unmount();
       roots.delete(el);
     }

--- a/apps/website/src/story-video-load.test.ts
+++ b/apps/website/src/story-video-load.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  STORY_VIDEO_PRELOAD,
+  STORY_VIDEO_ROOT_MARGIN,
+  nextStoryVideoLoadState,
+  shouldAttachStoryVideoSource,
+} from "./story-video-load";
+
+describe("story video load gating", () => {
+  it("keeps preload=none so the browser does not eager-fetch WebMs", () => {
+    expect(STORY_VIDEO_PRELOAD).toBe("none");
+  });
+
+  it("uses a modest rootMargin so clips warm up just before visible", () => {
+    expect(STORY_VIDEO_ROOT_MARGIN).toMatch(/px/);
+  });
+
+  it("stays idle until near the viewport", () => {
+    expect(nextStoryVideoLoadState("idle", false)).toBe("idle");
+    expect(nextStoryVideoLoadState("idle", true)).toBe("pending");
+  });
+
+  it("does not unload after the source has been attached", () => {
+    expect(nextStoryVideoLoadState("pending", false)).toBe("pending");
+    expect(nextStoryVideoLoadState("ready", false)).toBe("ready");
+    expect(nextStoryVideoLoadState("ready", true)).toBe("ready");
+  });
+
+  it("attaches the source only once loading has started", () => {
+    expect(shouldAttachStoryVideoSource("idle")).toBe(false);
+    expect(shouldAttachStoryVideoSource("pending")).toBe(true);
+    expect(shouldAttachStoryVideoSource("ready")).toBe(true);
+  });
+});

--- a/apps/website/src/story-video-load.ts
+++ b/apps/website/src/story-video-load.ts
@@ -1,0 +1,29 @@
+/**
+ * Feature-story video loading — keep WebMs off the critical path until
+ * a clip is near the viewport. Once attached, stay attached (don't tear
+ * down on scroll-away; Safari resume logic still needs the element).
+ */
+
+export type StoryVideoLoadState = "idle" | "pending" | "ready";
+
+/** Always `none` — we attach `<source>` only when near-viewport. */
+export const STORY_VIDEO_PRELOAD = "none" as const;
+
+/** Start fetching slightly before the clip enters view. */
+export const STORY_VIDEO_ROOT_MARGIN = "240px 0px";
+
+export function nextStoryVideoLoadState(
+  current: StoryVideoLoadState,
+  isNearViewport: boolean,
+): StoryVideoLoadState {
+  if (current === "ready" || current === "pending") return current;
+  if (isNearViewport) return "pending";
+  return "idle";
+}
+
+/** True once we've decided to attach the WebM source. */
+export function shouldAttachStoryVideoSource(
+  state: StoryVideoLoadState,
+): boolean {
+  return state === "pending" || state === "ready";
+}

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -1,4 +1,6 @@
-@import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap");
+/* Fonts (Manrope / DM Mono) are loaded from <head> via
+   buildHomepageSeoHead / apps/website/index.html — not @import here —
+   so they start before the React CSS chunk and don't block parsing. */
 
 /* Scoped under .silo-home so these rules don't leak onto VitePress docs
    routes after the homepage CSS chunk has been loaded. */
@@ -13,6 +15,18 @@
   background:
     radial-gradient(circle at 72% 8%, #242830 0, #11120f 32rem), #11120f;
 }
+
+/*
+ * Once marketing CSS is on the page (JS path), collapse the SEO shell's
+ * below-fold blocks so the handoff is hero→hero+demo — not a full text
+ * page→React. No-JS clients never load this file, so they still see the
+ * full shell from home-shell.css.
+ */
+.silo-home.silo-home-shell > footer,
+.silo-home.silo-home-shell > main > section {
+  display: none;
+}
+
 .silo-home *,
 .silo-home *::before,
 .silo-home *::after {


### PR DESCRIPTION
## Summary
- Seed dark first paint (`html.dark` + dark `html/body/#app`) before VitePress theme CSS so refresh no longer flashes white.
- Keep the SEO shell hero-aligned with marketing CSS, preload homepage styles, and remove `silo-home-shell` only after React paints so below-fold copy does not flash.
- Move Google Fonts out of a CSS `@import` into early `<link>` tags, and attach feature story WebMs only when near the viewport (`preload="none"`).

## Test plan
- [ ] `pnpm docs:dev` → hard-refresh `/` — no white flash; no below-fold “Workspaces…” flash before marketing UI
- [ ] Confirm fonts load without late FOUT (Network / quick visual check)
- [ ] Above the fold: no feature WebM media requests; after scrolling into story sections, WebMs load
- [ ] `pnpm --filter @silo-code/website test` green
- [ ] Production-ish: `pnpm docs:build` and smoke the built homepage if convenient


Made with [Cursor](https://cursor.com)