### PR TITLE
fix(terminal): gate PROTO_VERSION app_boot log to unix, fix Windows release build

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -147,14 +147,20 @@ pub fn run() {
             // Durable attach trail: one line at UI process start so post-mortems
             // can correlate proto / pid with later ui_* / host_* events in
             // terminal.log (see terminal_diag_log + logTerminalAttachTrace).
+            // `proto` is the pty-host unix-socket wire version; the Windows
+            // ConPTY backend (session_windows) has no equivalent, so it logs
+            // a fixed "conpty" label instead.
             {
-                use pty_host::proto::PROTO_VERSION;
+                #[cfg(unix)]
+                let proto = pty_host::proto::PROTO_VERSION.to_string();
+                #[cfg(windows)]
+                let proto = "conpty".to_string();
                 commands::session_backend::log_event(
                     "app_boot",
                     &format!(
                         "pid={} proto={} identifier={}",
                         std::process::id(),
-                        PROTO_VERSION,
+                        proto,
                         app.config().identifier
                     ),
                 );


### PR DESCRIPTION
## Summary

The Windows release build (`silo-v0.49.0`) was failing to compile, which blocked
that platform's release from being produced. A recent change added a startup log
line meant to help debug terminal reattach issues, but it accidentally used a
piece of terminal-backend code that only exists on macOS/Linux, not Windows.
Windows builds again as of this fix, with the same log line adapted to note it's
using the Windows-specific terminal backend instead.

## Details

### Root cause

`apps/desktop/src-tauri/src/lib.rs` (added in #368, the session-host backpressure
work) unconditionally does `use pty_host::proto::PROTO_VERSION` inside the
`app_boot` durable-trail log line. `pty-host` is declared as a
`[target.'cfg(unix)'.dependencies]` crate in `Cargo.toml` — it isn't a dependency
at all on Windows, which uses the separate ConPTY-based `session_windows` backend.
CI job: https://github.com/silo-code/silo/actions/runs/32191318820/job/96050277159
— `error[E0433]: cannot find module or crate 'pty_host'` on `windows-latest`.

### Fix

Gate the `PROTO_VERSION` lookup behind `#[cfg(unix)]`, matching the existing
`#[cfg(unix)]`/`#[cfg(windows)]` split already used elsewhere in this file (e.g.
`SILO_PTY_NS` setup, `session_maintenance::spawn_maintenance_sweep`). On Windows,
`proto` is logged as the fixed string `"conpty"` since that backend has no
equivalent wire-protocol version to report — the `app_boot` log line's other
fields (`pid`, `identifier`) are unaffected.

### Verification

- `cargo check --lib` in `apps/desktop/src-tauri` — clean (macOS host), only
  pre-existing unrelated warnings.
- Can't cross-compile for Windows locally; the fix is a straightforward
  `cfg`-gate mirroring the pattern already proven to work for every other
  Windows/Unix split in this same file.

### Test plan

- [x] `cargo check --lib` passes locally
- [ ] Windows release job (`windows-latest`) goes green on this branch