### PR TITLE
perf(git-explorer): virtualize the changed-file list

### DIFF
--- a/packages/extensions-silo/package.json
+++ b/packages/extensions-silo/package.json
@@ -14,6 +14,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@silo-code/git-api": "workspace:*",
     "@silo-code/sdk": "workspace:*",
+    "@tanstack/react-virtual": "^3.14.10",
     "mermaid": "^11.15.0",
     "react": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowsClockwise, CaretDown, CaretRight } from "@phosphor-icons/react";
+import type { Virtualizer } from "@tanstack/react-virtual";
 import {
   Badge,
   Tooltip,
+  focusGroupNextIndex,
   useFocusGroup,
   useServiceState,
   type ExtensionContext,
@@ -30,6 +32,8 @@ import { confirmAndRemoveWorktree } from "./confirm-and-remove-worktree";
 import { useViewStack } from "./use-view-stack";
 import { CommitsTakeover } from "./CommitsTakeover";
 import { shouldExitTakeover, shouldPushCommitsOnOpen } from "./takeover-model";
+import { VirtualFileRows } from "./VirtualFileRows";
+import { resolveRowScrollTarget } from "./git-virtual-model";
 
 const messageCache = new Map<string, string>();
 
@@ -171,6 +175,32 @@ export function GitView({
   // owned by useFocusGroup (same as the file Tree): the headers + file rows are
   // one Tab stop, ↑/↓/Home/End move between them, and Enter/Space toggles a
   // header or opens a row's diff.
+  const stagedVirtualizerRef = useRef<Virtualizer<HTMLElement, Element> | null>(
+    null,
+  );
+  const changesVirtualizerRef = useRef<Virtualizer<
+    HTMLElement,
+    Element
+  > | null>(null);
+
+  const scrollNavIndexToView = useCallback(
+    (navIdx: number) => {
+      const target = resolveRowScrollTarget(
+        navItems,
+        navIdx,
+        stagedFiles,
+        changedFiles,
+      );
+      if (!target) return;
+      const vz =
+        target.section === "staged"
+          ? stagedVirtualizerRef.current
+          : changesVirtualizerRef.current;
+      vz?.scrollToIndex(target.rowIndex, { align: "auto" });
+    },
+    [navItems, stagedFiles, changedFiles],
+  );
+
   const group = useFocusGroup({
     count: navItems.length,
     orientation: "vertical",
@@ -193,7 +223,28 @@ export function GitView({
   // it isn't a current nav item (e.g. a collapsed section's rows aren't rendered).
   function focusPropsFor(key: string): FocusGroupItemProps | undefined {
     const idx = navIndex.get(key);
-    return idx === undefined ? undefined : group.getItemProps(idx);
+    if (idx === undefined) return undefined;
+    const base = group.getItemProps(idx);
+    return {
+      ...base,
+      onKeyDown: (e) => {
+        const next = focusGroupNextIndex({
+          current: idx,
+          count: navItems.length,
+          key: e.key,
+          orientation: "vertical",
+          wrap: true,
+          isNavigable: () => true,
+        });
+        if (next !== null) {
+          e.preventDefault();
+          scrollNavIndexToView(next);
+          requestAnimationFrame(() => group.focusItem(next));
+          return;
+        }
+        base.onKeyDown(e);
+      },
+    };
   }
 
   async function stageAll() {
@@ -713,18 +764,23 @@ export function GitView({
                   },
                 ]}
               >
-                {stagedFiles.map((f) => (
-                  <FileRow
-                    key={`s-${f.path}`}
-                    file={f}
-                    folder={folder}
-                    kind="staged"
-                    onRowClick={() => openFileDiff(f, "staged")}
-                    onOpen={() => openFile(f)}
-                    onUnstage={() => unstage(f)}
-                    focusProps={focusPropsFor(`r:staged:${f.path}`)}
-                  />
-                ))}
+                <VirtualFileRows
+                  files={stagedFiles}
+                  enabled={stagedOpen}
+                  virtualizerRef={stagedVirtualizerRef}
+                  renderRow={(f) => (
+                    <FileRow
+                      key={`s-${f.path}`}
+                      file={f}
+                      folder={folder}
+                      kind="staged"
+                      onRowClick={() => openFileDiff(f, "staged")}
+                      onOpen={() => openFile(f)}
+                      onUnstage={() => unstage(f)}
+                      focusProps={focusPropsFor(`r:staged:${f.path}`)}
+                    />
+                  )}
+                />
               </Section>
             )}
 
@@ -754,19 +810,24 @@ export function GitView({
               {changedFiles.length === 0 && (
                 <div className="empty">No changes.</div>
               )}
-              {changedFiles.map((f) => (
-                <FileRow
-                  key={`c-${f.path}`}
-                  file={f}
-                  folder={folder}
-                  kind="changes"
-                  onRowClick={() => openFileDiff(f, "workingTree")}
-                  onOpen={() => openFile(f)}
-                  onStage={() => stage(f)}
-                  onRevert={() => revert(f)}
-                  focusProps={focusPropsFor(`r:changes:${f.path}`)}
-                />
-              ))}
+              <VirtualFileRows
+                files={changedFiles}
+                enabled={changesOpen}
+                virtualizerRef={changesVirtualizerRef}
+                renderRow={(f) => (
+                  <FileRow
+                    key={`c-${f.path}`}
+                    file={f}
+                    folder={folder}
+                    kind="changes"
+                    onRowClick={() => openFileDiff(f, "workingTree")}
+                    onOpen={() => openFile(f)}
+                    onStage={() => stage(f)}
+                    onRevert={() => revert(f)}
+                    focusProps={focusPropsFor(`r:changes:${f.path}`)}
+                  />
+                )}
+              />
             </Section>
           </div>
         </div>

--- a/packages/extensions-silo/src/git-explorer/VirtualFileRows.tsx
+++ b/packages/extensions-silo/src/git-explorer/VirtualFileRows.tsx
@@ -1,0 +1,111 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type ReactNode,
+} from "react";
+import { useVirtualizer, type Virtualizer } from "@tanstack/react-virtual";
+import type { GitFileStatus } from "../git/git-api";
+import { measureScrollMargin } from "./git-virtual-model";
+
+/** Rough initial row height — remeasured via {@link useVirtualizer}'s measureElement. */
+const ROW_ESTIMATE_PX = 24;
+
+/**
+ * Windowed file rows for one Git section (staged or changes). The panel scrolls
+ * on `.git-explorer-scroll`; only visible rows mount so large status lists stay
+ * cheap on workspace switch.
+ */
+export function VirtualFileRows({
+  files,
+  enabled,
+  virtualizerRef,
+  renderRow,
+}: {
+  files: GitFileStatus[];
+  /** When false (collapsed section), renders nothing and skips the virtualizer. */
+  enabled: boolean;
+  /** Imperative handle for keyboard-nav scroll-into-view. */
+  virtualizerRef?: MutableRefObject<Virtualizer<HTMLElement, Element> | null>;
+  renderRow: (file: GitFileStatus, index: number) => ReactNode;
+}) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  const measureLayout = useCallback(() => {
+    const listEl = listRef.current;
+    if (!listEl) return;
+    const parent = listEl.closest(".git-explorer-scroll");
+    if (!(parent instanceof HTMLElement)) return;
+    setScrollEl(parent);
+    setScrollMargin(measureScrollMargin(parent, listEl));
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    measureLayout();
+  }, [enabled, files.length, measureLayout]);
+
+  useLayoutEffect(() => {
+    if (!enabled || !scrollEl || !listRef.current) return;
+    const ro = new ResizeObserver(() => measureLayout());
+    ro.observe(scrollEl);
+    ro.observe(listRef.current);
+    return () => ro.disconnect();
+  }, [enabled, scrollEl, measureLayout]);
+
+  const virtualizer = useVirtualizer({
+    count: enabled ? files.length : 0,
+    getScrollElement: () => scrollEl,
+    estimateSize: () => ROW_ESTIMATE_PX,
+    scrollMargin,
+    overscan: 8,
+    enabled: enabled && scrollEl !== null,
+    measureElement: (el) => el.getBoundingClientRect().height,
+  });
+
+  useLayoutEffect(() => {
+    if (virtualizerRef) virtualizerRef.current = enabled ? virtualizer : null;
+  });
+
+  if (!enabled || files.length === 0) return null;
+
+  const items = virtualizer.getVirtualItems();
+
+  return (
+    <div
+      ref={listRef}
+      className="git-virtual-rows"
+      style={{
+        height: virtualizer.getTotalSize(),
+        width: "100%",
+        position: "relative",
+      }}
+    >
+      {items.map((v) => {
+        const file = files[v.index];
+        if (!file) return null;
+        return (
+          <div
+            key={v.key}
+            data-index={v.index}
+            ref={virtualizer.measureElement}
+            className="git-virtual-row-slot"
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${v.start - virtualizer.options.scrollMargin}px)`,
+            }}
+          >
+            {renderRow(file, v.index)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/git-virtual-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/git-virtual-model.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import type { GitFileStatus } from "../git/git-api";
+import { buildGitNavItems } from "./git-nav";
+import {
+  resolveRowScrollTarget,
+  measureScrollMargin,
+} from "./git-virtual-model";
+
+const file = (path: string, staged = false): GitFileStatus => ({
+  path,
+  staged: staged ? "M" : ".",
+  worktree: staged ? "." : "M",
+  isStaged: staged,
+  isModified: !staged,
+  isUntracked: false,
+  isRenamed: false,
+});
+
+describe("resolveRowScrollTarget", () => {
+  const staged = [file("a.ts", true), file("b.ts", true)];
+  const changed = [file("c.ts"), file("d.ts"), file("e.ts")];
+
+  it("maps a staged row nav index to the staged virtual list row index", () => {
+    const navItems = buildGitNavItems({
+      stagedFiles: staged,
+      changedFiles: changed,
+      stagedOpen: true,
+      changesOpen: true,
+    });
+    expect(resolveRowScrollTarget(navItems, 2, staged, changed)).toEqual({
+      section: "staged",
+      rowIndex: 1,
+    });
+  });
+
+  it("maps a changes row nav index to the changes virtual list row index", () => {
+    const navItems = buildGitNavItems({
+      stagedFiles: staged,
+      changedFiles: changed,
+      stagedOpen: true,
+      changesOpen: true,
+    });
+    expect(resolveRowScrollTarget(navItems, 4, staged, changed)).toEqual({
+      section: "changes",
+      rowIndex: 0,
+    });
+    expect(resolveRowScrollTarget(navItems, 5, staged, changed)).toEqual({
+      section: "changes",
+      rowIndex: 1,
+    });
+  });
+
+  it("returns null for section headers", () => {
+    const navItems = buildGitNavItems({
+      stagedFiles: staged,
+      changedFiles: changed,
+      stagedOpen: true,
+      changesOpen: true,
+    });
+    expect(resolveRowScrollTarget(navItems, 0, staged, changed)).toBeNull();
+    expect(resolveRowScrollTarget(navItems, 3, staged, changed)).toBeNull();
+  });
+
+  it("returns null for nav indices that are not open-section rows", () => {
+    const navItems = buildGitNavItems({
+      stagedFiles: staged,
+      changedFiles: changed,
+      stagedOpen: false,
+      changesOpen: true,
+    });
+    expect(resolveRowScrollTarget(navItems, 1, staged, changed)).toBeNull();
+  });
+});
+
+describe("measureScrollMargin", () => {
+  it("computes offset from scroll container top to list top", () => {
+    const scrollEl = {
+      scrollTop: 120,
+      getBoundingClientRect: () => ({ top: 50 }),
+    } as HTMLElement;
+    const listEl = {
+      getBoundingClientRect: () => ({ top: 200 }),
+    } as HTMLElement;
+    expect(measureScrollMargin(scrollEl, listEl)).toBe(270);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/git-virtual-model.ts
+++ b/packages/extensions-silo/src/git-explorer/git-virtual-model.ts
@@ -1,0 +1,39 @@
+import type { GitFileStatus } from "../git/git-api";
+import type { GitNavItem } from "./git-nav";
+
+/** Which virtualized file list a keyboard-nav row index maps to. */
+export type VirtualRowScrollTarget = {
+  section: "staged" | "changes";
+  /** Index within that section's `files` array (not the flat nav index). */
+  rowIndex: number;
+};
+
+/**
+ * Map a flat {@link buildGitNavItems} index to the staged/changes virtual list
+ * row the focus group is about to land on. Headers and collapsed-section rows
+ * return `null` — only open-section file rows need scrolling.
+ */
+export function resolveRowScrollTarget(
+  navItems: GitNavItem[],
+  navIndex: number,
+  stagedFiles: GitFileStatus[],
+  changedFiles: GitFileStatus[],
+): VirtualRowScrollTarget | null {
+  const item = navItems[navIndex];
+  if (!item || item.kind !== "row") return null;
+  const files = item.section === "staged" ? stagedFiles : changedFiles;
+  const rowIndex = files.findIndex((f) => f.path === item.file.path);
+  if (rowIndex < 0) return null;
+  return { section: item.section, rowIndex };
+}
+
+/** Offset from a scroll container's content top to a virtual list root element. */
+export function measureScrollMargin(
+  scrollEl: HTMLElement,
+  listEl: HTMLElement,
+): number {
+  const scrollTop = scrollEl.scrollTop;
+  const scrollRect = scrollEl.getBoundingClientRect();
+  const listRect = listEl.getBoundingClientRect();
+  return listRect.top - scrollRect.top + scrollTop;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,6 +741,9 @@ importers:
       '@silo-code/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@tanstack/react-virtual':
+        specifier: ^3.14.10
+        version: 3.14.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -2417,6 +2420,15 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@tauri-apps/api@2.11.0':
     resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
@@ -6526,6 +6538,14 @@ snapshots:
   '@speed-highlight/core@1.2.18': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tanstack/react-virtual@3.14.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@tauri-apps/api@2.11.0': {}
 


### PR DESCRIPTION
## Summary

- Virtualize staged and changes file lists in Git Explorer with `@tanstack/react-virtual` — only the visible window (~30 rows) mounts on workspace switch instead of every changed file
- Dynamic `measureElement` keeps row positioning correct at non-default `uiFontSize` scales
- Keyboard nav (`useFocusGroup`) scrolls off-screen rows into view via `scrollToIndex` before roving focus lands; section collapse behavior unchanged

## Performance

- **Before (main, ~2,000 changed files):** 536–866 ms rAF mount stall (UI Freeze Probe)
- **After:** _pending manual GUI verify_ — automated verifier could not keep Silo Dev alive in the agent session; please fill in after sandbox test

## Test plan

- [x] `pnpm --filter silo exec tsc --noEmit`
- [x] `pnpm lint`
- [x] `pnpm test` (includes `git-virtual-model.test.ts` — nav-index → virtual-row mapping + scroll-margin math)
- [ ] Sandbox workspace with ~2,000 changed files → `document.querySelectorAll('.git-file-row').length` ≈ 30
- [ ] Arrow-key / Home / End through list; focus reaches rows outside initial window with scroll following
- [ ] UI Freeze Probe (`core.toggleUiFreezeProbe`): mount stall well below 536 ms baseline when switching into large-repo workspace


Made with [Cursor](https://cursor.com)