### PR TITLE
feat(git): publish GitAPI.remotes for forge-aware extensions

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "silo"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/docs/guide/extension-apis.md
+++ b/apps/docs/guide/extension-apis.md
@@ -87,13 +87,20 @@ your-api/               ← published to npm: just the types (+ maybe a tiny hel
 
 A consumer adds your types package as a **devDependency** — never a regular
 dependency, since they only need it for compile-time types; the real
-implementation arrives at runtime via `getExtension`, not a bundled import —
-and marks it `external` in their bundler config, exactly how every extension
-already treats `@silo-code/sdk` and `react`:
+implementation arrives at runtime via `getExtension`, not a bundled import:
 
 ```sh
 npm i -D @you/your-api
 ```
+
+**Do not mark it `external`**, even though that's what an extension does for
+`@silo-code/sdk` and `react`. Those two work as externals because the host
+hands them to every loaded extension; your API package isn't on that list, so
+an external bare specifier survives into the consumer's bundle with nothing to
+resolve it and their extension fails to load. Leaving it bundled costs nothing
+— `import type` erases entirely, and a small runtime helper (like
+`@silo-code/git-api`'s `NULL_GIT_REPO_STORE`) inlines. The live implementation
+still comes from `getExtension` either way.
 
 ```ts
 import type { YourAPI } from "@you/your-api";

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -864,6 +864,60 @@ describe(
       writeFileSync(join(repo, "a.txt"), "v2\n");
       expect(await git.isBinaryDiff(repo, "a.txt", "workingTree")).toBe(false);
     });
+
+    it("remotes reads back what `git remote add` configured", async () => {
+      await realExec(
+        "git",
+        ["remote", "add", "origin", "git@github.com:silo-code/silo.git"],
+        { cwd: repo },
+      );
+      expect(await git.remotes(repo)).toEqual([
+        {
+          name: "origin",
+          fetchUrl: "git@github.com:silo-code/silo.git",
+          pushUrl: "git@github.com:silo-code/silo.git",
+        },
+      ]);
+    });
+
+    it("remotes separates a configured pushurl from the fetch url", async () => {
+      await realExec(
+        "git",
+        ["remote", "add", "origin", "https://github.com/silo-code/silo.git"],
+        { cwd: repo },
+      );
+      await realExec(
+        "git",
+        [
+          "remote",
+          "set-url",
+          "--push",
+          "origin",
+          "git@github.com:silo-code/silo.git",
+        ],
+        { cwd: repo },
+      );
+      expect(await git.remotes(repo)).toEqual([
+        {
+          name: "origin",
+          fetchUrl: "https://github.com/silo-code/silo.git",
+          pushUrl: "git@github.com:silo-code/silo.git",
+        },
+      ]);
+    });
+
+    it("remotes resolves to an empty array with no remotes configured", async () => {
+      expect(await git.remotes(repo)).toEqual([]);
+    });
+
+    it("remotes resolves to an empty array outside a repository", async () => {
+      const plain = mkdtempSync(join(tmpdir(), "silo-nonrepo-"));
+      try {
+        expect(await git.remotes(plain)).toEqual([]);
+      } finally {
+        rmSync(plain, { recursive: true, force: true });
+      }
+    });
   },
 );
 

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -1,6 +1,7 @@
 import type { GitAPI, GitLogEntry, GitStatus } from "@silo-code/git-api";
 import { parseGitStatus } from "./parse-status";
 import { parseBranches } from "./parse-branches";
+import { parseRemotes } from "./parse-remotes";
 import { parseWorktrees } from "./parse-worktrees";
 import {
   mergeCommitFiles,
@@ -404,6 +405,13 @@ export function createGitService(exec: ExecFn): Omit<GitAPI, "watchRepo"> {
       const { stdout, code } = await git(cwd, args);
       if (code !== 0) return false;
       return /^-\t-\t/.test(stdout);
+    },
+
+    async remotes(cwd) {
+      const { stdout, code } = await git(cwd, ["remote", "-v"]);
+      // Any error (e.g. not a git repository) → no remotes.
+      if (code !== 0) return [];
+      return parseRemotes(stdout);
     },
 
     async worktrees(cwd) {

--- a/packages/extensions-silo/src/git/parse-remotes.test.ts
+++ b/packages/extensions-silo/src/git/parse-remotes.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { parseRemotes } from "./parse-remotes";
+
+// Fixtures mimic `git remote -v`: one tab-separated `<name>\t<url> (fetch)`
+// line and one `(push)` line per remote, alphabetical by name.
+
+describe("parseRemotes", () => {
+  it("collapses a remote's fetch and push lines into one entry", () => {
+    const raw = [
+      "origin\tgit@github.com:silo-code/silo.git (fetch)",
+      "origin\tgit@github.com:silo-code/silo.git (push)",
+    ].join("\n");
+    expect(parseRemotes(raw)).toEqual([
+      {
+        name: "origin",
+        fetchUrl: "git@github.com:silo-code/silo.git",
+        pushUrl: "git@github.com:silo-code/silo.git",
+      },
+    ]);
+  });
+
+  it("keeps a distinct pushurl separate from the fetch url", () => {
+    const raw = [
+      "origin\thttps://github.com/silo-code/silo.git (fetch)",
+      "origin\tgit@github.com:silo-code/silo.git (push)",
+    ].join("\n");
+    expect(parseRemotes(raw)).toEqual([
+      {
+        name: "origin",
+        fetchUrl: "https://github.com/silo-code/silo.git",
+        pushUrl: "git@github.com:silo-code/silo.git",
+      },
+    ]);
+  });
+
+  it("preserves git's order across multiple remotes", () => {
+    const raw = [
+      "fork\tgit@github.com:me/silo.git (fetch)",
+      "fork\tgit@github.com:me/silo.git (push)",
+      "origin\tgit@github.com:silo-code/silo.git (fetch)",
+      "origin\tgit@github.com:silo-code/silo.git (push)",
+      "upstream\tgit@github.com:other/silo.git (fetch)",
+      "upstream\tgit@github.com:other/silo.git (push)",
+    ].join("\n");
+    expect(parseRemotes(raw).map((r) => r.name)).toEqual([
+      "fork",
+      "origin",
+      "upstream",
+    ]);
+  });
+
+  it("returns an empty array for a repo with no remotes", () => {
+    expect(parseRemotes("")).toEqual([]);
+    expect(parseRemotes("\n")).toEqual([]);
+  });
+
+  it("keeps a url containing ' (' intact", () => {
+    // A local remote can legally live under a path with parentheses; only the
+    // trailing direction marker ends the url.
+    const raw = [
+      "local\t/Users/me/Repos (old)/silo (fetch)",
+      "local\t/Users/me/Repos (old)/silo (push)",
+    ].join("\n");
+    expect(parseRemotes(raw)).toEqual([
+      {
+        name: "local",
+        fetchUrl: "/Users/me/Repos (old)/silo",
+        pushUrl: "/Users/me/Repos (old)/silo",
+      },
+    ]);
+  });
+
+  it("mirrors the present url when a direction line is missing", () => {
+    const raw = "origin\tgit@github.com:silo-code/silo.git (fetch)";
+    expect(parseRemotes(raw)).toEqual([
+      {
+        name: "origin",
+        fetchUrl: "git@github.com:silo-code/silo.git",
+        pushUrl: "git@github.com:silo-code/silo.git",
+      },
+    ]);
+  });
+
+  it("ignores lines that aren't remote entries", () => {
+    const raw = [
+      "not a remote line",
+      "origin\tgit@github.com:silo-code/silo.git (fetch)",
+      "origin\tgit@github.com:silo-code/silo.git (push)",
+    ].join("\n");
+    expect(parseRemotes(raw).map((r) => r.name)).toEqual(["origin"]);
+  });
+});

--- a/packages/extensions-silo/src/git/parse-remotes.ts
+++ b/packages/extensions-silo/src/git/parse-remotes.ts
@@ -1,0 +1,36 @@
+import type { GitRemote } from "./git-api";
+
+// Pure parser for `git remote -v`. Kept a pure string→GitRemote[] function (no
+// exec) so it's unit-testable against captured fixtures, the same way
+// parse-status.ts, parse-branches.ts, and parse-worktrees.ts are.
+
+// `<name>\t<url> (fetch|push)`. The URL is matched greedily so a path
+// containing " (" (legal in a local remote's path) can't be mistaken for the
+// trailing direction marker — only the *last* one on the line ends it.
+const LINE_RE = /^([^\t]+)\t(.+) \((fetch|push)\)$/;
+
+/**
+ * Parse `git remote -v` output into {@link GitRemote} entries, preserving
+ * git's own order (alphabetical by name). Git prints one `(fetch)` and one
+ * `(push)` line per remote; a remote with only one of the two — which git
+ * shouldn't emit, but a malformed config could — still yields an entry, with
+ * the missing URL mirroring the one that is present.
+ */
+export function parseRemotes(raw: string): GitRemote[] {
+  const byName = new Map<string, GitRemote>();
+  for (const line of raw.split("\n")) {
+    const m = LINE_RE.exec(line.trimEnd());
+    if (!m) continue;
+    const [, name, url, direction] = m;
+    let remote = byName.get(name!);
+    if (!remote) {
+      // Seed both sides with this URL so a remote that only lists one
+      // direction still reads coherently; the other line overwrites its own.
+      remote = { name: name!, fetchUrl: url!, pushUrl: url! };
+      byName.set(name!, remote);
+    }
+    if (direction === "fetch") remote.fetchUrl = url!;
+    else remote.pushUrl = url!;
+  }
+  return [...byName.values()];
+}

--- a/packages/git-api/README.md
+++ b/packages/git-api/README.md
@@ -55,19 +55,19 @@ runtime as `api.newThing is not a function`.
 Declare the floor in your extension's manifest so Silo can warn the user:
 
 ```json
-{ "silo": { "id": "you.your-extension", "engine": "^0.49.0" } }
+{ "silo": { "id": "you.your-extension", "engine": "^0.50.0" } }
 ```
 
 | `@silo-code/git-api` | First Silo release | Added                                              |
 | -------------------- | ------------------ | -------------------------------------------------- |
-| 0.4.0                | 0.49.0             | `remotes`, `GitRemote`                             |
+| 0.4.0                | 0.50.0             | `remotes`, `GitRemote`                             |
 | 0.3.0                | 0.49.0             | `lockWorktree`, `unlockWorktree`                   |
 | 0.2.0                | 0.47.0             | `watchRepo`, `GitRepoStore`, `NULL_GIT_REPO_STORE` |
 
 This package releases independently of the app, so a version can sit on npm
-for a while before any Silo release implements it — 0.3.0 published ahead of
-0.49.0 exactly that way. Check this table, not npm's "latest", when picking
-your `engine` floor.
+for a while before any Silo release implements it — 0.3.0 sat on npm from
+0.48.0 until 0.49.0 exactly that way. Check this table, not npm's
+"latest", when picking your `engine` floor.
 
 Note what `silo.engine` does and doesn't do: it's **advisory**. An
 incompatible extension shows a warning at install and in the extensions list,

--- a/packages/git-api/README.md
+++ b/packages/git-api/README.md
@@ -1,7 +1,8 @@
 # @silo-code/git-api
 
 Published types for [Silo](https://github.com/silo-code/silo)'s `silo.git`
-provider: the one-shot `GitAPI` (status, diff, commit, branches, worktrees, …)
+provider: the one-shot `GitAPI` (status, diff, commit, branches, remotes,
+worktrees, …)
 and the live `GitRepoStore` watch session (`GitAPI.watchRepo`). Import types
 from this package at build time; retrieve the live implementation at runtime
 through `@silo-code/sdk`'s `ctx.getExtension`.
@@ -35,6 +36,45 @@ import { useServiceState } from "@silo-code/sdk";
 const git = ctx.getExtension<GitAPI>("silo.git")?.api;
 const repo = git?.watchRepo(folder) ?? NULL_GIT_REPO_STORE;
 const { status, worktrees } = useServiceState(repo);
+```
+
+## Which Silo version ships which member
+
+`GitAPI` is implemented by `silo.git`, which is **bundled into the Silo app** —
+so the version that matters at runtime is the _host's_, not this package's. A
+newer `@silo-code/git-api` in your `devDependencies` will happily typecheck
+against a member the running host has never heard of; the failure lands at
+runtime as `api.newThing is not a function`.
+
+Declare the floor in your extension's manifest so Silo can warn the user:
+
+```json
+{ "silo": { "id": "you.your-extension", "engine": "^0.49.0" } }
+```
+
+| `@silo-code/git-api` | First Silo release | Added                                              |
+| -------------------- | ------------------ | -------------------------------------------------- |
+| 0.4.0                | 0.49.0             | `remotes`, `GitRemote`                             |
+| 0.3.0                | 0.49.0             | `lockWorktree`, `unlockWorktree`                   |
+| 0.2.0                | 0.47.0             | `watchRepo`, `GitRepoStore`, `NULL_GIT_REPO_STORE` |
+
+This package releases independently of the app, so a version can sit on npm
+for a while before any Silo release implements it — 0.3.0 published ahead of
+0.49.0 exactly that way. Check this table, not npm's "latest", when picking
+your `engine` floor.
+
+Note what `silo.engine` does and doesn't do: it's **advisory**. An
+incompatible extension shows a warning at install and in the extensions list,
+but the user can still install it, and the host still loads it. If you want a
+newer member without hard-breaking users on an older host, feature-detect it
+and keep a fallback:
+
+```ts
+const git = ctx.getExtension<GitAPI>("silo.git")?.api;
+const remotes =
+  typeof git?.remotes === "function"
+    ? await git.remotes(folder)
+    : await legacyRemotesViaExec(folder);
 ```
 
 See ADR 0009 and ADR 0037 in `silo-code/silo` for the rationale.

--- a/packages/git-api/README.md
+++ b/packages/git-api/README.md
@@ -13,11 +13,17 @@ through `@silo-code/sdk`'s `ctx.getExtension`.
 npm i -D @silo-code/git-api
 ```
 
-Install it as a **devDependency**: an extension never bundles this package.
-Mark `@silo-code/git-api` (alongside `@silo-code/sdk` and `react`) as
-**external** at build time — the Silo host provides the real `silo.git`
-extension at runtime, this package is types only (plus one small runtime
-fallback, `NULL_GIT_REPO_STORE`).
+Install it as a **devDependency** — you need it to compile, not to ship.
+
+**Do not mark it external.** Unlike `@silo-code/sdk` and `react`, this package
+is _not_ one of the modules the Silo host hands to a loaded extension
+(`SHARED_DEPS` is `react`, `react/jsx-runtime`, `@silo-code/sdk` — nothing
+else). An external bare `import … from "@silo-code/git-api"` survives into
+your bundle with nothing to resolve it, and the extension fails to load. Leave
+it bundled: the type-only imports erase to nothing, and the one runtime export
+(`NULL_GIT_REPO_STORE`, a small null-object literal) inlines. The real
+implementation still arrives at runtime through `ctx.getExtension("silo.git")`
+— that's unaffected either way.
 
 `@silo-code/sdk` is a **peer** dependency (`>=0.34.0`, a floor only — the same
 additive-only shape `silo.engine` uses), not a hard one: the only thing this

--- a/packages/git-api/src/git-api.ts
+++ b/packages/git-api/src/git-api.ts
@@ -113,6 +113,19 @@ export interface GitWorktree {
   prunable: string | null;
 }
 
+/** One configured remote, as listed by {@link GitAPI.remotes}. */
+export interface GitRemote {
+  /** Remote name, e.g. `origin`. */
+  name: string;
+  /** URL git fetches from. */
+  fetchUrl: string;
+  /**
+   * URL git pushes to — identical to {@link GitRemote.fetchUrl} unless a
+   * separate `remote.<name>.pushurl` is configured.
+   */
+  pushUrl: string;
+}
+
 /**
  * The typed API the `silo.git` provider publishes. All one-shot methods take
  * the repo working directory (`cwd`) as their first argument and run `git`
@@ -254,6 +267,20 @@ export interface GitAPI {
     mode: "workingTree" | "staged" | "commit",
     ref?: { commit: string; parent: string },
   ): Promise<boolean>;
+  /**
+   * The repo's configured remotes (`git remote -v`), in git's own order —
+   * `origin` is the convention, not a guarantee, so resolve by
+   * {@link GitRemote.name} rather than taking the first entry. Resolves to an
+   * empty array outside a repo or when no remote is configured.
+   *
+   * This is the seam for "which forge does this checkout belong to" — a
+   * GitHub/GitLab/… extension parses `owner/repo` out of
+   * {@link GitRemote.fetchUrl} instead of shelling out to
+   * `git config --get remote.origin.url` itself. Deliberately kept off the
+   * watch session's snapshot: remotes are effectively static, and that
+   * snapshot is re-read on every file change.
+   */
+  remotes(cwd: string): Promise<GitRemote[]>;
   /**
    * All working trees of the repo containing `cwd` (`git worktree list
    * --porcelain`), main worktree first — git lists the whole family from any

--- a/packages/git-api/src/git-repo-store.ts
+++ b/packages/git-api/src/git-repo-store.ts
@@ -156,6 +156,7 @@ const NULL_GIT_API: GitAPI = {
   branchBase: unavailable,
   commitDetail: unavailable,
   isBinaryDiff: unavailable,
+  remotes: unavailable,
   worktrees: unavailable,
   addWorktree: unavailable,
   removeWorktree: unavailable,

--- a/packages/git-api/src/index.ts
+++ b/packages/git-api/src/index.ts
@@ -14,6 +14,7 @@ export type {
   CommitFileChange,
   CommitDetail,
   GitBranch,
+  GitRemote,
   GitWorktree,
 } from "./git-api";
 export type { GitRepoSnapshot, GitRepoStore } from "./git-repo-store";


### PR DESCRIPTION
## Summary

Extensions that work with GitHub, GitLab, or any other code-hosting service need
to know which repository a folder actually belongs to. Silo's Git API could
already answer almost every question about a checkout — its branches, its
worktrees, its history — but not that one. So every extension that needed it
reached around Silo and ran `git` itself.

This adds that missing piece, so those extensions can ask Silo instead. The
three GitHub extensions in the `silo-extensions` repo each carried their own
copy of the workaround; a companion PR there deletes all three once this ships.

There is no user-visible change in this release — nothing in Silo's own UI calls
the new method yet. It ships in Silo 0.50.0 and `@silo-code/git-api` 0.4.0.

Also fixes two pieces of extension-authoring documentation that were actively
wrong, described below. Those are worth reading before merge — one of them would
break any extension that followed it.

## Details

### The API

`GitAPI.remotes(cwd)` → `GitRemote[]` (`name`, `fetchUrl`, `pushUrl`), backed by
`git remote -v` and a pure `parseRemotes` parser, in the same shape as the
existing `parse-branches` / `parse-worktrees` parsers. Empty array outside a repo
or with no remotes configured, matching how `branches()` and `worktrees()`
already behave.

Deliberately **not** added to `GitRepoSnapshot`: remotes are effectively static,
and the ADR 0037 watch session re-reads its snapshot on every file change.
Putting them there would add a third `git` invocation to a hot path for a value
that essentially never changes. It rides along free on `GitRepoStore.api`
through the existing `Omit<GitAPI, "watchRepo">`.

`origin` is not assumed to be first, or to exist — callers resolve by
`GitRemote.name`.

### Docs fixes

**`packages/git-api/README.md` told authors to mark `@silo-code/git-api`
external, which breaks the extension.** The host's `SHARED_DEPS` shim list is
exactly `react`, `react/jsx-runtime`, `@silo-code/sdk`. Anything else marked
external survives into the bundle as a bare specifier with nothing to rewrite
it, and the extension fails to load — which the README's *own* usage example
(importing the runtime `NULL_GIT_REPO_STORE`) would have triggered.

`apps/docs/guide/extension-apis.md` gave the same advice **generically for any
provider's types package**, so it misled anyone following the "publish your own
API" pattern, not just git-api consumers. Both now explain why.

### Version-compatibility table

Adds "which Silo release first ships which `GitAPI` member" to the git-api
README — [RFC 0025](https://github.com/silo-code/silo/blob/main/docs/proposals/0025-extension-to-extension-version-dependencies.md)
calls this out as "a documentation fix, not an architecture one" for the bundled-provider
case. It also records that `silo.engine` is advisory, and shows the
feature-detect fallback pattern, because git-api releases independently of the
app: 0.3.0 has been on npm since 0.48.0 with no host implementing it.

### Test plan

- `parse-remotes.test.ts` — 7 unit tests: fetch/push collapsing, a distinct
  `pushurl`, git's ordering, no remotes, a URL containing `" ("`, a missing
  direction line, junk lines.
- `git-service.test.ts` — 4 real-git contract tests against a temp repo:
  `git remote add` read back, `set-url --push` divergence, no remotes, outside a
  repo.
- `pnpm test`, `pnpm lint`, `pnpm --filter silo exec tsc --noEmit` all pass.
- **Verified in the running dev app**, not just in tests. Since no UI surfaces
  remotes, I used a discriminating probe: a repo whose only remote is named
  `upstream` produces `No "origin" remote in … — skipping` on the new path but
  `No git remote found in …` on the old `git config` path. Dev Silo logged the
  former, confirming `remotes()` resolving through `ctx.getExtension("silo.git")`
  end to end.

### Checklist

- [x] PR title is a valid Conventional Commit
- [x] `pnpm lint`, `pnpm format:check`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm test` pass
- [x] No new architecture-boundary violations
- [x] Docs updated (git-api README + extension-apis guide)

### Notes for the reviewer

No glossary entry — `remotes` introduces no user-facing vocabulary. No roadmap
change — Git is already `stable` and this is a member of an existing API, not a
feature flip.

Merging this and releasing `@silo-code/git-api` 0.4.0 unblocks
silo-code/silo-extensions#91, which is a draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)