### PR TITLE
feat(website): add agent trust band under hero demo

### DIFF
--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -41,6 +41,10 @@ description: One window — every project, every agent. Terminals, agents, and l
 <a href="https://github.com/silo-code/silo">Star on GitHub</a>
 </p>
 </div>
+<section aria-labelledby="home-agents-title">
+<h2 id="home-agents-title">Runs the agents you already use.</h2>
+<p>Claude, Cursor, Codex, Copilot, Grok, and anything else that talks to a terminal.</p>
+</section>
 <section aria-label="Product">
 <article>
 <p>Workspaces</p>

--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -4,6 +4,9 @@ import { DemoWorkspace } from "./DemoWorkspace";
 import { StoryVideo } from "./StoryVideo";
 import { DOWNLOAD_FALLBACK_HREF, fetchLatestDownloadUrl } from "./download-url";
 import {
+  AGENTS,
+  AGENTS_LINE,
+  AGENTS_TITLE,
   EYEBROW,
   FOOTER_COLUMNS,
   FOOTER_COPYRIGHT,
@@ -20,6 +23,7 @@ import {
   TRUST_LINE,
   TRUST_TITLE,
   FAQ_ITEMS,
+  type AgentIconId,
 } from "./homepage-copy";
 import siloIcon from "./silo-icon.png";
 import featureWorkspacesPoster from "./assets/feature-workspaces.png";
@@ -130,6 +134,116 @@ function ActionIcon({
   if (icon === "platform") return <PlatformIcon platform={platform} />;
   if (icon === "github") return <GitHubIcon />;
   return null;
+}
+
+function ClaudeIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      fill="none"
+      aria-hidden="true"
+    >
+      <line x1="12" y1="3" x2="12" y2="9" />
+      <line x1="12" y1="15" x2="12" y2="21" />
+      <line x1="3" y1="12" x2="9" y2="12" />
+      <line x1="15" y1="12" x2="21" y2="12" />
+      <line x1="5.6" y1="5.6" x2="9.6" y2="9.6" />
+      <line x1="14.4" y1="14.4" x2="18.4" y2="18.4" />
+      <line x1="18.4" y1="5.6" x2="14.4" y2="9.6" />
+      <line x1="9.6" y1="14.4" x2="5.6" y2="18.4" />
+    </svg>
+  );
+}
+
+function CursorIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M5 3 L19 12.2 L12.4 13.6 L16 20 L13.4 21.3 L9.8 14.9 L5 19.4 Z" />
+    </svg>
+  );
+}
+
+function CodexIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="8.2" r="4.1" />
+      <circle cx="8" cy="14.6" r="4.1" />
+      <circle cx="16" cy="14.6" r="4.1" />
+    </svg>
+  );
+}
+
+function CopilotIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="8.4" />
+      <path d="M12 3.6 L12 8.4 M12 15.6 L12 20.4 M3.6 12 L8.4 12 M15.6 12 L20.4 12" />
+    </svg>
+  );
+}
+
+function GrokIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <rect
+        x="10.9"
+        y="1.5"
+        width="2.2"
+        height="21"
+        rx="1.1"
+        transform="rotate(24 12 12)"
+      />
+      <rect
+        x="10.9"
+        y="1.5"
+        width="2.2"
+        height="21"
+        rx="1.1"
+        transform="rotate(-24 12 12)"
+      />
+    </svg>
+  );
+}
+
+function AgentIcon({ icon }: { icon: AgentIconId }) {
+  if (icon === "claude") return <ClaudeIcon />;
+  if (icon === "cursor") return <CursorIcon />;
+  if (icon === "codex") return <CodexIcon />;
+  if (icon === "copilot") return <CopilotIcon />;
+  return <GrokIcon />;
 }
 
 function XIcon() {
@@ -270,6 +384,20 @@ export function App() {
         <div className="demo-scroll">
           <DemoWorkspace scene={heroScene} focusable />
         </div>
+
+        <section className="home-agents" aria-labelledby="home-agents-title">
+          <h2 id="home-agents-title">{AGENTS_TITLE}</h2>
+          <p>{AGENTS_LINE}</p>
+          <ul className="home-agents-row">
+            {AGENTS.map((agent) => (
+              <li key={agent.name} className="home-agents-chip">
+                <AgentIcon icon={agent.icon} />
+                {agent.name}
+              </li>
+            ))}
+            <li className="home-agents-chip is-more">+ more</li>
+          </ul>
+        </section>
 
         <section className="home-stories" aria-label="Product">
           {STORY_SECTIONS.map((section, index) => {

--- a/apps/website/src/homepage-copy.ts
+++ b/apps/website/src/homepage-copy.ts
@@ -111,6 +111,26 @@ export const STORY_SECTIONS: StorySection[] = [
   },
 ];
 
+/** Agent trust band — sits directly under the hero demo. */
+export const AGENTS_TITLE = "Runs the agents you already use.";
+export const AGENTS_LINE =
+  "Claude, Cursor, Codex, Copilot, Grok, and anything else that talks to a terminal.";
+
+export type AgentIconId = "claude" | "cursor" | "codex" | "copilot" | "grok";
+
+export type AgentBadge = {
+  name: string;
+  icon: AgentIconId;
+};
+
+export const AGENTS: AgentBadge[] = [
+  { name: "Claude", icon: "claude" },
+  { name: "Cursor", icon: "cursor" },
+  { name: "Codex", icon: "codex" },
+  { name: "Copilot", icon: "copilot" },
+  { name: "Grok", icon: "grok" },
+];
+
 export const TRUST_TITLE = "100% open source. Free forever.";
 export const TRUST_LINE =
   "MIT licensed. No account. No telemetry. Nothing to lose by trying it.";

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -350,6 +350,72 @@ h1 em {
 .demo-wrap {
   min-width: 1100px;
 }
+.home-agents {
+  margin: 56px 0 8px;
+  padding: 40px 0;
+  border-top: 1px solid #1c2030;
+  border-bottom: 1px solid #1c2030;
+  text-align: center;
+}
+.home-agents h2 {
+  margin: 0 0 10px;
+  color: #f2f4ea;
+  font-size: clamp(20px, 2.4vw, 26px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+}
+.home-agents p {
+  margin: 0 auto 26px;
+  max-width: 34rem;
+  color: #9aa1b5;
+  font-size: 14px;
+  line-height: 1.55;
+}
+.home-agents-row {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+}
+.home-agents-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  padding: 13px 24px;
+  border-radius: 999px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #91958a;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+.home-agents-chip svg {
+  width: 21px;
+  height: 21px;
+  color: #7d8296;
+  transition: color 0.15s ease;
+}
+.home-agents-chip:hover {
+  color: #f2f4ea;
+  background: rgb(242 244 234 / 6%);
+}
+.home-agents-chip:hover svg {
+  color: var(--home-accent);
+}
+.home-agents-chip.is-more {
+  color: #565b6b;
+  font-weight: 500;
+}
+.home-agents-chip.is-more:hover {
+  color: #8b909e;
+  background: none;
+}
+
 .home-trust {
   margin: 24px 0 72px;
   padding: 48px 0;


### PR DESCRIPTION
## Summary

The homepage hero previously didn't say which coding agents Silo works with, which could read as though it's tied to one vendor. This adds a row directly under the hero demo — "Runs the agents you already use." — with icons for Claude, Cursor, Codex, Copilot, and Grok, so visitors immediately see it isn't locked to a single agent.

## Details

- New `home-agents` section in `apps/website/src/App.tsx`, rendered between the hero demo and the existing story sections, with inline SVG icons per agent (`ClaudeIcon`, `CursorIcon`, `CodexIcon`, `CopilotIcon`, `GrokIcon`).
- Copy (`AGENTS_TITLE`, `AGENTS_LINE`, `AGENTS` list) added to `apps/website/src/homepage-copy.ts`.
- Styling in `apps/website/src/styles.css` mirrors the existing `.home-trust` divider band (top/bottom border, centered layout, pill chips with hover accent).
- The same copy is duplicated into `apps/docs/index.md`'s SEO shell so no-JS clients and crawlers see the agent list too.
- Rebased onto latest `main` (past #362, the shell-vs-marketing CSS cascade fix) — no conflicts.

### Test plan

- [x] Rebased cleanly onto current `main`
- [ ] Visual check on getsilo.dev after merge — hero → trust band → story sections, light/dark, mobile wrap