### PR TITLE
fix(navigator): hide view-header border when view list is hidden

### DIFF
--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -85,6 +85,11 @@
   background: var(--silo-color-bg);
 }
 
+/* No view list above means no seam to draw under it. */
+.nav-view-header[data-view-list="false"] {
+  border-top: none;
+}
+
 .nav-view-header__title {
   flex: 1;
   min-width: 0;

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -154,7 +154,11 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
         // content — keyboard region-entry skips past this to land in the
         // active view itself (see `focusActivePaneContent`), the same way it
         // already skips a row's own out-of-order close button.
-        <div className="nav-view-header" data-focus-chrome>
+        <div
+          className="nav-view-header"
+          data-focus-chrome
+          data-view-list={showViewList ? "true" : "false"}
+        >
           <span className="nav-view-header__title">{activeView.title}</span>
           <ContributedToolbar
             surface="navigator"


### PR DESCRIPTION
## Summary

In the Navigator panel, when only one view is registered (e.g. just Workspaces), the row of view tabs is hidden. The subtle line separating that row from the view content below it stayed visible even with nothing above it to separate from. This change hides that border along with the view list, so a single-view Navigator has no orphaned line.

## Details

`.nav-view-header`'s `border-top` renders the seam under the `.nav-views` tablist. `NavigatorPanel.tsx` already computes `showViewList = views.length > 1` to conditionally render the tablist; this adds a `data-view-list` attribute on `.nav-view-header` reflecting the same boolean, and a CSS rule (`NavigatorPanel.css`) that drops `border-top` when it's `"false"`.

### Test plan

- `pnpm --filter silo exec tsc --noEmit` — passes
- `pnpm lint` — passes
- `pnpm --filter @silo-code/extensions-core test` — 321 tests passing
- No new unit test added: this is a pure CSS/markup change reusing the existing `showViewList` boolean, with no new branching logic to cover.