### PR TITLE
feat(git-explorer): add a command for opening the Branches modal

### DIFF
--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -19,7 +19,7 @@ import { buildGitNavItems, navItemKey } from "./git-nav";
 import { ICON_CHECK, ICON_PLUS, ICON_MINUS, ICON_UNDO } from "./git-icons";
 import { summarizeGitError } from "./notify-error";
 import { GitErrorModal } from "./GitErrorModal";
-import { BranchManager } from "./BranchManager";
+import { showBranchManager } from "./open-branch-manager";
 import {
   findWorktreeFor,
   shouldShowWorktreeManagerButton,
@@ -417,18 +417,7 @@ export function GitView({
   // Open the branch manager modal. The host owns the chrome; refresh() re-reads
   // status after a switch/create so the header reflects the new branch.
   function openBranchManager() {
-    ctx.ui.showModal(
-      (close) => (
-        <BranchManager
-          ctx={ctx}
-          folder={folder}
-          close={close}
-          onSwitched={refresh}
-          notifyError={notifyError}
-        />
-      ),
-      { title: "Switch branches", size: "md", dismissible: true },
-    );
+    showBranchManager(ctx, { folder, onSwitched: refresh });
   }
 
   // Open the worktree manager modal for this repo. Everything inside is

--- a/packages/extensions-silo/src/git-explorer/index.tsx
+++ b/packages/extensions-silo/src/git-explorer/index.tsx
@@ -7,6 +7,12 @@ import {
   type ManageWorktreesArgs,
 } from "./open-worktree-manager";
 import {
+  MANAGE_BRANCHES_COMMAND,
+  resolveManageBranchesTarget,
+  showBranchManager,
+  type ManageBranchesArgs,
+} from "./open-branch-manager";
+import {
   getPendingRemoveStatusLabel,
   getPendingWorktreeRemoves,
   subscribePendingWorktreeRemoves,
@@ -77,6 +83,22 @@ export const extension: Extension = {
         );
         if (!target) return;
         showWorktreeManager(ctx, target);
+      },
+    });
+
+    // A keybinding or the command palette can now reach the same Branches
+    // modal the Git panel's "Manage branches…" menu item opens — one
+    // implementation, multiple entry points (mirrors manageWorktrees above).
+    ctx.registerCommand({
+      id: MANAGE_BRANCHES_COMMAND,
+      label: "Manage Branches…",
+      run: (arg?: unknown) => {
+        const target = resolveManageBranchesTarget(
+          ctx.workspaces.getState(),
+          arg as ManageBranchesArgs | undefined,
+        );
+        if (!target) return;
+        showBranchManager(ctx, target);
       },
     });
   },

--- a/packages/extensions-silo/src/git-explorer/open-branch-manager.test.ts
+++ b/packages/extensions-silo/src/git-explorer/open-branch-manager.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { resolveManageBranchesTarget } from "./open-branch-manager";
+
+const state = {
+  activeId: "a",
+  all: [
+    { id: "a", folder: "/repo-a" },
+    { id: "b", folder: "/repo-b" },
+  ],
+};
+
+describe("resolveManageBranchesTarget", () => {
+  it("defaults to the active workspace's primary folder", () => {
+    expect(resolveManageBranchesTarget(state)).toEqual({ folder: "/repo-a" });
+  });
+
+  it("honors an explicit workspaceId", () => {
+    expect(resolveManageBranchesTarget(state, { workspaceId: "b" })).toEqual({
+      folder: "/repo-b",
+    });
+  });
+
+  it("honors an explicit folder override", () => {
+    expect(
+      resolveManageBranchesTarget(state, {
+        workspaceId: "a",
+        folder: "/repo-a-feat",
+      }),
+    ).toEqual({ folder: "/repo-a-feat" });
+  });
+
+  it("returns null when the workspace is missing", () => {
+    expect(
+      resolveManageBranchesTarget(state, { workspaceId: "missing" }),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no active workspace", () => {
+    expect(
+      resolveManageBranchesTarget({ activeId: null, all: state.all }),
+    ).toBeNull();
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/open-branch-manager.tsx
+++ b/packages/extensions-silo/src/git-explorer/open-branch-manager.tsx
@@ -1,0 +1,79 @@
+import type { ExtensionContext, NotifyOptions } from "@silo-code/sdk";
+import { GitErrorModal } from "./GitErrorModal";
+import { summarizeGitError } from "./notify-error";
+import { BranchManager } from "./BranchManager";
+
+/** Command id — opened from the Git panel menu, a keybinding, or the palette. */
+export const MANAGE_BRANCHES_COMMAND = "silo.git.manageBranches";
+
+export interface ManageBranchesArgs {
+  /** Workspace whose folder the manager opens against. Defaults to active. */
+  workspaceId?: string;
+  /**
+   * Repo working directory to list branches for. Defaults to the workspace's
+   * primary folder.
+   */
+  folder?: string;
+}
+
+/**
+ * Open the host-owned Branches modal for a repo folder. Shared by the Git
+ * panel menu and the `silo.git.manageBranches` command (keybinding/palette).
+ */
+export function showBranchManager(
+  ctx: ExtensionContext,
+  opts: {
+    folder: string;
+    /** Called after a switch/create so a live Git view can re-read status. */
+    onSwitched?: () => void;
+  },
+): void {
+  const notifyError = (title: string, err: unknown) => {
+    const { detail, summary, hasMore } = summarizeGitError(err, title);
+    const options: NotifyOptions = { title };
+    if (hasMore) {
+      options.actions = [
+        {
+          label: "View details",
+          run: () =>
+            ctx.ui.showModal(
+              (close) => <GitErrorModal detail={detail} onClose={close} />,
+              { title, dismissible: true, size: "lg" },
+            ),
+        },
+      ];
+    }
+    ctx.ui.notify("error", summary, options);
+  };
+
+  ctx.ui.showModal(
+    (close) => (
+      <BranchManager
+        ctx={ctx}
+        folder={opts.folder}
+        close={close}
+        onSwitched={opts.onSwitched ?? (() => {})}
+        notifyError={notifyError}
+      />
+    ),
+    { title: "Switch branches", size: "md", dismissible: true },
+  );
+}
+
+/**
+ * Resolve which workspace + folder a manage-branches invocation should open.
+ * Returns `null` when no matching workspace exists.
+ */
+export function resolveManageBranchesTarget(
+  state: {
+    activeId: string | null;
+    all: readonly { id: string; folder: string }[];
+  },
+  args?: ManageBranchesArgs,
+): { folder: string } | null {
+  const ws = args?.workspaceId
+    ? state.all.find((w) => w.id === args.workspaceId)
+    : state.all.find((w) => w.id === state.activeId);
+  if (!ws) return null;
+  return { folder: args?.folder ?? ws.folder };
+}


### PR DESCRIPTION
## Summary

The Git panel's branch switcher ("Manage branches…") was only reachable through its own menu item — there was no way to bind a keyboard shortcut to it or reach it from the command palette. This adds a real command for it, so it can be assigned a keybinding or invoked from the palette, matching how the existing "Manage Worktrees…" command already works.

## Details

- New `open-branch-manager.tsx`, mirroring the existing `open-worktree-manager.tsx`: exports `MANAGE_BRANCHES_COMMAND = "silo.git.manageBranches"`, `showBranchManager()`, and `resolveManageBranchesTarget()`.
- `git-explorer/index.tsx` registers the command.
- `GitView.tsx`'s "Manage branches…" menu item now delegates to the shared `showBranchManager` helper instead of duplicating the modal-open logic inline.

### Test plan

- `open-branch-manager.test.ts` covers `resolveManageBranchesTarget`'s workspace/folder resolution (default, explicit workspaceId, explicit folder override, missing workspace, no active workspace).
- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q92otBnCB93B5HtixgwHAC