### PR TITLE
fix(layout): keyboard region-entry skips a panel's own header chrome

### DIFF
--- a/apps/desktop/src/automation/keyboard-nav.it.test.ts
+++ b/apps/desktop/src/automation/keyboard-nav.it.test.ts
@@ -257,18 +257,12 @@ describe.skipIf(!canFocus)("keyboard navigation", () => {
   });
 
   it("hands Tab off from the dock to the center editor", async () => {
-    // The list is one Tab stop and the per-row close (×) is out of tab order, so
-    // the dock's last tabbable is the + Add button. Tab there hands off to the
-    // center (skipping the splitter + dock chrome) — the cursor, ready to type.
-    await silo.eval('document.querySelector(".ws-add-btn")?.focus()');
-    await expect
-      .poll(
-        async () =>
-          (await silo.activeElement())?.className.includes("ws-add-btn") ??
-          false,
-        { timeout: 2000, interval: 50 },
-      )
-      .toBe(true);
+    // The list is one Tab stop, the per-row close (×) is out of tab order, and
+    // the Navigator's header toolbar is entry-chrome (skipped by region entry,
+    // not by Tab) but comes BEFORE the list in DOM order — so the list's roving
+    // row is the dock's last tabbable. Tab from there hands off to the center
+    // (skipping the splitter + dock chrome) — the cursor, ready to type.
+    await enterWorkspaceList();
     await silo.key("Tab");
     await expect
       .poll(

--- a/packages/extension-host/src/layout/side-pane-focus.test.ts
+++ b/packages/extension-host/src/layout/side-pane-focus.test.ts
@@ -83,4 +83,32 @@ describe("focusActivePaneContent", () => {
     expect(focusActivePaneContent(host)).toBe(true);
     expect(document.activeElement).toBe(row1);
   });
+
+  it("skips a header's own chrome and lands on the content behind it", () => {
+    // Mirrors the Navigator: a header toolbar button (an ordinary, naturally
+    // tabbable <button>, no tabindex needed) sits before the active view's
+    // content in the DOM. Marked `data-focus-chrome`, so region entry must
+    // skip past it to the content's roving item, not stop on the button.
+    const host = document.createElement("div");
+    const pane = document.createElement("div");
+    pane.className = "tab-pane";
+    pane.dataset.active = "true";
+
+    const header = document.createElement("div");
+    header.dataset.focusChrome = "";
+    const addButton = document.createElement("button");
+    header.appendChild(addButton);
+
+    const list = document.createElement("ul");
+    const row = document.createElement("li");
+    row.tabIndex = 0;
+    list.appendChild(row);
+
+    pane.append(header, list);
+    host.appendChild(pane);
+    document.body.appendChild(host);
+
+    expect(focusActivePaneContent(host)).toBe(true);
+    expect(document.activeElement).toBe(row);
+  });
 });

--- a/packages/extension-host/src/layout/side-pane-focus.ts
+++ b/packages/extension-host/src/layout/side-pane-focus.ts
@@ -4,20 +4,34 @@
 // stay plain accessible components — they expose normal focusable content (a
 // roving `tabindex=0`, a button, an input) and this finds it.
 
-import { firstTabbable } from "../extension-host/focus-dom";
+import { tabbablesIn } from "../extension-host/focus-dom";
+
+/**
+ * A panel's own header/toolbar chrome (e.g. the Navigator's view header and
+ * its contributed actions), as opposed to the panel's actual content. Marked
+ * by the panel itself so entry-focus can skip past it — a header control is
+ * still reachable by an ordinary Tab press, just never the landing spot for
+ * region entry (see {@link focusActivePaneContent}).
+ */
+const CHROME_SELECTOR = "[data-focus-chrome]";
 
 /**
  * Focus the active panel's first tabbable element under `root` (the
- * `.tab-pane[data-active="true"]` within a side pane / tab host). Returns whether
- * it took focus. A panel using roving focus keeps its current item at
- * `tabindex=0` (the rest at `-1`), so this lands on that item; otherwise it lands
- * on the first natural control. `tabindex="-1"` controls are excluded (see the
- * shared `TABBABLE` selector), so a row's close button is never chosen ahead of
- * the roving item even when it appears earlier in the DOM.
+ * `.tab-pane[data-active="true"]` within a side pane / tab host) that isn't
+ * part of the panel's own {@link CHROME_SELECTOR} chrome. Returns whether it
+ * took focus. A panel using roving focus keeps its current item at
+ * `tabindex=0` (the rest at `-1`), so this lands on that item; otherwise it
+ * lands on the first natural control. `tabindex="-1"` controls are excluded
+ * (see the shared `TABBABLE` selector), so a row's close button is never
+ * chosen ahead of the roving item even when it appears earlier in the DOM —
+ * and a header toolbar button is never chosen ahead of the content it sits
+ * above, even though it's earlier still.
  */
 export function focusActivePaneContent(root: HTMLElement): boolean {
   const pane = root.querySelector<HTMLElement>('.tab-pane[data-active="true"]');
-  const first = pane ? firstTabbable(pane) : null;
+  const first = pane
+    ? (tabbablesIn(pane).find((el) => !el.closest(CHROME_SELECTOR)) ?? null)
+    : null;
   if (!first) return false;
   first.focus();
   return true;

--- a/packages/extension-host/src/panels/WorkspaceDock.tsx
+++ b/packages/extension-host/src/panels/WorkspaceDock.tsx
@@ -528,12 +528,18 @@ export function WorkspaceDock({
   }, [api, workspaceId]);
 
   // Activate a panel programmatically (used by openEditor / openPreviewEditor
-  // when the target panel is already mounted).
+  // when the target panel is already mounted, a view-type switch remounting
+  // onto the same panel, and the automation bridge's `activatePanel` op).
+  // Focus follows the activation — matching `applyTarget` above and every one
+  // of these callers' intent: the user asked to open this file (or switch its
+  // viewer), they expect the cursor there.
   useEffect(() => {
     function handler(e: Event) {
       const { panelId } = (e as CustomEvent<{ panelId: string }>).detail;
       const panel = apiRef.current?.getPanel(panelId);
-      if (panel) panel.api.setActive();
+      if (!panel) return;
+      panel.api.setActive();
+      focusPanelContent(panel.view.content.element);
     }
     window.addEventListener("app:activate-panel", handler);
     return () => window.removeEventListener("app:activate-panel", handler);

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -150,7 +150,11 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
           panel knows about, which is how the workspaces + button gets here
           without core.navigator importing a line of workspace code. */}
       {activeView && (
-        <div className="nav-view-header">
+        // `data-focus-chrome`: header controls (the contributed toolbar), not
+        // content — keyboard region-entry skips past this to land in the
+        // active view itself (see `focusActivePaneContent`), the same way it
+        // already skips a row's own out-of-order close button.
+        <div className="nav-view-header" data-focus-chrome>
           <span className="nav-view-header__title">{activeView.title}</span>
           <ContributedToolbar
             surface="navigator"


### PR DESCRIPTION
## Summary

Nightly integration CI has apparently been silently skipping `keyboard-nav.it.test.ts` on almost every run for at least the past two weeks — its window-foreground gate (a real macOS focus requirement, not a bug) just wasn't satisfied on the unattended cron runner. Today's nightly is only the second time in that window it actually executed, and it immediately hit real, pre-existing keyboard-navigation bugs that a green "last successful run" had been silently hiding.

Both bugs are fixed here:

1. Entering the left dock by keyboard (Cmd+Alt+, / Tab / clicking) landed focus on the Navigator's "+" add-workspace button instead of the workspace list. Traced to PR #325 (2026-08-06, "turn Workspaces panel into contributed Navigator views") — it's been broken since then, over two weeks before this branch existed.
2. Programmatically activating an already-open tab (`ctx.editors`/`ctx.workspaces` re-activation flows, and the test automation bridge) updated which tab was active without moving keyboard focus there, unlike a real click. Same age as bug 1.

One test also referenced a CSS class left over from before the "Add workspace" button moved into the Navigator's header toolbar.

A third failure in the same file ("region-cycles onto a markdown preview's scroll view...") is **not** a real bug — verified it already passes in CI, and locally it only failed because of a personally-installed `agent-inspector` extension (not part of `apps/desktop/src/builtins.ts`, not shipped, not something CI has) contributing an extra editor toolbar button. No production code touches this.

## Details

### Bug 1 — Navigator header intercepts left-dock keyboard entry

`NavigatorPanel` renders its header (title + `ContributedToolbar`, including the "Add workspace" action) *before* the active view's content in the DOM, for sticky-header/scroll reasons (existing comment in `NavigatorPanel.tsx`). The toolbar's "+" button is an ordinary `<button>` — naturally tabbable, no `tabindex` needed — so it was the first match `focusActivePaneContent` (`packages/extension-host/src/layout/side-pane-focus.ts`) found via `firstTabbable`, ahead of the workspace list's roving-tabindex row.

`focusActivePaneContent` backs the side-dock's keyboard region entry (region-cycle, Tab-boundary handoff, click-to-enter — see `focus-regions.ts`), so this DOM-order accident became a real regression: entering the left dock by keyboard stopped on the header toolbar instead of the workspace list, which cascaded into most of `keyboard-nav.it.test.ts`'s `enterWorkspaceList()`-based tests timing out.

**Fix:** `side-pane-focus.ts`'s `focusActivePaneContent` now skips any tabbable inside an element marked `data-focus-chrome`; `NavigatorPanel.tsx` marks its `.nav-view-header` with it. A header control stays reachable by an ordinary Tab press — it's excluded only as the region-entry landing spot.

### Bug 2 — `app:activate-panel` doesn't move DOM focus

`WorkspaceDock.tsx` has two effects that respond to panel-activation intent. `applyTarget` (its own workspace-activation-request path) correctly calls `panel.api.setActive()` *then* `focusPanelContent(...)`. The `app:activate-panel` CustomEvent handler — used by `openEditor`/`openPreviewEditor` when a target panel is already mounted, a view-type switch remount, and the automation bridge's `activatePanel` op — only called `setActive()`. dockview's `setActive()` updates which tab is highlighted but doesn't move keyboard focus; a real user click moves focus as a side effect of the click itself, which is why this never showed up as a real-world bug — every current dispatch site of `app:activate-panel` is a user-initiated "open/switch to this" action, so it's correct for focus to follow.

**Fix:** the handler now calls `focusPanelContent(panel.view.content.element)` after `setActive()`, matching the sibling `applyTarget` pattern already established in the same file.

### Test changes

- `keyboard-nav.it.test.ts`: "hands Tab off from the dock to the center editor" referenced `.ws-add-btn`, a class that doesn't exist anywhere in the current app (`grep` confirms zero matches outside the test) — a stale reference from before the add-workspace button moved into the header toolbar. Rewrote it to enter the list via the file's own `enterWorkspaceList()` helper and Tab from the list's roving row, which is genuinely the dock's last tabbable now that the header toolbar is entry-chrome but still DOM-order-first. No assertion was weakened — the expected behavior (Tab from the dock's last tabbable hands off to center) is unchanged.
- No other test assertions were changed. The other 8 of 10 originally-failing tests needed no test changes — only the two production fixes above.
- Added a unit test to `side-pane-focus.test.ts` mirroring the Navigator's exact DOM shape (chrome-marked header button before roving-tabindex content).

### Why "last successful run" was misleading

Checked every `integration.yml` run back to 2026-08-10: `keyboard-nav.it.test.ts` was skipped (`app window not foregrounded`) on every nightly cron run in that window except two — a manual `workflow_dispatch` on 2026-08-10 and today's nightly. Both of the runs where it actually executed hit the exact same failure signature (same test names, same line numbers). Bisected locally (full checkout + rebuild, not a partial file swap) against `096b9ba7` — main's tip during the last "successful" nightly (2026-08-21), predating the SideDock/Navigator-scale-up PRs merged later that day — and reproduced the identical 8-of-10 failures there too, confirming those PRs are unrelated; the bug predates them by at least two weeks and CI simply never observed it.

### Verification

- Reproduced live against a running dev app (`pnpm dev` + the automation RPC), including bisecting against `096b9ba7` (full checkout + rebuild) to confirm both bugs predate this week's PRs.
- `apps/desktop/src/automation/keyboard-nav.it.test.ts`: 8/10 → 10/10 failing tests now pass; the remaining local-only failure is the confirmed environment artifact described above (passes in real CI).
- Added a unit test to `side-pane-focus.test.ts` for the chrome-skip behavior.
- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all green.

## Test plan

- [x] `pnpm test` (unit, all packages)
- [x] `pnpm lint`
- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm --filter silo test:it` against a live dev app — `keyboard-nav.it.test.ts` passes in full except the confirmed-environmental case above
