### PR TITLE
feat(desktop): add optional UI freeze probe for Prod dogfood

### DIFF
--- a/apps/desktop/src/dev/ui-freeze-probe-model.test.ts
+++ b/apps/desktop/src/dev/ui-freeze-probe-model.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  correlateAroundFreeze,
+  DEFAULT_FREEZE_THRESHOLD_MS,
+  formatFreezeLog,
+  probeEnabledFromStorage,
+  summarizeCorrelation,
+  tickFreezeProbe,
+} from "./ui-freeze-probe-model";
+
+describe("tickFreezeProbe", () => {
+  const base = {
+    startedAtMs: 1000,
+    hidden: false,
+    thresholdMs: DEFAULT_FREEZE_THRESHOLD_MS,
+    warmupMs: 2000,
+  };
+
+  it("seeds the first frame without a freeze", () => {
+    expect(
+      tickFreezeProbe({ ...base, prevFrameMs: null, nowMs: 1500 }),
+    ).toEqual({ kind: "ok", gapMs: 0, nextPrev: 1500 });
+  });
+
+  it("skips while document is hidden and clears prev", () => {
+    expect(
+      tickFreezeProbe({
+        ...base,
+        prevFrameMs: 1500,
+        nowMs: 5000,
+        hidden: true,
+      }),
+    ).toEqual({ kind: "skip", nextPrev: null });
+  });
+
+  it("does not report freezes during warmup even on a large gap", () => {
+    expect(
+      tickFreezeProbe({
+        ...base,
+        prevFrameMs: 1100,
+        nowMs: 2500, // 1500ms gap, but only 1500ms since start (< 2000 warmup)
+      }),
+    ).toEqual({ kind: "ok", gapMs: 1400, nextPrev: 2500 });
+  });
+
+  it("reports a freeze when the gap crosses the threshold after warmup", () => {
+    expect(
+      tickFreezeProbe({
+        ...base,
+        prevFrameMs: 4000,
+        nowMs: 4500, // startedAt 1000 → 3500ms elapsed > warmup
+      }),
+    ).toEqual({ kind: "freeze", gapMs: 500, nextPrev: 4500 });
+  });
+
+  it("returns ok for normal frame gaps", () => {
+    expect(
+      tickFreezeProbe({
+        ...base,
+        prevFrameMs: 5000,
+        nowMs: 5016,
+      }),
+    ).toEqual({ kind: "ok", gapMs: 16, nextPrev: 5016 });
+  });
+});
+
+describe("formatFreezeLog", () => {
+  it("includes rounded duration and local wall-clock time", () => {
+    const at = new Date(2026, 7, 21, 14, 9, 3, 42); // month is 0-based
+    expect(formatFreezeLog(1032.4, at)).toBe(
+      "UI freeze 1032ms at 14:09:03.042 (rAF stalled)",
+    );
+  });
+});
+
+describe("correlateAroundFreeze", () => {
+  const entries = [
+    {
+      timestampMs: 1000,
+      channel: "ext:silo.github-prs",
+      message: "Fetching open PRs",
+    },
+    {
+      timestampMs: 1500,
+      channel: "ext:silo.git",
+      message: "> git status",
+    },
+    {
+      timestampMs: 1800,
+      channel: "silo:ui-freeze",
+      message: "UI freeze 400ms",
+    },
+    {
+      timestampMs: 5000,
+      channel: "ext:silo.github-prs",
+      message: "too late",
+    },
+  ];
+
+  it("keeps entries from stall onset−lookback through freeze end", () => {
+    // freeze ends at 2000, gap 400 → onset 1600; lookback 500 → start 1100
+    const hit = correlateAroundFreeze(entries, 2000, 400, 500);
+    expect(hit.map((e) => e.message)).toEqual(["> git status"]);
+  });
+
+  it("summarizes by channel count", () => {
+    expect(
+      summarizeCorrelation([
+        { timestampMs: 1, channel: "a", message: "1" },
+        { timestampMs: 2, channel: "b", message: "2" },
+        { timestampMs: 3, channel: "a", message: "3" },
+      ]),
+    ).toBe("3 nearby: a×2, b×1");
+    expect(summarizeCorrelation([])).toBe("no nearby Output activity");
+  });
+});
+
+describe("probeEnabledFromStorage", () => {
+  it("defaults on in Dev unless explicitly disabled", () => {
+    expect(probeEnabledFromStorage(null, true)).toBe(true);
+    expect(probeEnabledFromStorage("1", true)).toBe(true);
+    expect(probeEnabledFromStorage("0", true)).toBe(false);
+  });
+
+  it("defaults off in release unless explicitly enabled", () => {
+    expect(probeEnabledFromStorage(null, false)).toBe(false);
+    expect(probeEnabledFromStorage("0", false)).toBe(false);
+    expect(probeEnabledFromStorage("1", false)).toBe(true);
+  });
+});

--- a/apps/desktop/src/dev/ui-freeze-probe-model.ts
+++ b/apps/desktop/src/dev/ui-freeze-probe-model.ts
@@ -1,0 +1,118 @@
+/** Default gap that counts as a UI hitch (rAF stall). */
+export const DEFAULT_FREEZE_THRESHOLD_MS = 100;
+
+/** Ignore early frames — boot hydrate/extension load is expected jank. */
+export const DEFAULT_WARMUP_MS = 2000;
+
+export interface FreezeProbeTickInput {
+  prevFrameMs: number | null;
+  nowMs: number;
+  startedAtMs: number;
+  hidden: boolean;
+  thresholdMs: number;
+  warmupMs: number;
+}
+
+export type FreezeProbeTickResult =
+  | { kind: "skip"; nextPrev: number | null }
+  | { kind: "ok"; gapMs: number; nextPrev: number }
+  | { kind: "freeze"; gapMs: number; nextPrev: number };
+
+/**
+ * Pure rAF tick: compare wall-clock gap since the previous painted frame.
+ * Skips while the document is hidden (rAF pauses) and during warmup.
+ */
+export function tickFreezeProbe(
+  input: FreezeProbeTickInput,
+): FreezeProbeTickResult {
+  const { prevFrameMs, nowMs, startedAtMs, hidden, thresholdMs, warmupMs } =
+    input;
+
+  if (hidden) {
+    return { kind: "skip", nextPrev: null };
+  }
+
+  if (prevFrameMs === null) {
+    return { kind: "ok", gapMs: 0, nextPrev: nowMs };
+  }
+
+  const gapMs = nowMs - prevFrameMs;
+  const warmingUp = nowMs - startedAtMs < warmupMs;
+  if (warmingUp) {
+    return { kind: "ok", gapMs, nextPrev: nowMs };
+  }
+
+  if (gapMs >= thresholdMs) {
+    return { kind: "freeze", gapMs, nextPrev: nowMs };
+  }
+
+  return { kind: "ok", gapMs, nextPrev: nowMs };
+}
+
+/** Human-readable Output / overlay line for a detected stall. */
+export function formatFreezeLog(gapMs: number, at: Date): string {
+  const ms = Math.round(gapMs);
+  const hh = String(at.getHours()).padStart(2, "0");
+  const mm = String(at.getMinutes()).padStart(2, "0");
+  const ss = String(at.getSeconds()).padStart(2, "0");
+  const mss = String(at.getMilliseconds()).padStart(3, "0");
+  return `UI freeze ${ms}ms at ${hh}:${mm}:${ss}.${mss} (rAF stalled)`;
+}
+
+/** Gaps this large are usually background throttle / sleep, not in-app work. */
+export const BACKGROUND_GAP_MS = 5000;
+
+/** How far before stall *onset* to scan other Output channels. */
+export const CORRELATE_LOOKBACK_MS = 2000;
+
+export interface CorrelateEntry {
+  timestampMs: number;
+  channel: string;
+  message: string;
+}
+
+/**
+ * Pick Output lines that overlap a stall: from
+ * `(freezeEnd - gapMs - lookback)` through `freezeEnd`.
+ * Skips the freeze channel's own lines.
+ */
+export function correlateAroundFreeze(
+  entries: CorrelateEntry[],
+  freezeEndMs: number,
+  gapMs: number,
+  lookbackMs: number = CORRELATE_LOOKBACK_MS,
+  freezeChannelKey: string = "silo:ui-freeze",
+): CorrelateEntry[] {
+  const start = freezeEndMs - gapMs - lookbackMs;
+  return entries.filter(
+    (e) =>
+      e.channel !== freezeChannelKey &&
+      e.timestampMs >= start &&
+      e.timestampMs <= freezeEndMs,
+  );
+}
+
+/** Compact summary for the freeze log body (top channels by count). */
+export function summarizeCorrelation(
+  entries: CorrelateEntry[],
+  max = 8,
+): string {
+  if (entries.length === 0) return "no nearby Output activity";
+  const counts = new Map<string, number>();
+  for (const e of entries) {
+    counts.set(e.channel, (counts.get(e.channel) ?? 0) + 1);
+  }
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const parts = ranked.slice(0, max).map(([ch, n]) => `${ch}×${n}`);
+  const extra = ranked.length > max ? ` +${ranked.length - max} more` : "";
+  return `${entries.length} nearby: ${parts.join(", ")}${extra}`;
+}
+
+/** Dev: on unless `"0"`. Release: on only when `"1"`. */
+export function probeEnabledFromStorage(
+  raw: string | null,
+  isDev: boolean,
+): boolean {
+  if (isDev) return raw !== "0";
+  return raw === "1";
+}

--- a/apps/desktop/src/dev/ui-freeze-probe.css
+++ b/apps/desktop/src/dev/ui-freeze-probe.css
@@ -1,0 +1,62 @@
+/* Dev-only rAF freeze probe — design tokens only. */
+
+.ui-freeze-probe {
+  position: fixed;
+  right: 10px;
+  bottom: 28px; /* above status bar */
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 4px 4px;
+  border-radius: var(--silo-radius-md);
+  border: 1px solid var(--silo-color-border-strong);
+  background: color-mix(in srgb, var(--silo-color-bg) 92%, transparent);
+  color: var(--silo-color-text);
+  font: 11px/1.2 var(--silo-font-mono);
+  pointer-events: none;
+  user-select: none;
+  box-shadow: 0 1px 4px color-mix(in srgb, #000 35%, transparent);
+}
+
+.ui-freeze-probe__dial {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid var(--silo-color-border-strong);
+  background: var(--silo-color-bg-hover);
+  flex-shrink: 0;
+}
+
+.ui-freeze-probe__hand {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 1.5px;
+  height: 6px;
+  margin-left: -0.75px;
+  margin-top: -6px;
+  border-radius: 1px;
+  background: var(--silo-color-accent);
+  transform-origin: 50% 100%;
+  will-change: transform;
+}
+
+.ui-freeze-probe__label {
+  min-width: 3.5em;
+}
+
+.ui-freeze-probe--hit {
+  border-color: var(--silo-color-err);
+  color: var(--silo-color-err);
+  background: color-mix(
+    in srgb,
+    var(--silo-color-err) 18%,
+    var(--silo-color-bg)
+  );
+}
+
+.ui-freeze-probe--hit .ui-freeze-probe__hand {
+  background: var(--silo-color-err);
+}

--- a/apps/desktop/src/dev/ui-freeze-probe.ts
+++ b/apps/desktop/src/dev/ui-freeze-probe.ts
@@ -1,0 +1,222 @@
+import {
+  createHostChannel,
+  getOutputLogs,
+  commandRegistry,
+} from "@silo-code/extension-host";
+import {
+  BACKGROUND_GAP_MS,
+  CORRELATE_LOOKBACK_MS,
+  DEFAULT_FREEZE_THRESHOLD_MS,
+  DEFAULT_WARMUP_MS,
+  correlateAroundFreeze,
+  formatFreezeLog,
+  probeEnabledFromStorage,
+  summarizeCorrelation,
+  tickFreezeProbe,
+  type CorrelateEntry,
+} from "./ui-freeze-probe-model";
+import "./ui-freeze-probe.css";
+
+/** Persisted enable flag — Prod defaults off; Dev defaults on. */
+export const UI_FREEZE_PROBE_STORAGE_KEY = "silo.uiFreezeProbe";
+
+const channel = createHostChannel("silo:ui-freeze", "UI Freeze");
+
+export interface UiFreezeProbeOptions {
+  /** Gap (ms) that counts as a stall. Default 100. */
+  thresholdMs?: number;
+  /** Ignore stalls until this many ms after start. Default 2000. */
+  warmupMs?: number;
+}
+
+/** Dev: on unless explicitly `"0"`. Prod/release: on only when `"1"`. */
+export function isUiFreezeProbeEnabled(): boolean {
+  return probeEnabledFromStorage(
+    localStorage.getItem(UI_FREEZE_PROBE_STORAGE_KEY),
+    import.meta.env.DEV,
+  );
+}
+
+export function setUiFreezeProbeEnabled(on: boolean): void {
+  localStorage.setItem(UI_FREEZE_PROBE_STORAGE_KEY, on ? "1" : "0");
+}
+
+/** Snapshot every Output channel (best-effort) for freeze correlation. */
+function collectAllOutputEntries(): CorrelateEntry[] {
+  const discovery = getOutputLogs({ channel: "silo:ui-freeze", limit: 1 });
+  const out: CorrelateEntry[] = [];
+  for (const { key } of discovery.channels) {
+    if (key === "silo:ui-freeze") continue;
+    const res = getOutputLogs({ channel: key, limit: 80 });
+    for (const e of res.entries) {
+      const timestampMs = Date.parse(e.timestamp);
+      if (Number.isNaN(timestampMs)) continue;
+      out.push({ timestampMs, channel: key, message: e.message });
+    }
+  }
+  return out;
+}
+
+/**
+ * rAF freeze probe: paints a sweeper and logs stalls to Output → "UI Freeze"
+ * with a correlation summary of nearby Output activity.
+ *
+ * Returns a disposer.
+ */
+export function startUiFreezeProbe(
+  options: UiFreezeProbeOptions = {},
+): () => void {
+  const thresholdMs = options.thresholdMs ?? DEFAULT_FREEZE_THRESHOLD_MS;
+  const warmupMs = options.warmupMs ?? DEFAULT_WARMUP_MS;
+
+  const root = document.createElement("div");
+  root.className = "ui-freeze-probe";
+  root.setAttribute("aria-hidden", "true");
+  root.title =
+    "UI freeze probe — rAF sweeper. Stalls ≥ threshold log to Output → UI Freeze.";
+
+  const dial = document.createElement("div");
+  dial.className = "ui-freeze-probe__dial";
+  const hand = document.createElement("div");
+  hand.className = "ui-freeze-probe__hand";
+  dial.appendChild(hand);
+
+  const label = document.createElement("div");
+  label.className = "ui-freeze-probe__label";
+  label.textContent = "rAF";
+
+  root.append(dial, label);
+  document.body.appendChild(root);
+
+  const startedAtMs = performance.now();
+  let prevFrameMs: number | null = null;
+  let rafId = 0;
+  let lastLoggedGap = 0;
+  let angle = 0;
+
+  const paint = (nowMs: number) => {
+    const hidden = document.visibilityState === "hidden";
+    const result = tickFreezeProbe({
+      prevFrameMs,
+      nowMs,
+      startedAtMs,
+      hidden,
+      thresholdMs,
+      warmupMs,
+    });
+    prevFrameMs = result.nextPrev;
+
+    if (result.kind === "freeze") {
+      const wall = new Date();
+      const freezeEndMs = wall.getTime();
+      const gapMs = result.gapMs;
+      const likelyBackground = gapMs >= BACKGROUND_GAP_MS;
+
+      let nearby: CorrelateEntry[] = [];
+      try {
+        nearby = correlateAroundFreeze(
+          collectAllOutputEntries(),
+          freezeEndMs,
+          gapMs,
+          CORRELATE_LOOKBACK_MS,
+        );
+      } catch {
+        /* Output store not ready — still log the freeze */
+      }
+
+      const summary = summarizeCorrelation(nearby);
+      const base = formatFreezeLog(gapMs, wall);
+      const msg = likelyBackground
+        ? `${base} — likely background/throttle; ${summary}`
+        : `${base} — ${summary}`;
+
+      const sample = nearby.slice(-12).map((e) => ({
+        channel: e.channel,
+        message: e.message.slice(0, 160),
+        t: new Date(e.timestampMs).toISOString(),
+      }));
+
+      channel.warn(msg, {
+        gapMs: Math.round(gapMs),
+        thresholdMs,
+        atMs: freezeEndMs,
+        onsetMs: freezeEndMs - Math.round(gapMs),
+        likelyBackground,
+        nearbyCount: nearby.length,
+        nearbySample: sample,
+      });
+
+      lastLoggedGap = gapMs;
+      root.classList.add("ui-freeze-probe--hit");
+      label.textContent = `${Math.round(gapMs)}ms`;
+      window.setTimeout(() => {
+        root.classList.remove("ui-freeze-probe--hit");
+      }, 1200);
+    } else if (result.kind === "ok" && result.gapMs > 0) {
+      if (lastLoggedGap === 0) {
+        label.textContent = "rAF";
+      }
+    }
+
+    if (!hidden) {
+      angle = (angle + 6) % 360;
+      hand.style.transform = `rotate(${angle}deg)`;
+    }
+
+    rafId = requestAnimationFrame(paint);
+  };
+
+  rafId = requestAnimationFrame(paint);
+  channel.info(
+    `UI freeze probe armed (threshold ${thresholdMs}ms, warmup ${warmupMs}ms)`,
+  );
+
+  return () => {
+    cancelAnimationFrame(rafId);
+    root.remove();
+  };
+}
+
+let stopProbe: (() => void) | null = null;
+
+function syncProbeToFlag(): boolean {
+  const want = isUiFreezeProbeEnabled();
+  if (want && !stopProbe) {
+    stopProbe = startUiFreezeProbe();
+  } else if (!want && stopProbe) {
+    stopProbe();
+    stopProbe = null;
+    channel.info("UI freeze probe stopped");
+  }
+  return want;
+}
+
+/**
+ * Wire the probe for any build: Dev auto-starts; Prod starts only when the
+ * Help → "UI Freeze Probe" toggle (or localStorage) has enabled it.
+ */
+export function initUiFreezeProbe(): void {
+  try {
+    commandRegistry.register({
+      id: "core.toggleUiFreezeProbe",
+      label: "Toggle UI Freeze Probe",
+      run: () => {
+        const next = !isUiFreezeProbeEnabled();
+        setUiFreezeProbeEnabled(next);
+        const on = syncProbeToFlag();
+        channel.info(
+          on
+            ? "UI freeze probe enabled (Output → UI Freeze)"
+            : "UI freeze probe disabled",
+        );
+      },
+    });
+  } catch (err) {
+    // Duplicate register on HMR — ignore.
+    if (!(err instanceof Error && /duplicate id/.test(err.message))) {
+      console.error("ui freeze probe command register failed", err);
+    }
+  }
+
+  syncProbeToFlag();
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -87,6 +87,13 @@ initUserKeybindings().catch((err) =>
   console.error("initUserKeybindings failed", err),
 );
 
+// UI freeze probe (rAF hitch detector). Bundled in release too — Prod stays
+// off until Help → "Toggle UI Freeze Probe" (persists in localStorage). Dev
+// defaults on.
+import("./dev/ui-freeze-probe")
+  .then((m) => m.initUiFreezeProbe())
+  .catch((err) => console.error("ui freeze probe failed", err));
+
 // Dev-only automation bridge (paired with the Cargo `automation` feature on the
 // Rust side). The static `import.meta.env.DEV` guard keeps this dynamic import
 // out of release bundles entirely.

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -46,7 +46,7 @@ export { getThemeService } from "./extension-host/theme-service";
 export { getProcessService } from "./extension-host/process-service";
 export { getTerminalService } from "./extension-host/terminal-service";
 export { getWorkspaceService } from "./extension-host/workspace-service";
-export { executeCommand } from "./extension-host/commands";
+export { executeCommand, commandRegistry } from "./extension-host/commands";
 export { contextKeys } from "./extension-host/context-keys";
 export { sidePanelRegistry } from "./extension-host/side-panels";
 export { ensureMonaco } from "./docked/monaco-setup";
@@ -58,8 +58,10 @@ export { splitActivePanel, getActiveDockApi } from "./docked/dock-api-registry";
 // automation can't drive.
 export { restoreRegionFocus } from "./extension-host/focus-restore";
 // Output log query — lets the automation bridge surface logs to external tools.
+// `createHostChannel` is for app-owned diagnostics (e.g. the Dev UI freeze probe).
 export {
   getOutputLogs,
+  createHostChannel,
   type OutputLogsResult,
   type OutputLogEntry,
 } from "./extension-host/output-store";

--- a/packages/extensions-core/src/menu/index.ts
+++ b/packages/extensions-core/src/menu/index.ts
@@ -342,6 +342,17 @@ export const extension: Extension = {
       order: -10,
     });
 
+    // Dogfood: rAF hitch detector (apps/desktop ui-freeze-probe). Command is
+    // registered from the app composition root; this menu item ships in release
+    // so Prod can enable Output → UI Freeze correlation without a Dev build.
+    ctx.registerMenuItem({
+      id: "core.help.toggleUiFreezeProbe",
+      menu: "help",
+      command: "core.toggleUiFreezeProbe",
+      group: "9_diag",
+      order: -10,
+    });
+
     // Dev-only Window items. Silo suppresses the webview's native context menu
     // app-wide, so the Reload / Inspect Element it used to offer live here while
     // developing. Gated on the dev build — they don't ship in release.


### PR DESCRIPTION
## Summary
- Adds an rAF-driven UI freeze probe (painted sweeper + hitch detection) that logs stalls to **Output → UI Freeze** with nearby Output-channel correlation.
- Ships in release builds **off by default**; enable via **Help → Toggle UI Freeze Probe** (persists in `localStorage`). Dev still defaults on.
- Lets Prod dogfood hitch diagnosis without a Dev build — useful while comparing Prod (pre-git-api GitHub extensions) vs Dev.

## Test plan
- [ ] Dev: probe dial visible after reload; Output → UI Freeze shows arm message
- [ ] Dev: Help → Toggle UI Freeze Probe turns it off/on
- [ ] Release/Prod build: probe off by default; toggle enables dial + logging
- [ ] Induce a short hitch (e.g. workspace switch); freeze line includes `nearbySample` / channel summary when other Output activity is present
- [ ] Gaps ≥5s tagged `likely background/throttle`


Made with [Cursor](https://cursor.com)