### PR TITLE
fix(macos): declare NSLocalNetworkUsageDescription in Info.plist

### DIFF
--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -4,5 +4,13 @@
   <dict>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
+    <!--
+      Required on macOS 15+ for Silo (and the terminals, agents, and dev servers
+      it spawns) to reach devices and services on the local network. Without this
+      key macOS cannot show the Local Network prompt and silently denies the
+      access, surfacing as EHOSTUNREACH rather than a permission request.
+    -->
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Silo needs local network access so terminals, agents, and dev servers you run inside it can reach services on your network.</string>
   </dict>
 </plist>


### PR DESCRIPTION
## Summary

On recent versions of macOS, an app has to declare *why* it wants to talk to other
devices on your local network before the system will even offer you the choice.
Silo never declared that, so macOS quietly denied local network access instead of
asking — and the denial applied to everything Silo starts, including terminals,
coding agents, and dev servers. The symptom was confusing: connections to a machine
or service on the same network failed with a generic "no route to host" error, with
no permission prompt and no Silo entry in the system's Local Network settings.

This adds the missing declaration. Starting with the next release, the first time
Silo or something it runs reaches for the local network, macOS will show the normal
permission prompt, and Silo will appear in System Settings under Privacy & Security
→ Local Network so the choice can be changed later.

Nothing else changes, and nothing in Silo requests local network access on its own —
this only unblocks the tools people run inside it.

## Details

Adds `NSLocalNetworkUsageDescription` to `apps/desktop/src-tauri/Info.plist`.

- macOS 15+ gates local network access behind per-app TCC approval. With no usage
  string the system cannot render the prompt, so it denies the access outright;
  callers see `EHOSTUNREACH` rather than a permission dialog. Child processes are
  attributed to the responsible app (Silo), so the deny propagates to every spawned
  terminal / agent / dev server.
- One file covers every build: none of `tauri.conf.json`, `tauri.dev.conf.json`, or
  `tauri.nightly.conf.json` override the plist, and Tauri merges
  `src-tauri/Info.plist` into both `tauri dev` and bundled output. Verified the merge
  path by checking the installed 0.46.1 bundle — the repo's `CFBundleIconFile` is
  present in `/Applications/Silo.app/Contents/Info.plist`, and no usage descriptions
  are.
- Deliberately **not** adding `NSBonjourServices`: that's a separate key, needed only
  for mDNS *browsing*, and it requires enumerating specific service types. Nothing in
  the repo browses Bonjour today.

### Test plan

- `plutil -lint apps/desktop/src-tauri/Info.plist` → OK.
- `PlistBuddy -c "Print :NSLocalNetworkUsageDescription"` reads back the string.
- Pre-commit hook ran boundary lint + the full unit suite; green.
- No unit test added — this is bundle metadata with no code path to exercise.
  Runtime confirmation requires a signed build on macOS 15+: launch it, have a child
  process open a LAN connection, and check that the prompt appears and Silo is listed
  under Privacy & Security → Local Network. Note macOS caches TCC decisions per bundle
  ID, so a machine that already recorded a silent deny may need
  `tccutil reset` before it prompts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
