### PR TITLE
fix(layout): sync side panel active tab on workspace switch

### DIFF
--- a/packages/extension-host/src/layout/PanelPane.tsx
+++ b/packages/extension-host/src/layout/PanelPane.tsx
@@ -9,6 +9,7 @@ import { registerSidePane } from "./side-pane-registry";
 import { enterRegionOnPointer } from "../extension-host/focus-regions";
 import { TabBar } from "./TabBar";
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { resolveActiveSidePanelId } from "./active-side-panel-tab";
 
 interface PanelPaneProps {
   panels: SidePanel[];
@@ -168,28 +169,21 @@ export function PanelPane({
       ? "top"
       : null;
 
+  // Read through the snapshot so a workspace switch that rewrites
+  // `activeSidePanelTabs` (ADR 0035 — per-workspace when the sub-setting is
+  // off) re-runs this effect; reading `store.*` directly would not.
+  const savedActiveTab = snap.activeSidePanelTabs[slot];
   useEffect(() => {
-    if (panels.length === 0) {
-      if (activeId !== null) setActiveId(null);
-      return;
-    }
-    const saved = store.activeSidePanelTabs[slot];
-    if (!activeId || !panels.some((p) => p.id === activeId)) {
-      // No valid active tab yet — prefer saved, fall back to first
-      const preferred =
-        saved && panels.some((p) => p.id === saved) ? saved : panels[0].id;
-      setActiveId(preferred);
-    } else if (
-      saved &&
-      saved !== activeId &&
-      panels.some((p) => p.id === saved)
-    ) {
-      // Hydration completed after we already picked a default — switch to saved
-      setActiveId(saved);
-    }
-    // snap.hydrated ensures this re-runs after hydration loads saved tabs
+    const next = resolveActiveSidePanelId(
+      panels.map((p) => p.id),
+      activeId,
+      savedActiveTab,
+    );
+    if (next !== activeId) setActiveId(next);
+    // snap.hydrated: re-run after hydration loads saved tabs (first paint may
+    // have picked a default before the store was ready).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [panels, activeId, slot, snap.hydrated]);
+  }, [panels, activeId, slot, snap.hydrated, savedActiveTab]);
 
   useEffect(() => {
     if (!activeId) return;

--- a/packages/extension-host/src/layout/active-side-panel-tab.test.ts
+++ b/packages/extension-host/src/layout/active-side-panel-tab.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveActiveSidePanelId } from "./active-side-panel-tab";
+
+describe("resolveActiveSidePanelId", () => {
+  const panels = ["explorer", "search", "git"];
+
+  it("returns null when the pane is empty", () => {
+    expect(resolveActiveSidePanelId([], "explorer", "explorer")).toBeNull();
+  });
+
+  it("prefers the saved tab when there is no local selection yet", () => {
+    expect(resolveActiveSidePanelId(panels, null, "git")).toBe("git");
+  });
+
+  it("falls back to the first panel when nothing is saved", () => {
+    expect(resolveActiveSidePanelId(panels, null, undefined)).toBe("explorer");
+  });
+
+  it("falls back to the first panel when the saved id is no longer in the pane", () => {
+    expect(resolveActiveSidePanelId(panels, null, "gone")).toBe("explorer");
+  });
+
+  it("replaces a stale local selection with the saved tab", () => {
+    expect(resolveActiveSidePanelId(panels, "gone", "search")).toBe("search");
+  });
+
+  it("follows a workspace-switch change to the saved tab while local is still valid", () => {
+    // Local still shows the previous workspace's tab; store already holds the
+    // incoming workspace's saved tab — this is the ADR 0035 per-workspace path.
+    expect(resolveActiveSidePanelId(panels, "explorer", "git")).toBe("git");
+  });
+
+  it("keeps the local selection when it already matches the saved tab", () => {
+    expect(resolveActiveSidePanelId(panels, "search", "search")).toBe("search");
+  });
+
+  it("keeps a valid local selection when nothing is saved", () => {
+    expect(resolveActiveSidePanelId(panels, "git", undefined)).toBe("git");
+  });
+
+  it("keeps a valid local selection when the saved id is unknown", () => {
+    expect(resolveActiveSidePanelId(panels, "git", "gone")).toBe("git");
+  });
+});

--- a/packages/extension-host/src/layout/active-side-panel-tab.ts
+++ b/packages/extension-host/src/layout/active-side-panel-tab.ts
@@ -1,0 +1,25 @@
+/**
+ * Which panel id a {@link PanelPane} should show, given the ids currently in
+ * the pane, the pane's local selection, and the store's saved tab for that
+ * slot (`store.activeSidePanelTabs[slot]`).
+ *
+ * Used when the pane mounts, after hydration, and whenever the saved tab
+ * changes (e.g. workspace switch while "Also maintain active tab" is off —
+ * ADR 0035). Prefer the saved id when it's still a member of the pane; fall
+ * back to the first panel; keep the local selection when it already matches
+ * (or when nothing is saved).
+ */
+export function resolveActiveSidePanelId(
+  panelIds: readonly string[],
+  activeId: string | null,
+  savedId: string | undefined,
+): string | null {
+  if (panelIds.length === 0) return null;
+  if (!activeId || !panelIds.includes(activeId)) {
+    return savedId && panelIds.includes(savedId) ? savedId : panelIds[0];
+  }
+  if (savedId && savedId !== activeId && panelIds.includes(savedId)) {
+    return savedId;
+  }
+  return activeId;
+}

--- a/packages/extension-host/src/layout/active-side-panel-tab.ts
+++ b/packages/extension-host/src/layout/active-side-panel-tab.ts
@@ -4,7 +4,7 @@
  * slot (`store.activeSidePanelTabs[slot]`).
  *
  * Used when the pane mounts, after hydration, and whenever the saved tab
- * changes (e.g. workspace switch while "Also maintain active tab" is off —
+ * changes (e.g. workspace switch while "Also maintain active tab(s)" is off —
  * ADR 0035). Prefer the saved id when it's still a member of the pane; fall
  * back to the first panel; keep the local selection when it already matches
  * (or when nothing is saved).

--- a/packages/extension-host/src/state/workspaces.test.ts
+++ b/packages/extension-host/src/state/workspaces.test.ts
@@ -413,6 +413,29 @@ describe("global side panel layout (ADR 0035)", () => {
     expect(store.activeSidePanelTabs).toEqual({ left: "search" });
   });
 
+  it("activateWorkspace round-trips per-workspace active tabs while layout is shared but the sub-setting is off", () => {
+    store.workspaces = { w: makeWorkspace("w"), w2: makeWorkspace("w2") };
+    store.workspaceOrder = ["w", "w2"];
+    store.activeWorkspaceId = "w";
+    store.activeSidePanelTabs = { left: "explorer" };
+    store.workspaces.w.activeSidePanelTabs = { left: "explorer" };
+    store.workspaces.w2.activeSidePanelTabs = { left: "search" };
+
+    setGlobalPanelLayoutEnabled(true);
+    // globalActiveTabEnabled stays false — tabs must stay per-workspace.
+
+    activateWorkspace("w2");
+    expect(store.activeSidePanelTabs).toEqual({ left: "search" });
+    expect(store.workspaces.w.activeSidePanelTabs).toEqual({
+      left: "explorer",
+    });
+
+    store.activeSidePanelTabs = { left: "git" };
+    activateWorkspace("w");
+    expect(store.activeSidePanelTabs).toEqual({ left: "explorer" });
+    expect(store.workspaces.w2.activeSidePanelTabs).toEqual({ left: "git" });
+  });
+
   describe("hasSavedGlobalPanelLayout", () => {
     it("is false for a fresh/default record", () => {
       expect(hasSavedGlobalPanelLayout()).toBe(false);

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
@@ -89,7 +89,7 @@ export function makeLayoutSettingsPage(ctx: ExtensionContext) {
                 </div>
                 <div style={{ marginTop: "8px", marginBottom: "12px" }}>
                   <CheckboxRow
-                    label="Also maintain active tab"
+                    label="Also maintain active tab(s)"
                     checked={snap.globalActiveTabEnabled}
                     onChange={setGlobalActiveTabEnabled}
                     disabled={!snap.globalPanelLayoutEnabled}


### PR DESCRIPTION
## Summary
- With shared side panel layout but **Also maintain active tab** off, each workspace already stored its own selected side-panel tab — but `PanelPane` kept local React selection and ignored store updates on switch, so the UI stayed on the previous workspace’s tab.
- Sync selection from the valtio snapshot via `resolveActiveSidePanelId`, and cover the resolve helper plus an `activateWorkspace` round-trip.

## Test plan
- [ ] Enable **Share side panel layout across workspaces**; leave **Also maintain active tab** unchecked
- [ ] In workspace A, select FILES; switch to B, select GIT; switch back to A → FILES is selected
- [ ] Enable **Also maintain active tab** and confirm the selected tab stays shared across workspace switches
- [ ] `pnpm --filter @silo-code/extension-host exec vitest run src/layout/active-side-panel-tab.test.ts src/state/workspaces.test.ts`


Made with [Cursor](https://cursor.com)