### PR TITLE
fix(terminal): stop reattach from clobbering an agent tab's persisted title

### DIFF
--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -348,7 +348,10 @@ export {
 
 // Foreground-process updates for a terminal session (RFC 0010 N1) — consumed by
 // the built-in terminal for tab titles. Core-only; not public SDK surface.
-export { onTerminalForeground } from "./terminal-foreground";
+export {
+  onTerminalForeground,
+  terminalForegroundSnapshot,
+} from "./terminal-foreground";
 export type { TerminalForeground } from "./terminal-foreground";
 
 // `ctx.agents`'s death/reset hooks (RFC 0018) — called by the built-in

--- a/packages/extension-host/src/extension-host/terminal-foreground.ts
+++ b/packages/extension-host/src/extension-host/terminal-foreground.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
 // Foreground-process updates for a terminal session (RFC 0010 N1), forwarded by
@@ -41,4 +42,24 @@ export function onTerminalForeground(
     unlisten?.();
     unlisten = null;
   };
+}
+
+/**
+ * The host's last known foreground state for a session, or `null` if it has
+ * none yet.
+ *
+ * {@link onTerminalForeground} only fires on *change*, and the daemon's one
+ * push at attach time can land before a subscriber exists — so a consumer that
+ * needs the value *now* (rather than the next change) seeds from here. Without
+ * it, a session that reattaches and then sits idle — an agent waiting for input,
+ * a shell at a prompt — never reports its foreground state at all.
+ */
+export async function terminalForegroundSnapshot(
+  sessionId: string,
+): Promise<TerminalForeground | null> {
+  return (
+    (await invoke<TerminalForeground | null>("terminal_foreground_snapshot", {
+      sessionId,
+    })) ?? null
+  );
 }

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -28,11 +28,13 @@ import {
   retryFocus,
   useFocusOnActive,
   onTerminalForeground,
+  terminalForegroundSnapshot,
   registerSelectionSource,
   contextMenuEntriesFor,
   notifyTerminalSessionGone,
   notifyTerminalSessionRecreated,
   stripAgentStatusMarkers,
+  type TerminalForeground,
 } from "@silo-code/extension-host/internal";
 import { xtermThemeFor } from "./xterm-theme";
 import { effectiveFontFamily } from "./terminal-font";
@@ -46,6 +48,7 @@ import {
   type TerminalLinkRange,
 } from "./terminal-link-policy";
 import { findTerminalOwnerId } from "./terminal-lifecycle";
+import { deriveTitle, formatTitle, tmuxStatusTitle } from "./terminal-title";
 import { formatResumeBox } from "./resume-box";
 import { TerminalSearch } from "./TerminalSearch";
 import { Breadcrumb } from "../editor/Breadcrumb";
@@ -784,13 +787,9 @@ export function TerminalPanel(
     // Recreate flow uses the explicit `version` bump instead.
   }, [terminalId, version]);
 
-  // Derive the dockview tab title, in priority order:
-  //   1. a user-assigned name (right-click → Rename) — always wins;
-  //   2. a title the program pushed via an OSC 0/1/2 escape sequence (e.g.
-  //      Claude Code updating its title as its activity changes) — xterm
-  //      surfaces these through onTitleChange;
-  //   3. the tmux status line (last visible row) as a fallback for programs
-  //      that don't emit an OSC title.
+  // Derive the dockview tab title. The rules (and why a restored title outranks
+  // a running program's name) live in `terminal-title.ts`; this effect is the
+  // glue that feeds them live signals and writes the result out.
   // Reacts to PTY writes and also polls as a fallback (hidden panels still
   // render to the buffer but onWriteParsed may not fire if the panel is in a
   // detached group).
@@ -801,6 +800,11 @@ export function TerminalPanel(
 
     const { term } = live;
     let lastTitle = "";
+    // The title this mount inherited from persisted state, held until a live
+    // signal supersedes it (see `deriveTitle`). Seeded on the first read(),
+    // which is also where the terminal record is first in hand.
+    let restoredTitle = "";
+    let seeded = false;
     // Most recent title the program pushed via an OSC escape sequence ("" =
     // none yet), stored RAW. Set by onTitleChange; consulted by read() ahead of
     // the tmux scrape but behind any user-assigned customName.
@@ -816,24 +820,27 @@ export function TerminalPanel(
       store.terminalSettings.hideAgentStatusGlyphs
         ? stripAgentStatusMarkers(oscTitle)
         : oscTitle;
-    // Foreground process, from the host (RFC 0010 N1). `fgKnown` stays false
-    // until the first update so we fall back to legacy behavior if the signal
-    // never arrives. At a prompt, a program's stale OSC title is dropped (N1a);
-    // a running program with no OSC title shows its own name (N1b).
-    let fgKnown = false;
-    let fgAtPrompt = true;
-    let fgLeader = "";
-    const progName = (s: string) =>
-      (s.replace(/^-/, "").split("/").pop() ?? s).trim();
+    // Foreground process, from the host (RFC 0010 N1). `fg` stays null until the
+    // first update so we fall back to legacy behavior if the signal never
+    // arrives. At a prompt, a program's stale OSC title is dropped (N1a); a
+    // running program with no OSC title shows its own name (N1b).
+    let fg: TerminalForeground | null = null;
 
     function apply(text: string, rec: TerminalRecord | null) {
-      if (!text) text = "Terminal";
-      else if (text.length > 32) text = text.slice(0, 31) + "…";
-      if (text === lastTitle) return;
-      lastTitle = text;
-      props.api.setTitle(text);
+      const formatted = formatTitle(text);
+      if (formatted === lastTitle) return;
+      lastTitle = formatted;
+      props.api.setTitle(formatted);
       // Persist to workspace state so the tab title survives reload.
-      if (rec) rec.title = text;
+      if (rec) rec.title = formatted;
+    }
+
+    /** The tmux status line: quoted text on the last buffer row. */
+    function tmuxLine() {
+      const buffer = term.buffer.active;
+      const bottom = Math.max(0, buffer.length - 1);
+      const line = buffer.getLine(bottom);
+      return tmuxStatusTitle(line ? line.translateToString(true) : "");
     }
 
     function read() {
@@ -845,54 +852,39 @@ export function TerminalPanel(
       const ws = wsId ? store.workspaces[wsId] : null;
       const rec = ws?.terminals.find((t) => t.id === terminalId) ?? null;
 
-      // 1. A user-assigned name wins over any auto-derived title for the tab
-      // display. We still persist the live OSC title to rec.title so extensions
-      // can observe actual activity in custom-named terminals.
+      if (!seeded) {
+        seeded = true;
+        // What dockview already shows for this tab (it restores panels with the
+        // persisted `rec.title`), so `apply` can no-op when nothing changed —
+        // and so the reattach rule has something to hold onto.
+        lastTitle = rec?.customName ?? rec?.title ?? "";
+        restoredTitle = rec?.customName ? "" : (rec?.title ?? "");
+      }
+
       const shown = displayOscTitle();
+      const derived = deriveTitle({
+        customName: rec?.customName,
+        oscTitle: shown,
+        fg,
+        tmuxLine,
+        restoredTitle,
+      });
+      if (!derived) return;
 
-      if (rec?.customName) {
-        if (rec.customName !== lastTitle) {
-          lastTitle = rec.customName;
-          props.api.setTitle(rec.customName);
+      // A user-assigned name is shown verbatim (no truncation) and never
+      // written to rec.title. We still persist the live OSC title there so
+      // extensions can observe actual activity in custom-named terminals.
+      if (derived.source === "custom") {
+        if (derived.text !== lastTitle) {
+          lastTitle = derived.text;
+          props.api.setTitle(derived.text);
         }
-        if (shown && rec.title !== shown) rec.title = shown;
+        if (rec && shown && rec.title !== shown) rec.title = shown;
         return;
       }
 
-      const knownPrompt = fgKnown && fgAtPrompt; // host says: at a prompt
-      const knownRunning = fgKnown && !fgAtPrompt; // host says: program running
-
-      // 2. A title the program set via an OSC escape sequence (e.g. Claude Code).
-      //    Drop it once we KNOW we're back at a prompt (N1a — stale title fix);
-      //    otherwise trust it. A marker-only title strips to "" and falls
-      //    through to the program name below rather than showing "Terminal".
-      if (shown && !knownPrompt) {
-        apply(shown, rec);
-        return;
-      }
-
-      // 3. A running program with no OSC title of its own → show its name (N1b).
-      if (knownRunning && fgLeader) {
-        apply(progName(fgLeader), rec);
-        return;
-      }
-
-      // 4. The tmux status line (quoted text on the last row).
-      const buffer = term.buffer.active;
-      const bottom = Math.max(0, buffer.length - 1);
-      const line = buffer.getLine(bottom);
-      const raw = line ? line.translateToString(true) : "";
-      const match = raw.match(/"([^"]*)"/);
-      if (match) {
-        apply(match[1].trim(), rec);
-        return;
-      }
-
-      // 5. Back at a prompt with nothing better → the shell name (the visible
-      //    half of N1a: replace the stale program title). Otherwise leave as-is.
-      if (knownPrompt && fgLeader) {
-        apply(progName(fgLeader), rec);
-      }
+      restoredTitle = ""; // superseded by live evidence
+      apply(derived.text, rec);
     }
 
     const offTitle = term.onTitleChange((title) => {
@@ -900,20 +892,32 @@ export function TerminalPanel(
       read();
     });
     const offWrite = term.onWriteParsed(() => read());
-    const offForeground = onTerminalForeground(live.sessionId, (fg) => {
-      fgKnown = true;
-      fgAtPrompt = fg.atPrompt;
-      fgLeader = fg.leader;
-      if (fg.cwd) {
-        cwdRef.current = fg.cwd;
-        setCwd(fg.cwd);
+    const updateForeground = (next: TerminalForeground) => {
+      fg = next;
+      if (next.cwd) {
+        cwdRef.current = next.cwd;
+        setCwd(next.cwd);
       }
       read();
+    };
+    const offForeground = onTerminalForeground(
+      live.sessionId,
+      updateForeground,
+    );
+    // Seed from the host's cache: `onTerminalForeground` only fires on *change*,
+    // and the daemon's one push at attach time can land before this subscriber
+    // exists — so a reattached session that then sits idle (an agent waiting for
+    // input) would otherwise never report its foreground state at all. A live
+    // event that beat the snapshot back wins: it's the newer value.
+    let disposed = false;
+    void terminalForegroundSnapshot(live.sessionId).then((snapshot) => {
+      if (!disposed && snapshot && !fg) updateForeground(snapshot);
     });
     read();
     const interval = window.setInterval(read, 500);
 
     return () => {
+      disposed = true;
       offTitle.dispose();
       offWrite.dispose();
       offForeground();

--- a/packages/extensions-core/src/terminal/terminal-title.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-title.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  deriveTitle,
+  formatTitle,
+  programName,
+  tmuxStatusTitle,
+  type TitleInputs,
+} from "./terminal-title";
+
+/** Inputs with no signals at all; each test turns on the ones it's about. */
+function inputs(overrides: Partial<TitleInputs> = {}): TitleInputs {
+  return {
+    oscTitle: "",
+    fg: null,
+    tmuxLine: () => "",
+    restoredTitle: "",
+    ...overrides,
+  };
+}
+
+const running = (leader: string) => ({ atPrompt: false, leader });
+const atPrompt = (leader: string) => ({ atPrompt: true, leader });
+
+describe("programName", () => {
+  it("strips the login dash and any directory", () => {
+    expect(programName("-zsh")).toBe("zsh");
+    expect(programName("/opt/homebrew/bin/node")).toBe("node");
+    expect(programName(" claude ")).toBe("claude");
+  });
+});
+
+describe("tmuxStatusTitle", () => {
+  it("returns the quoted text on the row, trimmed", () => {
+    expect(tmuxStatusTitle('[0] 0:"build server"* "extra"')).toBe(
+      "build server",
+    );
+    expect(tmuxStatusTitle("no quotes here")).toBe("");
+  });
+});
+
+describe("formatTitle", () => {
+  it("falls back for an empty title and ellipsizes long ones", () => {
+    expect(formatTitle("")).toBe("Terminal");
+    expect(formatTitle("short")).toBe("short");
+    expect(formatTitle("x".repeat(32))).toBe("x".repeat(32));
+    expect(formatTitle("x".repeat(33))).toBe("x".repeat(31) + "…");
+  });
+});
+
+describe("deriveTitle priority", () => {
+  it("1. a custom name outranks everything", () => {
+    expect(
+      deriveTitle(
+        inputs({
+          customName: "deploy",
+          oscTitle: "Fix the flaky test",
+          fg: running("claude"),
+          tmuxLine: () => "tmux window",
+        }),
+      ),
+    ).toEqual({ text: "deploy", source: "custom" });
+  });
+
+  it("2. an OSC title outranks the process name while a program runs", () => {
+    expect(
+      deriveTitle(
+        inputs({ oscTitle: "Fix the flaky test", fg: running("claude") }),
+      ),
+    ).toEqual({ text: "Fix the flaky test", source: "osc" });
+  });
+
+  it("2. an OSC title is used when the foreground is unknown", () => {
+    expect(deriveTitle(inputs({ oscTitle: "vim README.md" }))).toEqual({
+      text: "vim README.md",
+      source: "osc",
+    });
+  });
+
+  it("2. a stale OSC title is dropped once we're back at a prompt (N1a)", () => {
+    expect(
+      deriveTitle(
+        inputs({ oscTitle: "Fix the flaky test", fg: atPrompt("-zsh") }),
+      ),
+    ).toEqual({ text: "zsh", source: "process" });
+  });
+
+  it("3. a running program with no OSC title shows its own name (N1b)", () => {
+    expect(deriveTitle(inputs({ fg: running("/usr/bin/vim") }))).toEqual({
+      text: "vim",
+      source: "process",
+    });
+  });
+
+  it("4. falls back to the tmux status line", () => {
+    expect(deriveTitle(inputs({ tmuxLine: () => "build server" }))).toEqual({
+      text: "build server",
+      source: "tmux",
+    });
+  });
+
+  it("5. shows the shell's name at a prompt with nothing better", () => {
+    expect(deriveTitle(inputs({ fg: atPrompt("-zsh") }))).toEqual({
+      text: "zsh",
+      source: "process",
+    });
+  });
+
+  it("leaves the title alone when no rule matches", () => {
+    expect(deriveTitle(inputs())).toBeNull();
+  });
+
+  it("does not scrape tmux when an earlier rule answers", () => {
+    const tmuxLine = vi.fn(() => "build server");
+    deriveTitle(inputs({ oscTitle: "Fix the flaky test", tmuxLine }));
+    expect(tmuxLine).not.toHaveBeenCalled();
+  });
+});
+
+describe("deriveTitle after a reattach", () => {
+  // An app restart or a workspace switch remounts the panel: the restored
+  // buffer is a cell snapshot with no escape sequences, so the agent's OSC
+  // title is gone even though the agent is still running.
+  it("keeps the restored title instead of the running program's name", () => {
+    expect(
+      deriveTitle(
+        inputs({ fg: running("claude"), restoredTitle: "Fix the flaky test" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("still prefers a fresh OSC title over the restored one", () => {
+    expect(
+      deriveTitle(
+        inputs({
+          oscTitle: "Review the PR",
+          fg: running("claude"),
+          restoredTitle: "Fix the flaky test",
+        }),
+      ),
+    ).toEqual({ text: "Review the PR", source: "osc" });
+  });
+
+  it("replaces the restored title with the shell once the agent exits", () => {
+    expect(
+      deriveTitle(
+        inputs({ fg: atPrompt("-zsh"), restoredTitle: "Fix the flaky test" }),
+      ),
+    ).toEqual({ text: "zsh", source: "process" });
+  });
+
+  it("does not let the restored title outlive a rename", () => {
+    expect(
+      deriveTitle(
+        inputs({
+          customName: "agent",
+          fg: running("claude"),
+          restoredTitle: "Fix the flaky test",
+        }),
+      ),
+    ).toEqual({ text: "agent", source: "custom" });
+  });
+
+  it("holds the restored title even when tmux has a status line", () => {
+    // Rule 3 answers first for a running program, so a quoted string that
+    // happens to be on the agent's last row can't hijack the tab either.
+    expect(
+      deriveTitle(
+        inputs({
+          fg: running("claude"),
+          tmuxLine: () => "some quoted text",
+          restoredTitle: "Fix the flaky test",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("derives normally once the restored title has been superseded", () => {
+    expect(deriveTitle(inputs({ fg: running("claude") }))).toEqual({
+      text: "claude",
+      source: "process",
+    });
+  });
+});

--- a/packages/extensions-core/src/terminal/terminal-title.ts
+++ b/packages/extensions-core/src/terminal/terminal-title.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure title-derivation rules for a terminal tab, factored out of
+ * `TerminalPanel` so they're unit-testable (the component stays glue: it feeds
+ * live signals in and writes the result to dockview + the terminal record).
+ *
+ * The priority order is RFC 0010's, plus one rule the reattach path needs:
+ *
+ *   1. a user-assigned name (right-click → Rename) — always wins;
+ *   2. a title the program pushed via an OSC 0/1/2 escape sequence (e.g. Claude
+ *      Code), dropped once the host says we're back at a prompt (N1a);
+ *   3. a running program with no OSC title of its own → its process name (N1b),
+ *      **unless a restored title is still standing** (see below);
+ *   4. the tmux status line;
+ *   5. back at a prompt with nothing better → the shell's name (N1a's visible
+ *      half — this is what clears a stale restored title).
+ *
+ * The restored-title rule (3) exists because a tab's OSC title does **not**
+ * survive a reattach — an app restart or a workspace switch, both of which
+ * remount the panel and re-attach the session. The buffer we restore is a
+ * serialized *cell* snapshot with no escape sequences in it, and agents only
+ * push a title when their status changes: an idle Claude Code sits there for
+ * hours without emitting one. So after a reattach `oscTitle` is `""` while the
+ * agent is still very much running, and rule 3 would replace the persisted
+ * conversation title ("Fix the flaky test") with the bare process name
+ * ("claude") — in the tab *and* in `TerminalRecord.title`, destroying it.
+ * Keeping the restored title until live evidence supersedes it costs nothing:
+ * for a non-agent program (`npm`, `node`) the restored title already *is* the
+ * process name, and the moment the program exits, rule 5 takes over.
+ */
+
+/** The foreground-process facts rules 3/5 need, as reported by the PTY host. */
+export interface TerminalForegroundState {
+  /** True when the foreground group is the shell itself (i.e. at a prompt). */
+  atPrompt: boolean;
+  /** The foreground leader's program name (e.g. `vim`, `node`, `-zsh`). */
+  leader: string;
+}
+
+/** Everything the rules read. `null`/`""` all mean "no signal yet". */
+export interface TitleInputs {
+  /** The user-assigned name, when the tab has one. */
+  customName?: string;
+  /**
+   * The OSC title as it should be displayed (already stripped of agent status
+   * markers), or `""` when the program hasn't pushed one this mount.
+   */
+  oscTitle: string;
+  /** Foreground state from the host, or `null` until it reports. */
+  fg: TerminalForegroundState | null;
+  /**
+   * The tmux status line's quoted text, `""` when the last row has none. Lazy:
+   * scraping the buffer costs a `translateToString`, and rules 1–3 usually
+   * answer first.
+   */
+  tmuxLine: () => string;
+  /**
+   * The persisted title this mount started with, until live evidence
+   * supersedes it; `""` once it has (or when there was none).
+   */
+  restoredTitle: string;
+}
+
+/**
+ * Which rule produced a title. `"custom"` is exempt from truncation — a name
+ * the user typed is shown as typed.
+ */
+export type TitleSource = "custom" | "osc" | "process" | "tmux";
+
+export interface DerivedTitle {
+  text: string;
+  source: TitleSource;
+}
+
+/** Shown when a rule produced an empty string. */
+export const FALLBACK_TITLE = "Terminal";
+/** Auto-derived titles longer than this are ellipsized. */
+export const MAX_TITLE_LENGTH = 32;
+
+/** `-zsh` → `zsh`, `/opt/homebrew/bin/node` → `node`. */
+export function programName(leader: string): string {
+  return (leader.replace(/^-/, "").split("/").pop() ?? leader).trim();
+}
+
+/** The quoted text tmux writes into its status line, or `""` if the row has none. */
+export function tmuxStatusTitle(row: string): string {
+  const match = row.match(/"([^"]*)"/);
+  return match ? match[1].trim() : "";
+}
+
+/** An auto-derived title as it should appear on the tab. */
+export function formatTitle(text: string): string {
+  if (!text) return FALLBACK_TITLE;
+  return text.length > MAX_TITLE_LENGTH
+    ? text.slice(0, MAX_TITLE_LENGTH - 1) + "…"
+    : text;
+}
+
+/**
+ * The title this terminal should show, or `null` to leave the current one
+ * alone (no rule matched, or a restored title is still the best answer).
+ */
+export function deriveTitle(input: TitleInputs): DerivedTitle | null {
+  const { customName, oscTitle, fg, restoredTitle } = input;
+
+  if (customName) return { text: customName, source: "custom" };
+
+  const atPrompt = fg !== null && fg.atPrompt; // host says: at a prompt
+  const running = fg !== null && !fg.atPrompt; // host says: program running
+
+  if (oscTitle && !atPrompt) return { text: oscTitle, source: "osc" };
+
+  if (running && fg.leader) {
+    // A reattached program's title is unknown this mount, not absent — the
+    // persisted one is better evidence than its process name.
+    if (restoredTitle) return null;
+    return { text: programName(fg.leader), source: "process" };
+  }
+
+  const tmuxLine = input.tmuxLine();
+  if (tmuxLine) return { text: tmuxLine, source: "tmux" };
+
+  if (atPrompt && fg.leader) {
+    return { text: programName(fg.leader), source: "process" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

A terminal's OSC title doesn't survive a reattach (an app restart, or the first workspace-switch to a workspace since launch): the restored buffer is a serialized cell snapshot with no escape sequences, and an idle agent won't push a fresh title until its status next changes. When the reattached foreground reports the agent as still running with no OSC title yet, the tab fell back to the bare process name (`claude`), clobbering a real, persisted conversation title.

Confirmed live mid-investigation: after a real dev-Silo restart, two `silo-extensions` Claude tabs with genuine conversation titles ("Check for work trees in reposit…", "Identify current employer or or…") both flattened to `claude`.

- Extracts the title-derivation priority rules into `terminal-title.ts` (pure, unit-tested), adding one rule: a **restored title outranks a running program's bare name** until live evidence — a fresh OSC title, or the shell returning to a prompt — supersedes it.
- Seeds foreground state from the host's `terminal_foreground_snapshot` cache in addition to the change-only `onTerminalForeground` event, since the daemon's one push at attach time can land before the panel's listener is registered.
- `TerminalPanel.tsx` is now glue: feeds live signals into `deriveTitle` and writes the result out.

## Test plan

- [x] `packages/extensions-core/src/terminal/terminal-title.test.ts` — 18 tests covering the full priority chain (custom name / OSC title / process name / tmux / prompt fallback) plus the reattach cases (holds restored title under a running program with no fresh OSC, yields to a fresh OSC title, yields once back at a prompt, never outlives a rename, survives a spurious tmux match).
- [x] `pnpm test` (full monorepo suite, via pre-commit hook)
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`
- [ ] Manual: restart Silo with an idle agent tab showing a real conversation title — title should survive (not yet re-verified against this exact branch after the live confirmation above; the fix targets the exact code path that produced it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)