### PR TITLE
feat(navigator): list every view instead of hiding them in a dropdown

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,8 +21,7 @@ _Avoid_: Workspaces panel (the old name for the Navigator itself)
 ### Navigator
 
 **Navigator**:
-The side panel you navigate the app from. A container: its body is one View at
-a time; its header holds the view selector and toolbar actions. Owned by
+The side panel you navigate the app from. A container of Views, owned by
 `core.navigator`.
 _Avoid_: Workspaces panel, sidebar (OS/VS Code sense), activity bar
 
@@ -33,9 +32,27 @@ navigate is a new View, not a second competing panel.
 _Avoid_: Side Panel (when the intent is navigation), tab, mode (prefer View),
 editor view (the CenterDock `viewType` sense)
 
+**Active View**:
+The one View currently rendered in the Navigator. A persisted, global user
+choice — unrelated to the focus/activation sense "active" carries for
+workspaces, docks, and panels.
+_Avoid_: Open view, current view, selected view, visible view
+
+**View List**:
+The rows at the top of the Navigator, one per registered View — how you reach a
+View, and what tells you which Views exist. Hidden when only one is registered.
+_Avoid_: View selector, view menu, view switcher, view picker (none of these are
+a dropdown any more), tab bar
+
+**View Header**:
+The bar between the View List and the panel body. Names the Active View and
+hosts its toolbar actions.
+_Avoid_: Navigator header (ambiguous with the View List above it), panel header,
+title bar
+
 **Open Workspace menu**:
-The shared "saved workspaces / New workspace…" menu offered from the Navigator
-header, the workspace status-bar item, and the empty CenterDock.
+The shared "saved workspaces / New workspace…" menu offered from the Navigator's
+View Header, the workspace status-bar item, and the empty CenterDock.
 _Avoid_: Add workspace menu, reopen picker (that's the closed-workspace path)
 
 ### Layout

--- a/apps/docs/api/registration/register-navigator-view.md
+++ b/apps/docs/api/registration/register-navigator-view.md
@@ -7,21 +7,34 @@ ctx.registerNavigatorView(view: NavigatorView): Disposable
 ```
 
 The Navigator is a container. Each registered view is one projection of "where
-can I go", and the user picks between them from the selector in its header. The
-built-in **Workspaces** view (the workspace list) is registered through this
-same API by `core.workspaces` — first-party and third-party views are the same
-kind of thing.
+can I go". Every registered view is listed by name at the top of the panel, so
+switching is a single click and your view is visible to the user whether or not
+it's the one on screen. The built-in **Workspaces** view (the workspace list) is
+registered through this same API by `core.workspaces` — first-party and
+third-party views are the same kind of thing.
 
 ## Example
 
 ```tsx
 ctx.registerNavigatorView({
-  id: "acme.by-status",
-  title: "Agents by status",
-  order: 1, // lower sorts first in the view menu; Workspaces registers at 0
+  id: "acme.agents",
+  title: "Agents",
+  order: 1, // lower sorts first in the view list; Workspaces registers at 0
   component: ({ active }) => <AgentList paused={!active} />,
 });
 ```
+
+## One view per projection
+
+Register one view for each genuinely different destination — not one per way of
+sorting or filtering the same list. Every view costs a permanent row in the
+Navigator's list, and two rows that render the same rows two ways read as two
+places to go when they aren't.
+
+If your view supports grouping, filtering or a display mode, make it a control
+_inside_ that view — a menu-backed [header action](#header-actions) is usually
+the right shape, since it costs no panel height and the choice can persist in
+your own [storage](/api/storage/).
 
 ## Prefer this over a second side panel
 
@@ -53,7 +66,8 @@ workspace) across workspace switches and restarts.
 A view's buttons are **toolbar items** on the `"navigator"`
 [surface](/api/registration/register-toolbar-item), not part of the view
 itself — so they get the host's button, dropdown, tooltip and ordering chrome,
-and can be either command-backed or menu-backed:
+and can be either command-backed or menu-backed. They render in the header that
+names the active view, between the view list and the view body:
 
 ```ts
 ctx.registerToolbarItem({
@@ -62,7 +76,7 @@ ctx.registerToolbarItem({
   icon: "ArrowsClockwise",
   tooltip: "Refresh",
   // Scope to your view; omit `when` to appear in every view.
-  when: (_keys, target) => target.viewId === "acme.by-status",
+  when: (_keys, target) => target.viewId === "acme.agents",
   command: "acme.refresh",
 });
 ```
@@ -70,6 +84,31 @@ ctx.registerToolbarItem({
 The target is `{ viewId }` — the view currently on screen. The workspaces `+`
 button is exactly this: a menu-backed item registered with no `when`, which is
 why adding a workspace stays one click away from whichever view you're in.
+
+A menu-backed item is also how a view offers its own display options. To let the
+user regroup your list without spending a second view on it:
+
+```ts
+ctx.registerToolbarItem({
+  id: "acme.group-by",
+  surface: "navigator",
+  title: "Group by",
+  when: (_keys, target) => target.viewId === "acme.agents",
+  menu: () => [
+    { type: "header", label: "Group by" },
+    {
+      label: "Status",
+      checked: groupBy === "status",
+      run: () => setGroupBy("status"),
+    },
+    {
+      label: "Workspace",
+      checked: groupBy === "workspace",
+      run: () => setGroupBy("workspace"),
+    },
+  ],
+});
+```
 
 ## Types
 

--- a/apps/docs/api/types/interfaces/DockPanelKind.md
+++ b/apps/docs/api/types/interfaces/DockPanelKind.md
@@ -1,6 +1,6 @@
 # Interface: DockPanelKind\<T\>
 
-Defined in: [packages/sdk/src/types.ts:551](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L551)
+Defined in: [packages/sdk/src/types.ts:555](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L555)
 
 Registers a kind of dock panel (a tab that can live in the center dock area,
 e.g. the terminal). Workspaces open panels of registered kinds by id. The
@@ -22,7 +22,7 @@ opened with — annotate your component with `DockPanelProps<T>` and
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:553](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L553)
+Defined in: [packages/sdk/src/types.ts:557](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L557)
 
 Unique id for this panel kind.
 
@@ -34,7 +34,7 @@ Unique id for this panel kind.
 component: ComponentType<DockPanelProps<T>>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:555](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L555)
+Defined in: [packages/sdk/src/types.ts:559](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L559)
 
 The React component that renders this panel; receives [DockPanelProps](DockPanelProps.md).
 
@@ -46,7 +46,7 @@ The React component that renders this panel; receives [DockPanelProps](DockPanel
 optional addMenuItem?: object;
 ```
 
-Defined in: [packages/sdk/src/types.ts:560](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L560)
+Defined in: [packages/sdk/src/types.ts:564](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L564)
 
 When set, this kind appears as an entry in the center dock's **+** add
 menu (the per-group header button). Omit to keep the kind internal.

--- a/apps/docs/api/types/interfaces/Extension.md
+++ b/apps/docs/api/types/interfaces/Extension.md
@@ -1,6 +1,6 @@
 # Interface: Extension\<API\>
 
-Defined in: [packages/sdk/src/types.ts:952](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L952)
+Defined in: [packages/sdk/src/types.ts:956](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L956)
 
 The shape of a Silo extension: a stable id plus an
 [activate](#activate) function the host calls once, passing
@@ -25,7 +25,7 @@ extensions that publish nothing.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:958](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L958)
+Defined in: [packages/sdk/src/types.ts:962](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L962)
 
 Unique extension id, conventionally namespaced: `core.*` for Silo's core
 feature set, `silo.*` for its optional bundled features, `<vendor>.*` for
@@ -39,7 +39,7 @@ third parties (e.g. `"core.editor"`, `"silo.git"`, `"acme.foo"`).
 optional manifest?: ExtensionManifest;
 ```
 
-Defined in: [packages/sdk/src/types.ts:965](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L965)
+Defined in: [packages/sdk/src/types.ts:969](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L969)
 
 Optional display metadata for the **Extensions** settings page. Built-in
 extensions declare it here so they can be listed (and disabled) with a name
@@ -54,7 +54,7 @@ package manifest instead. See [ExtensionManifest](ExtensionManifest.md).
 activate(ctx): void | API;
 ```
 
-Defined in: [packages/sdk/src/types.ts:972](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L972)
+Defined in: [packages/sdk/src/types.ts:976](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L976)
 
 Called once by the host; register contributions against `ctx` here.
 **Optionally return an API object** to publish it for other extensions to
@@ -79,7 +79,7 @@ extension publishes no API.
 optional deactivate(): void;
 ```
 
-Defined in: [packages/sdk/src/types.ts:974](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L974)
+Defined in: [packages/sdk/src/types.ts:978](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L978)
 
 Optional cleanup hook (reserved for dynamic load/unload).
 

--- a/apps/docs/api/types/interfaces/ExtensionContext.md
+++ b/apps/docs/api/types/interfaces/ExtensionContext.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionContext
 
-Defined in: [packages/sdk/src/types.ts:659](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L659)
+Defined in: [packages/sdk/src/types.ts:663](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L663)
 
 The object handed to [Extension.activate](Extension.md#activate). It is the *only* sanctioned
 way an extension touches the running app: register contributions, invoke
@@ -16,7 +16,7 @@ commands, and read/drive state through the typed consumer services. Every
 readonly extensionId: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:661](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L661)
+Defined in: [packages/sdk/src/types.ts:665](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L665)
 
 The activating extension's id (its [Extension.id](Extension.md#id)).
 
@@ -28,7 +28,7 @@ The activating extension's id (its [Extension.id](Extension.md#id)).
 readonly subscriptions: Disposable[];
 ```
 
-Defined in: [packages/sdk/src/types.ts:663](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L663)
+Defined in: [packages/sdk/src/types.ts:667](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L667)
 
 Disposables tracked for this extension; the host disposes them on teardown.
 
@@ -40,7 +40,7 @@ Disposables tracked for this extension; the host disposes them on teardown.
 readonly storage: ExtensionStorageScopes;
 ```
 
-Defined in: [packages/sdk/src/types.ts:679](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L679)
+Defined in: [packages/sdk/src/types.ts:683](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L683)
 
 Persisted, per-extension key/value storage, in two scopes
 ([ExtensionStorageScopes](ExtensionStorageScopes.md)): `global` (shared across all workspaces —
@@ -64,7 +64,7 @@ scope keyed by panel id, for panel-local UI state.)
 readonly workspaces: WorkspaceService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:761](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L761)
+Defined in: [packages/sdk/src/types.ts:765](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L765)
 
 Consumer API for driving workspace state — create, rename, reorder,
 activate, soft close/reopen, and hard delete. Subscribe to a frozen
@@ -78,7 +78,7 @@ state for read access without depending on Valtio.
 readonly editors: EditorService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:767](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L767)
+Defined in: [packages/sdk/src/types.ts:771](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L771)
 
 The editor & document domain — open files into editor tabs, drive the
 active editor (save / close), and register editor save handlers. Opening
@@ -92,7 +92,7 @@ editors lives here, not on [ExtensionContext.workspaces](#workspaces).
 readonly layout: LayoutService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:773](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L773)
+Defined in: [packages/sdk/src/types.ts:777](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L777)
 
 Consumer API for app layout — side-panel collapse state. Read via
 getState/useServiceState/subscribe; drive via toggleSidePanel /
@@ -106,7 +106,7 @@ setSidePanelCollapsed.
 readonly process: ProcessService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:779](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L779)
+Defined in: [packages/sdk/src/types.ts:783](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L783)
 
 Persistent process / PTY sessions that **survive app restarts** — the core
 primitive under the terminal (and future task runners, REPLs). Spawn or
@@ -120,7 +120,7 @@ re-attach a session and drive it via the returned `ProcessSession`.
 readonly processes: ProcessesService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:787](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L787)
+Defined in: [packages/sdk/src/types.ts:791](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L791)
 
 Workspace process observability — a live view of what is running in each
 terminal, with optional CPU/memory stats and a surgical kill that leaves the
@@ -136,7 +136,7 @@ See [ProcessesService](ProcessesService.md) for the full API.
 readonly agents: AgentsService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:797](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L797)
+Defined in: [packages/sdk/src/types.ts:801](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L801)
 
 Host-computed coding-agent activity and resume-identity observability —
 a live, read-only view of what each terminal's agent is doing
@@ -154,7 +154,7 @@ registration API. **@beta** — the shape may still change. See
 readonly terminals: TerminalService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:805](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L805)
+Defined in: [packages/sdk/src/types.ts:809](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L809)
 
 Consumer API for the terminal domain — open a terminal tab in a workspace
 (`create`) or reap a workspace's terminals (`closeWorkspace`). The terminal
@@ -170,7 +170,7 @@ from the workspace's records, and PTY sessions live on
 readonly files: FileService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:811](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L811)
+Defined in: [packages/sdk/src/types.ts:815](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L815)
 
 Host-mediated filesystem access — read / write / list / watch, all routed
 through the host rather than raw Tauri. The single privileged chokepoint
@@ -184,7 +184,7 @@ for the filesystem; watcher lifecycle is host-owned (see [FileService](FileServi
 readonly search: SearchService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:818](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L818)
+Defined in: [packages/sdk/src/types.ts:822](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L822)
 
 Cross-file content search over the workspace — the core primitive under the
 Search panel (and future quick-open / find-references). Runs a native search
@@ -199,7 +199,7 @@ with matches grouped by file. See [SearchService](SearchService.md).
 readonly theme: ThemeService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:825](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L825)
+Defined in: [packages/sdk/src/types.ts:829](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L829)
 
 Consumer API for the theme domain — read the merged preset set + active
 theme, switch themes, and manage custom themes. Read via getState /
@@ -214,7 +214,7 @@ subscribe; contribute a new preset via
 readonly dnd: DndService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:832](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L832)
+Defined in: [packages/sdk/src/types.ts:836](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L836)
 
 Drag-and-drop — be a drag source ([DndService.beginDrag](DndService.md#begindrag)) and a drop
 target ([DndService.registerDropTarget](DndService.md#registerdroptarget)), with typed payloads
@@ -229,7 +229,7 @@ drag affordance and the modifier-mode resolution.
 readonly ui: UiService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:839](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L839)
+Defined in: [packages/sdk/src/types.ts:843](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L843)
 
 User-interaction — the only sanctioned way to talk to the user (the host
 renders the chrome). Native file/folder pickers ([UiService.pickFolder](UiService.md#pickfolder),
@@ -244,7 +244,7 @@ notifications ([UiService.notify](UiService.md#notify)). Mirrors VS Code's `wind
 readonly net: NetworkService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:847](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L847)
+Defined in: [packages/sdk/src/types.ts:851](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L851)
 
 Server-side HTTP client — makes requests from the Rust backend, bypassing
 the browser's CORS policy. Use when browser `fetch` is insufficient:
@@ -260,7 +260,7 @@ loading a URL. See [NetworkService](NetworkService.md) for the full API.
 readonly webview: WebviewService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:854](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L854)
+Defined in: [packages/sdk/src/types.ts:858](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L858)
 
 Real DOM access, navigation control, and native pixel capture inside an
 `<iframe>` you own — including cross-origin content the browser's
@@ -275,7 +275,7 @@ same-origin policy would otherwise fully sandbox. Requires the
 readonly system: SystemService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:862](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L862)
+Defined in: [packages/sdk/src/types.ts:866](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L866)
 
 Static host-platform metadata — the OS, CPU architecture, and running Silo
 version. Values are baked into the binary at build time and never change
@@ -291,7 +291,7 @@ See [SystemService](SystemService.md) for the full API.
 readonly log: LogService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:875](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L875)
+Defined in: [packages/sdk/src/types.ts:879](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L879)
 
 Write-only structured logger scoped to this extension. Entries appear in
 the **Output** panel under the extension's display name. A channel is
@@ -312,7 +312,7 @@ ctx.log.show(); // open the Output panel, select this extension's channel
 registerEditor(editor): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:681](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L681)
+Defined in: [packages/sdk/src/types.ts:685](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L685)
 
 Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 
@@ -334,7 +334,7 @@ Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 registerFileType(type): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:683](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L683)
+Defined in: [packages/sdk/src/types.ts:687](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L687)
 
 Register a [FileType](FileType.md) (declarative file metadata).
 
@@ -356,7 +356,7 @@ Register a [FileType](FileType.md) (declarative file metadata).
 registerCommand(cmd): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:685](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L685)
+Defined in: [packages/sdk/src/types.ts:689](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L689)
 
 Register a [Command](Command.md) (a named, invokable action).
 
@@ -378,7 +378,7 @@ Register a [Command](Command.md) (a named, invokable action).
 registerMenuItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:687](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L687)
+Defined in: [packages/sdk/src/types.ts:691](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L691)
 
 Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a menu).
 
@@ -400,7 +400,7 @@ Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a
 registerContextMenuItem<S>(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:693](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L693)
+Defined in: [packages/sdk/src/types.ts:697](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L697)
 
 Register a [ContextMenuContribution](ContextMenuContribution.md) (add a command to a built-in
 surface's right-click context menu). The invoked command receives the
@@ -430,7 +430,7 @@ surface's [MenuContext](MenuContext.md) target as its first argument.
 registerToolbarItem<S>(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:704](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L704)
+Defined in: [packages/sdk/src/types.ts:708](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L708)
 
 Register a [ToolbarItemContribution](../type-aliases/ToolbarItemContribution.md) (icon-only, text-only,
 icon+text, or dropdown) in the trailing cluster of an editor or terminal
@@ -463,7 +463,7 @@ surface's breadcrumbs setting is on. See
 invalidateToolbarItems(): void;
 ```
 
-Defined in: [packages/sdk/src/types.ts:712](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L712)
+Defined in: [packages/sdk/src/types.ts:716](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L716)
 
 Signal that toolbar-item `when` / `checked` data changed. Causes every
 toolbar surface — editor, terminal, and the Navigator header — to re-query
@@ -481,7 +481,7 @@ contributions and re-render.
 registerKeybinding(binding): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:714](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L714)
+Defined in: [packages/sdk/src/types.ts:718](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L718)
 
 Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 
@@ -503,7 +503,7 @@ Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 registerSidePanel(panel): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:716](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L716)
+Defined in: [packages/sdk/src/types.ts:720](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L720)
 
 Register a [SidePanel](SidePanel.md) (a left/right column panel).
 
@@ -525,7 +525,7 @@ Register a [SidePanel](SidePanel.md) (a left/right column panel).
 registerNavigatorView(view): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:722](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L722)
+Defined in: [packages/sdk/src/types.ts:726](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L726)
 
 Register a [NavigatorView](NavigatorView.md) — a projection the user can switch the
 Navigator panel to. Prefer this over a second side panel when your surface
@@ -549,7 +549,7 @@ is another way to navigate the app.
 registerDockPanelKind<T>(kind): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:728](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L728)
+Defined in: [packages/sdk/src/types.ts:732](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L732)
 
 Register a [DockPanelKind](DockPanelKind.md) (a center-dock tab kind). The params
 generic `T` is inferred from the component's [DockPanelProps](DockPanelProps.md)
@@ -579,7 +579,7 @@ annotation, so kinds with typed params register without casts.
 registerStatusItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:732](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L732)
+Defined in: [packages/sdk/src/types.ts:736](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L736)
 
 Register a [StatusItem](StatusItem.md) (a status-bar widget).
 
@@ -601,7 +601,7 @@ Register a [StatusItem](StatusItem.md) (a status-bar widget).
 registerSettingsPage(page): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:734](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L734)
+Defined in: [packages/sdk/src/types.ts:738](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L738)
 
 Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 
@@ -623,7 +623,7 @@ Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 registerThemePreset(preset): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:740](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L740)
+Defined in: [packages/sdk/src/types.ts:744](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L744)
 
 Register a [ThemePreset](ThemePreset.md) (a selectable theme in the picker).
 
@@ -650,7 +650,7 @@ Use [ctx.theme.registerPreset()](ThemeService.md#registerpreset) instead.
 executeCommand<T>(id, ...args): Promise<T>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:755](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L755)
+Defined in: [packages/sdk/src/types.ts:759](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L759)
 
 Invoke a registered command by id — including commands contributed by
 other extensions. The minimal "operate" primitive; pairs with the typed
@@ -693,7 +693,7 @@ Expected return type of the command (defaults to `unknown`).
 getExtension<API>(id): ExtensionHandle<API> | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:889](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L889)
+Defined in: [packages/sdk/src/types.ts:893](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L893)
 
 Resolve a handle to another extension in order to consume the API it
 published (the value its [Extension.activate](Extension.md#activate) returned). This is how

--- a/apps/docs/api/types/interfaces/ExtensionHandle.md
+++ b/apps/docs/api/types/interfaces/ExtensionHandle.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionHandle\<API\>
 
-Defined in: [packages/sdk/src/types.ts:900](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L900)
+Defined in: [packages/sdk/src/types.ts:904](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L904)
 
 A handle to another extension, obtained via
 [ExtensionContext.getExtension](ExtensionContext.md#getextension). Lets one extension consume another's
@@ -20,7 +20,7 @@ published API while tolerating its absence.
 readonly id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:902](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L902)
+Defined in: [packages/sdk/src/types.ts:906](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L906)
 
 The resolved extension's id.
 
@@ -32,7 +32,7 @@ The resolved extension's id.
 readonly active: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:904](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L904)
+Defined in: [packages/sdk/src/types.ts:908](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L908)
 
 True once that extension has activated.
 
@@ -44,7 +44,7 @@ True once that extension has activated.
 readonly api: API | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:907](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L907)
+Defined in: [packages/sdk/src/types.ts:911](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L911)
 
 Its published API (what its `activate` returned), or `undefined` if it
 hasn't activated or published nothing.

--- a/apps/docs/api/types/interfaces/ExtensionManifest.md
+++ b/apps/docs/api/types/interfaces/ExtensionManifest.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionManifest
 
-Defined in: [packages/sdk/src/types.ts:923](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L923)
+Defined in: [packages/sdk/src/types.ts:927](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L927)
 
 Display metadata for an extension, surfaced in the **Extensions** settings
 page (name, one-line description, version, and [\* \| publisher](#publisher) brand). For built-in extensions this is declared in-code on the
@@ -18,7 +18,7 @@ namespace for the publisher) when one is absent.
 readonly optional name?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:925](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L925)
+Defined in: [packages/sdk/src/types.ts:929](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L929)
 
 Human-friendly name shown in the Extensions list (falls back to the id).
 
@@ -30,7 +30,7 @@ Human-friendly name shown in the Extensions list (falls back to the id).
 readonly optional description?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:927](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L927)
+Defined in: [packages/sdk/src/types.ts:931](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L931)
 
 One-line description shown beneath the name.
 
@@ -42,7 +42,7 @@ One-line description shown beneath the name.
 readonly optional version?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:929](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L929)
+Defined in: [packages/sdk/src/types.ts:933](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L933)
 
 Version string shown next to the name.
 
@@ -54,7 +54,7 @@ Version string shown next to the name.
 readonly optional publisher?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:936](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L936)
+Defined in: [packages/sdk/src/types.ts:940](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L940)
 
 The publisher/brand shown beside the name (e.g. `"Silo"`). Built-in
 extensions are always branded `"Silo"` by the host regardless of this field;

--- a/apps/docs/api/types/interfaces/NavigatorView.md
+++ b/apps/docs/api/types/interfaces/NavigatorView.md
@@ -1,17 +1,21 @@
 # Interface: NavigatorView
 
-Defined in: [packages/sdk/src/types.ts:525](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L525)
+Defined in: [packages/sdk/src/types.ts:529](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L529)
 
 A view in the **Navigator** — the side panel you navigate the app from. The
 Navigator is a container: each registered view is one projection of "where
-can I go", and the user switches between them from the selector in its
-header. The built-in **Workspaces** view (the workspace list) is itself
-registered this way, through this same API.
+can I go". Every registered view is listed by name at the top of the panel
+and is one click away; the built-in **Workspaces** view (the workspace list)
+is itself registered this way, through this same API.
 
 Reach for a view rather than [ExtensionContext.registerSidePanel](ExtensionContext.md#registersidepanel) when
 what you'd be adding is *another way to navigate the app*. Two navigators
 side by side leave the user with no rule for which one to trust; a view keeps
 one place to navigate from and changes only how it is projected.
+
+Register **one** view per projection, not one per way of sorting it — a
+grouping or filter your view supports is a control *inside* that view
+(contribute it as a toolbar item, see below), not a second entry in the list.
 
 A view owns the whole panel body. Header **actions** are contributed
 separately, as toolbar items on the `"navigator"`
@@ -23,8 +27,8 @@ dropdown chrome for free.
 
 ```tsx
 ctx.registerNavigatorView({
-  id: "my-ext.by-status",
-  title: "Agents by status",
+  id: "my-ext.agents",
+  title: "Agents",
   component: ({ active }) => <AgentList paused={!active} />,
 });
 ```
@@ -37,7 +41,7 @@ ctx.registerNavigatorView({
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:527](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L527)
+Defined in: [packages/sdk/src/types.ts:531](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L531)
 
 Unique id, conventionally `"<extension-id>.<view-name>"`.
 
@@ -49,9 +53,9 @@ Unique id, conventionally `"<extension-id>.<view-name>"`.
 title: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:529](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L529)
+Defined in: [packages/sdk/src/types.ts:533](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L533)
 
-Name shown in the Navigator's header and its view menu.
+Name shown for this view in the Navigator's view list.
 
 ***
 
@@ -61,9 +65,9 @@ Name shown in the Navigator's header and its view menu.
 optional icon?: ReactNode;
 ```
 
-Defined in: [packages/sdk/src/types.ts:531](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L531)
+Defined in: [packages/sdk/src/types.ts:535](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L535)
 
-Optional icon rendered to the left of the title in the view menu.
+Optional icon rendered to the left of the title in the view list.
 
 ***
 
@@ -73,7 +77,7 @@ Optional icon rendered to the left of the title in the view menu.
 component: ComponentType<NavigatorViewProps>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:533](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L533)
+Defined in: [packages/sdk/src/types.ts:537](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L537)
 
 The React component rendered as the whole panel body when active.
 
@@ -85,7 +89,7 @@ The React component rendered as the whole panel body when active.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:538](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L538)
+Defined in: [packages/sdk/src/types.ts:542](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L542)
 
-Sort order among views. Lower values appear first in the view menu.
+Sort order among views. Lower values appear first in the view list.
 Defaults to `0`; the built-in Workspaces view registers at `0`.

--- a/apps/docs/api/types/interfaces/SettingsPage.md
+++ b/apps/docs/api/types/interfaces/SettingsPage.md
@@ -1,6 +1,6 @@
 # Interface: SettingsPage
 
-Defined in: [packages/sdk/src/types.ts:624](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L624)
+Defined in: [packages/sdk/src/types.ts:628](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L628)
 
 A page in the Settings dialog, listed in the left rail.
 
@@ -12,7 +12,7 @@ A page in the Settings dialog, listed in the left rail.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:626](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L626)
+Defined in: [packages/sdk/src/types.ts:630](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L630)
 
 Unique id for this settings page.
 
@@ -24,7 +24,7 @@ Unique id for this settings page.
 title: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:628](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L628)
+Defined in: [packages/sdk/src/types.ts:632](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L632)
 
 Label shown in the Settings left rail.
 
@@ -36,7 +36,7 @@ Label shown in the Settings left rail.
 optional group?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:635](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L635)
+Defined in: [packages/sdk/src/types.ts:639](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L639)
 
 Optional grouping key for the left rail (groups sorted lexically, separated
 by a divider). Honored only for `core.*` pages; a page contributed by any
@@ -51,7 +51,7 @@ ignored for those.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:637](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L637)
+Defined in: [packages/sdk/src/types.ts:641](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L641)
 
 Sort order within the group. Lower sorts first. Defaults to 0.
 
@@ -63,7 +63,7 @@ Sort order within the group. Lower sorts first. Defaults to 0.
 component: ComponentType;
 ```
 
-Defined in: [packages/sdk/src/types.ts:639](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L639)
+Defined in: [packages/sdk/src/types.ts:643](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L643)
 
 Renders the right-hand pane when this page is selected.
 
@@ -76,7 +76,7 @@ optional badge?: ComponentType<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:646](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L646)
+Defined in: [packages/sdk/src/types.ts:650](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L650)
 
 Optional small indicator rendered after the title in the left rail (e.g.
 an update-available count). Rendered as its own component — separate from

--- a/apps/docs/api/types/interfaces/StatusItem.md
+++ b/apps/docs/api/types/interfaces/StatusItem.md
@@ -1,6 +1,6 @@
 # Interface: StatusItem
 
-Defined in: [packages/sdk/src/types.ts:587](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L587)
+Defined in: [packages/sdk/src/types.ts:591](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L591)
 
 A widget in the status bar (the strip along the bottom of the window).
 
@@ -21,7 +21,7 @@ for a value) to create visual distinctions within an item.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:589](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L589)
+Defined in: [packages/sdk/src/types.ts:593](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L593)
 
 Unique id for this status item.
 
@@ -33,7 +33,7 @@ Unique id for this status item.
 alignment: "left" | "right";
 ```
 
-Defined in: [packages/sdk/src/types.ts:591](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L591)
+Defined in: [packages/sdk/src/types.ts:595](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L595)
 
 Which end of the status bar this item sits at.
 
@@ -45,7 +45,7 @@ Which end of the status bar this item sits at.
 optional priority?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:605](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L605)
+Defined in: [packages/sdk/src/types.ts:609](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L609)
 
 Sort order within its alignment group. Defaults to 0.
 
@@ -67,7 +67,7 @@ may still choose a negative value intentionally to interleave with built-ins.
 optional tooltip?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:613](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L613)
+Defined in: [packages/sdk/src/types.ts:617](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L617)
 
 Tooltip shown on hover over the entire status item. The host renders a
 custom-styled popup (not the browser's native `title` tooltip). For items
@@ -83,6 +83,6 @@ internal barrel; external extensions may use the native `title` attribute).
 component: ComponentType;
 ```
 
-Defined in: [packages/sdk/src/types.ts:615](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L615)
+Defined in: [packages/sdk/src/types.ts:619](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L619)
 
 The React component (renders its own content; no props).

--- a/apps/docs/api/types/interfaces/ToolbarChromeFields.md
+++ b/apps/docs/api/types/interfaces/ToolbarChromeFields.md
@@ -1,6 +1,6 @@
 # Interface: ToolbarChromeFields\<S\>
 
-Defined in: [packages/sdk/src/toolbar-items.ts:129](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L129)
+Defined in: [packages/sdk/src/toolbar-items.ts:130](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L130)
 
 Shared placement fields for non-interactive toolbar chrome
 ([ToolbarSeparatorContribution](ToolbarSeparatorContribution.md) / [ToolbarSpacerContribution](ToolbarSpacerContribution.md)).
@@ -24,7 +24,7 @@ Shared placement fields for non-interactive toolbar chrome
 id: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:132](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L132)
+Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L133)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:132](https://github.com/silo-code
 surface: S;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L133)
+Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L134)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L134)
+Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L135)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code
 optional when?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L135)
+Defined in: [packages/sdk/src/toolbar-items.ts:136](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L136)
 
 #### Parameters
 

--- a/apps/docs/api/types/interfaces/ToolbarCommandItemContribution.md
+++ b/apps/docs/api/types/interfaces/ToolbarCommandItemContribution.md
@@ -1,6 +1,6 @@
 # Interface: ToolbarCommandItemContribution\<S\>
 
-Defined in: [packages/sdk/src/toolbar-items.ts:93](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L93)
+Defined in: [packages/sdk/src/toolbar-items.ts:94](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L94)
 
 Command-backed toolbar control — click runs [ToolbarCommandItemContribution.command](#command).
 
@@ -22,7 +22,7 @@ Command-backed toolbar control — click runs [ToolbarCommandItemContribution.co
 id: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:52](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L52)
+Defined in: [packages/sdk/src/toolbar-items.ts:53](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L53)
 
 Unique id for this contribution.
 
@@ -38,7 +38,7 @@ Unique id for this contribution.
 surface: S;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:54](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L54)
+Defined in: [packages/sdk/src/toolbar-items.ts:55](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L55)
 
 Which toolbar to contribute to.
 
@@ -54,7 +54,7 @@ Which toolbar to contribute to.
 optional icon?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:59](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L59)
+Defined in: [packages/sdk/src/toolbar-items.ts:60](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L60)
 
 Leading glyph as a [PhosphorIconName](../type-aliases/PhosphorIconName.md) (e.g. `"Flag"`). Omit for a
 text-only control (requires [title](ToolbarItemFields.md#title)).
@@ -71,7 +71,7 @@ text-only control (requires [title](ToolbarItemFields.md#title)).
 optional title?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:64](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L64)
+Defined in: [packages/sdk/src/toolbar-items.ts:65](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L65)
 
 Visible label painted in the control. Omit for icon-only. When both
 `icon` and `title` are set, the host renders icon + text.
@@ -88,7 +88,7 @@ Visible label painted in the control. Omit for icon-only. When both
 optional tooltip?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:66](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L66)
+Defined in: [packages/sdk/src/toolbar-items.ts:67](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L67)
 
 Hover tooltip (falls back to title / label / command label).
 
@@ -104,7 +104,7 @@ Hover tooltip (falls back to title / label / command label).
 optional label?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:72](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L72)
+Defined in: [packages/sdk/src/toolbar-items.ts:73](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L73)
 
 Accessible name (falls back to title / the command's label). Always used
 for `aria-label`; not painted unless [title](ToolbarItemFields.md#title)
@@ -122,7 +122,7 @@ is also set.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:74](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L74)
+Defined in: [packages/sdk/src/toolbar-items.ts:75](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L75)
 
 Ordering within the trailing cluster; lower sorts first.
 
@@ -138,7 +138,7 @@ Ordering within the trailing cluster; lower sorts first.
 optional when?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:78](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L78)
+Defined in: [packages/sdk/src/toolbar-items.ts:79](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L79)
 
 Visibility predicate. Returning false hides the item for this target.
 
@@ -168,7 +168,7 @@ Visibility predicate. Returning false hides the item for this target.
 optional checked?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:84](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L84)
+Defined in: [packages/sdk/src/toolbar-items.ts:85](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L85)
 
 Toggle-state predicate for command items. When provided, the host renders
 the control in a pressed/checked visual state whenever this returns true.
@@ -200,7 +200,7 @@ Menu items put checks on individual [MenuEntry](../type-aliases/MenuEntry.md) ro
 command: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:97](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L97)
+Defined in: [packages/sdk/src/toolbar-items.ts:98](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L98)
 
 The command to run; receives [ToolbarItemContext](ToolbarItemContext.md)[S] as its first arg.
 
@@ -212,7 +212,7 @@ The command to run; receives [ToolbarItemContext](ToolbarItemContext.md)[S] as i
 optional menu?: undefined;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:98](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L98)
+Defined in: [packages/sdk/src/toolbar-items.ts:99](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L99)
 
 ***
 
@@ -222,4 +222,4 @@ Defined in: [packages/sdk/src/toolbar-items.ts:98](https://github.com/silo-code/
 optional type?: undefined;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:99](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L99)
+Defined in: [packages/sdk/src/toolbar-items.ts:100](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L100)

--- a/apps/docs/api/types/interfaces/ToolbarItemContext.md
+++ b/apps/docs/api/types/interfaces/ToolbarItemContext.md
@@ -1,6 +1,6 @@
 # Interface: ToolbarItemContext
 
-Defined in: [packages/sdk/src/toolbar-items.ts:27](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L27)
+Defined in: [packages/sdk/src/toolbar-items.ts:28](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L28)
 
 The typed target each [ToolbarSurface](../type-aliases/ToolbarSurface.md) passes to an invoked command
 and to `when` / `checked` / [ToolbarMenuItemContribution.menu](ToolbarMenuItemContribution.md#menu) builders.
@@ -13,7 +13,7 @@ and to `when` / `checked` / [ToolbarMenuItemContribution.menu](ToolbarMenuItemCo
 editor: object;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:28](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L28)
+Defined in: [packages/sdk/src/toolbar-items.ts:29](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L29)
 
 #### editorId
 
@@ -29,7 +29,7 @@ editorId: string;
 terminal: object;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:29](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L29)
+Defined in: [packages/sdk/src/toolbar-items.ts:30](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L30)
 
 #### terminalId
 
@@ -45,7 +45,7 @@ terminalId: string;
 navigator: object;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:30](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L30)
+Defined in: [packages/sdk/src/toolbar-items.ts:31](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L31)
 
 #### viewId
 

--- a/apps/docs/api/types/interfaces/ToolbarItemFields.md
+++ b/apps/docs/api/types/interfaces/ToolbarItemFields.md
@@ -1,6 +1,6 @@
 # Interface: ToolbarItemFields\<S\>
 
-Defined in: [packages/sdk/src/toolbar-items.ts:50](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L50)
+Defined in: [packages/sdk/src/toolbar-items.ts:51](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L51)
 
 Shared fields for interactive toolbar contributions. Render chrome is driven
 by [icon](#icon) + [title](#title):
@@ -34,7 +34,7 @@ track UI zoom. Pass a React node is no longer supported — use the name.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:52](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L52)
+Defined in: [packages/sdk/src/toolbar-items.ts:53](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L53)
 
 Unique id for this contribution.
 
@@ -46,7 +46,7 @@ Unique id for this contribution.
 surface: S;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:54](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L54)
+Defined in: [packages/sdk/src/toolbar-items.ts:55](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L55)
 
 Which toolbar to contribute to.
 
@@ -58,7 +58,7 @@ Which toolbar to contribute to.
 optional icon?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:59](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L59)
+Defined in: [packages/sdk/src/toolbar-items.ts:60](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L60)
 
 Leading glyph as a [PhosphorIconName](../type-aliases/PhosphorIconName.md) (e.g. `"Flag"`). Omit for a
 text-only control (requires [title](#title)).
@@ -71,7 +71,7 @@ text-only control (requires [title](#title)).
 optional title?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:64](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L64)
+Defined in: [packages/sdk/src/toolbar-items.ts:65](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L65)
 
 Visible label painted in the control. Omit for icon-only. When both
 `icon` and `title` are set, the host renders icon + text.
@@ -84,7 +84,7 @@ Visible label painted in the control. Omit for icon-only. When both
 optional tooltip?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:66](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L66)
+Defined in: [packages/sdk/src/toolbar-items.ts:67](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L67)
 
 Hover tooltip (falls back to title / label / command label).
 
@@ -96,7 +96,7 @@ Hover tooltip (falls back to title / label / command label).
 optional label?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:72](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L72)
+Defined in: [packages/sdk/src/toolbar-items.ts:73](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L73)
 
 Accessible name (falls back to title / the command's label). Always used
 for `aria-label`; not painted unless [title](#title)
@@ -110,7 +110,7 @@ is also set.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:74](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L74)
+Defined in: [packages/sdk/src/toolbar-items.ts:75](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L75)
 
 Ordering within the trailing cluster; lower sorts first.
 
@@ -122,7 +122,7 @@ Ordering within the trailing cluster; lower sorts first.
 optional when?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:78](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L78)
+Defined in: [packages/sdk/src/toolbar-items.ts:79](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L79)
 
 Visibility predicate. Returning false hides the item for this target.
 
@@ -148,7 +148,7 @@ Visibility predicate. Returning false hides the item for this target.
 optional checked?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:84](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L84)
+Defined in: [packages/sdk/src/toolbar-items.ts:85](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L85)
 
 Toggle-state predicate for command items. When provided, the host renders
 the control in a pressed/checked visual state whenever this returns true.

--- a/apps/docs/api/types/interfaces/ToolbarMenuItemContribution.md
+++ b/apps/docs/api/types/interfaces/ToolbarMenuItemContribution.md
@@ -1,6 +1,6 @@
 # Interface: ToolbarMenuItemContribution\<S\>
 
-Defined in: [packages/sdk/src/toolbar-items.ts:110](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L110)
+Defined in: [packages/sdk/src/toolbar-items.ts:111](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L111)
 
 Menu-backed toolbar control — click opens a host dropdown via
 [UiService.showMenu](UiService.md#showmenu) with entries from
@@ -24,7 +24,7 @@ Menu-backed toolbar control — click opens a host dropdown via
 id: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:52](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L52)
+Defined in: [packages/sdk/src/toolbar-items.ts:53](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L53)
 
 Unique id for this contribution.
 
@@ -40,7 +40,7 @@ Unique id for this contribution.
 surface: S;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:54](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L54)
+Defined in: [packages/sdk/src/toolbar-items.ts:55](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L55)
 
 Which toolbar to contribute to.
 
@@ -56,7 +56,7 @@ Which toolbar to contribute to.
 optional icon?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:59](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L59)
+Defined in: [packages/sdk/src/toolbar-items.ts:60](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L60)
 
 Leading glyph as a [PhosphorIconName](../type-aliases/PhosphorIconName.md) (e.g. `"Flag"`). Omit for a
 text-only control (requires [title](ToolbarItemFields.md#title)).
@@ -73,7 +73,7 @@ text-only control (requires [title](ToolbarItemFields.md#title)).
 optional title?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:64](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L64)
+Defined in: [packages/sdk/src/toolbar-items.ts:65](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L65)
 
 Visible label painted in the control. Omit for icon-only. When both
 `icon` and `title` are set, the host renders icon + text.
@@ -90,7 +90,7 @@ Visible label painted in the control. Omit for icon-only. When both
 optional tooltip?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:66](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L66)
+Defined in: [packages/sdk/src/toolbar-items.ts:67](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L67)
 
 Hover tooltip (falls back to title / label / command label).
 
@@ -106,7 +106,7 @@ Hover tooltip (falls back to title / label / command label).
 optional label?: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:72](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L72)
+Defined in: [packages/sdk/src/toolbar-items.ts:73](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L73)
 
 Accessible name (falls back to title / the command's label). Always used
 for `aria-label`; not painted unless [title](ToolbarItemFields.md#title)
@@ -124,7 +124,7 @@ is also set.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:74](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L74)
+Defined in: [packages/sdk/src/toolbar-items.ts:75](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L75)
 
 Ordering within the trailing cluster; lower sorts first.
 
@@ -140,7 +140,7 @@ Ordering within the trailing cluster; lower sorts first.
 optional when?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:78](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L78)
+Defined in: [packages/sdk/src/toolbar-items.ts:79](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L79)
 
 Visibility predicate. Returning false hides the item for this target.
 
@@ -170,7 +170,7 @@ Visibility predicate. Returning false hides the item for this target.
 optional checked?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:84](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L84)
+Defined in: [packages/sdk/src/toolbar-items.ts:85](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L85)
 
 Toggle-state predicate for command items. When provided, the host renders
 the control in a pressed/checked visual state whenever this returns true.
@@ -204,7 +204,7 @@ menu: (target) =>
 | Promise<MenuEntry[]>;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:117](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L117)
+Defined in: [packages/sdk/src/toolbar-items.ts:118](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L118)
 
 Build the dropdown for this target. May be sync or async. The host
 anchors the menu on the toolbar control (`align: "end"`, toggle on).
@@ -228,7 +228,7 @@ anchors the menu on the toolbar control (`align: "end"`, toggle on).
 optional command?: undefined;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:118](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L118)
+Defined in: [packages/sdk/src/toolbar-items.ts:119](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L119)
 
 ***
 
@@ -238,4 +238,4 @@ Defined in: [packages/sdk/src/toolbar-items.ts:118](https://github.com/silo-code
 optional type?: undefined;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:119](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L119)
+Defined in: [packages/sdk/src/toolbar-items.ts:120](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L120)

--- a/apps/docs/api/types/interfaces/ToolbarSeparatorContribution.md
+++ b/apps/docs/api/types/interfaces/ToolbarSeparatorContribution.md
@@ -1,6 +1,6 @@
 # Interface: ToolbarSeparatorContribution\<S\>
 
-Defined in: [packages/sdk/src/toolbar-items.ts:146](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L146)
+Defined in: [packages/sdk/src/toolbar-items.ts:147](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L147)
 
 A light vertical rule between toolbar controls. Softer than the Text |
 Preview pipe — host paints it with a low-opacity mix of toolbar text, not
@@ -24,7 +24,7 @@ Preview pipe — host paints it with a low-opacity mix of toolbar text, not
 id: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:132](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L132)
+Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L133)
 
 #### Inherited from
 
@@ -38,7 +38,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:132](https://github.com/silo-code
 surface: S;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L133)
+Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L134)
 
 #### Inherited from
 
@@ -52,7 +52,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L134)
+Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L135)
 
 #### Inherited from
 
@@ -66,7 +66,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code
 optional when?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L135)
+Defined in: [packages/sdk/src/toolbar-items.ts:136](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L136)
 
 #### Parameters
 
@@ -94,4 +94,4 @@ Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code
 type: "separator";
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:149](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L149)
+Defined in: [packages/sdk/src/toolbar-items.ts:150](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L150)

--- a/apps/docs/api/types/interfaces/ToolbarSpacerContribution.md
+++ b/apps/docs/api/types/interfaces/ToolbarSpacerContribution.md
@@ -1,6 +1,6 @@
 # Interface: ToolbarSpacerContribution\<S\>
 
-Defined in: [packages/sdk/src/toolbar-items.ts:168](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L168)
+Defined in: [packages/sdk/src/toolbar-items.ts:169](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L169)
 
 An empty gap between toolbar controls (no rule). Use to group without a
 hard split; prefer [ToolbarSeparatorContribution](ToolbarSeparatorContribution.md) when a hairline helps.
@@ -23,7 +23,7 @@ hard split; prefer [ToolbarSeparatorContribution](ToolbarSeparatorContribution.m
 id: string;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:132](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L132)
+Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L133)
 
 #### Inherited from
 
@@ -37,7 +37,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:132](https://github.com/silo-code
 surface: S;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L133)
+Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L134)
 
 #### Inherited from
 
@@ -51,7 +51,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:133](https://github.com/silo-code
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L134)
+Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L135)
 
 #### Inherited from
 
@@ -65,7 +65,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:134](https://github.com/silo-code
 optional when?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L135)
+Defined in: [packages/sdk/src/toolbar-items.ts:136](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L136)
 
 #### Parameters
 
@@ -93,7 +93,7 @@ Defined in: [packages/sdk/src/toolbar-items.ts:135](https://github.com/silo-code
 type: "spacer";
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:171](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L171)
+Defined in: [packages/sdk/src/toolbar-items.ts:172](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L172)
 
 ***
 
@@ -103,6 +103,6 @@ Defined in: [packages/sdk/src/toolbar-items.ts:171](https://github.com/silo-code
 optional size?: ToolbarSpacerSize;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:173](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L173)
+Defined in: [packages/sdk/src/toolbar-items.ts:174](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L174)
 
 Default `"md"`.

--- a/apps/docs/api/types/type-aliases/ToolbarItemContribution.md
+++ b/apps/docs/api/types/type-aliases/ToolbarItemContribution.md
@@ -8,7 +8,7 @@ type ToolbarItemContribution<S> =
 | ToolbarSpacerContribution<S>;
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:193](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L193)
+Defined in: [packages/sdk/src/toolbar-items.ts:194](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L194)
 
 Adds a control or chrome element to the trailing cluster of a built-in
 editor or terminal toolbar. Register via

--- a/apps/docs/api/types/type-aliases/ToolbarSpacerSize.md
+++ b/apps/docs/api/types/type-aliases/ToolbarSpacerSize.md
@@ -4,7 +4,7 @@
 type ToolbarSpacerSize = "sm" | "md" | "lg";
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:159](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L159)
+Defined in: [packages/sdk/src/toolbar-items.ts:160](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L160)
 
 Gap size for [ToolbarSpacerContribution](../interfaces/ToolbarSpacerContribution.md). Maps to em of the toolbar
 font (`sm` 0.25em / `md` 0.5em / `lg` 0.75em).

--- a/apps/docs/api/types/type-aliases/ToolbarSurface.md
+++ b/apps/docs/api/types/type-aliases/ToolbarSurface.md
@@ -4,13 +4,14 @@
 type ToolbarSurface = "editor" | "terminal" | "navigator";
 ```
 
-Defined in: [packages/sdk/src/toolbar-items.ts:18](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L18)
+Defined in: [packages/sdk/src/toolbar-items.ts:19](https://github.com/silo-code/silo/blob/main/packages/sdk/src/toolbar-items.ts#L19)
 
 Built-in surfaces that accept [ToolbarItemContribution](ToolbarItemContribution.md)s. One surface
 per registration.
 
 `"editor"` and `"terminal"` are CenterDock breadcrumb toolbars; `"navigator"`
-is the header of the Navigator side panel, where contributions become that
-panel's action buttons. A navigator item's `when` receives the active
+is the header naming the Navigator's active view — the bar between its view
+list and the view body — where contributions become that view's action
+buttons. A navigator item's `when` receives the active
 [view](../interfaces/NavigatorView.md)'s id, so an action can be scoped to one view or
-left unscoped to appear across all of them.
+left unscoped to follow the user across all of them.

--- a/apps/docs/guide/workspaces.md
+++ b/apps/docs/guide/workspaces.md
@@ -18,8 +18,7 @@ That persistence pays off when you treat terminal tabs as dedicated slots for sp
 
 ## Opening a workspace
 
-Click the **+** button in the Navigator's header to open a folder
-picker. Select a folder (or multiple folders for a multi-root workspace) and
+Click the **+** button in the Navigator's view header to open a folder picker. Select a folder (or multiple folders for a multi-root workspace) and
 Silo creates a new workspace and activates it. If a workspace for that folder
 already exists, Silo brings it to the foreground instead.
 

--- a/docs/decisions/0038-navigator-view-list.md
+++ b/docs/decisions/0038-navigator-view-list.md
@@ -1,0 +1,130 @@
+---
+status: accepted
+date: 2026-08-13
+---
+
+# 0038. The Navigator lists its views instead of hiding them in a menu
+
+## Context
+
+RFC [0023](../proposals/0023-workspace-panel-views.md) turned the Navigator into a
+container of contributed **views** and put a **dropdown selector** in its header:
+the active view's title plus a caret, opening a checkable `ctx.ui.showMenu` list.
+That shape drove a second decision in the same RFC — `silo.agent-monitor` was told
+to register its two groupings as two separate views (**Agents** and **Agents by
+workspace**), because folding them into one view with its own grouping menu would
+have produced "a menu inside a menu — the panel's view selector and the
+extension's grouping selector are the same kind of control at two levels."
+
+Both decisions have worn badly in daily use, and for the same underlying reason:
+
+- **Switching costs two clicks and a read.** Opening a menu, scanning it, and
+  picking a row is the whole interaction — for a control used many times an hour,
+  on a panel whose entire job is navigation. The target isn't in a fixed place, so
+  it can't become muscle memory.
+- **The menu hides the app's shape.** A user with the Agents view open has no
+  standing indication that a Workspaces view exists. Discovery of contributed
+  views depends on opening a menu you have no reason to open.
+- **Two views for one list.** "Agents" and "Agents by workspace" render the same
+  rows sectioned two ways. As menu rows they read as two destinations, which is
+  exactly the confusion the RFC's flat list was supposed to avoid.
+
+The nesting objection that rejected a merged Agents view is **conditional on the
+selector being a menu**. Flatten the selector and there is no outer menu left to
+nest inside — so the two changes are one decision, and neither is worth making
+alone.
+
+## Decision
+
+The Navigator renders **every registered view as a row in an always-visible list**
+at the top of the panel, one click each. Below the list, a **view header** names
+the active view and carries that view's toolbar contributions. The dropdown
+selector is gone.
+
+Splitting "where can I go" (the list) from "where am I" (the header) is
+deliberate: the rows stay unhighlighted, so the list reads as a set of
+destinations rather than a segmented control with a stuck state, and the header
+gives the actions a fixed home instead of moving them onto whichever row is
+selected. Rows carry an icon in a reserved column, so titles align whether or not
+a given view supplies one.
+
+Consequently, `silo.agent-monitor` registers **one** Agents view, and its status
+vs. workspace sectioning becomes a persisted **`groupBy` preference** flipped from
+a "Group by" toolbar contribution in the Navigator header. This reverses the RFC's
+rejection of that shape.
+
+## Consequences
+
+- Switching views is one click at a fixed screen position, and every contributed
+  view is visible without opening anything — the panel now advertises what it can
+  show.
+- The panel spends roughly **30px per registered view**, plus a single ~24px view
+  header, permanently. That is more chrome than the dropdown it replaces — the
+  trade bought for it is that switching is one click and every contributed view
+  is visible without opening anything. Fine at the two or three views that exist
+  today; a user who installs several view-contributing extensions pays for a list
+  they may rarely touch. If that becomes the common case, the answer is scrolling
+  or collapsing the list — not going back to a menu.
+- Toolbar contributions on the `"navigator"` surface keep a **fixed position** —
+  the view header, not a moving row. An intentionally unscoped item (e.g.
+  `core.workspaces.add`) stays in the same place as the user switches views,
+  which the earlier active-row placement would not have given it.
+- Which view is active is conveyed **visually by the header alone**; the rows carry
+  `aria-selected` but no highlight. Assistive tech is told at the point of choice,
+  sighted users read it off the header.
+- With **only one view registered the list is not rendered at all** — a one-row
+  list of destinations you are already at is pure chrome. The header still names
+  the view and carries its actions, so nothing is lost. The bodies drop their
+  `role="tabpanel"` in that case too, since there is no tablist for them to
+  belong to.
+- The view list is a `role="tablist"` driven by the SDK's `useFocusGroup`
+  (ADR [0021](./0021-keyboard-navigation-architecture.md)), so it is one Tab stop
+  with ↑/↓ between rows and gets the shared keyboard ring for free.
+- `silo.agent-monitor.by-workspace` is **retired**. Anyone whose persisted active
+  view was that id falls back to Workspaces once, then picks Agents from the list.
+  We accepted that one-time reset rather than adding a view-id migration mechanism
+  to the SDK: the always-visible list makes recovery a single labelled click,
+  which is materially cheaper than it would have been under the dropdown.
+- `NavigatorView.icon` becomes load-bearing in a way it wasn't when it only
+  decorated menu rows: both first-party views now set one, and a third-party view
+  that omits it will look unfinished beside them. It is still optional and still a
+  `React.ReactNode`, while toolbar items have since moved to `PhosphorIconName`
+  strings — an inconsistency this ADR notes but does not resolve.
+
+## Alternatives considered
+
+- **A segmented control / tab strip in the existing header.** One click and zero
+  extra vertical space, since it reuses the header row. Rejected: it stops working
+  past about three views in a ~250px panel, and the overflow it then needs is a
+  menu — reintroducing exactly what this ADR removes, at the point where the user
+  has the most views to choose between.
+- **Stacked collapsible sections** (all views open at once, VS Code Explorer
+  style). Genuinely more capable — you stop switching and watch two views at once
+  — and tested well as a mockup. **Deferred, not rejected.** It changes what a
+  `NavigatorView` _is_, from "owns the panel body" to "owns a section that may be
+  80px tall," which is an SDK contract change every existing view has to absorb.
+  Worth revisiting if watching agents and workspaces simultaneously turns out to
+  be the real need behind the frequent switching.
+- **An icon rail** down the panel's edge. Scales to many views for almost no
+  space. Rejected for now: it forces `NavigatorView.icon` from optional to
+  required, breaking third-party views that don't set one.
+- **Keeping the dropdown and adding a cycle keybinding.** Cheapest possible fix.
+  Rejected as the primary answer — it helps the author of the keybinding and
+  nobody else, and does nothing for discovery. A keybinding remains worth adding
+  _alongside_ the list.
+- **A view-id migration mechanism in the SDK** (e.g. `NavigatorView.replaces`), so
+  a retired id resolves onto its successor. Deferred: it is a real gap in the view
+  lifecycle and the right shape if view renames become common, but adding public
+  SDK surface — with the publish lag that imposes on third-party extensions — to
+  save one labelled click was not justified for a single retirement.
+
+## References
+
+- RFC [0023](../proposals/0023-workspace-panel-views.md) — the Navigator and its
+  contributed views; the dropdown selector and the merged-view rejection this
+  supersedes.
+- ADR [0021](./0021-keyboard-navigation-architecture.md) — `useFocusGroup`, the
+  roving-focus primitive the view list is built on.
+- ADR [0029](./0029-adornments-vs-registration.md) — why panel chrome is
+  contributed rather than owned by the panel.
+- `packages/extensions-core/src/navigator/` — the panel and its pure view model.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -71,3 +71,5 @@ A small, obvious choice needs neither.
 | [0034](./0034-focus-and-activation-authority.md)        | Focus/activation: the live dock, and only the active panel | 2026-08-07 | proposed |
 | [0035](./0035-global-side-panel-layout.md)              | Global Side Panel Layout is an opt-in shared arrangement   | 2026-08-08 | accepted |
 | [0036](./0036-unified-update-ui-and-changelog.md)       | Unified update UI, in-app changelog, and skip-version      | 2026-08-10 | accepted |
+| [0037](./0037-git-repo-watch-session.md)                | A published, live git-state session (`GitAPI.watchRepo`)   | 2026-08-12 | accepted |
+| [0038](./0038-navigator-view-list.md)                   | The Navigator lists its views instead of hiding them       | 2026-08-13 | accepted |

--- a/docs/proposals/0023-workspace-panel-views.md
+++ b/docs/proposals/0023-workspace-panel-views.md
@@ -5,6 +5,14 @@ created: 2026-08-06
 
 # 0023. The Navigator — a side panel of contributed views
 
+> **Partly superseded by ADR [0038](../decisions/0038-navigator-view-list.md).**
+> The Navigator, `ctx.registerNavigatorView`, and the `"navigator"` toolbar
+> surface are all as described here. Two things are not: the header **selector
+> is a visible list of every view**, not a dropdown, and agent-monitor ships
+> **one** Agents view with a `Group by` control rather than the two views
+> proposed below (the "menu inside a menu" objection in _Alternatives_ no longer
+> applies once the outer menu is gone).
+
 ## Summary
 
 Turn the Workspaces side panel into the **Navigator**: a container whose body is

--- a/docs/ui-terminology.md
+++ b/docs/ui-terminology.md
@@ -19,7 +19,10 @@ This document defines the high-level terminology for the Silo UI components. Use
 - **Dock**: A container that manages flexible layout and tab grouping (e.g., `WorkspaceDock` uses the `dockview` library).
 - **Group**: A collection of panels sharing a single tab bar within a Dock. Groups can be split horizontally or vertically.
 - **Panel**: The fundamental unit of UI content (e.g., a Terminal, a File Explorer, or an Editor). There are `Side Panels` that live in the `SideDock` and `Content or File Panels` that live in the `CenterDock`.
-- **Navigator**: The side panel you navigate the app from (`core.navigator`). It is a _container_: its body is one **View** at a time, chosen from the selector in its header, and its header actions are toolbar contributions on the `"navigator"` surface. See [RFC 0023](./proposals/0023-workspace-panel-views.md).
+- **Navigator**: The side panel you navigate the app from (`core.navigator`). It is a _container_: every registered **View** is listed by name at the top of the panel (the **View List**), and the **Active View** renders below a **View Header** that names it and holds its actions — toolbar contributions on the `"navigator"` surface. The View List is hidden when only one View is registered. See [RFC 0023](./proposals/0023-workspace-panel-views.md) and [ADR 0038](./decisions/0038-navigator-view-list.md).
+- **Active View**: The View currently rendered in the Navigator — a persisted, global user choice, not the focus/activation sense "active" carries for workspaces, docks, and panels.
+- **View List**: The rows at the top of the Navigator, one per registered View. Deliberately not highlighted for the Active View — the View Header below is what names it.
+- **View Header**: The bar under the View List naming the Active View and hosting its toolbar actions.
 - **View**: One projection inside the Navigator — "where can I go", rendered a particular way. The **Workspaces** view (the workspace list, contributed by `core.workspaces`) is the default one; extensions add their own via `ctx.registerNavigatorView`. A View is _not_ a Panel: adding another way to navigate means adding a View, not a second Side Panel.
 - **Tab**: The UI handle used to switch between Panels within a Group.
 

--- a/packages/extension-host/src/extension-host/navigator-view-registry.ts
+++ b/packages/extension-host/src/extension-host/navigator-view-registry.ts
@@ -2,8 +2,8 @@ import type { NavigatorView } from "@silo-code/sdk";
 
 // Host-side registry for Navigator views (RFC 0023).
 // Extensions register views via the public ctx.registerNavigatorView(); the
-// read side (list/subscribe) is core-only, since painting the view selector
-// and mounting the active body needs the React component references.
+// read side (list/subscribe) is core-only, since painting the view list and
+// mounting the active view's body needs the React component references.
 //
 // The Workspaces view is in here like any other — core.workspaces registers it
 // through the same public API, so first-party and third-party views are the

--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -1,75 +1,147 @@
-/* The Navigator is a column of [sticky header][one visible view]. It only sets
-   a min-height — the host `.tab-pane` above it stays the sole scroller, which
-   is what its scroll persistence and every registered view assume. */
+/* The Navigator is a column of [sticky view list][view header][one visible
+   view]. It only sets a min-height — the host `.tab-pane` above it stays the
+   sole scroller, which is what its scroll persistence and every registered
+   view assume. */
 .nav-panel {
   display: flex;
   flex-direction: column;
   min-height: 100%;
 }
 
-.nav-header {
+/* Every registered view, always on screen, one click each. Stays put while the
+   active view scrolls under it; opaque so rows don't show through. */
+/* Rows sit tight against each other; the breathing room goes around the block
+   instead, weighted toward the bottom so the list reads as separated from the
+   view header under it rather than floating between the two. */
+.nav-views {
   display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--silo-color-border);
-  /* Stays put while the active view scrolls under it; opaque so rows don't
-     show through. */
+  flex-direction: column;
+  gap: 0;
+  padding: 15px 6px 18px;
   position: sticky;
   top: 0;
   z-index: 1;
   background: var(--silo-color-bg);
 }
 
-.nav-header__actions {
-  display: inline-flex;
+/* Deliberately unhighlighted when selected — `.nav-view-header` below names
+   the open view instead. Hover is the only row state, so the list reads as a
+   set of destinations rather than a segmented control. */
+.nav-view-row {
+  display: flex;
   align-items: center;
-  margin-left: auto;
+  gap: 9px;
   min-width: 0;
+  min-height: 26px;
+  padding: 3px 8px;
+  border-radius: var(--silo-radius-sm);
+  color: var(--silo-color-text-hi);
+  font-family: var(--silo-font-ui);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Already the panel's brightest text, so hover moves the background only. */
+.nav-view-row:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+/* Fixed width so titles line up whether or not a given view supplies an icon.
+   Only rendered at all when at least one view has one. */
+.nav-view-row__icon {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+}
+
+.nav-view-row__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Names the open view and hosts its contributed actions. Reads as a section
+   heading over the view body — the same uppercase treatment the views use for
+   their own section headings, so the hierarchy is [destinations][you are
+   here][content]. */
+.nav-view-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  /* --silo-color-border is transparent in dark theme (theme.css), so it reads
+     as no border at all there — the seam under the list needs an actually
+     visible (if subtle) line, which is what -strong is for. */
+  border-top: 1px solid var(--silo-color-border-strong);
+  border-bottom: 1px solid var(--silo-color-border);
+  background: var(--silo-color-bg);
+}
+
+.nav-view-header__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--silo-color-text);
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 /* ContributedToolbar ships the editor breadcrumb's bar chrome — its own
-   background and bottom rule. Inside the Navigator header that reads as a bar
-   within a bar, so the cluster is flattened to just its buttons here; the
-   header is already the bar. */
-.nav-header .contributed-toolbar {
+   background and bottom rule. Inside this header that reads as a bar within a
+   bar, so the cluster is flattened to just its buttons here; the header is
+   already the bar. */
+.nav-view-header .contributed-toolbar {
   min-height: 0;
   padding: 0;
   background: none;
   border-bottom: none;
 }
 
-/* The view selector. Disabled (and caret-less) when only one view is
-   registered — there'd be nothing to switch to. */
-.nav-view-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  min-width: 0;
-  padding: 2px 5px;
-  border: none;
-  background: none;
-  border-radius: var(--silo-radius-sm);
+/* Actions read as part of the header line rather than as controls sitting on
+   it, so they take the title's color instead of the toolbar surface's. Both
+   control shapes are covered: text / icon+text / menu controls are
+   `.contributed-toolbar__btn`, while icon-only ones are SDK IconButtons
+   (`.silo-icon-button-toolbar`) — the workspaces + is one of those.
+
+   Each selector below excludes `[data-checked="true"]`/`[aria-pressed="true"]`
+   rather than relying on a specificity win over ContributedToolbar.css's
+   checked-state rule — that rule is the same specificity as this one, so
+   without the exclusion, load order (not intent) would decide whether the
+   accent color survives. Excluding by selector means it always does. */
+.nav-view-header
+  .contributed-toolbar__btn:not([data-checked="true"]):not(
+    [aria-pressed="true"]
+  ),
+.nav-view-header
+  .contributed-toolbar__btn:hover:not(:disabled):not([data-checked="true"]):not(
+    [aria-pressed="true"]
+  ),
+.nav-view-header
+  .contributed-toolbar__btn:active:not(:disabled):not(
+    [data-checked="true"]
+  ):not([aria-pressed="true"]),
+.nav-view-header
+  .silo-icon-button-toolbar:not([data-checked="true"]):not(
+    [aria-pressed="true"]
+  ),
+.nav-view-header
+  .silo-icon-button-toolbar:hover:not(:disabled):not([data-checked="true"]):not(
+    [aria-pressed="true"]
+  ),
+.nav-view-header
+  .silo-icon-button-toolbar:active:not(:disabled):not(
+    [data-checked="true"]
+  ):not([aria-pressed="true"]) {
   color: var(--silo-color-text);
-  font-family: var(--silo-font-ui);
-  font-size: 1em;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.nav-view-btn:disabled {
-  cursor: default;
-}
-
-.nav-view-btn:hover:not(:disabled) {
-  background: var(--silo-color-bg-hover);
-  color: var(--silo-color-text-hi);
-}
-
-.nav-view-btn__label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* One registered view per container; all mounted ones stay in the DOM so they

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useRef, useState } from "react";
-import { CaretDown } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
 import type { ExtensionContext } from "@silo-code/sdk";
+import { useFocusGroup } from "@silo-code/sdk";
 import {
   ErrorBoundary,
   navigatorViewRegistry,
 } from "@silo-code/extension-host/internal";
 import { ContributedToolbar } from "../shared/ContributedToolbar";
 import {
-  activeViewTitle,
-  buildViewMenuItems,
+  activeViewIndex,
+  buildViewRows,
   resolveActiveView,
 } from "./navigator-views";
 import "./NavigatorPanel.css";
@@ -17,6 +17,12 @@ import "./NavigatorPanel.css";
 // a preference about how you read the panel, and swapping it on every workspace
 // switch is exactly the disorientation views exist to remove.
 const ACTIVE_VIEW_KEY = "activeView";
+
+// Ids wiring each tab to its panel for assistive tech. View ids are
+// `<extension-id>.<view-name>` by convention, so these contain dots — fine in
+// an HTML id, and nothing selects them from CSS (where they'd need escaping).
+const tabId = (viewId: string) => `nav-tab-${viewId}`;
+const tabPanelId = (viewId: string) => `nav-tabpanel-${viewId}`;
 
 export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
   // Re-render when views are registered or unregistered.
@@ -56,63 +62,123 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
     );
   }, [activeViewId]);
 
-  const viewBtnRef = useRef<HTMLButtonElement | null>(null);
-
   function pickView(viewId: string) {
     ctx.storage.global.set(ACTIVE_VIEW_KEY, viewId);
     setSavedViewId(viewId);
   }
 
-  function openViewMenu() {
-    void ctx.ui.showMenu({
-      items: buildViewMenuItems(views, activeViewId, pickView),
-      anchor: viewBtnRef.current,
-      align: "start",
-    });
-  }
+  // The view list is one Tab stop with ↑/↓ between rows and Enter/Space to
+  // switch — useFocusGroup owns that, plus the WebKit-safe keyboard ring the
+  // host styles off `data-focus-item` (ADR 0021). Focus parks on the active
+  // row so arrowing starts from what's on screen.
+  const group = useFocusGroup({
+    count: views.length,
+    orientation: "vertical",
+    start: activeViewIndex(views, activeViewId),
+    onActivate: (i) => {
+      const view = views[i];
+      if (view) pickView(view.id);
+    },
+  });
+
+  // Reserve the icon column for every row as soon as *any* view has an icon,
+  // so a mix of icon and icon-less views still aligns down one edge. `icon` is
+  // optional on NavigatorView, so all-text lists spend no space on it.
+  const hasIcons = views.some((view) => view.icon);
+  const activeView = views.find((view) => view.id === activeViewId);
+  const viewRows = buildViewRows(views, activeViewId);
+  // With nothing to switch to there is no tablist — so the bodies below stop
+  // calling themselves tab panels too, rather than pointing `aria-labelledby`
+  // at a tab that isn't rendered.
+  const showViewList = views.length > 1;
 
   return (
     <div className="nav-panel">
-      {/* Panel chrome, present whichever view is active: the view selector, and
-          the active view's actions. The actions are toolbar contributions on
-          the "navigator" surface rather than anything this panel knows about —
-          that's how the workspaces + button gets here without core.navigator
-          importing a line of workspace code. Sticky rather than a flex header
-          so the host tab-pane stays the panel's sole scroller, which is what
-          its scroll persistence (and every view) assumes. */}
-      <div className="nav-header">
-        <button
-          type="button"
-          className="nav-view-btn"
-          ref={viewBtnRef}
-          aria-haspopup="menu"
-          onClick={openViewMenu}
-          disabled={views.length < 2}
+      {/* Every registered view, named and one click away — no menu (RFC 0023's
+          selector was a dropdown; the list is the same choice made visible).
+          Which one is open is said by the header below rather than by
+          highlighting a row up here, so the list reads as a set of
+          destinations rather than a control with a stuck state.
+
+          Dropped entirely below two views: a one-row list of destinations you
+          are already at is pure chrome, and the header below still names the
+          view and carries its actions. The old dropdown went inert in the same
+          case; this reclaims the space instead.
+
+          Sticky rather than a flex header so the host tab-pane stays the
+          panel's sole scroller, which is what its scroll persistence (and
+          every view) assumes. */}
+      {showViewList && (
+        <div
+          className="nav-views"
+          role="tablist"
+          aria-orientation="vertical"
+          aria-label="Navigator views"
+          {...group.containerProps}
         >
-          <span className="nav-view-btn__label">
-            {activeViewTitle(views, activeViewId)}
-          </span>
-          {views.length > 1 && <CaretDown size={12} weight="bold" />}
-        </button>
-        {activeViewId && (
-          <div className="nav-header__actions">
-            <ContributedToolbar
-              surface="navigator"
-              target={{ viewId: activeViewId }}
-              showMenu={ctx.ui.showMenu}
-            />
-          </div>
-        )}
-      </div>
+          {viewRows.map((row, i) => (
+            <div
+              key={row.id}
+              {...group.getItemProps(i)}
+              role="tab"
+              id={tabId(row.id)}
+              // Selection is still announced even though it isn't painted on
+              // the row — assistive tech needs it named here, where the choice
+              // is.
+              aria-selected={row.selected}
+              // Omitted until the panel actually mounts (views mount lazily on
+              // first activation, below) — pointing at an id that isn't in the
+              // DOM yet would be a dangling reference for any view not yet
+              // visited this session.
+              aria-controls={
+                mountedViewIds.has(row.id) ? tabPanelId(row.id) : undefined
+              }
+              className="nav-view-row"
+              onClick={() => pickView(row.id)}
+            >
+              {hasIcons && (
+                <span className="nav-view-row__icon">{row.icon}</span>
+              )}
+              <span className="nav-view-row__label">{row.title}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* The active view, named — and the place its actions live. They're toolbar
+          contributions on the "navigator" surface rather than anything this
+          panel knows about, which is how the workspaces + button gets here
+          without core.navigator importing a line of workspace code. */}
+      {activeView && (
+        <div className="nav-view-header">
+          <span className="nav-view-header__title">{activeView.title}</span>
+          <ContributedToolbar
+            surface="navigator"
+            target={{ viewId: activeView.id }}
+            showMenu={ctx.ui.showMenu}
+          />
+        </div>
+      )}
 
       {views.map((view) => {
         if (!mountedViewIds.has(view.id)) return null;
         const isActive = activeViewId === view.id;
         const Comp = view.component;
+        // Only a real tabpanel when there's a tablist for it to belong to —
+        // the three ARIA attributes rise and fall together, so they're one
+        // conditional rather than three that could drift out of sync.
+        const tabPanelAttrs = showViewList
+          ? {
+              role: "tabpanel" as const,
+              id: tabPanelId(view.id),
+              "aria-labelledby": tabId(view.id),
+            }
+          : {};
         return (
           <div
             key={view.id}
             className="nav-view"
+            {...tabPanelAttrs}
             data-active={isActive ? "true" : "false"}
           >
             <ErrorBoundary name={view.id}>

--- a/packages/extensions-core/src/navigator/index.tsx
+++ b/packages/extensions-core/src/navigator/index.tsx
@@ -9,8 +9,9 @@ import { NavigatorPanel } from "./NavigatorPanel";
  * {@link NavigatorView} registered through the public
  * `ctx.registerNavigatorView`, including the workspace list, which
  * `core.workspaces` contributes exactly the way a third-party extension would.
- * Everything in its header is either the view selector or a toolbar
- * contribution on the `"navigator"` surface. So this extension holds no
+ * Its chrome is the view list (every registered view, named) and the view
+ * header, whose actions are toolbar contributions on the `"navigator"`
+ * surface. So this extension holds no
  * workspace code, no agent code, and no knowledge of what any view shows —
  * which is the point: a new way to navigate is a new view, not a competing
  * side panel.

--- a/packages/extensions-core/src/navigator/navigator-views.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.test.ts
@@ -1,14 +1,18 @@
-import { describe, it, expect, vi } from "vitest";
-import type { MenuItem, NavigatorView } from "@silo-code/sdk";
+import { describe, it, expect } from "vitest";
+import type { NavigatorView } from "@silo-code/sdk";
 import {
   DEFAULT_VIEW_ID,
-  activeViewTitle,
-  buildViewMenuItems,
+  activeViewIndex,
+  buildViewRows,
   resolveActiveView,
 } from "./navigator-views";
 
-function view(id: string, title = id): NavigatorView {
-  return { id, title, component: () => null };
+function view(
+  id: string,
+  title = id,
+  icon?: NavigatorView["icon"],
+): NavigatorView {
+  return { id, title, icon, component: () => null };
 }
 
 const views = [
@@ -41,49 +45,59 @@ describe("resolveActiveView", () => {
   });
 });
 
-describe("activeViewTitle", () => {
-  it("names the active view", () => {
-    expect(activeViewTitle(views, "ext.status")).toBe("Agents by status");
+describe("activeViewIndex", () => {
+  it("points at the active row so focus enters on what's on screen", () => {
+    expect(activeViewIndex(views, DEFAULT_VIEW_ID)).toBe(0);
+    expect(activeViewIndex(views, "ext.ws")).toBe(2);
   });
 
-  it("falls back to the panel name for an unknown or absent id", () => {
-    expect(activeViewTitle(views, "gone.view")).toBe("Navigator");
-    expect(activeViewTitle([], undefined)).toBe("Navigator");
+  // -1 isn't clamped here — the sole caller passes this straight to
+  // useFocusGroup's `start`, which already treats a negative index as "park
+  // on the first row" (see the doc comment on activeViewIndex).
+  it("returns -1 when the active view isn't in the list", () => {
+    expect(activeViewIndex(views, "gone.view")).toBe(-1);
+    expect(activeViewIndex(views, undefined)).toBe(-1);
+  });
+
+  it("returns -1 when nothing is registered", () => {
+    expect(activeViewIndex([], undefined)).toBe(-1);
   });
 });
 
-describe("buildViewMenuItems", () => {
-  const items = (activeId: string | undefined, onPick = () => {}) =>
-    buildViewMenuItems(views, activeId, onPick);
-
-  it("leads with a header, then every view in registry order", () => {
-    const rows = items(DEFAULT_VIEW_ID);
-    expect(rows[0]).toEqual({ type: "header", label: "View" });
-    expect(rows.slice(1).map((r) => (r as MenuItem).label)).toEqual([
-      "Workspaces",
-      "Agents by status",
-      "Agents by workspace",
+describe("buildViewRows", () => {
+  it("returns one row per view, in registry order", () => {
+    const rows = buildViewRows(views, DEFAULT_VIEW_ID);
+    expect(rows.map((r) => r.id)).toEqual([
+      DEFAULT_VIEW_ID,
+      "ext.status",
+      "ext.ws",
     ]);
   });
 
-  it("checks exactly the active row", () => {
-    const checked = items("ext.ws")
-      .filter((r): r is MenuItem => "label" in r && Boolean(r.checked))
-      .map((r) => r.label);
-    expect(checked).toEqual(["Agents by workspace"]);
+  it("selects exactly the active row", () => {
+    const rows = buildViewRows(views, "ext.ws");
+    expect(rows.map((r) => r.selected)).toEqual([false, false, true]);
   });
 
-  it("checks nothing when no view is active", () => {
-    const checked = items(undefined).filter(
-      (r) => "label" in r && Boolean(r.checked),
-    );
-    expect(checked).toEqual([]);
+  it("selects nothing when no view is active", () => {
+    const rows = buildViewRows(views, undefined);
+    expect(rows.every((r) => !r.selected)).toBe(true);
   });
 
-  it("passes the picked view's id to onPick", () => {
-    const onPick = vi.fn();
-    const rows = items(DEFAULT_VIEW_ID, onPick) as MenuItem[];
-    rows[2].run?.();
-    expect(onPick).toHaveBeenCalledWith("ext.status");
+  it("selects nothing when the active id isn't registered", () => {
+    // The extension that owned it was disabled or uninstalled — same case
+    // resolveActiveView falls back for; this just confirms the row list
+    // doesn't strand a stale checkmark on some other row.
+    const rows = buildViewRows(views, "gone.view");
+    expect(rows.every((r) => !r.selected)).toBe(true);
+  });
+
+  it("passes each view's own title and icon through unchanged", () => {
+    // A plain string stands in for a React node here — this file has no JSX,
+    // and buildViewRows never inspects the icon, only forwards it.
+    const withIcon = view("acme.x", "Acme", "🔧");
+    const [row] = buildViewRows([withIcon], undefined);
+    expect(row.title).toBe("Acme");
+    expect(row.icon).toBe("🔧");
   });
 });

--- a/packages/extensions-core/src/navigator/navigator-views.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.ts
@@ -1,9 +1,10 @@
-import type { MenuEntry, NavigatorView } from "@silo-code/sdk";
+import type { NavigatorView } from "@silo-code/sdk";
 
-// Pure model for the Navigator's view selector (RFC 0023). The panel renders
-// one registered view at a time; nothing here is special-cased for the
-// Workspaces view — it is registered through the same public API as any other,
-// and only named below as the fallback the panel opens on.
+// Pure model for the Navigator's view list (RFC 0023). The panel names every
+// registered view in a list at the top and renders one of them below; nothing
+// here is special-cased for the Workspaces view — it is registered through the
+// same public API as any other, and only named below as the fallback the panel
+// opens on.
 
 /**
  * The view the Navigator opens with when the user hasn't chosen one — the
@@ -31,30 +32,46 @@ export function resolveActiveView(
   return views[0]?.id;
 }
 
-/** The active view's title, for the header selector. */
-export function activeViewTitle(
+/**
+ * Where roving focus parks when it enters the view list — the active row, so
+ * arrowing starts from what's on screen. `findIndex`'s `-1` (no active view,
+ * e.g. nothing registered yet) is passed through rather than clamped here:
+ * the sole caller feeds this straight to `useFocusGroup`'s `start`, which
+ * already clamps a negative index to the first row, so a second clamp here
+ * would just be the same guarantee asserted twice.
+ */
+export function activeViewIndex(
   views: readonly NavigatorView[],
   activeId: string | undefined,
-): string {
-  return views.find((v) => v.id === activeId)?.title ?? "Navigator";
+): number {
+  return views.findIndex((v) => v.id === activeId);
+}
+
+/** One row of the view list, as the panel renders it. */
+export interface ViewRow {
+  id: string;
+  title: string;
+  icon: NavigatorView["icon"];
+  /** Whether this is the active view — the row's `aria-selected`. Not painted
+   * (ADR 0038: the view header names the active view instead), but still the
+   * one place "which row is the active one" is decided. */
+  selected: boolean;
 }
 
 /**
- * Rows for the header's view menu — every registered view in registry order,
- * with a check on the active one.
+ * Rows for the view list — every registered view in registry order. Pulled
+ * out as data, mirroring the pre-ADR-0038 `buildViewMenuItems`, so "exactly
+ * the active view is selected" is a unit test rather than something only
+ * exercised by clicking through the running app.
  */
-export function buildViewMenuItems(
+export function buildViewRows(
   views: readonly NavigatorView[],
   activeId: string | undefined,
-  onPick: (viewId: string) => void,
-): MenuEntry[] {
-  return [
-    { type: "header", label: "View" },
-    ...views.map((v) => ({
-      label: v.title,
-      icon: v.icon,
-      checked: activeId === v.id,
-      run: () => onPick(v.id),
-    })),
-  ];
+): ViewRow[] {
+  return views.map((v) => ({
+    id: v.id,
+    title: v.title,
+    icon: v.icon,
+    selected: v.id === activeId,
+  }));
 }

--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -1,4 +1,5 @@
 import type { Extension } from "@silo-code/sdk";
+import { SquaresFour } from "@phosphor-icons/react";
 import {
   store,
   groupIdForWorkspace,
@@ -53,6 +54,9 @@ export const extension: Extension = {
       id: "workspaces",
       title: "Workspaces",
       order: 0,
+      // Same glyph the workspace rows themselves carry, so the entry in the
+      // Navigator's view list and the rows it leads to read as one thing.
+      icon: <SquaresFour size={16} weight="duotone" />,
       // Inject ctx so the view reaches workspaces/terminals/files through the
       // public primitives, not host getters (see silo.file-explorer, 6662dcc).
       // Forward NavigatorViewProps (incl. `active`) so the first Adapter

--- a/packages/sdk/src/toolbar-items.ts
+++ b/packages/sdk/src/toolbar-items.ts
@@ -7,10 +7,11 @@ import type { MenuEntry } from "./ui-service";
  * per registration.
  *
  * `"editor"` and `"terminal"` are CenterDock breadcrumb toolbars; `"navigator"`
- * is the header of the Navigator side panel, where contributions become that
- * panel's action buttons. A navigator item's `when` receives the active
+ * is the header naming the Navigator's active view — the bar between its view
+ * list and the view body — where contributions become that view's action
+ * buttons. A navigator item's `when` receives the active
  * {@link NavigatorView | view}'s id, so an action can be scoped to one view or
- * left unscoped to appear across all of them.
+ * left unscoped to follow the user across all of them.
  *
  * @category Registration
  * @public

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -495,14 +495,18 @@ export interface NavigatorViewProps {
 /**
  * A view in the **Navigator** — the side panel you navigate the app from. The
  * Navigator is a container: each registered view is one projection of "where
- * can I go", and the user switches between them from the selector in its
- * header. The built-in **Workspaces** view (the workspace list) is itself
- * registered this way, through this same API.
+ * can I go". Every registered view is listed by name at the top of the panel
+ * and is one click away; the built-in **Workspaces** view (the workspace list)
+ * is itself registered this way, through this same API.
  *
  * Reach for a view rather than {@link ExtensionContext.registerSidePanel} when
  * what you'd be adding is *another way to navigate the app*. Two navigators
  * side by side leave the user with no rule for which one to trust; a view keeps
  * one place to navigate from and changes only how it is projected.
+ *
+ * Register **one** view per projection, not one per way of sorting it — a
+ * grouping or filter your view supports is a control *inside* that view
+ * (contribute it as a toolbar item, see below), not a second entry in the list.
  *
  * A view owns the whole panel body. Header **actions** are contributed
  * separately, as toolbar items on the `"navigator"`
@@ -513,8 +517,8 @@ export interface NavigatorViewProps {
  * @example
  * ```tsx
  * ctx.registerNavigatorView({
- *   id: "my-ext.by-status",
- *   title: "Agents by status",
+ *   id: "my-ext.agents",
+ *   title: "Agents",
  *   component: ({ active }) => <AgentList paused={!active} />,
  * });
  * ```
@@ -525,14 +529,14 @@ export interface NavigatorViewProps {
 export interface NavigatorView {
   /** Unique id, conventionally `"<extension-id>.<view-name>"`. */
   id: string;
-  /** Name shown in the Navigator's header and its view menu. */
+  /** Name shown for this view in the Navigator's view list. */
   title: string;
-  /** Optional icon rendered to the left of the title in the view menu. */
+  /** Optional icon rendered to the left of the title in the view list. */
   icon?: React.ReactNode;
   /** The React component rendered as the whole panel body when active. */
   component: React.ComponentType<NavigatorViewProps>;
   /**
-   * Sort order among views. Lower values appear first in the view menu.
+   * Sort order among views. Lower values appear first in the view list.
    * Defaults to `0`; the built-in Workspaces view registers at `0`.
    */
   order?: number;


### PR DESCRIPTION
## Summary

- Replace the Navigator's dropdown view selector with an always-visible view list — every registered view is named at the top of the panel, one click each. Below it, a view header names the active view and hosts its toolbar actions (the workspaces `+`, etc.).
- The view list is skipped entirely when only one view is registered, so a single-view Navigator costs nothing over today.
- Reverses RFC 0023's rejection of a merged agent-monitor view — that rejection was conditional on the selector being a menu ("a menu inside a menu"), and removing the outer menu removes the objection. Recorded as [ADR 0038](docs/decisions/0038-navigator-view-list.md), which supersedes the relevant part of RFC 0023.
- `NavigatorView.icon` and the `"navigator"` toolbar surface's TSDoc/generated docs updated to describe the list + header, not the dropdown. `docs/ui-terminology.md` and `CONTEXT.md` gain **Active View** / **View List** / **View Header** as named terms.
- Companion PR in `silo-code/silo-extensions` merges agent-monitor's two Agents views (by-status / by-workspace) back into one, with grouping now a "Group by" header control — see silo-code/silo-extensions#86.

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint` (boundary + design-token stylelint)
- [x] `pnpm test` — 11/11 tasks
- [x] `pnpm docs:api && pnpm docs:build` — clean, no dead links
- [x] Pre-commit hook (full test suite + docs build + commitlint) passed
- [ ] Manual click-through in the running app (`pnpm dev`) — not yet done this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)