### PR TITLE
fix(extensions): don't offer an update the running host can't run

### DIFF
--- a/packages/extension-host/src/extension-host/registry-client.test.ts
+++ b/packages/extension-host/src/extension-host/registry-client.test.ts
@@ -217,6 +217,45 @@ describe("findUpdates", () => {
     // Registry row that the index no longer lists → nothing to offer.
     expect(findUpdates([row({})], index([]))).toEqual([]);
   });
+
+  it("skips an update whose engine floor is above the running host", () => {
+    const idx = index([
+      entry("acme.weather", { latest: latest("2.0.0", { engine: "^0.50.0" }) }),
+    ]);
+    expect(findUpdates([row({ hostVersion: "0.49.0" })], idx)).toEqual([]);
+  });
+
+  it("offers that same update once the host meets the floor", () => {
+    const idx = index([
+      entry("acme.weather", { latest: latest("2.0.0", { engine: "^0.50.0" }) }),
+    ]);
+    expect(
+      findUpdates([row({ hostVersion: "0.50.0" })], idx).map(
+        (u) => u.latestVersion,
+      ),
+    ).toEqual(["2.0.0"]);
+  });
+
+  it("treats a missing engine as unconstrained", () => {
+    const idx = index([
+      entry("acme.weather", { latest: latest("2.0.0", { engine: null }) }),
+    ]);
+    expect(
+      findUpdates([row({ hostVersion: "0.1.0" })], idx).map(
+        (u) => u.latestVersion,
+      ),
+    ).toEqual(["2.0.0"]);
+  });
+
+  it("treats an unparsable host version as unconstrained", () => {
+    // appVersion() failing leaves hostVersion "" — don't hide updates over it.
+    const idx = index([
+      entry("acme.weather", { latest: latest("2.0.0", { engine: "^0.50.0" }) }),
+    ]);
+    expect(
+      findUpdates([row({ hostVersion: "" })], idx).map((u) => u.latestVersion),
+    ).toEqual(["2.0.0"]);
+  });
 });
 
 describe("registryReadmeUrl", () => {

--- a/packages/extension-host/src/extension-host/registry-client.ts
+++ b/packages/extension-host/src/extension-host/registry-client.ts
@@ -11,6 +11,7 @@
  */
 import type { Permission } from "@silo-code/sdk";
 import type { InstalledExtension } from "./extension-manager";
+import { isEngineCompatible } from "./engine-compat";
 
 /** The official registry. Federated/private registries (P3) are other base URLs. */
 export const DEFAULT_REGISTRY_URL = "https://registry.getsilo.dev";
@@ -241,6 +242,15 @@ export function compareVersions(a: string, b: string): number {
  * Diff installed registry-sourced extensions against the index. Only rows
  * installed from the registry are considered (folder/URL installs have no
  * upstream; npm installs re-resolve through npm in `update()`).
+ *
+ * An update whose `engine` floor is above the running host is **skipped**, not
+ * offered: everything downstream of this list is an invitation to act (the
+ * Update button, the page's count badge, the status bar's update dot), and
+ * updating into a build this host can't run is a downgrade, not an upgrade.
+ * The user sees it again once they update Silo itself. An entry with no
+ * `engine`, or a host version that won't parse, is unconstrained and still
+ * offered — same "no data means no constraint" default `isEngineCompatible`
+ * uses everywhere else.
  */
 export function findUpdates(
   extensions: readonly InstalledExtension[],
@@ -253,6 +263,8 @@ export function findUpdates(
     const latest = entry?.latest;
     if (!latest) continue;
     if (compareVersions(latest.version, ext.version) <= 0) continue;
+    if (!isEngineCompatible(latest.engine ?? undefined, ext.hostVersion))
+      continue;
     updates.push({
       id: ext.id,
       name: ext.name,


### PR DESCRIPTION
## Summary

Silo could offer you an extension update that your version of Silo can't
actually run. The extension registry records which Silo version each release
needs, but the update check ignored it — so the Update button, the count badge
on the Extensions page, and the update dot in the status bar all lit up for
releases built against a newer Silo than the one you have. Taking the update
left you with an extension your app couldn't run.

Now those updates simply aren't offered. They reappear on their own once you
update Silo itself.

This matters most right now for anyone running an older Silo while newer
extensions ship — the only thing previously standing between them and a broken
extension was a warning dialog they could click straight through.

## Details

### The bug

`findUpdates` (`packages/extension-host/src/extension-host/registry-client.ts`)
compared versions and permissions but never looked at the index's per-version
`engine`, even though `RegistryVersionInfo.engine` is parsed and carried right
there. Everything downstream reads the same `availableUpdates` list — the
Extensions page row's Update button and "Update available: vX" hint, the page's
count `Badge`, and the status bar settings button's update dot — so one omission
lit up every surface.

`updateNeedsConsent` *did* check the engine, but it only runs after the user has
already clicked Update, and it's advisory: the consent modal's Grant button
stays enabled. So the engine floor was never load-bearing anywhere.

### The fix

One guard in `findUpdates`, which fixes every surface at once precisely because
they all read that one list:

```ts
if (!isEngineCompatible(latest.engine ?? undefined, ext.hostVersion)) continue;
```

`InstalledExtension.hostVersion` is already populated on every row by `refresh()`,
so no new plumbing. `updateNeedsConsent` keeps its own check as the backstop for
the direct `update(id)` path.

A release with no `engine`, or a host version that won't parse (`appVersion()`
failed, leaving `""`), stays unconstrained — the same "no data means no
constraint" default `isEngineCompatible` applies everywhere else, so a
diagnostic failure can never silently hide every update.

### Trade-off worth a reviewer's opinion

A blocked update is now **silently** absent rather than shown-and-warned. The
user gets no "there's a newer version, but it needs Silo 0.50" signal; it just
reappears after they update Silo.

I think that's right — the installed version keeps working, and Silo has its own
update prompt (ADR 0036) to drive the host upgrade that unblocks it. But the
alternative is defensible: keep the row visible with a disabled button and a
reason. That's a UI addition on top of this, not a different fix, and easy to
add later if support questions show up.

### Test plan

Four new cases in `registry-client.test.ts`:

- skips an update whose engine floor is above the running host
- offers that same update once the host meets the floor
- treats a missing `engine` as unconstrained
- treats an unparsable host version as unconstrained

`pnpm test`, `pnpm lint`, `pnpm format:check`, `pnpm --filter silo exec tsc --noEmit` all pass.

### Checklist

- [x] PR title is a valid Conventional Commit
- [x] `pnpm lint`, `pnpm format:check`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm test` pass
- [x] No new architecture-boundary violations
- [x] No public extension surface change

Independent of #381 — no shared files, either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)