### PR TITLE
feat(navigator): scale up the view list type, icons, and row padding

### DIFF
--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -32,11 +32,15 @@
   align-items: center;
   gap: 9px;
   min-width: 0;
-  min-height: 26px;
-  padding: 3px 8px;
+  min-height: 30px;
+  padding: 5px 10px;
   border-radius: var(--silo-radius-sm);
   color: var(--silo-color-text-hi);
   font-family: var(--silo-font-ui);
+  /* A pixel over the surrounding left-panel size (SideColumn.css sets that to
+     base + 1px) so the destinations read a step louder than the view bodies
+     they lead to. The icon column and `size={19}` glyphs are scaled to match. */
+  font-size: calc(var(--silo-font-size-base) + 2px);
   cursor: pointer;
   user-select: none;
 }
@@ -53,7 +57,7 @@
   flex: none;
   align-items: center;
   justify-content: center;
-  width: 16px;
+  width: 19px;
 }
 
 .nav-view-row__label {

--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -56,7 +56,7 @@ export const extension: Extension = {
       order: 0,
       // Same glyph the workspace rows themselves carry, so the entry in the
       // Navigator's view list and the rows it leads to read as one thing.
-      icon: <SquaresFour size={16} weight="duotone" />,
+      icon: <SquaresFour size={19} weight="duotone" />,
       // Inject ctx so the view reaches workspaces/terminals/files through the
       // public primitives, not host getters (see silo.file-explorer, 6662dcc).
       // Forward NavigatorViewProps (incl. `active`) so the first Adapter


### PR DESCRIPTION
## Summary

The Navigator's list of views (Workspaces, Agents, …) was reading a little quiet and cramped next to the content it leads to. This gives it more presence: the names are a pixel larger, the icons are bigger to match, and each row has more breathing room around it.

Purely visual — nothing about how the Navigator behaves changes.

Bundled extensions ship their own icons, so the **Agents** view's icon is sized in the separate `silo-extensions` repo (companion PR); until that lands and is released, an installed Agents view still draws its icon at the old size next to the larger Workspaces one.

## Details

### Changes

- `packages/extensions-core/src/navigator/NavigatorPanel.css`
  - `.nav-view-row` — `font-size: calc(var(--silo-font-size-base) + 2px)`. Rows previously inherited the left panel's size (`SideColumn.css` sets `--silo-internal-font-size-left-panel` to `base + 1px`), so this is the requested one-pixel bump over the surrounding panel. Written against the public `--silo-font-size-base` design token, not the internal left-panel one, so it keeps scaling with `uiFontSize` and stays inside the extension theming contract (ADR 0017).
  - `.nav-view-row` — `padding: 3px 8px` → `5px 10px` (2px on every side) and `min-height: 26px` → `30px` so the taller content isn't clipped by the old floor.
  - `.nav-view-row__icon` — column `width: 16px` → `19px`.
- `packages/extensions-core/src/workspaces/index.tsx` — the Workspaces view's `<SquaresFour>` glyph `size={16}` → `size={19}`.

### Design note — icon sizing stays the view's business

`NavigatorView.icon` is an arbitrary `React.ReactNode`, so each registering extension owns its glyph's size; the CSS column only reserves space. The alternative considered was normalizing host-side (`.nav-view-row__icon svg { width: 19px; height: 19px }`), which would resize every view's icon including third-party ones regardless of what they passed. Left out deliberately — the host overriding an explicit `size` prop is a bigger change to the contract than this visual tweak warrants, and it can be added later if icon drift across published extensions becomes a real problem.

### Test plan

- No behavior change, so no new tests — this is CSS plus one icon-size prop, with no testable logic per the repo's pure-logic Vitest convention.
- `pnpm --filter @silo-code/extensions-core test` — 29 files / 321 tests pass (the navigator's `navigator-views.test.ts` included).
- `pnpm lint` clean, including `silo/extension-design-tokens-only` over the changed CSS.
- Pre-commit hook (boundary lint + full unit tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkpP9mfTR5drzWKTvZHb4H