### PR TITLE
docs(agents): say plainly that Windows is activity-only, not "detected"

### DIFF
--- a/apps/docs/guide/agent-sessions.md
+++ b/apps/docs/guide/agent-sessions.md
@@ -39,8 +39,14 @@ only ever adds or removes its own entry (marked `# silo-managed-agent-hook`);
 your other hooks are never touched. If a settings file exists but isn't valid
 JSON, Silo refuses to rewrite it — fix or remove the file first.
 
-Exact resume works on **macOS and Linux**; on Windows, agents are still
-detected, but exact resume isn't available. The hook runs a small, readable
+Exact resume works on **macOS and Linux**. On Windows it isn't available, and
+agent support is more limited than that alone suggests: Silo can see that a
+terminal is _busy or idle_ (from the status signals agents emit), but it cannot
+currently tell you **which** agent is running — naming the agent relies on
+reading the terminal's foreground process, which Windows' console API doesn't
+expose. So on Windows a terminal running Claude or Copilot shows activity, but
+not the agent's name, and Settings → Agents has nothing to install. The hook
+runs a small, readable
 shell script Silo writes to `~/.silo/agent-hooks/track-session.sh` — you can
 open and inspect it, and it needs no interpreter or dependency beyond the shell
 your agent already runs its hooks with. See the

--- a/apps/docs/roadmap/agent-system.md
+++ b/apps/docs/roadmap/agent-system.md
@@ -132,8 +132,14 @@ These are unsettled — the reason this page is `experimental`:
 - **Sub-agent correlation** — the hook events give a count and a bag of running
   types, but no key to pair a specific sub-agent start with its stop; a precise
   tree is out of scope.
-- **Platform** — exact resume is macOS + Linux only (it needs a foreground
-  process-group id to correlate against); Windows stays detection-only.
+- **Platform** — macOS + Linux only, and for two separate reasons. _Exact
+  resume_ needs a foreground process-group id to correlate the hook's event
+  against, which ConPTY has no equivalent for. _Agent identity_ has the same
+  root: `agentByLeader` reads the foreground process name, so on Windows a
+  terminal is classified as active-or-idle from its OSC signals but never
+  named — pi is the sole exception, being the only catalog agent whose own
+  title carries its identity. Windows is therefore **activity-only**, not
+  "detection-only": the status is real, the agent's name is not resolved.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

The docs told Windows users that agents "are still detected" and only exact
resume was missing. That's not what happens. Silo can tell that a terminal is
busy or idle, but on Windows it can't tell you *which* agent is running — so a
user who reads the current page and then watches Copilot never appear has been
misled by us, not confused by their setup.

This corrects both places that made the claim and says what actually happens:
on Windows you get activity, not the agent's name.

No code change — this is the honest description of today's behavior. The fix
itself is a separate question.

## Details

Found while investigating a real report: GitHub Copilot never appeared in a
Silo terminal on Windows, focused or not.

### Why identity doesn't resolve on Windows

- `SessionWindowsBackend::subscribe_foreground` returns `None` — ConPTY has no
  process-group concept — so there is no foreground stream on Windows.
- `agentByLeader` (`agents-service.ts:884`) is what names an agent, and it is
  driven entirely by that foreground stream.
- OSC detectors carry *status*, not identity: `DetectionResult` has `status` and
  `source` but no agent id. `stampDetectedAgentIdentity` is only reached when a
  detector supplies `result.agentId`, and pi's title detector
  (`agent-osc-detectors.ts:354`) is the **only** one in the catalog that does.

So on Windows every agent except pi is detected as active-or-idle and never
named. "Detection-only" was the wrong shorthand; **activity-only** is accurate.

### Changed

- `apps/docs/guide/agent-sessions.md` — states that activity is visible but the
  agent isn't named, and why, plus that Settings → Agents has nothing to install
  there.
- `apps/docs/roadmap/agent-system.md` — the Platform bullet now separates the
  two distinct causes (exact resume *and* identity) that share one root.

### Test plan

`pnpm docs:build` clean, no dead links. Prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTNr2wgiuarrFe91MdZVG2
