### PR TITLE
ci(release): make silo app releases land as drafts pending manual publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -96,6 +96,18 @@ jobs:
       # action exposes the aggregate `releases_created` (plural) — NOT the bare
       # `release_created`, which is only set in legacy single-package mode and is
       # always empty here (the per-path output is `apps/desktop--release_created`).
+      #
+      # The silo app release-please config sets `draft: true` (soak-test the
+      # signed build on real production data before it goes public) plus
+      # `force-tag-creation: true` — GitHub otherwise defers creating a draft
+      # release's tag until it's published, which would leave this trigger firing
+      # against a tag that doesn't exist yet. `release_created` still fires for a
+      # draft, and release.yml's `tauri-action` (also configured with
+      # `releaseDraft: true`) finds the pre-tagged draft by tag name and uploads
+      # the installers onto it rather than creating a second release. The release
+      # stays private until someone runs
+      # `gh release edit silo-vX.Y.Z --draft=false` — see
+      # apps/docs/guide/release-channels.md.
       - name: trigger installer build
         if: ${{ steps.release.outputs['.--release_created'] }}
         env:

--- a/apps/docs/guide/release-channels.md
+++ b/apps/docs/guide/release-channels.md
@@ -8,7 +8,17 @@ applications and share no data by default.
 
 The default. Stable releases go through the full release cycle — conventional
 commits feed a version-bump PR, maintainers review and merge it, and the tag
-triggers a signed build. New stable releases land roughly monthly.
+triggers a signed, notarized build. New stable releases land roughly monthly.
+
+Merging the release PR does not make the release public. The build lands as a
+**draft** GitHub release — a deliberate checkpoint to soak-test it on real
+production data first: install the draft over your existing Silo (same bundle
+identifier, so the same workspaces, terminal sessions, and settings carry over
+automatically) and run it for a few days. When you're satisfied, publish the
+draft — `gh release edit silo-vX.Y.Z --draft=false`, or "Publish release" on
+GitHub — and it immediately becomes "Latest": every existing install's
+auto-updater, the website's download button, and the docs download links all
+pick it up with no further steps.
 
 Download from the [GitHub Releases](https://github.com/silo-code/silo/releases/latest) page.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,8 @@
       "package-name": "silo",
       "component": "silo",
       "changelog-path": "apps/desktop/CHANGELOG.md",
+      "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

Silo app releases (not SDK or git-api) now land as a private, downloadable draft instead of going public the moment a release-please PR is merged. The build is still fully signed and notarized, so it can be installed straight over an existing production install — same app identity, same workspaces, terminal sessions, and settings — and run on real data for a few days before anyone decides to make it public with a single click.

This needs to land before #351 (the open `release silo 0.47.0` PR) merges, so that release goes out as a draft rather than the old way.

## Details

### What changed

- `release-please-config.json` — added `draft: true` and `force-tag-creation: true` to the `.` (silo app) package only. SDK and git-api packages are untouched; they keep publishing to npm exactly as before, independent of this.
- `.github/workflows/release-please.yml` — added a comment explaining why `force-tag-creation` has to be paired with `draft`: GitHub normally defers creating a draft release's tag until it's published, which would otherwise break both the installer-build trigger (`tauri-action` needs an existing tag to attach assets to) and release-please's own changelog diffing (it needs the previous tag to compute what's new).
- `apps/docs/guide/release-channels.md` — updated the Stable section to describe the new draft checkpoint and the publish command.

### Why this doesn't affect anything else

Everything that surfaces "what's public" — the website's download button, the docs homepage/guide links, README, and the `updates.getsilo.dev` auto-updater proxy — all resolve through GitHub's own `/releases/latest`, which by definition already excludes drafts and prereleases. So none of those needed changes; they'll keep pointing at the last published release until the draft is published, then pick it up automatically (the updater has a 5-minute edge cache on top of that).

### How to use it

1. Merge a release-please PR as usual.
2. The signed/notarized build lands as a draft GitHub release (`silo-vX.Y.Z`), invisible on the public releases page and not reachable via the updater endpoint.
3. Download and install it over production Silo — same bundle identifier, so it opens straight into existing data.
4. Soak-test for as long as needed.
5. `gh release edit silo-vX.Y.Z --draft=false` (or "Publish release" on GitHub) when ready — it becomes "Latest" and every existing install's auto-updater picks it up.

### Test plan

- [x] Pre-commit hooks (boundary lint, unit tests, docs build/link-check) passed on this change.
- [ ] Verify on the next real release-please merge that the resulting `silo-v*` release is created as a draft with a real tag, and that `release.yml`'s installer build attaches assets to it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)