### PR TITLE
fix(keybindings): dispatch user-assigned keys for commands with no default

### DIFF
--- a/apps/desktop/src/automation/bridge.ts
+++ b/apps/desktop/src/automation/bridge.ts
@@ -22,6 +22,21 @@ import {
   setBusyStatus,
   clearBusyStatus,
 } from "@silo-code/extension-host";
+// Keybinding introspection for the shortcut-dispatch ops below. The privileged
+// barrel is where the host exposes its command/keybinding/keymap registries
+// (it's what the core.keybindings settings page reads); apps/desktop is the
+// composition root and already owns the host, so this is the same tier — not
+// an extension reaching in.
+import {
+  commandRegistry,
+  keybindingRegistry,
+  keybindingsPath,
+  menuFor,
+  defaultKey,
+  overrideKey,
+  effectiveKey,
+} from "@silo-code/extension-host/internal";
+import type { Disposable } from "@silo-code/sdk";
 
 // --- Monaco introspection (source of truth, not DOM scraping) ---------------
 // We tap Monaco's own focus events and editor/model registry via the
@@ -776,9 +791,81 @@ async function handleOp(
         limit: args.limit !== undefined ? Number(args.limit) : undefined,
       });
 
+    // --- Keybindings ---------------------------------------------------------
+    // The shortcut chain has three independent layers that can each break
+    // silently — keybindings.json on disk → the keymap → `dispatchKey`. These
+    // ops let a test drive all three: `keybindingState` reports where a
+    // command's key stands at every layer (so a failure names the layer), and
+    // the probe command is a synthetic, side-effect-free target to bind a key
+    // to and count invocations of.
+
+    case "keybindingState": {
+      const command = String(args.command ?? "");
+      return {
+        command,
+        keybindingsPath: await keybindingsPath(),
+        registered: commandRegistry.get(command) !== undefined,
+        // A registry default (`ctx.registerKeybinding`), if the command has one.
+        registryKey:
+          keybindingRegistry.list().find((b) => b.command === command)?.key ??
+          null,
+        // Menu-homed commands fire via their native accelerator, not dispatchKey.
+        menuHomed: menuFor(command) !== undefined,
+        defaultKey: defaultKey(command) ?? null,
+        overrideKey: overrideKey(command) ?? null,
+        effectiveKey: effectiveKey(command) ?? null,
+      };
+    }
+
+    case "armProbeCommand": {
+      disposeProbe();
+      probeCommand = commandRegistry.register({
+        id: PROBE_COMMAND_ID,
+        label: "Automation: Probe",
+        run: () => {
+          probeRuns += 1;
+        },
+      });
+      // With `key`, the probe also gets a registry DEFAULT — the
+      // `ctx.registerKeybinding` path, distinct from a keybindings.json override.
+      const key = args.key === undefined ? undefined : String(args.key);
+      if (key) {
+        probeKeybinding = keybindingRegistry.register({
+          id: `${PROBE_COMMAND_ID}.key`,
+          command: PROBE_COMMAND_ID,
+          key,
+        });
+      }
+      return { id: PROBE_COMMAND_ID, runs: probeRuns, key: key ?? null };
+    }
+
+    case "probeCommandRuns":
+      return { id: PROBE_COMMAND_ID, runs: probeRuns };
+
+    case "disarmProbeCommand": {
+      disposeProbe();
+      return { id: PROBE_COMMAND_ID, disarmed: true };
+    }
+
     default:
       throw new Error(`unknown op: ${op}`);
   }
+}
+
+// A command that exists only to be dispatched at. Registered on demand by
+// `armProbeCommand` (and gone again on `disarmProbeCommand`) so the running
+// app isn't left carrying an automation entry in its command palette.
+const PROBE_COMMAND_ID = "automation.probe";
+let probeCommand: Disposable | null = null;
+let probeKeybinding: Disposable | null = null;
+let probeRuns = 0;
+
+function disposeProbe(): void {
+  probeKeybinding?.dispose();
+  probeKeybinding = null;
+  probeCommand?.dispose();
+  probeCommand = null;
+  probeRuns = 0;
 }
 
 function requireActiveWorkspace(): string {

--- a/apps/desktop/src/automation/client.ts
+++ b/apps/desktop/src/automation/client.ts
@@ -100,6 +100,22 @@ export interface ThemeState {
   customThemes: ThemeRef[];
 }
 
+/** One command's key at each layer of the shortcut chain (`keybindingState`). */
+export interface KeybindingState {
+  command: string;
+  /** Absolute path the app reads user overrides from. */
+  keybindingsPath: string;
+  /** The command id resolves in the command registry. */
+  registered: boolean;
+  /** Default declared via `ctx.registerKeybinding`, if any. */
+  registryKey: string | null;
+  /** Homed in the native menu — fires via its accelerator, not `dispatchKey`. */
+  menuHomed: boolean;
+  defaultKey: string | null;
+  overrideKey: string | null;
+  effectiveKey: string | null;
+}
+
 /** A typed wrapper around the automation RPC. One instance per app under test. */
 export class SiloAutomation {
   constructor(private readonly base: string = DEFAULT_BASE) {}
@@ -496,13 +512,21 @@ export class SiloAutomation {
       metaKey?: boolean;
       ctrlKey?: boolean;
       altKey?: boolean;
+      /**
+       * `KeyboardEvent.code` (the physical key). Defaults to the code a real
+       * keyboard would report for `key` ("g" → "KeyG", "1" → "Digit1", named
+       * keys verbatim). Registered keybindings match on `code`, not `key`, so
+       * a chord dispatched without one would never fire.
+       */
+      code?: string;
       /** Dispatch at this element instead of `document.activeElement`. */
       selector?: string;
     } = {},
   ): Promise<ActiveElement | null> {
-    const { selector, ...mods } = opts;
+    const { selector, code, ...mods } = opts;
     const init = JSON.stringify({
       key,
+      code: code ?? codeForKey(key),
       bubbles: true,
       cancelable: true,
       composed: true,
@@ -517,4 +541,53 @@ export class SiloAutomation {
     );
     return this.activeElement();
   }
+
+  /**
+   * Where a command's key stands at every layer of the shortcut chain:
+   * the registry default it shipped with, the user override read from
+   * keybindings.json, the resulting effective key, and whether it is
+   * menu-homed (menu-homed commands fire via their native accelerator instead
+   * of `dispatchKey`). A dispatch assertion that fails next to this can name
+   * the layer that broke.
+   */
+  keybindingState(command: string): Promise<KeybindingState> {
+    return this.call("keybindingState", { command });
+  }
+
+  /**
+   * Register (and zero) a synthetic command to aim a shortcut at — a target
+   * with no UI side effects, so a dispatch test asserts on the shortcut chain
+   * alone. Pass `key` to also give it a registry default (the
+   * `ctx.registerKeybinding` path); omit it for a command with no default at
+   * all, which only a keybindings.json override can bind. Pair with
+   * {@link disarmProbeCommand} so the app isn't left with an automation entry
+   * in its command palette.
+   */
+  armProbeCommand(key?: string): Promise<{
+    id: string;
+    runs: number;
+    key: string | null;
+  }> {
+    return this.call("armProbeCommand", { key });
+  }
+
+  /** How many times the probe command has run since it was armed. */
+  probeCommandRuns(): Promise<{ id: string; runs: number }> {
+    return this.call("probeCommandRuns");
+  }
+
+  /** Unregister the probe command. */
+  disarmProbeCommand(): Promise<{ id: string; disarmed: boolean }> {
+    return this.call("disarmProbeCommand");
+  }
+}
+
+/** The `KeyboardEvent.code` a real keyboard reports for a one-token key spec. */
+function codeForKey(key: string): string {
+  if (key.length === 1) {
+    if (/[a-z]/i.test(key)) return `Key${key.toUpperCase()}`;
+    if (/[0-9]/.test(key)) return `Digit${key}`;
+  }
+  // Named keys ("ArrowDown", "Enter", "Escape", "F5") already are codes.
+  return key;
 }

--- a/apps/desktop/src/automation/keybindings.it.test.ts
+++ b/apps/desktop/src/automation/keybindings.it.test.ts
@@ -1,0 +1,163 @@
+// Integration test (Layer 2): the keyboard-shortcut chain end-to-end in the
+// REAL running app — keybindings.json on disk → the file watcher → the keymap →
+// `dispatchKey` → the command. Three independent layers, each of which can
+// break without any unit test noticing, and whose failure is silent by nature:
+// a shortcut that stops firing looks exactly like a shortcut nobody pressed.
+//
+// The regression this pins: a user-assigned key on a command that shipped NO
+// default (no `ctx.registerKeybinding`, no menu item) — the shape of every
+// third-party extension command — used to be saved and displayed by the
+// Keyboard Shortcuts page but never dispatched, because `dispatchKey` only
+// iterated the keybinding registry.
+//
+// Everything is aimed at the synthetic `automation.probe` command (armProbe /
+// probeRuns ops), so the suite asserts on the shortcut chain alone and leaves
+// no UI side effects. Chords use the hyper modifier set so they cannot collide
+// with a real Silo binding.
+//
+// Requires the dev app (`pnpm dev`); SKIPS otherwise, so `pnpm test` and CI stay
+// green without one. `pnpm --filter silo test:it` is the command that expects a
+// live app.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { readFile, writeFile, rm } from "node:fs/promises";
+import { SiloAutomation } from "./client";
+
+const silo = new SiloAutomation();
+const available = await silo.available();
+
+if (!available) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[keybindings.it] no dev app reachable on :7878 — skipping. " +
+      "Run `pnpm dev` to exercise this suite.",
+  );
+}
+
+const PROBE = "automation.probe";
+
+/** Two chords nothing in Silo binds — hyper + a letter. */
+const CHORD_J = { metaKey: true, ctrlKey: true, altKey: true, shiftKey: true };
+const KEY_J = "j";
+const KEY_K = "k";
+const SPEC_J = "cmd+ctrl+alt+shift+j";
+const SPEC_K = "cmd+ctrl+alt+shift+k";
+
+describe.skipIf(!available)("keyboard shortcuts", () => {
+  let path: string;
+  /** The user's real keybindings.json, restored verbatim in afterAll. */
+  let original: string | null = null;
+
+  /** Wait for the app's file watcher to reload keybindings.json. */
+  async function waitForOverride(expected: string | null): Promise<void> {
+    for (let i = 0; i < 50; i++) {
+      const state = await silo.keybindingState(PROBE);
+      if ((state.overrideKey ?? null) === expected) return;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    const state = await silo.keybindingState(PROBE);
+    throw new Error(
+      `keybindings.json never reloaded: expected override ${expected}, ` +
+        `keymap still reports ${state.overrideKey} (${path})`,
+    );
+  }
+
+  /** Replace keybindings.json and wait for the keymap to catch up. */
+  async function setUserBindings(
+    bindings: Array<{ command: string; key: string }>,
+    expected: string | null,
+  ): Promise<void> {
+    await writeFile(path, `${JSON.stringify(bindings, null, 2)}\n`);
+    await waitForOverride(expected);
+  }
+
+  beforeAll(async () => {
+    path = (await silo.keybindingState(PROBE)).keybindingsPath;
+    original = await readFile(path, "utf8").catch(() => null);
+    // The suite rewrites the running identity's real keybindings.json and puts
+    // it back in afterAll. Leave a copy on disk too, so an interrupted run is
+    // recoverable by hand rather than having silently dropped the user's
+    // shortcuts. (This is the dev identity's config root, not production.)
+    if (original !== null) await writeFile(`${path}.it-backup`, original);
+  });
+
+  beforeEach(async () => {
+    await silo.disarmProbeCommand();
+  });
+
+  afterAll(async () => {
+    await silo.disarmProbeCommand();
+    if (original === null) await rm(path, { force: true });
+    else await writeFile(path, original);
+    await waitForOverride(null);
+    await rm(`${path}.it-backup`, { force: true });
+  });
+
+  it("fires a registry default (ctx.registerKeybinding), no user config", async () => {
+    await setUserBindings([], null);
+    await silo.armProbeCommand(SPEC_J);
+
+    const state = await silo.keybindingState(PROBE);
+    expect(state.registryKey).toBe(SPEC_J);
+    expect(state.menuHomed).toBe(false);
+    expect(state.effectiveKey).toBe(SPEC_J);
+
+    await silo.key(KEY_J, CHORD_J);
+    expect((await silo.probeCommandRuns()).runs).toBe(1);
+  });
+
+  it("fires a user override on a command that shipped NO default", async () => {
+    // The regression: the Keyboard Shortcuts page binds ANY command, including
+    // one with no registry default and no menu item — keybindings.json is then
+    // the only record of the chord, and nothing else can dispatch it.
+    await silo.armProbeCommand();
+    await setUserBindings([{ command: PROBE, key: SPEC_J }], SPEC_J);
+
+    const state = await silo.keybindingState(PROBE);
+    expect(state.registryKey).toBeNull();
+    expect(state.defaultKey).toBeNull();
+    expect(state.menuHomed).toBe(false);
+    expect(state.effectiveKey).toBe(SPEC_J);
+
+    await silo.key(KEY_J, CHORD_J);
+    expect((await silo.probeCommandRuns()).runs).toBe(1);
+  });
+
+  it("prefers a user override over the registry default", async () => {
+    await silo.armProbeCommand(SPEC_J);
+    await setUserBindings([{ command: PROBE, key: SPEC_K }], SPEC_K);
+
+    await silo.key(KEY_K, CHORD_J);
+    expect((await silo.probeCommandRuns()).runs).toBe(1);
+
+    // The superseded default must go quiet, not double-bind.
+    await silo.key(KEY_J, CHORD_J);
+    expect((await silo.probeCommandRuns()).runs).toBe(1);
+  });
+
+  it("fires exactly once — never double-dispatches", async () => {
+    await silo.armProbeCommand(SPEC_J);
+    await setUserBindings([{ command: PROBE, key: SPEC_J }], SPEC_J);
+
+    await silo.key(KEY_J, CHORD_J);
+    expect((await silo.probeCommandRuns()).runs).toBe(1);
+  });
+
+  it('honors an unbind entry ("-command")', async () => {
+    await silo.armProbeCommand(SPEC_J);
+    await setUserBindings([{ command: `-${PROBE}`, key: "" }], null);
+
+    expect((await silo.keybindingState(PROBE)).effectiveKey).toBeNull();
+    await silo.key(KEY_J, CHORD_J);
+    expect((await silo.probeCommandRuns()).runs).toBe(0);
+  });
+
+  it("does not fire on a near-miss chord (modifiers must match exactly)", async () => {
+    await silo.armProbeCommand(SPEC_J);
+    await setUserBindings([], null);
+
+    await silo.key(KEY_J, { ...CHORD_J, shiftKey: false });
+    await silo.key(KEY_J, { metaKey: true });
+    expect((await silo.probeCommandRuns()).runs).toBe(0);
+  });
+});

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -258,6 +258,46 @@ curl -s localhost:7878 -H 'X-Silo-Automation: 1' -d '{"op":"openFile","args":{"p
 curl -s localhost:7878 -H 'X-Silo-Automation: 1' -d '{"op":"activatePanel","args":{"panelId":"editor:ed_…"}}'
 ```
 
+### Keybinding ops
+
+The keyboard-shortcut chain has three layers that each fail silently —
+`keybindings.json` on disk → the keymap → `dispatchKey`. These ops let a test
+drive all three (`keybindings.it.test.ts`).
+
+| op                   | args                  | result                                                                                                         |
+| -------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `keybindingState`    | `{ command: string }` | `{ keybindingsPath, registered, registryKey, menuHomed, defaultKey, overrideKey, effectiveKey }`               |
+| `armProbeCommand`    | `{ key?: string }`    | `{ id: "automation.probe", runs: 0, key }` — registers the probe command (and, with `key`, a registry default) |
+| `probeCommandRuns`   | —                     | `{ id, runs }` — how many times the probe has been dispatched since arming                                     |
+| `disarmProbeCommand` | —                     | `{ id, disarmed }` — unregisters it again                                                                      |
+
+Notes:
+
+- `keybindingState` reports a command's key at **every layer**, so a failed
+  dispatch assertion names the layer that broke: `registryKey` is the
+  `ctx.registerKeybinding` default, `overrideKey` is what was read from
+  `keybindings.json`, `effectiveKey` is what should actually fire, and
+  `menuHomed: true` means the command dispatches via its **native menu
+  accelerator** instead of `dispatchKey` (a synthetic key event can't reach it).
+- `keybindingsPath` is the path the _app itself_ resolves, so a test writes
+  overrides exactly where the running identity reads them — no re-deriving the
+  identity → config-root mapping.
+- The **probe command** (`automation.probe`) is a synthetic dispatch target with
+  no UI side effects, so a shortcut test asserts on the chain alone rather than
+  on some real command's visible behavior. Always `disarmProbeCommand` after, or
+  the running app is left carrying an automation entry in its command palette.
+- Synthetic key events match on `KeyboardEvent.code`, like the real dispatcher —
+  `client.key()` derives it from the key name ("g" → `KeyG`), or takes an
+  explicit `code`.
+
+```bash
+# Bind the probe to a chord, press it, count the dispatches
+curl -s localhost:7878 -H 'X-Silo-Automation: 1' -d '{"op":"armProbeCommand","args":{"key":"cmd+ctrl+alt+shift+j"}}'
+curl -s localhost:7878 -H 'X-Silo-Automation: 1' -d '{"op":"keybindingState","args":{"command":"automation.probe"}}'
+# {"ok":true,"result":{"registryKey":"cmd+ctrl+alt+shift+j","effectiveKey":"cmd+ctrl+alt+shift+j",...}}
+curl -s localhost:7878 -H 'X-Silo-Automation: 1' -d '{"op":"probeCommandRuns"}'
+```
+
 ### Output logs
 
 Read and filter entries from the Output panel's log store. Useful for agents and

--- a/packages/extension-host/src/extension-host/keybindings.test.ts
+++ b/packages/extension-host/src/extension-host/keybindings.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { dispatchKey, keybindingRegistry } from "./keybindings";
+import { commandRegistry } from "./commands";
+import { menuItemRegistry } from "./menu-items";
+import { setUserBindings } from "./keymap";
+
+// Registering a menu item / changing user bindings rebuilds the native menu;
+// stub the Tauri menu API so that stays inert under the test environment.
+vi.mock("@tauri-apps/api/menu", () => {
+  const stub = { new: async () => ({ setAsAppMenu: async () => {} }) };
+  return {
+    Menu: stub,
+    MenuItem: stub,
+    PredefinedMenuItem: stub,
+    Submenu: stub,
+  };
+});
+
+/** Minimal stand-in for a keydown event on the capture phase. */
+function keyEvent(init: {
+  code: string;
+  meta?: boolean;
+  ctrl?: boolean;
+  alt?: boolean;
+  shift?: boolean;
+}) {
+  return {
+    code: init.code,
+    metaKey: init.meta ?? false,
+    ctrlKey: init.ctrl ?? false,
+    altKey: init.alt ?? false,
+    shiftKey: init.shift ?? false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as KeyboardEvent;
+}
+
+describe("dispatchKey", () => {
+  let run: ReturnType<typeof vi.fn>;
+  const disposables: Array<{ dispose: () => void }> = [];
+
+  beforeEach(() => {
+    for (const d of disposables.splice(0)) d.dispose();
+    setUserBindings([]);
+    run = vi.fn();
+    disposables.push(
+      commandRegistry.register({ id: "ext.toggle", label: "Toggle", run }),
+    );
+  });
+
+  it("fires a registry binding on its default key", () => {
+    disposables.push(
+      keybindingRegistry.register({
+        id: "ext.toggle.key",
+        command: "ext.toggle",
+        key: "cmd+alt+g",
+      }),
+    );
+    const e = keyEvent({ code: "KeyG", meta: true, alt: true });
+
+    expect(dispatchKey(e)).toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+
+  it("fires a user override on a command that declared no default key", () => {
+    // The Keyboard Shortcuts page can bind ANY command, including one that
+    // never called registerKeybinding and has no menu item — keybindings.json
+    // is then the only record of the chord.
+    setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
+    const e = keyEvent({ code: "KeyG", meta: true, alt: true });
+
+    expect(dispatchKey(e)).toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(e.stopPropagation).toHaveBeenCalled();
+  });
+
+  it("ignores an override whose chord does not match", () => {
+    setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
+
+    expect(dispatchKey(keyEvent({ code: "KeyG", meta: true }))).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("does not double-fire a menu-homed command bound by the user", () => {
+    // Menu-homed commands run via their native accelerator; dispatching here
+    // too would fire them twice.
+    disposables.push(
+      menuItemRegistry.register({
+        id: "ext.toggle.menu",
+        menu: "view",
+        command: "ext.toggle",
+        label: "Toggle",
+      }),
+    );
+    setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
+
+    expect(dispatchKey(keyEvent({ code: "KeyG", meta: true, alt: true }))).toBe(
+      false,
+    );
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("fires an override-only command exactly once", () => {
+    setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
+    dispatchKey(keyEvent({ code: "KeyG", meta: true, alt: true }));
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches a function key (spec is lowercased; the event code is not)", () => {
+    setUserBindings([{ command: "ext.toggle", key: "f9" }]);
+
+    expect(dispatchKey(keyEvent({ code: "F9" }))).toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a command the user also unbound", () => {
+    setUserBindings([
+      { command: "ext.toggle", key: "cmd+alt+g" },
+      { command: "-ext.toggle", key: "" },
+    ]);
+
+    expect(dispatchKey(keyEvent({ code: "KeyG", meta: true, alt: true }))).toBe(
+      false,
+    );
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension-host/src/extension-host/keybindings.ts
+++ b/packages/extension-host/src/extension-host/keybindings.ts
@@ -6,6 +6,7 @@ import {
   clearKeybindingDefaults,
   isKeybindingCaptureActive,
   isRemoved,
+  overrideEntries,
   overrideKey,
   recordKeybindingDefault,
 } from "./keymap";
@@ -75,7 +76,10 @@ function tokenToCode(token: string): string {
     if (/[a-z]/i.test(token)) return `Key${token.toUpperCase()}`;
     if (/[0-9]/.test(token)) return `Digit${token}`;
   }
-  // Already a code-like name ("F1", "Escape", "Enter", "Space").
+  // Function keys: specs are lowercased before this runs ("F5" → "f5"), but the
+  // event's `code` is "F5" — without this they could never match.
+  if (/^f\d{1,2}$/.test(token)) return token.toUpperCase();
+  // Already a code-like name ("Escape", "Enter", "Space").
   return token;
 }
 
@@ -129,7 +133,8 @@ function matches(p: ParsedKey, e: KeyboardEvent): boolean {
  */
 export function dispatchKey(e: KeyboardEvent): boolean {
   if (isKeybindingCaptureActive()) return false;
-  for (const binding of keybindingRegistry.list()) {
+  const bindings = keybindingRegistry.list();
+  for (const binding of bindings) {
     // Menu-homed commands dispatch via their native menu accelerator (which the
     // menu builder sources from the keymap); skip them here to avoid double-fire.
     if (commandHasMenuItem(binding.command)) continue;
@@ -143,6 +148,29 @@ export function dispatchKey(e: KeyboardEvent): boolean {
     e.preventDefault();
     e.stopPropagation();
     executeCommand(binding.command);
+    return true;
+  }
+  return dispatchOverrideOnly(e, bindings);
+}
+
+/**
+ * Dispatch a user override on a command that declared **no** default key.
+ * The Keyboard Shortcuts page lets any command be bound, so such a command has
+ * no registry entry to iterate above and (with no menu item) no native
+ * accelerator either — keybindings.json is the only record of the chord.
+ */
+function dispatchOverrideOnly(
+  e: KeyboardEvent,
+  bindings: readonly Keybinding[],
+): boolean {
+  for (const [command, key] of overrideEntries()) {
+    if (bindings.some((b) => b.command === command)) continue;
+    if (commandHasMenuItem(command)) continue;
+    if (isRemoved(command)) continue;
+    if (!matches(parseKey(key), e)) continue;
+    e.preventDefault();
+    e.stopPropagation();
+    executeCommand(command);
     return true;
   }
   return false;

--- a/packages/extension-host/src/extension-host/keymap.ts
+++ b/packages/extension-host/src/extension-host/keymap.ts
@@ -205,6 +205,15 @@ export function overrideKey(command: string): string | undefined {
   return overrides.get(command);
 }
 
+/**
+ * Every user override, as `[command, normalized key]`. A command the user
+ * bound by hand may have no extension-declared default at all, in which case
+ * this map is the *only* record of that chord — see `dispatchKey`.
+ */
+export function overrideEntries(): Array<[string, string]> {
+  return [...overrides.entries()];
+}
+
 /** Extension/menu-declared default, ignoring user overrides and unbinds. */
 export function defaultKey(command: string): string | undefined {
   return menuDefaults.get(command) ?? keybindingDefaults.get(command);


### PR DESCRIPTION
## Summary

Keyboard shortcuts you assign yourself now actually work.

Assigning a shortcut in Settings → Keyboard Shortcuts saved it and showed it on the row, but pressing the keys did nothing unless that command already shipped with a built-in shortcut. Most extension commands don't, so for those the feature looked like it worked and silently didn't. Found via a third-party extension command bound to Cmd+Opt+G.

Two smaller things came along with it:

1. Function-key shortcuts (F1–F12) could never fire at all, whether built in or user-assigned.
2. A new automated test drives the real running app end to end — assign a key, press it, check the command ran — so this can't quietly break again. It runs in the nightly integration job, not on every PR.

No user action needed beyond updating; existing shortcuts keep working exactly as before.

## Details

### The bug

`dispatchKey` (`packages/extension-host/src/extension-host/keybindings.ts`) iterated **only** `keybindingRegistry` — commands that declared a default via `ctx.registerKeybinding`. The Keyboard Shortcuts page, however, lists every command in `commandRegistry` and lets any of them be bound. So for a command with no registry default **and** no menu item, the override was written to `keybindings.json`, resolved correctly by the keymap, rendered on the row — and had nothing to dispatch it. Nothing logged, nothing errored.

Menu-homed commands were unaffected: the menu builder sources accelerators from the keymap's `effectiveKey`, so their overrides fired via the native accelerator. That's why the failure looked extension-specific — `silo.*` / third-party extension commands are exactly the ones that are neither menu-homed nor keybinding-registered. Repro from the report: `silo.follow-ups.toggle` (registers three commands, no `registerKeybinding`, no menu item) bound to `cmd+alt+g`.

### The fix

- `keymap.ts` — new `overrideEntries()` exposing the user-override map (`command → normalized key`).
- `keybindings.ts` — `dispatchOverrideOnly()` runs after the registry loop: matches user overrides for commands with no registry binding, skipping menu-homed ones (they fire via their accelerator) and unbound ones (`-command`). The registry loop is unchanged, so nothing double-fires.

### Function keys

Separate latent bug in the same file, found while picking chords for the integration test. `parseKey` lowercases the whole spec (`"F9"` → `"f9"`), but `KeyboardEvent.code` is `"F9"` and `matches()` compares `code` exactly — so `tokenToCode` returned `"f9"` and no F-key binding could ever match. It now uppercases them back, mirroring what `toTauriAccelerator` already did. Note `keybindings-model.ts`'s `codeToToken` stores captured F-keys lowercase, so user-assigned F-keys were hitting this too.

### Tests

**Unit** — `keybindings.test.ts` (new, 7 cases): registry dispatch, override-only dispatch, non-matching chord, the menu-homed no-double-fire rule, single-fire, function keys, `-command` unbind.

**Integration** — `keybindings.it.test.ts` (new, 6 cases) drives the live app over the automation RPC across the full chain: `keybindings.json` → file watcher → keymap → `dispatchKey` → command. Covers registry default fires; override-only fires (this regression); override beats default without double-binding; fires exactly once; unbind honored; near-miss modifiers don't fire.

It aims at a synthetic `automation.probe` command rather than a real one, so it has no UI side effects and can't be broken by unrelated extension changes. Supporting automation ops (documented in `docs/automation.md`):

| op | purpose |
| --- | --- |
| `keybindingState` | a command's key at every layer (`registryKey` / `overrideKey` / `effectiveKey` / `menuHomed` / `keybindingsPath`) — a failed assertion names the layer that broke |
| `armProbeCommand` / `probeCommandRuns` / `disarmProbeCommand` | register a side-effect-free dispatch target and count invocations |

`client.key()` now sends `KeyboardEvent.code` (derived from the key name, or explicit) — without it a synthetic event could never match a real binding, since the dispatcher matches on `code`.

**Caveat:** the integration suite temporarily rewrites the running identity's `keybindings.json` and restores it in `afterAll`, leaving a `.it-backup` copy for an interrupted run. That's the only honest way to exercise the disk → watcher → keymap path. Fine for the nightly runner; worth knowing before Ctrl-C'ing it locally.

### Verification

- `pnpm test` — 1227 unit tests green.
- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint` — clean.
- `pnpm --filter silo test:it src/automation/keybindings.it.test.ts` — 6/6 against a live dev app.
- **Regression proof:** reverted `dispatchOverrideOnly` and re-ran the integration suite — `× fires a user override on a command that shipped NO default / expected +0 to be 1`. Restored, back to 6/6. `keybindings.json` came back byte-identical.

Not run: the rest of the integration suite (creates/deletes sandbox workspaces in the live app) — that's the nightly job's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
