### PR TITLE
fix(terminal): resolve file links against terminal cwd

### DIFF
--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -42,6 +42,7 @@ import { xtermThemeFor } from "./xterm-theme";
 import { effectiveFontFamily } from "./terminal-font";
 import { buildTerminalPaste } from "./terminal-path-paste";
 import { findFileLinks, getHomeDir } from "./terminal-links";
+import { resolveTerminalFilePath } from "./terminal-open-file";
 import {
   isLinkActivationClick,
   linkMenuLabels,
@@ -119,20 +120,18 @@ async function openFileFromTerminal(
   const wsId = findTerminalOwnerId(Object.values(store.workspaces), terminalId);
   if (!wsId) return;
   const ws = store.workspaces[wsId];
+  const tRec = ws.terminals.find((t) => t.id === terminalId);
 
-  // Pull off the optional :LINE:COL suffix. We don't currently honor it
-  // (editor doesn't expose a goto-line API), but stripping it ensures the
-  // path resolves to a real file.
-  const lineColMatch = matched.match(/^(.+?)(?::(\d+))?(?::(\d+))?$/);
-  let path = lineColMatch?.[1] ?? matched;
-
-  if (path.startsWith("~/")) {
-    const home = await getHomeDir();
-    path = `${home}/${path.slice(2)}`;
-  } else if (!path.startsWith("/")) {
-    const rel = path.replace(/^\.\//, "");
-    path = `${ws.folder.replace(/\/$/, "")}/${rel}`;
+  // Relative paths resolve against the terminal's cwd (which may be a
+  // worktree or extra folder), not the workspace's primary folder.
+  let baseDir = tRec?.cwd ?? ws.folder;
+  if (tRec?.sessionId) {
+    const fg = await terminalForegroundSnapshot(tRec.sessionId);
+    if (fg?.cwd) baseDir = fg.cwd;
   }
+
+  const home = matched.startsWith("~/") ? await getHomeDir() : undefined;
+  const path = resolveTerminalFilePath(matched, baseDir, home);
 
   editors.open(path, { workspaceId: wsId });
 }

--- a/packages/extensions-core/src/terminal/terminal-lifecycle.ts
+++ b/packages/extensions-core/src/terminal/terminal-lifecycle.ts
@@ -5,7 +5,7 @@
  * record was actually removed — tab close / workspace delete — never when the
  * panel merely unmounts because the dock is hidden or the last open workspace
  * soft-closed, since records and sessions must survive that) and resolving a
- * terminal-matched file path against its owning workspace's folder.
+ * terminal-matched file path against its owning terminal's cwd.
  */
 export function findTerminalOwnerId(
   workspaces: Iterable<

--- a/packages/extensions-core/src/terminal/terminal-open-file.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-open-file.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveTerminalFilePath } from "./terminal-open-file";
+
+describe("resolveTerminalFilePath", () => {
+  const mainRepo = "/Users/dev/silo";
+  const worktree = "/Users/dev/silo-wt-feat";
+
+  it("resolves relative paths against the terminal cwd, not workspace root", () => {
+    expect(resolveTerminalFilePath("src/foo.ts", worktree)).toBe(
+      "/Users/dev/silo-wt-feat/src/foo.ts",
+    );
+    expect(resolveTerminalFilePath("./src/foo.ts", worktree)).toBe(
+      "/Users/dev/silo-wt-feat/src/foo.ts",
+    );
+  });
+
+  it("handles parent-directory segments relative to cwd", () => {
+    expect(resolveTerminalFilePath("../shared/config.json", worktree)).toBe(
+      "/Users/dev/shared/config.json",
+    );
+  });
+
+  it("leaves absolute paths unchanged", () => {
+    expect(resolveTerminalFilePath("/etc/hosts", worktree)).toBe("/etc/hosts");
+  });
+
+  it("expands home-relative paths", () => {
+    expect(resolveTerminalFilePath("~/notes.txt", mainRepo, "/Users/dev")).toBe(
+      "/Users/dev/notes.txt",
+    );
+  });
+
+  it("strips optional :line:col suffix before resolving", () => {
+    expect(resolveTerminalFilePath("src/foo.ts:42:7", worktree)).toBe(
+      "/Users/dev/silo-wt-feat/src/foo.ts",
+    );
+  });
+});

--- a/packages/extensions-core/src/terminal/terminal-open-file.ts
+++ b/packages/extensions-core/src/terminal/terminal-open-file.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolve a file-path span from terminal output to an absolute path.
+ * Relative paths are resolved against the terminal's working directory
+ * (which may be a git worktree or extra workspace folder), not the
+ * workspace's primary folder.
+ */
+export function resolveTerminalFilePath(
+  matched: string,
+  baseDir: string,
+  homeDir?: string,
+): string {
+  // Pull off the optional :LINE:COL suffix. We don't currently honor it
+  // (editor doesn't expose a goto-line API), but stripping it ensures the
+  // path resolves to a real file.
+  const lineColMatch = matched.match(/^(.+?)(?::(\d+))?(?::(\d+))?$/);
+  let path = lineColMatch?.[1] ?? matched;
+
+  if (path.startsWith("~/")) {
+    const home = homeDir?.replace(/\/$/, "") ?? "";
+    return home ? `${home}/${path.slice(2)}` : path;
+  }
+  if (path.startsWith("/")) return path;
+
+  const rel = path.replace(/^\.\//, "");
+  return joinPosixPath(baseDir.replace(/\/$/, ""), rel);
+}
+
+/** Join `base` and `rel`, normalizing `.` / `..` segments (POSIX). */
+function joinPosixPath(base: string, rel: string): string {
+  const parts = base.split("/").filter(Boolean);
+  for (const segment of rel.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") parts.pop();
+    else parts.push(segment);
+  }
+  return `/${parts.join("/")}`;
+}


### PR DESCRIPTION
## Summary
- Resolve relative terminal file links against the terminal's live cwd (foreground snapshot → record cwd → workspace folder), not the workspace primary folder
- Extract `resolveTerminalFilePath()` with POSIX `../` handling and unit tests

## Test plan
- [x] `pnpm --filter @silo-code/extensions-core exec vitest run src/terminal/terminal-open-file.test.ts`
- [x] Manual verify in Silo Dev: workspace with git worktree, terminal cwd in worktree, cmd-click `src/click-me.ts` opens the worktree copy


Made with [Cursor](https://cursor.com)