### PR TITLE
fix(workspaces): close add-workspace menu after permanent delete

### DIFF
--- a/packages/extension-host/src/extension-host/open-workspace-menu-delete.test.ts
+++ b/packages/extension-host/src/extension-host/open-workspace-menu-delete.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { MenuItem } from "@silo-code/sdk";
+import { store } from "../state/store";
+import { buildOpenWorkspaceItems } from "./open-workspace-menu";
+import { closeMenu, getMenu, openMenu } from "./menu-controller";
+import { getGlobalExtensionStorage } from "./extension-storage";
+import { closeGroup, createGroup } from "../state/workspaces";
+
+vi.mock("./terminal-service", () => ({
+  reapWorkspaceTerminals: vi.fn(),
+}));
+
+vi.mock("./file-service", () => ({
+  getFileService: () => ({
+    pathExists: vi.fn().mockResolvedValue(true),
+  }),
+}));
+
+import { reapWorkspaceTerminals } from "./terminal-service";
+
+const workspacesStorage = getGlobalExtensionStorage("core.workspaces");
+
+function addClosedWorkspace(id: string) {
+  store.workspaces[id] = {
+    id,
+    name: id,
+    folder: `/tmp/${id}`,
+    createdAt: "2026-01-01T00:00:00Z",
+    lastOpenedAt: "2026-01-01T00:00:00Z",
+    closedAt: "2026-02-01T00:00:00Z",
+    terminals: [],
+    editors: [],
+  } as (typeof store.workspaces)[string];
+}
+
+function trailingDelete(items: ReturnType<typeof buildOpenWorkspaceItems>) {
+  const row = items.find(
+    (item): item is MenuItem => !("type" in item) && item.label === "solo",
+  );
+  expect(row?.trailing?.onClick).toBeTruthy();
+  return row!.trailing!.onClick;
+}
+
+beforeEach(() => {
+  closeMenu();
+  workspacesStorage.set("deleteWorkspace.dontShowAgain", true);
+  workspacesStorage.set("deleteGroup.dontShowAgain", true);
+  vi.mocked(reapWorkspaceTerminals).mockClear();
+});
+
+afterEach(() => {
+  store.workspaces = {};
+  store.workspaceOrder = [];
+  store.groups = {};
+  store.panelOrder = [];
+  workspacesStorage.set("deleteWorkspace.dontShowAgain", undefined);
+  workspacesStorage.set("deleteGroup.dontShowAgain", undefined);
+  closeMenu();
+  vi.restoreAllMocks();
+});
+
+describe("open workspace menu delete", () => {
+  it("removes the workspace and closes the open menu", async () => {
+    addClosedWorkspace("solo");
+    const items = buildOpenWorkspaceItems({
+      closed: [
+        {
+          id: "solo",
+          name: "solo",
+          folder: "/tmp/solo",
+          createdAt: "2026-01-01T00:00:00Z",
+          lastOpenedAt: "2026-01-01T00:00:00Z",
+          closedAt: "2026-02-01T00:00:00Z",
+          terminals: [],
+          editors: [],
+        },
+      ],
+      folderExistence: new Map(),
+      onNew: () => {},
+    });
+    void openMenu({ items, anchor: document.createElement("button") });
+    expect(getMenu()).not.toBeNull();
+
+    trailingDelete(items)();
+    await vi.waitFor(() => {
+      expect(store.workspaces.solo).toBeUndefined();
+    });
+
+    expect(reapWorkspaceTerminals).toHaveBeenCalledWith("solo");
+    expect(getMenu()).toBeNull();
+  });
+
+  it("removes the group and closes the open menu", async () => {
+    const group = createGroup("Group");
+    closeGroup(group.id);
+    const items = buildOpenWorkspaceItems({
+      closed: [],
+      closedGroups: [
+        {
+          id: group.id,
+          name: "Group",
+          memberCount: 0,
+          closedAt: "2026-02-01T00:00:00Z",
+        },
+      ],
+      folderExistence: new Map(),
+      onNew: () => {},
+    });
+    void openMenu({ items, anchor: document.createElement("button") });
+
+    const row = items.find(
+      (item): item is MenuItem => !("type" in item) && item.label === "Group",
+    );
+    row?.trailing?.onClick();
+    await vi.waitFor(() => {
+      expect(store.groups[group.id]).toBeUndefined();
+    });
+
+    expect(getMenu()).toBeNull();
+  });
+});

--- a/packages/extension-host/src/extension-host/open-workspace-menu.tsx
+++ b/packages/extension-host/src/extension-host/open-workspace-menu.tsx
@@ -24,6 +24,7 @@ import { getFileService } from "./file-service";
 import { confirmWithDontShowAgain } from "./confirm-with-dont-show-again";
 import { getGlobalExtensionStorage } from "./extension-storage";
 import { executeCommand } from "./commands";
+import { closeMenu } from "./menu-controller";
 import { reapWorkspaceTerminals } from "./terminal-service";
 
 // The **one** builder for the "Open workspace" menu — saved groups to restore,
@@ -59,6 +60,9 @@ async function confirmAndDeleteWorkspace(
   // records synchronously) so no PTY is orphaned in the pty-host daemon.
   void reapWorkspaceTerminals(id);
   deleteWorkspace(id);
+  // The menu snapshot is taken at open time; dismiss it so the delete reads as
+  // having happened instead of leaving a stale row until click-away.
+  closeMenu();
 }
 
 /** Confirm, then delete a group. Member workspaces are kept and reappear
@@ -73,6 +77,7 @@ async function confirmAndDeleteGroup(id: string, name: string): Promise<void> {
   });
   if (!ok) return;
   deleteGroup(id);
+  closeMenu();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Dismiss the Saved picker after permanently deleting a workspace or group via the trash icon
- The menu previously captured its rows at open time, so deletes succeeded in state but left a stale row until click-away

## Test plan
- [x] Unit tests for workspace and group delete paths (`open-workspace-menu-delete.test.ts`)
- [ ] Open Navigator → Workspaces → + → trash a saved workspace; menu closes immediately
- [ ] Repeat for a saved group
- [ ] Cancel the confirm dialog; menu stays open


Made with [Cursor](https://cursor.com)