### PR TITLE
fix(layout): ctx.log.show() actually selects the caller's Output channel

### DIFF
--- a/apps/docs/api/types/interfaces/LayoutService.md
+++ b/apps/docs/api/types/interfaces/LayoutService.md
@@ -127,7 +127,7 @@ openPanel(
    options?): void;
 ```
 
-Defined in: [packages/sdk/src/layout-service.ts:71](https://github.com/silo-code/silo/blob/main/packages/sdk/src/layout-service.ts#L71)
+Defined in: [packages/sdk/src/layout-service.ts:73](https://github.com/silo-code/silo/blob/main/packages/sdk/src/layout-service.ts#L73)
 
 Open a new tab in the center dock for the given registered
 [DockPanelKind](DockPanelKind.md). Use this to programmatically open a custom panel
@@ -154,8 +154,10 @@ Arbitrary params forwarded to the panel component.
 
 `singleton: true` opens at most one instance at a time:
   if a panel with `kindId` already exists, it is focused instead of
-  creating a new one. The panel's id equals `kindId` (not UUID-based) when
-  singleton is set.
+  creating a new one — `params` is still shallow-merged into that
+  existing panel first, so a later call can retarget it (e.g. switching
+  which channel the Output panel shows). The panel's id equals `kindId`
+  (not UUID-based) when singleton is set.
 
 ###### singleton?
 
@@ -173,7 +175,7 @@ Arbitrary params forwarded to the panel component.
 openSingletonPanel(kindId, params?): void;
 ```
 
-Defined in: [packages/sdk/src/layout-service.ts:81](https://github.com/silo-code/silo/blob/main/packages/sdk/src/layout-service.ts#L81)
+Defined in: [packages/sdk/src/layout-service.ts:83](https://github.com/silo-code/silo/blob/main/packages/sdk/src/layout-service.ts#L83)
 
 Open a **singleton** dock panel.
 

--- a/packages/extension-host/src/extension-host/context.ts
+++ b/packages/extension-host/src/extension-host/context.ts
@@ -215,7 +215,7 @@ export function createContext(
       show: () =>
         getLayoutService().openPanel(
           "output",
-          { title: "Output" },
+          { title: "Output", channel: channelKey },
           { singleton: true },
         ),
       clear: () => clearChannel(channelKey),

--- a/packages/extension-host/src/extension-host/layout-service.test.ts
+++ b/packages/extension-host/src/extension-host/layout-service.test.ts
@@ -7,11 +7,16 @@ import { sidePanelRegistry } from "./side-panels";
 
 // Fake just the slice of DockviewApi that openPanel touches: getPanel for the
 // singleton existence check, addPanel returning a panel whose api.setActive
-// the service must call.
+// (and api.updateParameters, for a singleton reopen) the service must call.
 function makeDockApi() {
-  const panels = new Map<string, { api: { setActive: () => void } }>();
+  const panels = new Map<
+    string,
+    { api: { setActive: () => void; updateParameters: (p: object) => void } }
+  >();
   const addPanel = vi.fn((opts: { id: string }) => {
-    const panel = { api: { setActive: vi.fn() } };
+    const panel = {
+      api: { setActive: vi.fn(), updateParameters: vi.fn() },
+    };
     panels.set(opts.id, panel);
     return panel;
   });
@@ -74,6 +79,22 @@ describe("LayoutService.openPanel", () => {
 
     expect(dock.addPanel).toHaveBeenCalledTimes(1); // no second instance
     expect(existing.api.setActive).toHaveBeenCalled();
+  });
+
+  it("singleton: forwards new params to the existing panel on reopen", () => {
+    layout.openPanel("output", { title: "Output" }, { singleton: true });
+    const existing = dock.panels.get("output")!;
+
+    layout.openPanel(
+      "output",
+      { title: "Output", channel: "ext:silo.git" },
+      { singleton: true },
+    );
+
+    expect(existing.api.updateParameters).toHaveBeenCalledWith({
+      title: "Output",
+      channel: "ext:silo.git",
+    });
   });
 
   it("openSingletonPanel delegates to openPanel({ singleton: true })", () => {

--- a/packages/extension-host/src/extension-host/layout-service.ts
+++ b/packages/extension-host/src/extension-host/layout-service.ts
@@ -61,6 +61,11 @@ export function getLayoutService(): LayoutService {
       if (options?.singleton) {
         const existing = api.getPanel(kindId);
         if (existing) {
+          // Reopening an already-open singleton still forwards new params
+          // (e.g. `ctx.log.show()` re-targeting the Output panel at a
+          // different channel each call) — a bare focus would strand the
+          // panel on whatever params it was first created with.
+          if (params) existing.api.updateParameters(params);
           existing.api.setActive();
           return;
         }

--- a/packages/extensions-core/src/output/OutputPanel.tsx
+++ b/packages/extensions-core/src/output/OutputPanel.tsx
@@ -16,6 +16,7 @@ import {
   formatTimestamp,
   channelOptions,
   copyEntries,
+  resolveInitialChannel,
   type OutputFilter,
 } from "./output-model";
 import "./OutputPanel.css";
@@ -28,11 +29,17 @@ function safeStringify(data: unknown): string {
   }
 }
 
-interface OutputPanelProps extends DockPanelProps {
+/** Params this panel is opened with — `channel` steers which channel shows. */
+export interface OutputPanelParams {
+  /** Channel key to select on open, overriding the last-remembered channel. */
+  channel?: string;
+}
+
+interface OutputPanelProps extends DockPanelProps<OutputPanelParams> {
   ctx: ExtensionContext;
 }
 
-export function OutputPanel({ ctx }: OutputPanelProps) {
+export function OutputPanel({ ctx, params }: OutputPanelProps) {
   const snap = useSnapshot(outputStore);
   const { host, builtinExtensions, extensions } = channelOptions(
     snap.channels as typeof outputStore.channels,
@@ -40,7 +47,10 @@ export function OutputPanel({ ctx }: OutputPanelProps) {
   );
 
   const [selectedKey, setSelectedKey] = useState<string>(() =>
-    ctx.storage.workspace.get("outputChannel", "silo:notifications"),
+    resolveInitialChannel(
+      params.channel,
+      ctx.storage.workspace.get("outputChannel", "silo:notifications"),
+    ),
   );
   const [filter, setFilter] = useState<OutputFilter>({
     level: "all",
@@ -77,6 +87,17 @@ export function OutputPanel({ ctx }: OutputPanelProps) {
     });
     return () => sub.dispose();
   }, [ctx.storage.workspace]);
+
+  // Jump to a caller-requested channel (`ctx.log.show()`) every time it's
+  // asked for, even a repeat of the same channel — dockview hands this panel
+  // a fresh `params` object on every open/reopen (see layout-service.ts's
+  // singleton `updateParameters` forwarding), so this re-fires on each call
+  // rather than only the first mount.
+  useEffect(() => {
+    if (!params.channel) return;
+    setSelectedKey(params.channel);
+    ctx.storage.workspace.set("outputChannel", params.channel);
+  }, [params, ctx.storage.workspace]);
 
   // Clear selection when channel or filter changes
   useEffect(() => {

--- a/packages/extensions-core/src/output/index.tsx
+++ b/packages/extensions-core/src/output/index.tsx
@@ -1,6 +1,6 @@
 import type { DockPanelProps, Extension } from "@silo-code/sdk";
 import { Code } from "@phosphor-icons/react";
-import { OutputPanel } from "./OutputPanel";
+import { OutputPanel, type OutputPanelParams } from "./OutputPanel";
 
 export const extension: Extension = {
   id: "core.output",
@@ -12,7 +12,7 @@ export const extension: Extension = {
   activate(ctx) {
     ctx.registerDockPanelKind({
       id: "output",
-      component: (props: DockPanelProps) => (
+      component: (props: DockPanelProps<OutputPanelParams>) => (
         <OutputPanel {...props} ctx={ctx} />
       ),
     });

--- a/packages/extensions-core/src/output/output-model.test.ts
+++ b/packages/extensions-core/src/output/output-model.test.ts
@@ -4,6 +4,7 @@ import {
   formatTimestamp,
   channelOptions,
   copyEntries,
+  resolveInitialChannel,
   type OutputFilter,
 } from "./output-model";
 import type { OutputEntry } from "@silo-code/extension-host/internal";
@@ -162,6 +163,20 @@ describe("copyEntries", () => {
 
   it("returns empty string for empty array", () => {
     expect(copyEntries([])).toBe("");
+  });
+});
+
+describe("resolveInitialChannel", () => {
+  it("prefers a caller-requested channel over the stored one", () => {
+    expect(resolveInitialChannel("ext:silo.git", "silo:notifications")).toBe(
+      "ext:silo.git",
+    );
+  });
+
+  it("falls back to the stored channel when none was requested", () => {
+    expect(resolveInitialChannel(undefined, "silo:notifications")).toBe(
+      "silo:notifications",
+    );
   });
 });
 

--- a/packages/extensions-core/src/output/output-model.ts
+++ b/packages/extensions-core/src/output/output-model.ts
@@ -63,6 +63,19 @@ export function copyEntries(entries: readonly OutputEntry[]): string {
     .join("\n");
 }
 
+/**
+ * Which channel the panel should show: a caller-requested channel
+ * (`params.channel`, from `ctx.log.show()`) always wins over the last one the
+ * user had selected, so an extension's diagnostics land where it says they
+ * will instead of wherever the panel was last left.
+ */
+export function resolveInitialChannel(
+  paramsChannel: string | undefined,
+  storedChannel: string,
+): string {
+  return paramsChannel ?? storedChannel;
+}
+
 export interface ChannelOption {
   key: string;
   displayName: string;

--- a/packages/sdk/src/layout-service.ts
+++ b/packages/sdk/src/layout-service.ts
@@ -65,8 +65,10 @@ export interface LayoutService {
    *   close/reopen.
    * @param options - `singleton: true` opens at most one instance at a time:
    *   if a panel with `kindId` already exists, it is focused instead of
-   *   creating a new one. The panel's id equals `kindId` (not UUID-based) when
-   *   singleton is set.
+   *   creating a new one — `params` is still shallow-merged into that
+   *   existing panel first, so a later call can retarget it (e.g. switching
+   *   which channel the Output panel shows). The panel's id equals `kindId`
+   *   (not UUID-based) when singleton is set.
    */
   openPanel(
     kindId: string,


### PR DESCRIPTION
## Summary

`ctx.log.show()` (used by e.g. Git's "Log Watch Session Diagnostics" command) is documented to open the Output panel already showing the calling extension's own channel — but it never actually did that. It just opened whichever channel the Output panel had last been left on. This fix makes it do what it says: every call now jumps Output straight to the right channel.

## Details

Two independent gaps combined to cause this:

1. `ctx.log.show()` (`context.ts`) called `layout.openPanel("output", { title: "Output" }, { singleton: true })` — no channel in the params at all.
2. Even if it had passed one, `LayoutService.openPanel`'s singleton branch (`layout-service.ts`) just called `existing.api.setActive()` on an already-open panel and returned, silently dropping the new `params` — so a second `.show()` call while Output was already open wouldn't have changed anything.

Fixes:

- `context.ts`: `log.show()` now passes `{ title: "Output", channel: channelKey }`.
- `layout-service.ts`: the singleton-reopen branch now calls `existing.api.updateParameters(params)` before focusing, so params are forwarded on every call, not just the first. Updated the public `openPanel` TSDoc (`packages/sdk/src/layout-service.ts`) to describe this, and regenerated `apps/docs/api` via `pnpm docs:api`.
- `OutputPanel.tsx` / `output-model.ts`: the panel now honors `params.channel`, via a new pure `resolveInitialChannel(paramsChannel, storedChannel)` helper. An effect re-applies `params.channel` on every fresh `params` object (dockview hands the panel a new object on each `updateParameters` call, even for a repeated value), so calling `.show()` again reselects the channel even if the user had since switched away manually. `core.openOutput` (the generic "Output" command/button) still opens with no channel, so it keeps showing whatever was last selected.

### Test plan

- `layout-service.test.ts`: new case asserting a singleton reopen calls `updateParameters` with the new params.
- `output-model.test.ts`: new cases for `resolveInitialChannel`'s precedence (explicit channel wins; falls back to stored).
- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q92otBnCB93B5HtixgwHAC