### PR TITLE
fix(layout): stop the peeked side panel hanging 36px below the column

### DIFF
--- a/packages/extension-host/src/layout/AppShell.css
+++ b/packages/extension-host/src/layout/AppShell.css
@@ -85,6 +85,16 @@
   position: absolute;
   top: 0;
   bottom: 0;
+  /* Drop the base rule's `height: 100%` — it must not survive into the
+   * absolutely-positioned state. With `top`, `height` and `bottom` all set the
+   * box is over-constrained, so CSS discards `bottom` and solves from
+   * top + height. And `height: 100%` resolves against the containing block's
+   * *padding* box, which on macOS includes `.app-col`'s 36px traffic-light
+   * reservation — so the overlay ended up 36px taller than the column and hung
+   * that far below it, clipped away by the panel group. The hidden strip cost
+   * the panel its last row of content and cut the bottom off its scrollbar
+   * thumb. `auto` lets top/bottom drive the height again. */
+  height: auto;
   width: var(--peek-width, 400px);
   background: var(--silo-color-bg);
   box-shadow: 2px 0 16px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary

On macOS, when a side panel is showing as the small-screen "peek" overlay, the panel is drawn 36 pixels taller than the space it has. That extra strip falls behind the status bar, so the bottom of the panel is invisible and unreachable — the last row of content is cut off, and the scrollbar visibly runs off the bottom edge of the app instead of ending cleanly.

The fix corrects the overlay's height so it stops exactly at the status bar.

Reported against the Git panel, but it was never specific to Git — every side panel was affected, in either the left or right dock, whenever it was peeking. Windows and Linux were never affected.

## Details

### Root cause

`.side-peek-host` carries `height: 100%` for its normal in-flow (docked) case. That declaration survived into the `.peeking` state, where the host is absolutely positioned with both `top` and `bottom` set.

With all three of `top` / `height` / `bottom` non-`auto`, the box is over-constrained, so CSS discards `bottom` and solves the height from `top + height` (CSS 2.1 §10.6.4).

`height: 100%` then resolves against the containing block's **padding** box — and on macOS `.app-col` carries `padding-top: 36px` as the traffic-light reservation. So the overlay's used height was the full column height while its top edge started 36px down, leaving it hanging 36px below the column, where the panel group's `overflow: hidden` clipped it away.

On Linux/Windows `padding-top` is `0`, so `top: 0` + `height: 100%` happened to land correctly and the bug never appeared.

### Fix

`height: auto` in `.side-peek-host.peeking`, so `top`/`bottom` drive the height again. One declaration, plus a comment recording why the base rule's `height` must not reach this state.

### Verification

Measured in the running dev app with an absolutely-positioned probe using the real containing block (`.app-col`, height 869, `padding-top: 36px`):

| `height` | used height | overhang past column bottom |
| --- | --- | --- |
| `100%` (before) | 869 | **36px** |
| `auto` (after) | 833 | **0** |

Diagnosis started from the reported screenshot: the scrollbar thumb has a correctly rounded cap at its top but is cut off perfectly flat at the bottom, exactly at the status-bar line — the signature of a scroll container extending past its visible clip rather than a thumb that has simply reached the end of its track.

### Tests

None added — this is a single CSS declaration with no logic seam, and the repo's Vitest suites are pure-logic by convention. `pnpm lint` and `pnpm test` are green (1082 + 14 tests, 11/11 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkCe2iUEB9NXwPstf6Ltzu
