### PR TITLE
docs(guide): add user-facing process model guide

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -242,6 +242,7 @@ export default withMermaid(
               { text: "Side panels", link: "/guide/panels" },
               { text: "Extensions", link: "/guide/extensions" },
               { text: "Using agents", link: "/guide/agent-sessions" },
+              { text: "Process model", link: "/guide/process-model" },
               { text: "The `silo` command", link: "/guide/cli" },
               { text: "Release channels", link: "/guide/release-channels" },
             ],

--- a/apps/docs/guide/index.md
+++ b/apps/docs/guide/index.md
@@ -10,6 +10,8 @@ Download the latest release for your platform and open a folder to create your f
 
 **[Workspaces](/guide/workspaces)** — the core model: what a workspace is, how to open and switch between them, and how closing differs from deleting.
 
+**[Silo's process model](/guide/process-model)** — why Activity Monitor shows many Silo-related processes and what is normal.
+
 **[Side panels](/guide/panels)** — the left and right columns, what's in them, and how to show, hide, and rearrange them.
 
 **[Extensions](/guide/extensions)** — the built-in extensions (Files, Git, Search, Themes, Markdown Preview…) and how to install more.

--- a/apps/docs/guide/process-model.md
+++ b/apps/docs/guide/process-model.md
@@ -1,0 +1,85 @@
+# Silo's process model
+
+If you open Activity Monitor (macOS) or Task Manager (Windows) and filter for
+**Silo**, you will usually see **more than one process**. That is normal — Silo
+is not a single monolithic app like a simple text editor.
+
+This page explains what those processes are and when you might need to worry.
+
+## Why more than one process?
+
+Silo splits work across a few cooperating pieces:
+
+| Piece               | What it does                                                                            |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| **Main app**        | The window, menus, and keyboard shortcuts                                               |
+| **UI (webview)**    | Everything you see — panels, editors, file tree, terminal panes                         |
+| **Browser helpers** | GPU, network, and other standard webview plumbing                                       |
+| **Session hosts**   | The backend for each **live terminal** — your shell, an agent, `npm run dev`, and so on |
+
+The important Silo-specific part: **terminals keep running in the background**
+when you switch workspaces. The UI can hide a terminal tab; the shell keeps going
+until you close that terminal or quit Silo. That is why you may see several
+**session-host** processes even when you are only looking at one workspace.
+
+## What you see on macOS (Activity Monitor)
+
+Names vary slightly by macOS version, but a typical install looks like this:
+
+| Process name                    | What it is                                                                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Silo** (with the app icon)    | The main app — owns the window and coordinates everything else.                                                                                  |
+| **`tauri://localhost`**         | The embedded UI. Most of Silo's interactive work happens here. Often the highest CPU user when the UI is busy or terminals are streaming output. |
+| **Silo Graphics and Media**     | GPU helper for the UI (including terminal rendering).                                                                                            |
+| **Silo Networking**             | Network helper (extension updates, GitHub, and other online features).                                                                           |
+| **AutoFill (Silo)**             | WebKit autofill helper. Harmless; usually idle.                                                                                                  |
+| **`silo`** (lowercase, no icon) | One **session host** per live terminal backend.                                                                                                  |
+
+You may also see **`com.apple.WebKit.WebContent`** in some views; on recent macOS
+versions Activity Monitor often labels the UI as **`tauri://localhost`** instead.
+
+### Counting the lowercase `silo` rows
+
+Rough rule of thumb:
+
+```
+number of lowercase silo rows ≈ number of live terminal sessions
+```
+
+Background workspaces count — if you keep five workspaces open and each has an
+active terminal, expect **about five** session hosts, plus the main app and UI
+processes.
+
+Those session hosts are **intentional**, not leaks. They let you switch
+workspaces instantly without killing agents or dev servers mid-run.
+
+## Windows
+
+On Windows the same idea applies, but names differ — **Silo.exe** for the main
+app, and **WebView2** / **msedgewebview2** for the UI. You may see extra Silo
+processes for the same reason: **one per live terminal session**.
+
+## CPU and memory — what is normal?
+
+**Idle Silo** (one workspace, nothing streaming in a terminal): UI CPU is usually
+**under ~1–2%**. The main **Silo** process stays low too.
+
+**Active use** (agents streaming output, large file trees, many panels): the UI
+and graphics helpers can rise — that is expected while work is happening.
+
+**Many session hosts at ~0% CPU** with an occasional bump: normal. They wake
+when their terminal receives or sends data.
+
+### When to look closer
+
+| Symptom                                                | What to try                                                                                                                   |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Many more `silo` rows than you have open terminals** | Stale sessions from a crash or long uptime. Quit Silo completely and relaunch, or restart your Mac.                           |
+| **Sustained high CPU with idle terminals**             | Often a runaway process _inside_ a terminal (not Silo itself). Check the terminal pane for a stuck command or runaway script. |
+
+## Related reading
+
+- **[Workspaces](/guide/workspaces)** — why background workspaces keep terminals
+  alive.
+- **[Using agents](/guide/agent-sessions)** — agents run in those persistent
+  terminal sessions.


### PR DESCRIPTION
## Summary

- Add `/guide/process-model` explaining why Activity Monitor shows multiple Silo-related processes (main app, UI webview, browser helpers, terminal session hosts).
- Written for semi-technical users — no ADRs, dev install notes, or internal diagnostics.
- Link the guide from the Getting Started index and docs sidebar.

## Test plan

- [x] Pre-commit docs build passed (link check)
- [ ] Preview at `/guide/process-model` via `pnpm docs:dev`
- [ ] Confirm sidebar and Getting Started links resolve


Made with [Cursor](https://cursor.com)