### PR TITLE
fix(docs): win the shell-vs-marketing CSS cascade on wide viewports

### DIFF
--- a/apps/docs/.vitepress/theme/home-shell.css
+++ b/apps/docs/.vitepress/theme/home-shell.css
@@ -12,7 +12,17 @@
   color: #f2f4ea;
 }
 
-.silo-home-shell {
+/*
+ * `.silo-home.silo-home-shell` (not just `.silo-home-shell`): #silo-home
+ * carries both classes throughout the handoff, and marketing styles.css's
+ * `.silo-home { margin: 0 }` is loaded *after* this stylesheet — at equal
+ * specificity the later rule wins the cascade, silently dropping this
+ * `margin: 0 auto` and left-justifying the 1440px-capped shell on wide
+ * viewports for a frame. The compound selector outranks it regardless of
+ * load order (repro: visible jump on wide windows, invisible under 1440px
+ * since there's no centering to lose).
+ */
+.silo-home.silo-home-shell {
   font-family:
     Manrope,
     system-ui,


### PR DESCRIPTION
## Summary

On wide browser windows, the homepage briefly jumped from left-justified to centered while the page finished loading — visible as a flash right around when the interactive homepage takes over from the pre-rendered version search engines see. Narrow windows never showed it, since there was no centering to lose.

## Details

`#silo-home` carries both `.silo-home` and `.silo-home-shell` classes throughout the handoff from the static SEO shell (`apps/docs/index.md`) to the React marketing homepage (`@silo-code/website`). Marketing `styles.css`'s `.silo-home { margin: 0 }` loads *after* `home-shell.css`, so at equal CSS specificity it silently overrode the shell's `margin: 0 auto` — left-justifying the 1440px-capped shell for a frame before React's own centered `.page-shell` replaced it and snapped it back to centered.

Fix: scope the shell's box-model rule to the compound selector `.silo-home.silo-home-shell`, which outranks the marketing rule regardless of stylesheet load order.

### Verification

- Reproduced and confirmed root cause via computed styles in a live browser session (`getComputedStyle` on `#silo-home` showed `margin: 0px` pre-fix vs. `margin: 372.5px auto`-equivalent post-fix on a 2200px-wide viewport, matching `.page-shell`'s eventual centered position exactly).
- `pnpm lint` (stylelint) passes on the changed file.
- Pre-commit hooks (unit tests, docs build/link-check, commitlint) all passed.

### Test plan

- [ ] Load getsilo.dev (or `pnpm docs:dev`) on a browser window wider than 1440px and confirm no left-to-center jump during load
- [ ] Confirm narrow-viewport load is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)