### PR TITLE
docs(sdk): document what a command's run() receives per invocation surface

### DIFF
--- a/apps/docs/api/registration/register-command.md
+++ b/apps/docs/api/registration/register-command.md
@@ -16,6 +16,44 @@ ctx.registerCommand({
 });
 ```
 
+## What `run` receives
+
+The host passes a target **only** for invocations that have one. Everything else
+calls `run()` with no arguments:
+
+| Invoked from                | `args[0]`                                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------------------------- |
+| a toolbar item              | [`ToolbarItemContext`](/api/types/interfaces/ToolbarItemContext)`[S]` — the tab the button sits on |
+| a tab context menu          | [`MenuContext`](/api/types/interfaces/MenuContext)`[S]` — the tab that was right-clicked           |
+| `ctx.executeCommand(id, …)` | whatever the caller passed                                                                         |
+| a keybinding or menu item   | **nothing**                                                                                        |
+
+A command that reads its target only from `args` therefore **cannot be bound to
+a key** — it runs and silently does nothing, which looks exactly like the
+shortcut never firing. Users can bind any command from Settings → Keyboard
+Shortcuts, so this applies even to commands you never registered a keybinding
+for.
+
+If one command backs both a surface and a shortcut, fall back to the active tab:
+
+```tsx
+ctx.registerCommand({
+  id: "acme.flagTab",
+  label: "Acme: Flag Tab",
+  run: (...args) => {
+    const target = args[0] as { editorId?: string } | undefined;
+    const editorId =
+      target?.editorId ?? ctx.editors.getState().active?.editorId ?? null;
+    if (!editorId) return; // nothing focused
+    flag(editorId);
+  },
+});
+```
+
+Use [`ctx.terminals.getActive()`](/api/types/interfaces/TerminalService#getactive) for the terminal side — at
+most one of the two is set, since both report the single active center-dock
+panel.
+
 ## Types
 
 Pass [`Command`](/api/types/interfaces/Command).

--- a/apps/docs/api/registration/register-keybinding.md
+++ b/apps/docs/api/registration/register-keybinding.md
@@ -16,6 +16,16 @@ ctx.registerKeybinding({
 });
 ```
 
+## The command runs with no arguments
+
+A keybinding invokes its command with **no arguments** — unlike a toolbar item
+or a tab context menu, which pass the tab they belong to. A command that reads
+its target only from its arguments will run and silently do nothing when bound
+to a key; see [what `run` receives](/api/registration/register-command#what-run-receives).
+
+This applies to commands you never bind here too: users can assign a shortcut
+to any command from Settings → Keyboard Shortcuts.
+
 ## Types
 
 Pass [`Keybinding`](/api/types/interfaces/Keybinding).

--- a/apps/docs/api/types/interfaces/Command.md
+++ b/apps/docs/api/types/interfaces/Command.md
@@ -38,11 +38,26 @@ Human-readable label (shown where the command surfaces in UI).
 run: (...args) => unknown;
 ```
 
-Defined in: [packages/sdk/src/types.ts:261](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L261)
+Defined in: [packages/sdk/src/types.ts:276](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L276)
 
-The action. May accept arguments passed through from
-[ExtensionContext.executeCommand](ExtensionContext.md#executecommand) and may return a value (sync or
-async); `executeCommand` resolves with whatever this returns.
+The action. May return a value (sync or async); `executeCommand` resolves
+with whatever this returns.
+
+**What `args` holds depends on how the command was invoked** — the host
+does not synthesize a target for invocations that carry none:
+
+| Invoked from                                            | `args[0]`                          |
+| ------------------------------------------------------- | ---------------------------------- |
+| [ExtensionContext.registerToolbarItem](ExtensionContext.md#registertoolbaritem)             | [ToolbarItemContext](ToolbarItemContext.md)`[S]`    |
+| [ExtensionContext.registerContextMenuItem](ExtensionContext.md#registercontextmenuitem)         | [MenuContext](MenuContext.md)`[S]`           |
+| [ExtensionContext.executeCommand](ExtensionContext.md#executecommand)                  | whatever the caller passed         |
+| a keybinding, a menu item, the command palette            | **nothing**                        |
+
+So a command that reads its target only from `args` **cannot be bound to
+a key**: it will run and silently do nothing. If the same command backs
+both a surface and a shortcut, fall back to the active tab
+([EditorService.getState](EditorService.md#getstate)`().active`,
+[TerminalService.getActive](TerminalService.md#getactive)) when no context arrives.
 
 Zero-argument, void-returning commands are still valid — `() => void`
 satisfies this type, so existing registrations compile unchanged.

--- a/apps/docs/api/types/interfaces/ContextMenuContribution.md
+++ b/apps/docs/api/types/interfaces/ContextMenuContribution.md
@@ -1,6 +1,6 @@
 # Interface: ContextMenuContribution\<S\>
 
-Defined in: [packages/sdk/src/types.ts:375](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L375)
+Defined in: [packages/sdk/src/types.ts:390](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L390)
 
 Adds a command to the right-click context menu of a built-in surface.
 Register via [ExtensionContext.registerContextMenuItem](ExtensionContext.md#registercontextmenuitem).
@@ -24,7 +24,7 @@ and dispatches the chosen command with the target as its first argument.
 surface: S;
 ```
 
-Defined in: [packages/sdk/src/types.ts:377](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L377)
+Defined in: [packages/sdk/src/types.ts:392](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L392)
 
 Which context menu to contribute to.
 
@@ -36,7 +36,7 @@ Which context menu to contribute to.
 command: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:379](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L379)
+Defined in: [packages/sdk/src/types.ts:394](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L394)
 
 The command to run; receives the surface's [MenuContext\[S\]](MenuContext.md) as its first arg.
 
@@ -48,7 +48,7 @@ The command to run; receives the surface's [MenuContext\[S\]](MenuContext.md) as
 optional label?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:381](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L381)
+Defined in: [packages/sdk/src/types.ts:396](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L396)
 
 Menu label (falls back to the command's label).
 
@@ -60,7 +60,7 @@ Menu label (falls back to the command's label).
 optional icon?: ReactNode;
 ```
 
-Defined in: [packages/sdk/src/types.ts:383](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L383)
+Defined in: [packages/sdk/src/types.ts:398](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L398)
 
 Leading glyph for the row (e.g. a Phosphor icon element), same as [MenuItem.icon](MenuItem.md#icon).
 
@@ -72,7 +72,7 @@ Leading glyph for the row (e.g. a Phosphor icon element), same as [MenuItem.icon
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:385](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L385)
+Defined in: [packages/sdk/src/types.ts:400](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L400)
 
 Ordering within the menu; lower sorts first.
 
@@ -84,7 +84,7 @@ Ordering within the menu; lower sorts first.
 optional group?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:391](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L391)
+Defined in: [packages/sdk/src/types.ts:406](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L406)
 
 Optional group id — items with the same group render together with a
 separator between groups. Group names sort lexically; defaults to
@@ -98,7 +98,7 @@ separator between groups. Group names sort lexically; defaults to
 optional when?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:396](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L396)
+Defined in: [packages/sdk/src/types.ts:411](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L411)
 
 Enable/visibility predicate. Receives the same per-surface context as the
 command plus the current context keys. Returning false hides the item.
@@ -125,7 +125,7 @@ command plus the current context keys. Returning false hides the item.
 optional checked?: (ctx, target) => boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:404](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L404)
+Defined in: [packages/sdk/src/types.ts:419](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L419)
 
 Toggle-row predicate. When provided, the item renders with a checkmark
 in the leading gutter whenever this returns true — the same rendering

--- a/apps/docs/api/types/interfaces/DockPanelKind.md
+++ b/apps/docs/api/types/interfaces/DockPanelKind.md
@@ -1,6 +1,6 @@
 # Interface: DockPanelKind\<T\>
 
-Defined in: [packages/sdk/src/types.ts:555](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L555)
+Defined in: [packages/sdk/src/types.ts:577](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L577)
 
 Registers a kind of dock panel (a tab that can live in the center dock area,
 e.g. the terminal). Workspaces open panels of registered kinds by id. The
@@ -22,7 +22,7 @@ opened with — annotate your component with `DockPanelProps<T>` and
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:557](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L557)
+Defined in: [packages/sdk/src/types.ts:579](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L579)
 
 Unique id for this panel kind.
 
@@ -34,7 +34,7 @@ Unique id for this panel kind.
 component: ComponentType<DockPanelProps<T>>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:559](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L559)
+Defined in: [packages/sdk/src/types.ts:581](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L581)
 
 The React component that renders this panel; receives [DockPanelProps](DockPanelProps.md).
 
@@ -46,7 +46,7 @@ The React component that renders this panel; receives [DockPanelProps](DockPanel
 optional addMenuItem?: object;
 ```
 
-Defined in: [packages/sdk/src/types.ts:564](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L564)
+Defined in: [packages/sdk/src/types.ts:586](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L586)
 
 When set, this kind appears as an entry in the center dock's **+** add
 menu (the per-group header button). Omit to keep the kind internal.

--- a/apps/docs/api/types/interfaces/Extension.md
+++ b/apps/docs/api/types/interfaces/Extension.md
@@ -1,6 +1,6 @@
 # Interface: Extension\<API\>
 
-Defined in: [packages/sdk/src/types.ts:956](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L956)
+Defined in: [packages/sdk/src/types.ts:978](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L978)
 
 The shape of a Silo extension: a stable id plus an
 [activate](#activate) function the host calls once, passing
@@ -25,7 +25,7 @@ extensions that publish nothing.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:962](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L962)
+Defined in: [packages/sdk/src/types.ts:984](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L984)
 
 Unique extension id, conventionally namespaced: `core.*` for Silo's core
 feature set, `silo.*` for its optional bundled features, `<vendor>.*` for
@@ -39,7 +39,7 @@ third parties (e.g. `"core.editor"`, `"silo.git"`, `"acme.foo"`).
 optional manifest?: ExtensionManifest;
 ```
 
-Defined in: [packages/sdk/src/types.ts:969](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L969)
+Defined in: [packages/sdk/src/types.ts:991](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L991)
 
 Optional display metadata for the **Extensions** settings page. Built-in
 extensions declare it here so they can be listed (and disabled) with a name
@@ -54,7 +54,7 @@ package manifest instead. See [ExtensionManifest](ExtensionManifest.md).
 activate(ctx): void | API;
 ```
 
-Defined in: [packages/sdk/src/types.ts:976](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L976)
+Defined in: [packages/sdk/src/types.ts:998](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L998)
 
 Called once by the host; register contributions against `ctx` here.
 **Optionally return an API object** to publish it for other extensions to
@@ -79,7 +79,7 @@ extension publishes no API.
 optional deactivate(): void;
 ```
 
-Defined in: [packages/sdk/src/types.ts:978](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L978)
+Defined in: [packages/sdk/src/types.ts:1000](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L1000)
 
 Optional cleanup hook (reserved for dynamic load/unload).
 

--- a/apps/docs/api/types/interfaces/ExtensionContext.md
+++ b/apps/docs/api/types/interfaces/ExtensionContext.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionContext
 
-Defined in: [packages/sdk/src/types.ts:663](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L663)
+Defined in: [packages/sdk/src/types.ts:685](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L685)
 
 The object handed to [Extension.activate](Extension.md#activate). It is the *only* sanctioned
 way an extension touches the running app: register contributions, invoke
@@ -16,7 +16,7 @@ commands, and read/drive state through the typed consumer services. Every
 readonly extensionId: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:665](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L665)
+Defined in: [packages/sdk/src/types.ts:687](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L687)
 
 The activating extension's id (its [Extension.id](Extension.md#id)).
 
@@ -28,7 +28,7 @@ The activating extension's id (its [Extension.id](Extension.md#id)).
 readonly subscriptions: Disposable[];
 ```
 
-Defined in: [packages/sdk/src/types.ts:667](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L667)
+Defined in: [packages/sdk/src/types.ts:689](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L689)
 
 Disposables tracked for this extension; the host disposes them on teardown.
 
@@ -40,7 +40,7 @@ Disposables tracked for this extension; the host disposes them on teardown.
 readonly storage: ExtensionStorageScopes;
 ```
 
-Defined in: [packages/sdk/src/types.ts:683](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L683)
+Defined in: [packages/sdk/src/types.ts:705](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L705)
 
 Persisted, per-extension key/value storage, in two scopes
 ([ExtensionStorageScopes](ExtensionStorageScopes.md)): `global` (shared across all workspaces —
@@ -64,7 +64,7 @@ scope keyed by panel id, for panel-local UI state.)
 readonly workspaces: WorkspaceService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:765](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L765)
+Defined in: [packages/sdk/src/types.ts:787](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L787)
 
 Consumer API for driving workspace state — create, rename, reorder,
 activate, soft close/reopen, and hard delete. Subscribe to a frozen
@@ -78,7 +78,7 @@ state for read access without depending on Valtio.
 readonly editors: EditorService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:771](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L771)
+Defined in: [packages/sdk/src/types.ts:793](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L793)
 
 The editor & document domain — open files into editor tabs, drive the
 active editor (save / close), and register editor save handlers. Opening
@@ -92,7 +92,7 @@ editors lives here, not on [ExtensionContext.workspaces](#workspaces).
 readonly layout: LayoutService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:777](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L777)
+Defined in: [packages/sdk/src/types.ts:799](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L799)
 
 Consumer API for app layout — side-panel collapse state. Read via
 getState/useServiceState/subscribe; drive via toggleSidePanel /
@@ -106,7 +106,7 @@ setSidePanelCollapsed.
 readonly process: ProcessService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:783](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L783)
+Defined in: [packages/sdk/src/types.ts:805](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L805)
 
 Persistent process / PTY sessions that **survive app restarts** — the core
 primitive under the terminal (and future task runners, REPLs). Spawn or
@@ -120,7 +120,7 @@ re-attach a session and drive it via the returned `ProcessSession`.
 readonly processes: ProcessesService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:791](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L791)
+Defined in: [packages/sdk/src/types.ts:813](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L813)
 
 Workspace process observability — a live view of what is running in each
 terminal, with optional CPU/memory stats and a surgical kill that leaves the
@@ -136,7 +136,7 @@ See [ProcessesService](ProcessesService.md) for the full API.
 readonly agents: AgentsService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:801](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L801)
+Defined in: [packages/sdk/src/types.ts:823](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L823)
 
 Host-computed coding-agent activity and resume-identity observability —
 a live, read-only view of what each terminal's agent is doing
@@ -154,7 +154,7 @@ registration API. **@beta** — the shape may still change. See
 readonly terminals: TerminalService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:809](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L809)
+Defined in: [packages/sdk/src/types.ts:831](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L831)
 
 Consumer API for the terminal domain — open a terminal tab in a workspace
 (`create`) or reap a workspace's terminals (`closeWorkspace`). The terminal
@@ -170,7 +170,7 @@ from the workspace's records, and PTY sessions live on
 readonly files: FileService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:815](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L815)
+Defined in: [packages/sdk/src/types.ts:837](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L837)
 
 Host-mediated filesystem access — read / write / list / watch, all routed
 through the host rather than raw Tauri. The single privileged chokepoint
@@ -184,7 +184,7 @@ for the filesystem; watcher lifecycle is host-owned (see [FileService](FileServi
 readonly search: SearchService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:822](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L822)
+Defined in: [packages/sdk/src/types.ts:844](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L844)
 
 Cross-file content search over the workspace — the core primitive under the
 Search panel (and future quick-open / find-references). Runs a native search
@@ -199,7 +199,7 @@ with matches grouped by file. See [SearchService](SearchService.md).
 readonly theme: ThemeService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:829](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L829)
+Defined in: [packages/sdk/src/types.ts:851](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L851)
 
 Consumer API for the theme domain — read the merged preset set + active
 theme, switch themes, and manage custom themes. Read via getState /
@@ -214,7 +214,7 @@ subscribe; contribute a new preset via
 readonly dnd: DndService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:836](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L836)
+Defined in: [packages/sdk/src/types.ts:858](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L858)
 
 Drag-and-drop — be a drag source ([DndService.beginDrag](DndService.md#begindrag)) and a drop
 target ([DndService.registerDropTarget](DndService.md#registerdroptarget)), with typed payloads
@@ -229,7 +229,7 @@ drag affordance and the modifier-mode resolution.
 readonly ui: UiService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:843](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L843)
+Defined in: [packages/sdk/src/types.ts:865](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L865)
 
 User-interaction — the only sanctioned way to talk to the user (the host
 renders the chrome). Native file/folder pickers ([UiService.pickFolder](UiService.md#pickfolder),
@@ -244,7 +244,7 @@ notifications ([UiService.notify](UiService.md#notify)). Mirrors VS Code's `wind
 readonly net: NetworkService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:851](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L851)
+Defined in: [packages/sdk/src/types.ts:873](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L873)
 
 Server-side HTTP client — makes requests from the Rust backend, bypassing
 the browser's CORS policy. Use when browser `fetch` is insufficient:
@@ -260,7 +260,7 @@ loading a URL. See [NetworkService](NetworkService.md) for the full API.
 readonly webview: WebviewService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:858](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L858)
+Defined in: [packages/sdk/src/types.ts:880](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L880)
 
 Real DOM access, navigation control, and native pixel capture inside an
 `<iframe>` you own — including cross-origin content the browser's
@@ -275,7 +275,7 @@ same-origin policy would otherwise fully sandbox. Requires the
 readonly system: SystemService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:866](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L866)
+Defined in: [packages/sdk/src/types.ts:888](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L888)
 
 Static host-platform metadata — the OS, CPU architecture, and running Silo
 version. Values are baked into the binary at build time and never change
@@ -291,7 +291,7 @@ See [SystemService](SystemService.md) for the full API.
 readonly log: LogService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:879](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L879)
+Defined in: [packages/sdk/src/types.ts:901](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L901)
 
 Write-only structured logger scoped to this extension. Entries appear in
 the **Output** panel under the extension's display name. A channel is
@@ -312,7 +312,7 @@ ctx.log.show(); // open the Output panel, select this extension's channel
 registerEditor(editor): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:685](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L685)
+Defined in: [packages/sdk/src/types.ts:707](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L707)
 
 Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 
@@ -334,7 +334,7 @@ Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 registerFileType(type): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:687](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L687)
+Defined in: [packages/sdk/src/types.ts:709](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L709)
 
 Register a [FileType](FileType.md) (declarative file metadata).
 
@@ -356,7 +356,7 @@ Register a [FileType](FileType.md) (declarative file metadata).
 registerCommand(cmd): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:689](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L689)
+Defined in: [packages/sdk/src/types.ts:711](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L711)
 
 Register a [Command](Command.md) (a named, invokable action).
 
@@ -378,7 +378,7 @@ Register a [Command](Command.md) (a named, invokable action).
 registerMenuItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:691](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L691)
+Defined in: [packages/sdk/src/types.ts:713](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L713)
 
 Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a menu).
 
@@ -400,7 +400,7 @@ Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a
 registerContextMenuItem<S>(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:697](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L697)
+Defined in: [packages/sdk/src/types.ts:719](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L719)
 
 Register a [ContextMenuContribution](ContextMenuContribution.md) (add a command to a built-in
 surface's right-click context menu). The invoked command receives the
@@ -430,7 +430,7 @@ surface's [MenuContext](MenuContext.md) target as its first argument.
 registerToolbarItem<S>(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:708](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L708)
+Defined in: [packages/sdk/src/types.ts:730](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L730)
 
 Register a [ToolbarItemContribution](../type-aliases/ToolbarItemContribution.md) (icon-only, text-only,
 icon+text, or dropdown) in the trailing cluster of an editor or terminal
@@ -463,7 +463,7 @@ surface's breadcrumbs setting is on. See
 invalidateToolbarItems(): void;
 ```
 
-Defined in: [packages/sdk/src/types.ts:716](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L716)
+Defined in: [packages/sdk/src/types.ts:738](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L738)
 
 Signal that toolbar-item `when` / `checked` data changed. Causes every
 toolbar surface — editor, terminal, and the Navigator header — to re-query
@@ -481,7 +481,7 @@ contributions and re-render.
 registerKeybinding(binding): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:718](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L718)
+Defined in: [packages/sdk/src/types.ts:740](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L740)
 
 Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 
@@ -503,7 +503,7 @@ Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 registerSidePanel(panel): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:720](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L720)
+Defined in: [packages/sdk/src/types.ts:742](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L742)
 
 Register a [SidePanel](SidePanel.md) (a left/right column panel).
 
@@ -525,7 +525,7 @@ Register a [SidePanel](SidePanel.md) (a left/right column panel).
 registerNavigatorView(view): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:726](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L726)
+Defined in: [packages/sdk/src/types.ts:748](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L748)
 
 Register a [NavigatorView](NavigatorView.md) — a projection the user can switch the
 Navigator panel to. Prefer this over a second side panel when your surface
@@ -549,7 +549,7 @@ is another way to navigate the app.
 registerDockPanelKind<T>(kind): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:732](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L732)
+Defined in: [packages/sdk/src/types.ts:754](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L754)
 
 Register a [DockPanelKind](DockPanelKind.md) (a center-dock tab kind). The params
 generic `T` is inferred from the component's [DockPanelProps](DockPanelProps.md)
@@ -579,7 +579,7 @@ annotation, so kinds with typed params register without casts.
 registerStatusItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:736](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L736)
+Defined in: [packages/sdk/src/types.ts:758](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L758)
 
 Register a [StatusItem](StatusItem.md) (a status-bar widget).
 
@@ -601,7 +601,7 @@ Register a [StatusItem](StatusItem.md) (a status-bar widget).
 registerSettingsPage(page): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:738](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L738)
+Defined in: [packages/sdk/src/types.ts:760](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L760)
 
 Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 
@@ -623,7 +623,7 @@ Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 registerThemePreset(preset): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:744](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L744)
+Defined in: [packages/sdk/src/types.ts:766](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L766)
 
 Register a [ThemePreset](ThemePreset.md) (a selectable theme in the picker).
 
@@ -650,7 +650,7 @@ Use [ctx.theme.registerPreset()](ThemeService.md#registerpreset) instead.
 executeCommand<T>(id, ...args): Promise<T>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:759](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L759)
+Defined in: [packages/sdk/src/types.ts:781](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L781)
 
 Invoke a registered command by id — including commands contributed by
 other extensions. The minimal "operate" primitive; pairs with the typed
@@ -693,7 +693,7 @@ Expected return type of the command (defaults to `unknown`).
 getExtension<API>(id): ExtensionHandle<API> | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:893](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L893)
+Defined in: [packages/sdk/src/types.ts:915](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L915)
 
 Resolve a handle to another extension in order to consume the API it
 published (the value its [Extension.activate](Extension.md#activate) returned). This is how

--- a/apps/docs/api/types/interfaces/ExtensionHandle.md
+++ b/apps/docs/api/types/interfaces/ExtensionHandle.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionHandle\<API\>
 
-Defined in: [packages/sdk/src/types.ts:904](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L904)
+Defined in: [packages/sdk/src/types.ts:926](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L926)
 
 A handle to another extension, obtained via
 [ExtensionContext.getExtension](ExtensionContext.md#getextension). Lets one extension consume another's
@@ -20,7 +20,7 @@ published API while tolerating its absence.
 readonly id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:906](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L906)
+Defined in: [packages/sdk/src/types.ts:928](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L928)
 
 The resolved extension's id.
 
@@ -32,7 +32,7 @@ The resolved extension's id.
 readonly active: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:908](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L908)
+Defined in: [packages/sdk/src/types.ts:930](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L930)
 
 True once that extension has activated.
 
@@ -44,7 +44,7 @@ True once that extension has activated.
 readonly api: API | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:911](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L911)
+Defined in: [packages/sdk/src/types.ts:933](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L933)
 
 Its published API (what its `activate` returned), or `undefined` if it
 hasn't activated or published nothing.

--- a/apps/docs/api/types/interfaces/ExtensionManifest.md
+++ b/apps/docs/api/types/interfaces/ExtensionManifest.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionManifest
 
-Defined in: [packages/sdk/src/types.ts:927](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L927)
+Defined in: [packages/sdk/src/types.ts:949](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L949)
 
 Display metadata for an extension, surfaced in the **Extensions** settings
 page (name, one-line description, version, and [\* \| publisher](#publisher) brand). For built-in extensions this is declared in-code on the
@@ -18,7 +18,7 @@ namespace for the publisher) when one is absent.
 readonly optional name?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:929](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L929)
+Defined in: [packages/sdk/src/types.ts:951](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L951)
 
 Human-friendly name shown in the Extensions list (falls back to the id).
 
@@ -30,7 +30,7 @@ Human-friendly name shown in the Extensions list (falls back to the id).
 readonly optional description?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:931](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L931)
+Defined in: [packages/sdk/src/types.ts:953](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L953)
 
 One-line description shown beneath the name.
 
@@ -42,7 +42,7 @@ One-line description shown beneath the name.
 readonly optional version?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:933](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L933)
+Defined in: [packages/sdk/src/types.ts:955](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L955)
 
 Version string shown next to the name.
 
@@ -54,7 +54,7 @@ Version string shown next to the name.
 readonly optional publisher?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:940](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L940)
+Defined in: [packages/sdk/src/types.ts:962](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L962)
 
 The publisher/brand shown beside the name (e.g. `"Silo"`). Built-in
 extensions are always branded `"Silo"` by the host regardless of this field;

--- a/apps/docs/api/types/interfaces/Keybinding.md
+++ b/apps/docs/api/types/interfaces/Keybinding.md
@@ -1,8 +1,15 @@
 # Interface: Keybinding
 
-Defined in: [packages/sdk/src/types.ts:413](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L413)
+Defined in: [packages/sdk/src/types.ts:435](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L435)
 
 Binds a keyboard shortcut to a [Command](Command.md).
+
+The command is invoked with **no arguments** — see [Command.run](Command.md#run) for
+what that means for a command shared with a toolbar or context-menu surface.
+
+Users can also bind any command themselves from Settings → Keyboard
+Shortcuts, whether or not the extension registered a default here, so this
+applies to every command an extension exposes.
 
 ## Properties
 
@@ -12,7 +19,7 @@ Binds a keyboard shortcut to a [Command](Command.md).
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:415](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L415)
+Defined in: [packages/sdk/src/types.ts:437](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L437)
 
 Unique id for this binding.
 
@@ -24,7 +31,7 @@ Unique id for this binding.
 key: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:421](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L421)
+Defined in: [packages/sdk/src/types.ts:443](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L443)
 
 Shortcut spec like "cmd+s", "ctrl+shift+s", "cmd+1", "cmd+shift+=".
 Parsed against KeyboardEvent.code for layout-stable letter/digit keys
@@ -38,7 +45,7 @@ plus a small alias table for symbol keys (= → Equal, - → Minus, etc.).
 command: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:423](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L423)
+Defined in: [packages/sdk/src/types.ts:445](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L445)
 
 Id of the [Command](Command.md) to invoke.
 
@@ -50,7 +57,7 @@ Id of the [Command](Command.md) to invoke.
 optional when?: (ctx) => boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:425](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L425)
+Defined in: [packages/sdk/src/types.ts:447](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L447)
 
 Optional predicate against context keys; the binding is inert when false.
 

--- a/apps/docs/api/types/interfaces/MenuContext.md
+++ b/apps/docs/api/types/interfaces/MenuContext.md
@@ -1,6 +1,6 @@
 # Interface: MenuContext
 
-Defined in: [packages/sdk/src/types.ts:348](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L348)
+Defined in: [packages/sdk/src/types.ts:363](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L363)
 
 The typed **context object** each [MenuSurface](../type-aliases/MenuSurface.md) passes to an invoked
 command (as its first argument) and to the contribution's
@@ -21,7 +21,7 @@ the workspace's metadata (id, folder, name) wholesale.
 explorer/item: object;
 ```
 
-Defined in: [packages/sdk/src/types.ts:349](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L349)
+Defined in: [packages/sdk/src/types.ts:364](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L364)
 
 #### path
 
@@ -49,7 +49,7 @@ workspaceId: string;
 editor/tab: object;
 ```
 
-Defined in: [packages/sdk/src/types.ts:350](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L350)
+Defined in: [packages/sdk/src/types.ts:365](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L365)
 
 #### editorId
 
@@ -77,7 +77,7 @@ viewId: string;
 terminal/tab: object;
 ```
 
-Defined in: [packages/sdk/src/types.ts:351](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L351)
+Defined in: [packages/sdk/src/types.ts:366](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L366)
 
 #### terminalId
 
@@ -99,7 +99,7 @@ workspaceId: string;
 terminal/link: object;
 ```
 
-Defined in: [packages/sdk/src/types.ts:359](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L359)
+Defined in: [packages/sdk/src/types.ts:374](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L374)
 
 The right-clicked link's kind (`"url"` for OSC-8/`WebLinksAddon`-detected
 links, `"path"` for Silo's own file-path provider) and its literal text
@@ -133,4 +133,4 @@ text: string;
 workspace: Workspace;
 ```
 
-Defined in: [packages/sdk/src/types.ts:360](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L360)
+Defined in: [packages/sdk/src/types.ts:375](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L375)

--- a/apps/docs/api/types/interfaces/MenuItemContribution.md
+++ b/apps/docs/api/types/interfaces/MenuItemContribution.md
@@ -1,6 +1,6 @@
 # Interface: MenuItemContribution
 
-Defined in: [packages/sdk/src/types.ts:280](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L280)
+Defined in: [packages/sdk/src/types.ts:295](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L295)
 
 Places a command into one of the application menus.
 
@@ -12,7 +12,7 @@ Places a command into one of the application menus.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:282](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L282)
+Defined in: [packages/sdk/src/types.ts:297](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L297)
 
 Unique id for this menu entry.
 
@@ -24,7 +24,7 @@ Unique id for this menu entry.
 menu: MenuId;
 ```
 
-Defined in: [packages/sdk/src/types.ts:284](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L284)
+Defined in: [packages/sdk/src/types.ts:299](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L299)
 
 Which application menu to place the item in.
 
@@ -36,7 +36,7 @@ Which application menu to place the item in.
 command: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:286](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L286)
+Defined in: [packages/sdk/src/types.ts:301](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L301)
 
 Id of the [Command](Command.md) this item invokes.
 
@@ -48,7 +48,7 @@ Id of the [Command](Command.md) this item invokes.
 optional label?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:288](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L288)
+Defined in: [packages/sdk/src/types.ts:303](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L303)
 
 Override label; defaults to the command's label.
 
@@ -60,7 +60,7 @@ Override label; defaults to the command's label.
 optional accelerator?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:290](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L290)
+Defined in: [packages/sdk/src/types.ts:305](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L305)
 
 Accelerator shown next to the item (display only; bind via [Keybinding](Keybinding.md)).
 
@@ -72,7 +72,7 @@ Accelerator shown next to the item (display only; bind via [Keybinding](Keybindi
 optional group?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:297](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L297)
+Defined in: [packages/sdk/src/types.ts:312](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L312)
 
 Group key used to bucket items in the same submenu. Items in different
 groups are visually separated by a separator. Group names are sorted
@@ -87,7 +87,7 @@ Defaults to "9_default" so unspecified items land at the bottom.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:305](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L305)
+Defined in: [packages/sdk/src/types.ts:320](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L320)
 
 Sort order within a group. Defaults to 0.
 
@@ -103,7 +103,7 @@ the same group by default.
 optional when?: (ctx) => boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:312](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L312)
+Defined in: [packages/sdk/src/types.ts:327](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L327)
 
 Optional predicate against current context keys. Items whose `when`
 returns false stay visible in the app menu but are disabled (macOS

--- a/apps/docs/api/types/interfaces/NavigatorView.md
+++ b/apps/docs/api/types/interfaces/NavigatorView.md
@@ -1,6 +1,6 @@
 # Interface: NavigatorView
 
-Defined in: [packages/sdk/src/types.ts:529](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L529)
+Defined in: [packages/sdk/src/types.ts:551](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L551)
 
 A view in the **Navigator** — the side panel you navigate the app from. The
 Navigator is a container: each registered view is one projection of "where
@@ -41,7 +41,7 @@ ctx.registerNavigatorView({
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:531](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L531)
+Defined in: [packages/sdk/src/types.ts:553](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L553)
 
 Unique id, conventionally `"<extension-id>.<view-name>"`.
 
@@ -53,7 +53,7 @@ Unique id, conventionally `"<extension-id>.<view-name>"`.
 title: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:533](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L533)
+Defined in: [packages/sdk/src/types.ts:555](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L555)
 
 Name shown for this view in the Navigator's view list.
 
@@ -65,7 +65,7 @@ Name shown for this view in the Navigator's view list.
 optional icon?: ReactNode;
 ```
 
-Defined in: [packages/sdk/src/types.ts:535](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L535)
+Defined in: [packages/sdk/src/types.ts:557](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L557)
 
 Optional icon rendered to the left of the title in the view list.
 
@@ -77,7 +77,7 @@ Optional icon rendered to the left of the title in the view list.
 component: ComponentType<NavigatorViewProps>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:537](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L537)
+Defined in: [packages/sdk/src/types.ts:559](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L559)
 
 The React component rendered as the whole panel body when active.
 
@@ -89,7 +89,7 @@ The React component rendered as the whole panel body when active.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:542](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L542)
+Defined in: [packages/sdk/src/types.ts:564](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L564)
 
 Sort order among views. Lower values appear first in the view list.
 Defaults to `0`; the built-in Workspaces view registers at `0`.

--- a/apps/docs/api/types/interfaces/NavigatorViewProps.md
+++ b/apps/docs/api/types/interfaces/NavigatorViewProps.md
@@ -1,6 +1,6 @@
 # Interface: NavigatorViewProps
 
-Defined in: [packages/sdk/src/types.ts:485](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L485)
+Defined in: [packages/sdk/src/types.ts:507](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L507)
 
 Props passed to a [NavigatorView](NavigatorView.md) component.
 
@@ -12,7 +12,7 @@ Props passed to a [NavigatorView](NavigatorView.md) component.
 active: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:492](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L492)
+Defined in: [packages/sdk/src/types.ts:514](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L514)
 
 Whether this view is the one currently on screen. A view mounts the first
 time it is selected and then stays mounted — hidden, not unmounted — so it

--- a/apps/docs/api/types/interfaces/SettingsPage.md
+++ b/apps/docs/api/types/interfaces/SettingsPage.md
@@ -1,6 +1,6 @@
 # Interface: SettingsPage
 
-Defined in: [packages/sdk/src/types.ts:628](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L628)
+Defined in: [packages/sdk/src/types.ts:650](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L650)
 
 A page in the Settings dialog, listed in the left rail.
 
@@ -12,7 +12,7 @@ A page in the Settings dialog, listed in the left rail.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:630](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L630)
+Defined in: [packages/sdk/src/types.ts:652](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L652)
 
 Unique id for this settings page.
 
@@ -24,7 +24,7 @@ Unique id for this settings page.
 title: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:632](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L632)
+Defined in: [packages/sdk/src/types.ts:654](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L654)
 
 Label shown in the Settings left rail.
 
@@ -36,7 +36,7 @@ Label shown in the Settings left rail.
 optional group?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:639](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L639)
+Defined in: [packages/sdk/src/types.ts:661](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L661)
 
 Optional grouping key for the left rail (groups sorted lexically, separated
 by a divider). Honored only for `core.*` pages; a page contributed by any
@@ -51,7 +51,7 @@ ignored for those.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:641](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L641)
+Defined in: [packages/sdk/src/types.ts:663](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L663)
 
 Sort order within the group. Lower sorts first. Defaults to 0.
 
@@ -63,7 +63,7 @@ Sort order within the group. Lower sorts first. Defaults to 0.
 component: ComponentType;
 ```
 
-Defined in: [packages/sdk/src/types.ts:643](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L643)
+Defined in: [packages/sdk/src/types.ts:665](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L665)
 
 Renders the right-hand pane when this page is selected.
 
@@ -76,7 +76,7 @@ optional badge?: ComponentType<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:650](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L650)
+Defined in: [packages/sdk/src/types.ts:672](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L672)
 
 Optional small indicator rendered after the title in the left rail (e.g.
 an update-available count). Rendered as its own component — separate from

--- a/apps/docs/api/types/interfaces/SidePanel.md
+++ b/apps/docs/api/types/interfaces/SidePanel.md
@@ -1,6 +1,6 @@
 # Interface: SidePanel
 
-Defined in: [packages/sdk/src/types.ts:460](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L460)
+Defined in: [packages/sdk/src/types.ts:482](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L482)
 
 A panel mounted in the left or right side column (e.g. file explorer, git).
 
@@ -12,7 +12,7 @@ A panel mounted in the left or right side column (e.g. file explorer, git).
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:462](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L462)
+Defined in: [packages/sdk/src/types.ts:484](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L484)
 
 Unique id, conventionally namespaced.
 
@@ -24,7 +24,7 @@ Unique id, conventionally namespaced.
 location: "left" | "right";
 ```
 
-Defined in: [packages/sdk/src/types.ts:464](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L464)
+Defined in: [packages/sdk/src/types.ts:486](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L486)
 
 Which side column to mount in.
 
@@ -36,7 +36,7 @@ Which side column to mount in.
 title: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:466](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L466)
+Defined in: [packages/sdk/src/types.ts:488](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L488)
 
 Title shown in the column's panel switcher.
 
@@ -48,7 +48,7 @@ Title shown in the column's panel switcher.
 component: ComponentType<SidePanelProps>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:468](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L468)
+Defined in: [packages/sdk/src/types.ts:490](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L490)
 
 The React component; receives [SidePanelProps](SidePanelProps.md).
 
@@ -60,7 +60,7 @@ The React component; receives [SidePanelProps](SidePanelProps.md).
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:470](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L470)
+Defined in: [packages/sdk/src/types.ts:492](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L492)
 
 Sort order within the side column. Defaults to 0.
 
@@ -72,7 +72,7 @@ Sort order within the side column. Defaults to 0.
 optional lazyMount?: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:476](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L476)
+Defined in: [packages/sdk/src/types.ts:498](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L498)
 
 If true, defer mounting the component until the first time this panel
 becomes active. Once mounted, stays mounted (panel can use `active`

--- a/apps/docs/api/types/interfaces/SidePanelProps.md
+++ b/apps/docs/api/types/interfaces/SidePanelProps.md
@@ -1,6 +1,6 @@
 # Interface: SidePanelProps
 
-Defined in: [packages/sdk/src/types.ts:434](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L434)
+Defined in: [packages/sdk/src/types.ts:456](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L456)
 
 Props passed to a [SidePanel](SidePanel.md) component.
 
@@ -12,7 +12,7 @@ Props passed to a [SidePanel](SidePanel.md) component.
 active: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:436](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L436)
+Defined in: [packages/sdk/src/types.ts:458](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L458)
 
 True when this side panel is currently visible / selected in its column.
 
@@ -24,7 +24,7 @@ True when this side panel is currently visible / selected in its column.
 storage: ExtensionStorage;
 ```
 
-Defined in: [packages/sdk/src/types.ts:445](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L445)
+Defined in: [packages/sdk/src/types.ts:467](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L467)
 
 Namespaced, persisted key/value storage scoped to this panel id (the
 `workspace` scope of [ExtensionStorageScopes](ExtensionStorageScopes.md), keyed by panel rather
@@ -41,7 +41,7 @@ extension-level settings shared across surfaces and workspaces, use
 hydrated: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:451](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L451)
+Defined in: [packages/sdk/src/types.ts:473](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L473)
 
 True once the persisted app state has finished loading from disk.
 Panels should defer restoring values from `storage` until this is true

--- a/apps/docs/api/types/interfaces/StatusItem.md
+++ b/apps/docs/api/types/interfaces/StatusItem.md
@@ -1,6 +1,6 @@
 # Interface: StatusItem
 
-Defined in: [packages/sdk/src/types.ts:591](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L591)
+Defined in: [packages/sdk/src/types.ts:613](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L613)
 
 A widget in the status bar (the strip along the bottom of the window).
 
@@ -21,7 +21,7 @@ for a value) to create visual distinctions within an item.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:593](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L593)
+Defined in: [packages/sdk/src/types.ts:615](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L615)
 
 Unique id for this status item.
 
@@ -33,7 +33,7 @@ Unique id for this status item.
 alignment: "left" | "right";
 ```
 
-Defined in: [packages/sdk/src/types.ts:595](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L595)
+Defined in: [packages/sdk/src/types.ts:617](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L617)
 
 Which end of the status bar this item sits at.
 
@@ -45,7 +45,7 @@ Which end of the status bar this item sits at.
 optional priority?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:609](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L609)
+Defined in: [packages/sdk/src/types.ts:631](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L631)
 
 Sort order within its alignment group. Defaults to 0.
 
@@ -67,7 +67,7 @@ may still choose a negative value intentionally to interleave with built-ins.
 optional tooltip?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:617](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L617)
+Defined in: [packages/sdk/src/types.ts:639](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L639)
 
 Tooltip shown on hover over the entire status item. The host renders a
 custom-styled popup (not the browser's native `title` tooltip). For items
@@ -83,6 +83,6 @@ internal barrel; external extensions may use the native `title` attribute).
 component: ComponentType;
 ```
 
-Defined in: [packages/sdk/src/types.ts:619](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L619)
+Defined in: [packages/sdk/src/types.ts:641](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L641)
 
 The React component (renders its own content; no props).

--- a/apps/docs/api/types/type-aliases/MenuId.md
+++ b/apps/docs/api/types/type-aliases/MenuId.md
@@ -4,7 +4,7 @@
 type MenuId = "file" | "edit" | "view" | "window" | "help";
 ```
 
-Defined in: [packages/sdk/src/types.ts:272](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L272)
+Defined in: [packages/sdk/src/types.ts:287](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L287)
 
 The top-level application menus a [MenuItemContribution](../interfaces/MenuItemContribution.md) can target.
 `"help"` is present on all platforms; `"file"`, `"edit"`, `"view"`, and

--- a/apps/docs/api/types/type-aliases/MenuSurface.md
+++ b/apps/docs/api/types/type-aliases/MenuSurface.md
@@ -9,7 +9,7 @@ type MenuSurface =
   | "workspace";
 ```
 
-Defined in: [packages/sdk/src/types.ts:326](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L326)
+Defined in: [packages/sdk/src/types.ts:341](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L341)
 
 The context menus of built-in surfaces that a
 [ContextMenuContribution](../interfaces/ContextMenuContribution.md) can target — distinct from the menubar

--- a/apps/docs/guide/extension-checklist.md
+++ b/apps/docs/guide/extension-checklist.md
@@ -48,6 +48,17 @@ doesn't repeat the reasoning, just the list.
 - [ ] Settings pages and property tabs have **no footer** — every control
       persists the moment it changes.
 
+## Commands
+
+- [ ] Every command works when invoked with **no arguments**. Toolbar items and
+      tab context menus pass the tab they belong to; a keybinding, a menu item,
+      and the command palette pass nothing — and users can bind any command from
+      Settings → Keyboard Shortcuts. A command that reads its target only from
+      its arguments runs and silently does nothing, which is indistinguishable
+      from the shortcut never firing. Fall back to the active tab
+      (`ctx.editors.getState().active`, `ctx.terminals.getActive()`). See
+      [what `run` receives](/api/registration/register-command#what-run-receives).
+
 ## Lifecycle
 
 - [ ] Everything registered in `activate(ctx)` comes back as a

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -251,9 +251,24 @@ export interface Command {
   /** Human-readable label (shown where the command surfaces in UI). */
   label: string;
   /**
-   * The action. May accept arguments passed through from
-   * {@link ExtensionContext.executeCommand} and may return a value (sync or
-   * async); `executeCommand` resolves with whatever this returns.
+   * The action. May return a value (sync or async); `executeCommand` resolves
+   * with whatever this returns.
+   *
+   * **What `args` holds depends on how the command was invoked** — the host
+   * does not synthesize a target for invocations that carry none:
+   *
+   * | Invoked from                                            | `args[0]`                          |
+   * | ------------------------------------------------------- | ---------------------------------- |
+   * | {@link ExtensionContext.registerToolbarItem}             | {@link ToolbarItemContext}`[S]`    |
+   * | {@link ExtensionContext.registerContextMenuItem}         | {@link MenuContext}`[S]`           |
+   * | {@link ExtensionContext.executeCommand}                  | whatever the caller passed         |
+   * | a keybinding, a menu item, the command palette            | **nothing**                        |
+   *
+   * So a command that reads its target only from `args` **cannot be bound to
+   * a key**: it will run and silently do nothing. If the same command backs
+   * both a surface and a shortcut, fall back to the active tab
+   * ({@link EditorService.getState}`().active`,
+   * {@link TerminalService.getActive}) when no context arrives.
    *
    * Zero-argument, void-returning commands are still valid — `() => void`
    * satisfies this type, so existing registrations compile unchanged.
@@ -406,6 +421,13 @@ export interface ContextMenuContribution<S extends MenuSurface = MenuSurface> {
 
 /**
  * Binds a keyboard shortcut to a {@link Command}.
+ *
+ * The command is invoked with **no arguments** — see {@link Command.run} for
+ * what that means for a command shared with a toolbar or context-menu surface.
+ *
+ * Users can also bind any command themselves from Settings → Keyboard
+ * Shortcuts, whether or not the extension registered a default here, so this
+ * applies to every command an extension exposes.
  *
  * @category Registration
  * @public


### PR DESCRIPTION
## Summary

Documents a trap that just cost us a bug: an extension command behaves differently depending on how it's invoked, and the docs only said so from one side.

When a command runs from a toolbar button or a tab's right-click menu, the host tells it which tab to act on. When it runs from a keyboard shortcut or a menu, it gets nothing. That was written down on the surfaces that pass a tab, but nowhere an author reads when writing the command itself — so "just read the tab from the first argument" looks correct, and quietly makes the command impossible to bind to a key. It runs and does nothing, which is indistinguishable from the shortcut not working.

This is now spelled out in the four places an author would look: the type reference for a command's action, both the `registerCommand` and `registerKeybinding` pages, and the extension checklist. It matters for every extension, not just ones that ship a shortcut, because users can assign a shortcut to any command from Settings.

Docs only — no behavior change.

## Details

Context: the Follow-ups extension's toggle did nothing when bound to a key ([silo-extensions#94](https://github.com/silo-code/silo-extensions/pull/94)) — it resolved its target purely from `args[0]`, which a keybinding invocation doesn't have. The host side is fixed separately in #395; this is the authoring-side gap that let the bug be written in the first place.

### What was missing

`ToolbarCommandItemContribution.command` and `registerContextMenuItem` both document that they pass their target as the first argument. Nothing documented the **receiving** side — `Command.run`'s TSDoc mentioned only `executeCommand` pass-through — so there was no signal that some invocations carry no target at all.

### Changes

- **`packages/sdk/src/types.ts`**
  - `Command.run` — a table of invocation surface → `args[0]` (toolbar item, context menu, `executeCommand`, and the keybinding/menu/palette case that passes nothing), the consequence ("cannot be bound to a key: it will run and silently do nothing"), and the active-tab fallback (`EditorService.getState().active`, `TerminalService.getActive()`).
  - `Keybinding` — states that the command is invoked with no arguments, and that users can bind any command themselves regardless of what the extension registers.
- **`apps/docs/api/registration/register-command.md`** — new "What `run` receives" section with the same table plus a worked fallback example.
- **`apps/docs/api/registration/register-keybinding.md`** — new "The command runs with no arguments" section, cross-linked to the above.
- **`apps/docs/guide/extension-checklist.md`** — new **Commands** section: every command works when invoked with no arguments.
- Regenerated the API reference (`pnpm docs:api`). The churn across the other type pages is source line-number links shifting from the added TSDoc — no content change.

### Verification

`pnpm docs:build` clean (caught and fixed one dead link — there's no `/api/terminals/` section; `getActive` is linked at `/api/types/interfaces/TerminalService#getactive`). `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, and `pnpm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
