### PR TITLE
ci(release): auto-publish git-api to npm on release

### DIFF
--- a/.github/workflows/release-git-api.yml
+++ b/.github/workflows/release-git-api.yml
@@ -16,14 +16,13 @@ name: release-git-api
 # npm cannot do a package's FIRST publish over OIDC (npm/cli#8544), and the
 # trusted-publisher settings page doesn't exist until the package does. So the
 # listing was created by hand-publishing a throwaway 0.0.0 placeholder, the
-# trusted publisher was configured against that, and 0.1.0 — the first real
+# trusted publisher was configured against that, and 0.2.0 — the first real
 # version — was published by this workflow. Note a `--dry-run` never
 # authenticates, so it proves the built artifact but says nothing about whether
 # the trusted-publisher config is correct; only a real publish tests that.
 #
-# NOT YET WIRED into release-please.yml's auto-trigger (unlike release-sdk.yml,
-# which release-please dispatches automatically on every SDK release) — do that
-# once a real publish through here has succeeded at least once.
+# WIRED into release-please.yml's auto-trigger, same as release-sdk.yml —
+# release-please dispatches this with `publish: true` on every git-api release.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -135,3 +135,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run release-sdk.yml --ref main -R ${{ github.repository }} -f publish=true
+
+      - name: publish git-api to npm
+        if: ${{ steps.release.outputs['packages/git-api--release_created'] }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release-git-api.yml --ref main -R ${{ github.repository }} -f publish=true


### PR DESCRIPTION
## Summary

- Wires `release-please.yml` to auto-dispatch `release-git-api.yml` with `publish: true` on every git-api release, mirroring the existing SDK step — `release-git-api.yml`'s own header comment said this should happen "once a real publish through here has succeeded at least once," which just occurred: merging #354 bumped `packages/git-api` to 0.2.0 in the repo, but npm was never actually updated because the publish workflow was manually-gated only. I manually dispatched `release-git-api.yml` (dry-run, then a real publish) to get `@silo-code/git-api@0.2.0` onto npm — this PR prevents that manual step from being needed again.
- Fixes the now-stale comment in `release-git-api.yml` that said "0.1.0 — the first real version" (it was actually 0.2.0) and updates the "NOT YET WIRED" note now that it is.

## Test plan

- [x] YAML syntax validated for both edited workflow files
- [x] Confirmed `@silo-code/git-api@0.2.0` is now live on npm (`latest` dist-tag)
- [x] `pnpm test` (pre-commit hook ran the full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)