### PR TITLE
fix(git): treat a missing worktree cwd as no worktrees, not a raw error

### DIFF
--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -990,3 +990,27 @@ describe("GitService.status against a rejecting exec (e.g. missing cwd)", () => 
     expect(s.missing).toBeUndefined();
   });
 });
+
+// worktrees() shares status()'s missing-cwd handling — a background read (fs
+// watch, autofetch, or the tracker's initial read) races an external delete
+// of the folder (e.g. a worktree removed outside Silo) just as easily on this
+// call as on status().
+describe("GitService.worktrees against a rejecting exec (e.g. missing cwd)", () => {
+  it("treats 'no such file or directory' as no worktrees, not a throw", async () => {
+    const execRejects: ExecFn = () =>
+      Promise.reject(
+        new Error("failed to run git: No such file or directory (os error 2)"),
+      );
+    const git = createGitService(execRejects);
+    await expect(git.worktrees("/gone")).resolves.toEqual([]);
+  });
+
+  it("still throws for other spawn failures (e.g. git not installed)", async () => {
+    const execRejects: ExecFn = () =>
+      Promise.reject(new Error("failed to run git: permission denied"));
+    const git = createGitService(execRejects);
+    await expect(git.worktrees("/somewhere")).rejects.toThrow(
+      "permission denied",
+    );
+  });
+});

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -415,11 +415,21 @@ export function createGitService(exec: ExecFn): Omit<GitAPI, "watchRepo"> {
     },
 
     async worktrees(cwd) {
-      const { stdout, code } = await git(cwd, [
-        "worktree",
-        "list",
-        "--porcelain",
-      ]);
+      let stdout: string, code: number;
+      try {
+        ({ stdout, code } = await git(cwd, [
+          "worktree",
+          "list",
+          "--porcelain",
+        ]));
+      } catch (err) {
+        // A missing `cwd` fails the process spawn itself and rejects — the
+        // same missing-folder case `status()` handles (e.g. a worktree
+        // deleted outside Silo); treat it the same way instead of surfacing
+        // the raw OS error on every background refresh.
+        if (MISSING_CWD_RE.test(String(err))) return [];
+        throw err;
+      }
       // Any error (e.g. not a git repository) → no worktrees.
       if (code !== 0) return [];
       return parseWorktrees(stdout);


### PR DESCRIPTION
## Summary

When a worktree or extra workspace folder was removed from disk outside Silo (e.g. by another tool, or a Claude Code agent cleaning up its own worktree), the Git panel showed two conflicting notifications instead of one: the expected "could not be found, remove it from the workspace?" prompt, *and* a raw `failed to run git: No such file or directory (os error 2)` error toast right alongside it. The second one was noise — it exposed an internal OS error instead of the same graceful "folder is gone" message the panel already knows how to show.

## Details

`GitService.status()` already handled a deleted `cwd` gracefully: it catches the exec rejection (or a non-zero exit with "unable to read current working directory"), matches it against `MISSING_CWD_RE`, and returns `{ inRepo: false, missing: true }` instead of throwing. `GitService.worktrees()` had no equivalent handling — it called `git worktree list` directly with no try/catch, so a deleted `cwd` propagated the raw spawn rejection.

The repo tracker's `performRead` (`repo-tracker.ts`) calls both `status()` and `worktrees()` together in one `Promise.allSettled` on every fs-watch/debounced/autofetch read. When the folder went missing, `status()` resolved to `missing: true` (correctly driving the WARN "could not be found" toast via `onFolderMissing`), but `worktrees()`'s rejection landed in `tracker.snapshot.error = { op: "worktrees", cause: <raw error> }`, which `GitView`'s effect surfaces as a second, contradictory ERROR toast.

Fix: `worktrees()` now catches the rejection and applies the same `MISSING_CWD_RE` check as `status()`, returning `[]` for a missing `cwd` instead of throwing.

### Tests

Added `packages/extensions-silo/src/git/git-service.test.ts` coverage mirroring the existing `status()` missing-cwd tests:
- a rejecting exec matching "no such file or directory" resolves to `[]`
- other spawn failures (e.g. permission denied) still throw

### Verification

Reproduced live in dev Silo via the automation bridge: added a throwaway `git worktree` as an extra workspace folder, deleted it from outside Silo, and confirmed both the WARN and ERROR toasts fired together (same millisecond timestamp, confirming the shared `allSettled` read). After the fix, only the WARN toast fires.