### PR TITLE
feat(agents): resolve the foreground process on Windows

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "app:dev": "tauri dev --config src-tauri/tauri.dev.conf.json --features automation",
+    "app:dev": "node scripts/unlock-dev-binary.mjs && tauri dev --config src-tauri/tauri.dev.conf.json --features automation",
     "app:build": "tauri build",
     "test": "vitest run --project unit --passWithNoTests",
     "test:watch": "vitest --project unit --passWithNoTests",

--- a/apps/desktop/scripts/unlock-dev-binary.mjs
+++ b/apps/desktop/scripts/unlock-dev-binary.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// Unblock `cargo build` on Windows when session-host daemons still hold the
+// dev binary open.
+//
+// Silo's Windows terminal backend has no separate helper binary: it re-execs
+// its own `silo.exe` as a headless ConPTY daemon (`spawn_daemon` in
+// `src-tauri/src/commands/session_windows.rs`). That IS the persistence
+// promise — terminals outlive the app window — but it means every live daemon
+// keeps `target\debug\silo.exe` mapped as its running image. Windows refuses
+// to delete a mapped image ("Access is denied. (os error 5)"), so cargo's
+// uplift step — which removes the old `silo.exe` before hardlinking the newly
+// linked one out of `deps\` — fails, and the next `pnpm dev` can't build at
+// all until someone hunts down and kills the orphaned daemons.
+//
+// Windows does allow *renaming* a running image; only delete/overwrite is
+// blocked (this is how Chrome self-updates). So move the locked artifacts
+// aside before cargo runs: the daemons keep running from the renamed file,
+// their terminals stay alive, and cargo gets a clean path to write. Nothing
+// is killed, so the persistence promise is preserved.
+//
+// Both artifacts are handled, because cargo hardlinks
+// `deps\silo-<hash>.exe` to `target\debug\silo.exe` — one file under two
+// names, so renaming only the second leaves the first still locked.
+//
+// Safe in both directions of misdetection: a false "not locked" leaves cargo
+// to fail exactly as it does today (no worse), and a false "locked" just
+// renames a file cargo was about to replace anyway.
+//
+// Scope: dev loop only. This touches `target\debug\` build artifacts, which
+// are never bundled and never shipped — release builds write to
+// `target\release\` and are not considered here. It is a no-op on macOS and
+// Linux, where a rebuild simply replaces the inode out from under a running
+// daemon and no lock exists to break.
+//
+// Usage (wired into the `app:dev` script):
+//   node scripts/unlock-dev-binary.mjs
+//   node scripts/unlock-dev-binary.mjs --dry-run   # report, change nothing
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const PREFIX = "[unlock-dev-binary]";
+
+// Suffix marking an artifact we moved aside. Kept globbable so a later run
+// can sweep the ones whose daemon has since exited.
+const LOCKED_SUFFIX_RE = /\.locked-\d+$/;
+
+/** The cargo target root, honoring `CARGO_TARGET_DIR` the way cargo does. */
+function targetRoot() {
+  const override = process.env.CARGO_TARGET_DIR;
+  if (override) return path.resolve(override);
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..", "src-tauri", "target");
+}
+
+/**
+ * The artifacts a running daemon can pin: the uplifted `silo.exe` and the
+ * `deps\silo-<hash>.exe` it is hardlinked from. The hash is cargo's stable
+ * metadata hash (crate + version + features + profile), not a content hash,
+ * so the deps path persists across rebuilds and can stay locked too.
+ */
+function candidates(debugDir) {
+  const found = [path.join(debugDir, "silo.exe")];
+  const depsDir = path.join(debugDir, "deps");
+  let entries = [];
+  try {
+    entries = fs.readdirSync(depsDir);
+  } catch {
+    return found;
+  }
+  for (const name of entries) {
+    if (/^silo-[0-9a-f]+\.exe$/.test(name))
+      found.push(path.join(depsDir, name));
+  }
+  return found;
+}
+
+/**
+ * Is this file held open as a running image? Probes with a write-mode open,
+ * which Windows refuses with a sharing violation while any process has the
+ * file mapped — non-destructive, unlike attempting the delete itself.
+ * Returns null when the file simply is not there.
+ */
+function isLocked(file) {
+  let fd;
+  try {
+    fd = fs.openSync(file, "r+");
+    return false;
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    return (
+      err.code === "EBUSY" || err.code === "EPERM" || err.code === "EACCES"
+    );
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+/**
+ * Delete artifacts moved aside by earlier runs. One stays behind for as long
+ * as its daemon lives, so failures here are expected and ignored — the next
+ * run tries again. Returns how many were actually removed.
+ */
+function sweepPrevious(dirs) {
+  let removed = 0;
+  for (const dir of dirs) {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      if (!LOCKED_SUFFIX_RE.test(name)) continue;
+      const file = path.join(dir, name);
+      if (DRY_RUN) {
+        console.log(`${PREFIX} would try to remove stale ${file}`);
+        continue;
+      }
+      try {
+        fs.unlinkSync(file);
+        removed += 1;
+      } catch {
+        // Still pinned by a live daemon — leave it for a later run.
+      }
+    }
+  }
+  return removed;
+}
+
+function main() {
+  if (process.platform !== "win32") return;
+
+  const debugDir = path.join(targetRoot(), "debug");
+  if (!fs.existsSync(debugDir)) return;
+
+  const swept = sweepPrevious([debugDir, path.join(debugDir, "deps")]);
+  if (swept > 0) {
+    console.log(
+      `${PREFIX} removed ${swept} artifact(s) whose daemon has exited`,
+    );
+  }
+
+  const stamp = Date.now();
+  let moved = 0;
+  for (const file of candidates(debugDir)) {
+    if (isLocked(file) !== true) continue;
+
+    const aside = `${file}.locked-${stamp}`;
+    if (DRY_RUN) {
+      console.log(`${PREFIX} would move ${file} -> ${path.basename(aside)}`);
+      moved += 1;
+      continue;
+    }
+    try {
+      fs.renameSync(file, aside);
+      moved += 1;
+      console.log(
+        `${PREFIX} moved locked ${path.basename(file)} aside as ${path.basename(aside)}`,
+      );
+    } catch (err) {
+      // Renaming a running image is supposed to be allowed, so this means
+      // something else is wrong. Fail loudly here rather than letting cargo
+      // report it as an opaque "Access is denied. (os error 5)".
+      console.error(
+        `${PREFIX} could not move ${file} aside: ${err.message}\n` +
+          `${PREFIX} the build will fail while this file is held open. ` +
+          `Check for leftover 'silo.exe --win-session-host' processes.`,
+      );
+      process.exit(1);
+    }
+  }
+
+  if (moved > 0) {
+    console.log(
+      `${PREFIX} ${moved} artifact(s) still in use by session-host daemons; ` +
+        `their terminals keep running and the build can proceed`,
+    );
+  }
+}
+
+main();

--- a/apps/desktop/scripts/unlock-dev-binary.mjs
+++ b/apps/desktop/scripts/unlock-dev-binary.mjs
@@ -134,7 +134,13 @@ function main() {
   if (process.platform !== "win32") return;
 
   const debugDir = path.join(targetRoot(), "debug");
-  if (!fs.existsSync(debugDir)) return;
+  if (!fs.existsSync(debugDir)) {
+    // Silence here would be indistinguishable from "nothing was locked", which
+    // is exactly the ambiguity that makes a dry run useless as a check.
+    if (DRY_RUN) console.log(`${PREFIX} no build dir at ${debugDir}`);
+    return;
+  }
+  if (DRY_RUN) console.log(`${PREFIX} inspecting ${debugDir}`);
 
   const swept = sweepPrevious([debugDir, path.join(debugDir, "deps")]);
   if (swept > 0) {
@@ -145,8 +151,18 @@ function main() {
 
   const stamp = Date.now();
   let moved = 0;
-  for (const file of candidates(debugDir)) {
-    if (isLocked(file) !== true) continue;
+  const found = candidates(debugDir);
+  if (DRY_RUN && found.length === 0) {
+    console.log(`${PREFIX} no silo.exe artifacts here yet — nothing to check`);
+  }
+  for (const file of found) {
+    const locked = isLocked(file);
+    if (DRY_RUN) {
+      const state =
+        locked === null ? "absent" : locked ? "LOCKED" : "not locked";
+      console.log(`${PREFIX}   ${state}: ${file}`);
+    }
+    if (locked !== true) continue;
 
     const aside = `${file}.locked-${stamp}`;
     if (DRY_RUN) {

--- a/apps/desktop/src-tauri/src/commands/fs.rs
+++ b/apps/desktop/src-tauri/src/commands/fs.rs
@@ -237,10 +237,76 @@ pub fn fs_reveal(path: String) -> Result<(), String> {
     }
     #[cfg(target_os = "windows")]
     {
+        use std::os::windows::process::CommandExt;
+        // `raw_arg`, not `arg`: Explorer parses its own command line rather
+        // than going through CommandLineToArgvW, so the quoting has to be
+        // exactly what `explorer_reveal_arg` produced.
         std::process::Command::new("explorer")
-            .arg(format!("/select,{}", path))
+            .raw_arg(explorer_reveal_arg(&path))
             .spawn()
             .map(|_| ())
             .map_err(|e| e.to_string())
+    }
+}
+
+/// The command line for `explorer.exe` that reveals `path` in its folder.
+///
+/// Two things Explorer is strict about, and this is where both used to go
+/// wrong. Every path crossing the IPC boundary uses forward slashes (see
+/// [`normalize_path`]), but `/select` only understands backslashes — given
+/// `C:/x/y` it silently ignores the selection and opens the default view,
+/// which is exactly what "reveal opened the wrong folder" looks like. And the
+/// path has to be quoted *inside* the `/select,` argument; Rust's normal
+/// argument quoting wraps the whole thing instead (`"/select,C:\a b\c"`),
+/// which Explorer rejects the moment the path holds a space.
+#[cfg(any(target_os = "windows", test))]
+fn explorer_reveal_arg(path: &str) -> String {
+    let win_path = path.replace('/', "\\");
+    let target = win_path.trim_end_matches('\\');
+    if target.is_empty() || target.ends_with(':') {
+        // A drive root has no item to select — just open it. Left unquoted: a
+        // bare drive letter can't contain a space, and a trailing backslash
+        // before a closing quote would escape the quote.
+        format!("{}\\", target)
+    } else {
+        format!("/select,\"{}\"", target)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reveal_arg_converts_separators_and_quotes_the_path() {
+        // The frontend always hands us forward slashes, even on Windows.
+        assert_eq!(
+            explorer_reveal_arg("C:/dev/silo/README.md"),
+            "/select,\"C:\\dev\\silo\\README.md\""
+        );
+    }
+
+    #[test]
+    fn reveal_arg_survives_spaces() {
+        assert_eq!(
+            explorer_reveal_arg("C:/Users/Dev User/My Notes/a b.txt"),
+            "/select,\"C:\\Users\\Dev User\\My Notes\\a b.txt\""
+        );
+    }
+
+    #[test]
+    fn reveal_arg_opens_a_drive_root_without_selecting() {
+        // `/select,"C:\"` would escape its own closing quote, so a root opens
+        // directly instead.
+        assert_eq!(explorer_reveal_arg("C:/"), "C:\\");
+        assert_eq!(explorer_reveal_arg("C:"), "C:\\");
+    }
+
+    #[test]
+    fn reveal_arg_ignores_a_trailing_separator_on_a_folder() {
+        assert_eq!(
+            explorer_reveal_arg("C:/dev/silo/"),
+            "/select,\"C:\\dev\\silo\""
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -12,6 +12,9 @@ pub mod fs;
 pub mod process;
 pub mod search;
 pub mod watch;
+// Foreground-process resolution for Windows (no ConPTY equivalent of
+// tcgetpgrp — the leader is inferred by walking the process tree).
+pub mod process_tree;
 pub mod session_backend;
 // Terminal identity carrier for the session environment (RFC 0028).
 pub mod session_env;

--- a/apps/desktop/src-tauri/src/commands/process_tree.rs
+++ b/apps/desktop/src-tauri/src/commands/process_tree.rs
@@ -51,6 +51,8 @@ pub struct Leader {
 pub fn resolve_leader(nodes: &[ProcessNode], root_pid: u32) -> Option<Leader> {
     let root = nodes.iter().find(|n| n.pid == root_pid)?;
 
+    let interesting = |n: &ProcessNode| !is_console_infrastructure(&n.name);
+
     // Depth-first from the root, tracking the deepest node found. Guarded
     // against cycles: pid reuse can, in principle, produce a parent chain that
     // loops, and an unguarded walk would hang the poll thread.
@@ -65,6 +67,14 @@ pub fn resolve_leader(nodes: &[ProcessNode], root_pid: u32) -> Option<Leader> {
             }
             seen.push(child.pid);
             let d = depth + 1;
+            // Descend through infrastructure but never report it as the
+            // leader — `conhost.exe` is a real child of the shell in a ConPTY
+            // session and was observed winning the walk, which named the
+            // terminal after the console host instead of the agent.
+            if !interesting(child) {
+                stack.push((child.pid, d));
+                continue;
+            }
             // Strictly deeper wins; equal depth keeps the lower pid.
             if d > best.0 || (d == best.0 && child.pid < best.1) {
                 best = (d, child.pid, child.name.clone());
@@ -80,6 +90,17 @@ pub fn resolve_leader(nodes: &[ProcessNode], root_pid: u32) -> Option<Leader> {
         // process, so nothing is running under it.
         at_prompt: best.0 == 0,
     })
+}
+
+/// Processes Windows creates as part of running a console, which are never the
+/// thing the user is interacting with. `conhost.exe` is spawned as a child of
+/// the shell in a ConPTY session, so it competes with the real program in the
+/// walk; naming a terminal "conhost" would be strictly wrong.
+fn is_console_infrastructure(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "conhost.exe" | "openconsole.exe"
+    )
 }
 
 /// Snapshot every process on the machine via the ToolHelp API.
@@ -229,6 +250,45 @@ mod tests {
         let b = resolve_leader(&reordered, 100).unwrap();
         assert_eq!(a, b);
         assert_eq!(a.pid, 200);
+    }
+
+    /// Observed live on Windows: `conhost.exe` is a real child of the shell in
+    /// a ConPTY session and briefly won the walk, naming the terminal after the
+    /// console host rather than the agent.
+    #[test]
+    fn console_infrastructure_never_becomes_the_leader() {
+        let nodes = vec![
+            node(100, 1, "cmd.exe"),
+            node(4972, 100, "conhost.exe"),
+            node(3572, 100, "copilot.exe"),
+        ];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.name, "copilot.exe");
+        assert_eq!(leader.pid, 3572);
+    }
+
+    /// A shell with nothing but a console host under it is still at a prompt —
+    /// conhost must not make it look like something is running.
+    #[test]
+    fn a_shell_with_only_a_console_host_is_at_the_prompt() {
+        let nodes = vec![node(100, 1, "cmd.exe"), node(4972, 100, "conhost.exe")];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.pid, 100);
+        assert!(leader.at_prompt);
+    }
+
+    /// Infrastructure is descended *through*, not pruned — an agent launched
+    /// under a console host must still be found.
+    #[test]
+    fn the_walk_descends_through_infrastructure() {
+        let nodes = vec![
+            node(100, 1, "cmd.exe"),
+            node(4972, 100, "conhost.exe"),
+            node(3572, 4972, "copilot.exe"),
+        ];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.name, "copilot.exe");
+        assert!(!leader.at_prompt);
     }
 
     /// A shell that has exited leaves nothing to report.

--- a/apps/desktop/src-tauri/src/commands/process_tree.rs
+++ b/apps/desktop/src-tauri/src/commands/process_tree.rs
@@ -1,5 +1,13 @@
 // Foreground-process resolution for the Windows session backend.
 //
+// Only `session_windows.rs` consumes this, so on other platforms nothing
+// constructs these types and rustc rightly says so. The module is still
+// *compiled* everywhere on purpose: `resolve_leader` is pure, and its tests
+// are the only place the tree-walk logic is exercised on a machine a
+// developer is likely to be sitting at. Silence the dead-code lint off
+// Windows rather than lose that.
+#![cfg_attr(not(windows), allow(dead_code))]
+//
 // Unix answers "what is running in this terminal right now?" with
 // `tcgetpgrp` on the PTY master — the kernel tracks a foreground process
 // *group*, and the answer is one syscall. ConPTY has no equivalent: there are

--- a/apps/desktop/src-tauri/src/commands/process_tree.rs
+++ b/apps/desktop/src-tauri/src/commands/process_tree.rs
@@ -1,0 +1,255 @@
+// Foreground-process resolution for the Windows session backend.
+//
+// Unix answers "what is running in this terminal right now?" with
+// `tcgetpgrp` on the PTY master — the kernel tracks a foreground process
+// *group*, and the answer is one syscall. ConPTY has no equivalent: there are
+// no process groups, and nothing records which process owns the console's
+// input. So Windows has to infer it, by walking the process tree down from the
+// shell the daemon spawned and taking the deepest descendant.
+//
+// That inference is what this module does. The Win32 snapshot itself lives in
+// `snapshot()` (Windows-only); everything that decides *which* process counts
+// as the leader is pure and lives in `resolve_leader`, so the interesting logic
+// is unit-testable on any platform. The bugs here are all in the tree walk, not
+// in the FFI.
+
+/// One process as reported by a snapshot: its own id, its parent's, and its
+/// executable name (no path — that is all `PROCESSENTRY32W` carries).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessNode {
+    pub pid: u32,
+    pub parent_pid: u32,
+    pub name: String,
+}
+
+/// The resolved foreground of a session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Leader {
+    /// The process we treat as the session leader. Reported as `pgid` across
+    /// the `SessionBackend` seam — Windows has no process groups, so "the pid
+    /// standing in for the group" is the honest reading of that field.
+    pub pid: u32,
+    /// Executable name, e.g. `"copilot.exe"`.
+    pub name: String,
+    /// True when the shell itself is the deepest process — i.e. nothing is
+    /// running under it, so the user is sitting at a prompt.
+    pub at_prompt: bool,
+}
+
+/// Find the deepest descendant of `root_pid`, which is the process actually
+/// interacting with the console.
+///
+/// "Deepest" rather than "only child" because real shells nest: `pwsh` runs
+/// `npm`, which runs `node`. The thing the user is waiting on is at the bottom.
+/// Ties (a process with two live children, e.g. a shell pipeline) resolve to
+/// the lowest pid, purely so the answer is stable between polls rather than
+/// flapping between two equally-deep siblings — a flapping leader would look
+/// like the agent starting and stopping.
+///
+/// Returns `None` if `root_pid` isn't in the snapshot at all, which means the
+/// shell has exited and the session is gone.
+pub fn resolve_leader(nodes: &[ProcessNode], root_pid: u32) -> Option<Leader> {
+    let root = nodes.iter().find(|n| n.pid == root_pid)?;
+
+    // Depth-first from the root, tracking the deepest node found. Guarded
+    // against cycles: pid reuse can, in principle, produce a parent chain that
+    // loops, and an unguarded walk would hang the poll thread.
+    let mut best = (0usize, root.pid, root.name.clone());
+    let mut stack = vec![(root_pid, 0usize)];
+    let mut seen = vec![root_pid];
+
+    while let Some((pid, depth)) = stack.pop() {
+        for child in nodes.iter().filter(|n| n.parent_pid == pid) {
+            if seen.contains(&child.pid) {
+                continue;
+            }
+            seen.push(child.pid);
+            let d = depth + 1;
+            // Strictly deeper wins; equal depth keeps the lower pid.
+            if d > best.0 || (d == best.0 && child.pid < best.1) {
+                best = (d, child.pid, child.name.clone());
+            }
+            stack.push((child.pid, d));
+        }
+    }
+
+    Some(Leader {
+        pid: best.1,
+        name: best.2,
+        // Depth 0 means we never left the root: the shell is the deepest
+        // process, so nothing is running under it.
+        at_prompt: best.0 == 0,
+    })
+}
+
+/// Snapshot every process on the machine via the ToolHelp API.
+///
+/// Declared with raw `extern "system"` rather than pulling in the `windows`
+/// crate, matching how `kill_child` already talks to Win32 in
+/// `session_windows.rs`.
+#[cfg(windows)]
+pub fn snapshot() -> Vec<ProcessNode> {
+    use std::ffi::c_void;
+
+    const TH32CS_SNAPPROCESS: u32 = 0x0000_0002;
+    const MAX_PATH: usize = 260;
+
+    #[repr(C)]
+    struct ProcessEntry32W {
+        dw_size: u32,
+        cnt_usage: u32,
+        th32_process_id: u32,
+        th32_default_heap_id: usize,
+        th32_module_id: u32,
+        cnt_threads: u32,
+        th32_parent_process_id: u32,
+        pc_pri_class_base: i32,
+        dw_flags: u32,
+        sz_exe_file: [u16; MAX_PATH],
+    }
+
+    extern "system" {
+        fn CreateToolhelp32Snapshot(flags: u32, pid: u32) -> *mut c_void;
+        fn Process32FirstW(snapshot: *mut c_void, entry: *mut ProcessEntry32W) -> i32;
+        fn Process32NextW(snapshot: *mut c_void, entry: *mut ProcessEntry32W) -> i32;
+        fn CloseHandle(handle: *mut c_void) -> i32;
+    }
+
+    let mut out = Vec::new();
+    unsafe {
+        let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        // INVALID_HANDLE_VALUE is -1, not null.
+        if snap.is_null() || snap as isize == -1 {
+            return out;
+        }
+        let mut entry: ProcessEntry32W = std::mem::zeroed();
+        entry.dw_size = std::mem::size_of::<ProcessEntry32W>() as u32;
+
+        if Process32FirstW(snap, &mut entry) != 0 {
+            loop {
+                let len = entry
+                    .sz_exe_file
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(MAX_PATH);
+                out.push(ProcessNode {
+                    pid: entry.th32_process_id,
+                    parent_pid: entry.th32_parent_process_id,
+                    name: String::from_utf16_lossy(&entry.sz_exe_file[..len]),
+                });
+                if Process32NextW(snap, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snap);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(pid: u32, parent_pid: u32, name: &str) -> ProcessNode {
+        ProcessNode {
+            pid,
+            parent_pid,
+            name: name.to_string(),
+        }
+    }
+
+    /// The shell alone: the user is sitting at a prompt.
+    #[test]
+    fn a_lone_shell_is_at_the_prompt() {
+        let nodes = vec![node(100, 1, "pwsh.exe")];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.pid, 100);
+        assert_eq!(leader.name, "pwsh.exe");
+        assert!(leader.at_prompt);
+    }
+
+    /// The case this whole module exists for: an agent running under the shell
+    /// must be the reported leader, so `agentByLeader` can name it.
+    #[test]
+    fn an_agent_under_the_shell_becomes_the_leader() {
+        let nodes = vec![node(100, 1, "pwsh.exe"), node(200, 100, "copilot.exe")];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.pid, 200);
+        assert_eq!(leader.name, "copilot.exe");
+        assert!(!leader.at_prompt);
+    }
+
+    /// Real shells nest — the process the user is waiting on is at the bottom.
+    #[test]
+    fn the_deepest_descendant_wins() {
+        let nodes = vec![
+            node(100, 1, "pwsh.exe"),
+            node(200, 100, "npm.cmd"),
+            node(300, 200, "node.exe"),
+        ];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.pid, 300);
+        assert_eq!(leader.name, "node.exe");
+    }
+
+    /// Unrelated processes on the machine must never be considered — the
+    /// snapshot covers every process, not just this session's.
+    #[test]
+    fn processes_outside_the_session_are_ignored() {
+        let nodes = vec![
+            node(100, 1, "pwsh.exe"),
+            node(200, 100, "copilot.exe"),
+            // A deeper tree belonging to somebody else entirely.
+            node(500, 1, "explorer.exe"),
+            node(600, 500, "chrome.exe"),
+            node(700, 600, "chrome.exe"),
+        ];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.pid, 200);
+    }
+
+    /// Two equally-deep children must resolve the same way on every poll, or
+    /// the leader flaps and the agent looks like it keeps starting and stopping.
+    #[test]
+    fn ties_resolve_to_the_lowest_pid_for_stability() {
+        let nodes = vec![
+            node(100, 1, "pwsh.exe"),
+            node(300, 100, "grep.exe"),
+            node(200, 100, "cat.exe"),
+        ];
+        let a = resolve_leader(&nodes, 100).unwrap();
+        // Same set, different snapshot ordering — Win32 makes no ordering
+        // promise, so the answer must not depend on it.
+        let reordered = vec![
+            node(200, 100, "cat.exe"),
+            node(100, 1, "pwsh.exe"),
+            node(300, 100, "grep.exe"),
+        ];
+        let b = resolve_leader(&reordered, 100).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.pid, 200);
+    }
+
+    /// A shell that has exited leaves nothing to report.
+    #[test]
+    fn a_missing_root_resolves_to_nothing() {
+        let nodes = vec![node(500, 1, "explorer.exe")];
+        assert!(resolve_leader(&nodes, 100).is_none());
+    }
+
+    /// Pid reuse can produce a parent chain that loops. An unguarded walk would
+    /// spin forever on the daemon's poll thread.
+    #[test]
+    fn a_cyclic_parent_chain_terminates() {
+        let nodes = vec![
+            node(100, 1, "pwsh.exe"),
+            node(200, 100, "a.exe"),
+            node(300, 200, "b.exe"),
+            // b's "child" is actually its grandparent.
+            node(100, 300, "pwsh.exe"),
+        ];
+        let leader = resolve_leader(&nodes, 100).unwrap();
+        assert_eq!(leader.pid, 300);
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/session_windows.rs
+++ b/apps/desktop/src-tauri/src/commands/session_windows.rs
@@ -19,7 +19,8 @@ use parking_lot::Mutex;
 use portable_pty::PtySize;
 
 use super::session_backend::{
-    log_event, Connection, ForegroundSub, SessionBackend, SessionChild, SessionMaster,
+    log_event, Connection, ForegroundInfo, ForegroundSub, SessionBackend, SessionChild,
+    SessionMaster,
 };
 use super::session_env::{encode_session_env, SESSION_ENV_CARRIER};
 
@@ -28,6 +29,23 @@ use super::session_env::{encode_session_env, SESSION_ENV_CARRIER};
 const T_DATA: u8 = 0;
 const T_RESIZE: u8 = 1;
 const T_KILL: u8 = 2;
+/// Daemon → client: a foreground-process update, tab-separated
+/// `<pid>\t<at_prompt 0|1>\t<leader name>`. Mirrors the Unix host's T_FG_REP.
+const T_FG_REP: u8 = 4;
+/// Client → daemon: turn this connection into a foreground-events subscriber.
+/// Such a connection must never join `clients` — under MAX_DATA_CLIENTS = 1 it
+/// would evict the live data client (the same regression RFC 0026 hit on Unix).
+const T_SUBSCRIBE_FG: u8 = 6;
+
+/// How often to re-snapshot the process tree while a foreground subscriber is
+/// attached. `CreateToolhelp32Snapshot` enumerates *every* process on the
+/// machine, so this is not free — with a dozen terminals open a tight loop is
+/// real overhead. Poll briskly right after a change (an agent starting is what
+/// the user is waiting to see) and back off while the answer is stable.
+const FG_POLL_FAST: Duration = Duration::from_millis(500);
+const FG_POLL_IDLE: Duration = Duration::from_millis(2500);
+/// Stay on the fast cadence for this long after the leader last changed.
+const FG_SETTLE: Duration = Duration::from_secs(5);
 
 const RING_CAPACITY: usize = 256 * 1024;
 const CONNECT_TIMEOUT: Duration = Duration::from_millis(3000);
@@ -61,6 +79,64 @@ fn read_frame<R: Read>(r: &mut R) -> io::Result<(u8, Vec<u8>)> {
         r.read_exact(&mut payload)?;
     }
     Ok((tag, payload))
+}
+
+/// Serve one foreground-events subscriber until it disconnects.
+///
+/// Unix gets this for free: `tcgetpgrp` on the PTY master reports the
+/// foreground process group, and the daemon blocks until it changes. ConPTY has
+/// no such notion, so the leader is *inferred* by walking the process tree from
+/// the shell we spawned (see `process_tree`). That inference is only as good as
+/// its cadence, hence the poll — there is no change event to wait on.
+///
+/// Only differences are sent, so a terminal sitting at a prompt costs one
+/// snapshot every `FG_POLL_IDLE` and no traffic at all.
+#[cfg(windows)]
+fn serve_foreground(mut stream: TcpStream, child_pid: Arc<AtomicU32>) {
+    use super::process_tree;
+
+    let mut last: Option<(u32, bool)> = None;
+    let mut last_change = Instant::now();
+
+    loop {
+        let root = child_pid.load(Ordering::Acquire);
+        if root == 0 {
+            return; // shell never started, or already reaped
+        }
+
+        match process_tree::resolve_leader(&process_tree::snapshot(), root) {
+            Some(leader) => {
+                let key = (leader.pid, leader.at_prompt);
+                if last != Some(key) {
+                    last = Some(key);
+                    last_change = Instant::now();
+                    // `cwd` is deliberately absent: Unix reads it from
+                    // /proc or KERN_PROCARGS, and Windows has no cheap
+                    // equivalent. The seam allows "" for unknown.
+                    let payload = format!(
+                        "{}\t{}\t{}",
+                        leader.pid,
+                        if leader.at_prompt { 1 } else { 0 },
+                        leader.name
+                    );
+                    if write_frame(&mut stream, T_FG_REP, payload.as_bytes()).is_err() {
+                        return; // subscriber gone
+                    }
+                }
+            }
+            None => {
+                // The shell is no longer in the snapshot — the session is over.
+                return;
+            }
+        }
+
+        let interval = if last_change.elapsed() < FG_SETTLE {
+            FG_POLL_FAST
+        } else {
+            FG_POLL_IDLE
+        };
+        thread::sleep(interval);
+    }
 }
 
 // ── Paths ─────────────────────────────────────────────────────────────────────
@@ -254,6 +330,13 @@ pub fn run_daemon(
                 }
             };
             let _ = cmd_stream.set_read_timeout(None);
+
+            // A foreground subscriber never becomes a data client — joining
+            // `clients` here would evict the live one under MAX_DATA_CLIENTS.
+            if matches!(first, Some((T_SUBSCRIBE_FG, _))) {
+                serve_foreground(stream, child_pid);
+                return;
+            }
 
             let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
 
@@ -520,8 +603,41 @@ impl SessionBackend for SessionWindowsBackend {
         Ok(())
     }
 
-    fn subscribe_foreground(&self, _handle: &str) -> Option<Box<dyn ForegroundSub>> {
-        None
+    fn subscribe_foreground(&self, handle: &str) -> Option<Box<dyn ForegroundSub>> {
+        // A second connection dedicated to foreground events, mirroring the
+        // Unix backend: announce with T_SUBSCRIBE_FG so the daemon serves
+        // updates on it instead of treating it as a data client.
+        let mut stream = self.connect(handle).ok()?;
+        write_frame(&mut stream, T_SUBSCRIBE_FG, &[]).ok()?;
+        Some(Box::new(TcpForegroundSub { stream }))
+    }
+}
+
+/// Streams `T_FG_REP` frames from the daemon into the neutral `ForegroundInfo`.
+struct TcpForegroundSub {
+    stream: TcpStream,
+}
+
+impl ForegroundSub for TcpForegroundSub {
+    fn next(&mut self) -> Option<ForegroundInfo> {
+        loop {
+            let (tag, payload) = read_frame(&mut self.stream).ok()?;
+            if tag != T_FG_REP {
+                continue;
+            }
+            let text = String::from_utf8_lossy(&payload);
+            let mut parts = text.split('\t');
+            let pgid: i32 = parts.next()?.parse().ok()?;
+            let at_prompt = parts.next()? == "1";
+            let leader = parts.next().unwrap_or("").to_string();
+            return Some(ForegroundInfo {
+                pgid,
+                at_prompt,
+                leader,
+                // Windows has no cheap per-process cwd; the seam allows "".
+                cwd: String::new(),
+            });
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/commands/session_windows.rs
+++ b/apps/desktop/src-tauri/src/commands/session_windows.rs
@@ -136,7 +136,37 @@ fn serve_foreground(mut stream: TcpStream, child_pid: Arc<AtomicU32>) {
             FG_POLL_IDLE
         };
         thread::sleep(interval);
+
+        // Only *changes* are written, so a gone subscriber would otherwise go
+        // unnoticed until the next leader change — for a terminal sitting at a
+        // prompt, never. This thread would then snapshot every process on the
+        // machine forever, once per reattach. Check the socket for EOF instead.
+        if subscriber_gone(&stream) {
+            return;
+        }
     }
+}
+
+/// True once the subscriber has closed its end. A foreground subscriber sends
+/// nothing after `T_SUBSCRIBE_FG`, so a readable zero-length read is EOF and
+/// anything else readable is protocol noise we can ignore.
+#[cfg(windows)]
+fn subscriber_gone(stream: &TcpStream) -> bool {
+    if stream.set_nonblocking(true).is_err() {
+        return false;
+    }
+    let mut probe = [0u8; 1];
+    let mut peer: &TcpStream = stream;
+    let gone = match peer.read(&mut probe) {
+        Ok(0) => true,
+        Ok(_) => false,
+        Err(e) => !matches!(
+            e.kind(),
+            io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+        ),
+    };
+    let _ = stream.set_nonblocking(false);
+    gone
 }
 
 // ── Paths ─────────────────────────────────────────────────────────────────────

--- a/apps/docs/guide/agent-sessions.md
+++ b/apps/docs/guide/agent-sessions.md
@@ -39,8 +39,18 @@ only ever adds or removes its own entry (marked `# silo-managed-agent-hook`);
 your other hooks are never touched. If a settings file exists but isn't valid
 JSON, Silo refuses to rewrite it — fix or remove the file first.
 
-Exact resume works on **macOS and Linux**; on Windows, agents are still
-detected, but exact resume isn't available. The hook runs a small, readable
+Exact resume works on **macOS and Linux**. On Windows, Silo detects which
+agent is running and shows its activity, but exact resume isn't available —
+the hook is a POSIX shell script, so there's nothing to install there, and
+Settings → Agents is read-only.
+
+One caveat on Windows activity: Silo reads the status signals an agent emits,
+and not every agent emits them per turn. GitHub Copilot CLI, for instance,
+announces a task when it starts one but not when it finishes, so its
+busy/idle state is less reliable than Claude's or Codex's. Which agent is
+running is always correct; how busy it is may lag.
+
+The hook runs a small, readable
 shell script Silo writes to `~/.silo/agent-hooks/track-session.sh` — you can
 open and inspect it, and it needs no interpreter or dependency beyond the shell
 your agent already runs its hooks with. See the

--- a/apps/docs/roadmap/agent-system.md
+++ b/apps/docs/roadmap/agent-system.md
@@ -132,8 +132,18 @@ These are unsettled — the reason this page is `experimental`:
 - **Sub-agent correlation** — the hook events give a count and a bag of running
   types, but no key to pair a specific sub-agent start with its stop; a precise
   tree is out of scope.
-- **Platform** — exact resume is macOS + Linux only (it needs a foreground
-  process-group id to correlate against); Windows stays detection-only.
+- **Platform** — exact resume is macOS + Linux only: the hook is a POSIX
+  shell script, and correlation matches the hook's recorded pgid against the
+  terminal's foreground process group. Windows has **detection and identity**
+  — `SessionWindowsBackend` resolves a foreground leader by walking the
+  process tree from the shell it spawned (ConPTY exposes no `tcgetpgrp`
+  equivalent), which feeds the same `agentByLeader` path every platform uses.
+  What it lacks is a per-turn *activity* signal for agents that don't emit
+  one: Copilot CLI announces a task's start via its OSC 0 title but never its
+  end, so its busy/idle state relies on a debounce rather than an explicit
+  signal. Deriving activity from process-tree churn (a tool subprocess running
+  under the agent means "working") would fix that class of agent on every
+  platform, and is not yet designed.
 
 ## Non-goals
 

--- a/apps/docs/roadmap/agent-system.md
+++ b/apps/docs/roadmap/agent-system.md
@@ -138,7 +138,7 @@ These are unsettled — the reason this page is `experimental`:
   — `SessionWindowsBackend` resolves a foreground leader by walking the
   process tree from the shell it spawned (ConPTY exposes no `tcgetpgrp`
   equivalent), which feeds the same `agentByLeader` path every platform uses.
-  What it lacks is a per-turn *activity* signal for agents that don't emit
+  What it lacks is a per-turn _activity_ signal for agents that don't emit
   one: Copilot CLI announces a task's start via its OSC 0 title but never its
   end, so its busy/idle state relies on a debounce rather than an explicit
   signal. Deriving activity from process-tree churn (a tool subprocess running

--- a/packages/extension-host/src/extension-host/agent-catalog.test.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.test.ts
@@ -44,9 +44,7 @@ describe("leaderBasename — Windows executable names (RFC: Windows agents)", ()
   });
 
   it("handles a backslash-separated path", () => {
-    expect(agentByLeader("C:\\Users\\x\\bin\\copilot.exe")?.id).toBe(
-      "copilot",
-    );
+    expect(agentByLeader("C:\\Users\\x\\bin\\copilot.exe")?.id).toBe("copilot");
   });
 
   it("leaves Unix leaders exactly as they were", () => {

--- a/packages/extension-host/src/extension-host/agent-catalog.test.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.test.ts
@@ -27,6 +27,39 @@ import {
   detectFromOutput,
 } from "./agent-catalog";
 
+describe("leaderBasename — Windows executable names (RFC: Windows agents)", () => {
+  // Observed live: the process-tree walk correctly reported `copilot.exe`, and
+  // agentByLeader still said "isn't a known agent" — `leaderNames` is written
+  // the Unix way (`copilot`), so nothing matched and no agent was ever named
+  // on Windows.
+  it("strips a .exe extension so Windows leaders match the catalog", () => {
+    expect(agentByLeader("copilot.exe")?.id).toBe("copilot");
+    expect(agentByLeader("claude.exe")?.id).toBe("claude");
+  });
+
+  it("strips the other Windows executable extensions", () => {
+    expect(leaderBasename("copilot.cmd")).toBe("copilot");
+    expect(leaderBasename("copilot.bat")).toBe("copilot");
+    expect(leaderBasename("copilot.COM")).toBe("copilot");
+  });
+
+  it("handles a backslash-separated path", () => {
+    expect(agentByLeader("C:\\Users\\x\\bin\\copilot.exe")?.id).toBe(
+      "copilot",
+    );
+  });
+
+  it("leaves Unix leaders exactly as they were", () => {
+    expect(agentByLeader("/usr/local/bin/copilot")?.id).toBe("copilot");
+    expect(leaderBasename("/Users/x/.local/bin/claude")).toBe("claude");
+  });
+
+  it("does not strip a dot that isn't an executable extension", () => {
+    // A hypothetical `agent.py` must not silently become `agent`.
+    expect(leaderBasename("agent.py")).toBe("agent.py");
+  });
+});
+
 describe("catalog integrity", () => {
   it("has unique agent ids", () => {
     const ids = AGENT_CATALOG.map((a) => a.id);

--- a/packages/extension-host/src/extension-host/agent-catalog.test.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.test.ts
@@ -763,6 +763,39 @@ describe("detectIdleAfterWorking", () => {
 
   it("returns null for signals other detectors already own (braille, ✳, empty)", () => {
     expect(detectIdleAfterWorking(0, "⠋ my-project", true)).toBeNull();
+  });
+
+  it("does not let one agent's fallback end another agent's turn", () => {
+    // Codex's rule is "any plain title ends the turn". Copilot shelling out
+    // sets the title to "Windows PowerShell" (observed live on Windows), which
+    // would otherwise read as Codex going idle and end Copilot's turn
+    // mid-task. Once a terminal's agent is known, only that agent may speak.
+    expect(
+      detectIdleAfterWorking(0, "Windows PowerShell", true, "copilot"),
+    ).toBeNull();
+  });
+
+  it("still applies the fallback for the agent it belongs to", () => {
+    expect(detectIdleAfterWorking(0, "my-project", true, "codex")).toEqual({
+      status: "idle",
+      source: "agent",
+      timer: "clear",
+    });
+  });
+
+  it("applies any agent's fallback when identity is not yet known", () => {
+    // Before a terminal is identified there is nothing to gate on, so the
+    // pre-existing behavior must be preserved exactly.
+    expect(detectIdleAfterWorking(0, "my-project", true, null)).toEqual({
+      status: "idle",
+      source: "agent",
+      timer: "clear",
+    });
+    expect(detectIdleAfterWorking(0, "my-project", true, undefined)).toEqual({
+      status: "idle",
+      source: "agent",
+      timer: "clear",
+    });
     expect(detectIdleAfterWorking(0, "✳ waiting…", true)).toBeNull();
     expect(detectIdleAfterWorking(0, "", true)).toBeNull();
   });

--- a/packages/extension-host/src/extension-host/agent-catalog.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.ts
@@ -3,6 +3,7 @@ import {
   detectCodexCLI,
   detectCodexIdleAfterWorking,
   detectCopilotCLI,
+  detectCopilotTitle,
   detectPiTitle,
   detectCursorAgent,
   detectCursorAgentOutput,
@@ -484,9 +485,11 @@ const copilot: AgentDefinition = {
   id: "copilot",
   displayName: "GitHub Copilot CLI",
   leaderNames: ["copilot"],
-  // OSC 9;4 (ConEmu/Windows Terminal progress protocol), ported from
-  // silo-extensions/agent-monitor.
-  activityDetectors: [detectCopilotCLI],
+  // Title first: captured live on Windows (2026-08-24), Copilot emitted no
+  // OSC 9;4 at all for a whole session, so the progress detector alone left
+  // its activity permanently stale. The title is its per-turn signal and also
+  // identifies it. OSC 9;4 stays as a second source where it does fire.
+  activityDetectors: [detectCopilotTitle, detectCopilotCLI],
   resume: {
     kind: "hook",
     installStrategy: "copilot-hooks-dir",

--- a/packages/extension-host/src/extension-host/agent-catalog.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.ts
@@ -695,8 +695,13 @@ export const AGENT_CATALOG: AgentDefinition[] = [
  * Bun-compiled `claude` reporting as `/Users/x/.local/bin/claude`, not bare
  * `claude`) — match on the basename, not the whole string. */
 export function leaderBasename(leader: string): string {
-  const idx = leader.lastIndexOf("/");
-  return idx >= 0 ? leader.slice(idx + 1) : leader;
+  // Windows reports a bare executable name with its extension (`copilot.exe`)
+  // and uses `\` as the separator; Unix reports a path with `/` and no
+  // extension. `leaderNames` is written the Unix way, so normalize to that —
+  // without this, no agent matches on Windows at all.
+  const idx = Math.max(leader.lastIndexOf("/"), leader.lastIndexOf("\\"));
+  const base = idx >= 0 ? leader.slice(idx + 1) : leader;
+  return base.replace(/\.(exe|cmd|bat|com)$/i, "");
 }
 
 /** The catalog entry whose `leaderNames` includes this foreground leader's

--- a/packages/extension-host/src/extension-host/agent-catalog.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.ts
@@ -813,14 +813,22 @@ export function detectFromOsc(
  * OSC pair — a catalog agent's `idleAfterWorking` (only Codex has one today)
  * gets a chance to interpret it *given* whether this terminal was already in
  * an agent-sourced working state. First non-null result wins.
+ *
+ * `agentCatalogId` is the terminal's already-established identity, when there
+ * is one: once we know *which* agent is running, only that agent's fallback
+ * may speak for it. Without this gate Codex's "any plain title ends the turn"
+ * rule fires for every agent — e.g. Copilot shelling out sets the title to
+ * `"Windows PowerShell"`, which would end Copilot's turn mid-task.
  */
 export function detectIdleAfterWorking(
   code: number,
   payload: string,
   wasAgentWorking: boolean,
+  agentCatalogId?: string | null,
 ): DetectionResult | null {
   for (const agent of AGENT_CATALOG) {
     if (!agent.idleAfterWorking) continue;
+    if (agentCatalogId && agent.id !== agentCatalogId) continue;
     const result = agent.idleAfterWorking(code, payload, wasAgentWorking);
     if (result) return result;
   }

--- a/packages/extension-host/src/extension-host/agent-hook-runtime.ts
+++ b/packages/extension-host/src/extension-host/agent-hook-runtime.ts
@@ -184,6 +184,10 @@ export function createHookRuntime(deps: HookRuntimeDeps): HookRuntime {
   }
 
   async function startAgentHooksWatch() {
+    // Unconditional: on Windows the hooks dir may not resolve or the watch may
+    // fail outright, and that is precisely the platform whose capability line
+    // matters — `bindForeground`'s "no snapshot" message points readers at it.
+    void logPlatformCapabilities();
     try {
       const dir = await resolveAgentHooksDir();
       await invoke("fs_create_dir", { path: dir });
@@ -195,7 +199,6 @@ export function createHookRuntime(deps: HookRuntimeDeps): HookRuntime {
       agentsChannel.info(
         `Hook-events watch started on ${dir} (consume on write, not polled).`,
       );
-      void logPlatformCapabilities();
     } catch (err) {
       agentsChannel.warn(
         "Could not start agent-hooks file watch; catch-up reads only.",

--- a/packages/extension-host/src/extension-host/agent-hook-runtime.ts
+++ b/packages/extension-host/src/extension-host/agent-hook-runtime.ts
@@ -4,6 +4,7 @@
  * {@link HookRuntimeDeps}.
  */
 import { invoke } from "@tauri-apps/api/core";
+import { systemInfo } from "../services/tauri-system";
 import { agentsChannel } from "./agents-channel";
 import {
   readNewHookEvents,
@@ -194,6 +195,7 @@ export function createHookRuntime(deps: HookRuntimeDeps): HookRuntime {
       agentsChannel.info(
         `Hook-events watch started on ${dir} (consume on write, not polled).`,
       );
+      void logPlatformCapabilities();
     } catch (err) {
       agentsChannel.warn(
         "Could not start agent-hooks file watch; catch-up reads only.",
@@ -221,4 +223,31 @@ export function createHookRuntime(deps: HookRuntimeDeps): HookRuntime {
     startAgentHooksWatch,
     dispose,
   };
+}
+
+/**
+ * State what agent machinery is actually available on this platform, once, at
+ * startup.
+ *
+ * Every other line in this channel describes something that happened. This one
+ * describes what *can* happen — which is the line that was missing when agents
+ * silently failed to be identified on Windows: the channel logged the
+ * foreground path in detail and said nothing about the fact that there is no
+ * foreground path there at all. A user reporting "my agent doesn't show up" can
+ * paste this instead of us reading source.
+ */
+async function logPlatformCapabilities(): Promise<void> {
+  try {
+    const { os } = await systemInfo();
+    const windows = os === "windows";
+    agentsChannel.info(
+      `Agent capabilities on ${os}: ` +
+        `foreground=${windows ? "process-tree walk" : "tcgetpgrp"} · ` +
+        `identity=${windows ? "leader name (via walk)" : "leader name"} · ` +
+        `hooks=${windows ? "unavailable (POSIX shell only)" : "available"} · ` +
+        `activity=OSC`,
+    );
+  } catch {
+    // Never let diagnostics break startup.
+  }
 }

--- a/packages/extension-host/src/extension-host/agent-osc-detectors.test.ts
+++ b/packages/extension-host/src/extension-host/agent-osc-detectors.test.ts
@@ -10,6 +10,7 @@ import {
   detectShellIntegration,
   stripAgentStatusMarkers,
   CURSOR_SPINNER_FRAMES,
+  detectCopilotTitle,
 } from "./agent-osc-detectors";
 
 // Test cases adapted from silo-extensions/agent-monitor's own
@@ -495,5 +496,59 @@ describe("stripAgentStatusMarkers", () => {
     expect(stripAgentStatusMarkers("notes - Workingham")).toBe(
       "notes - Workingham",
     );
+  });
+});
+
+describe("detectCopilotTitle — captured live on Windows 2026-08-24", () => {
+  it("reads the bare title as idle and identifies Copilot", () => {
+    expect(detectCopilotTitle(0, "GitHub Copilot")).toEqual({
+      status: "idle",
+      source: "agent",
+      identity: true,
+      agentId: "copilot",
+    });
+  });
+
+  it("reads a task title as working", () => {
+    // Exactly what Copilot emitted when asked to do something slow.
+    expect(detectCopilotTitle(0, "Implement Quick Task - GitHub Copilot")).toEqual(
+      {
+        status: "working",
+        source: "agent",
+        timer: "schedule-agent",
+        agentId: "copilot",
+      },
+    );
+  });
+
+  it("handles a task title echoing the user's own prompt", () => {
+    const r = detectCopilotTitle(
+      0,
+      "do something simple for 20 seconds - GitHub Copilot",
+    );
+    expect(r?.status).toBe("working");
+    expect(r?.agentId).toBe("copilot");
+  });
+
+  it("ignores titles set by subprocesses Copilot spawns", () => {
+    // Observed in the same capture: powershell and cmd overwrite the title
+    // while Copilot shells out. Neither should change agent state.
+    expect(detectCopilotTitle(0, "Windows PowerShell")).toBeNull();
+    expect(
+      detectCopilotTitle(0, "C:\\WINDOWS\\system32\\cmd.exe - copilot"),
+    ).toBeNull();
+  });
+
+  it("ignores non-title OSC codes", () => {
+    // OSC 4/10/11 colour queries appeared throughout the same capture.
+    expect(detectCopilotTitle(4, "0;?")).toBeNull();
+    expect(detectCopilotTitle(11, "#0D1117")).toBeNull();
+    expect(detectCopilotTitle(9, "4;1;50")).toBeNull();
+  });
+
+  it("does not match a title that merely mentions Copilot", () => {
+    // Must be the suffix, not a substring anywhere — otherwise a shell whose
+    // cwd is a folder named "GitHub Copilot" would read as an agent.
+    expect(detectCopilotTitle(0, "GitHub Copilot notes - vim")).toBeNull();
   });
 });

--- a/packages/extension-host/src/extension-host/agent-osc-detectors.test.ts
+++ b/packages/extension-host/src/extension-host/agent-osc-detectors.test.ts
@@ -511,14 +511,14 @@ describe("detectCopilotTitle — captured live on Windows 2026-08-24", () => {
 
   it("reads a task title as working", () => {
     // Exactly what Copilot emitted when asked to do something slow.
-    expect(detectCopilotTitle(0, "Implement Quick Task - GitHub Copilot")).toEqual(
-      {
-        status: "working",
-        source: "agent",
-        timer: "schedule-agent",
-        agentId: "copilot",
-      },
-    );
+    expect(
+      detectCopilotTitle(0, "Implement Quick Task - GitHub Copilot"),
+    ).toEqual({
+      status: "working",
+      source: "agent",
+      timer: "schedule-agent",
+      agentId: "copilot",
+    });
   });
 
   it("handles a task title echoing the user's own prompt", () => {

--- a/packages/extension-host/src/extension-host/agent-osc-detectors.ts
+++ b/packages/extension-host/src/extension-host/agent-osc-detectors.ts
@@ -355,6 +355,52 @@ export function detectPiTitle(
   };
 }
 
+/**
+ * Copilot CLI's OSC 0 title, which is both a state and an identity signal:
+ *
+ * ```
+ * GitHub Copilot                                    idle, at its prompt
+ * Implement Quick Task - GitHub Copilot             working on a task
+ * do something simple for 20 seconds - GitHub Copilot
+ * ```
+ *
+ * Captured live on Windows (2026-08-24). This matters more than it looks:
+ * Copilot emitted **no OSC 9;4 progress at all** in that session, so
+ * {@link detectCopilotCLI} — the progress detector — never fired and
+ * Copilot's activity never changed. The title is its only per-turn signal.
+ *
+ * The suffix is specific enough to carry `agentId`, unlike the OSC 9;4
+ * progress protocol, which is generic to Windows consoles and would label any
+ * `winget` install as Copilot.
+ *
+ * A working title arms the agent-idle debounce rather than promising an
+ * explicit idle: Copilot sets a title when a task *starts* and was not
+ * observed resetting it on completion, so silence is what ends the turn —
+ * the same shape as Cursor Agent's spinner fallback.
+ */
+const COPILOT_TITLE = "GitHub Copilot";
+const COPILOT_TITLE_SUFFIX = ` - ${COPILOT_TITLE}`;
+
+export function detectCopilotTitle(
+  code: number,
+  payload: string,
+): DetectionResult | null {
+  if (code !== 0) return null;
+  const title = payload.trim();
+  if (title === COPILOT_TITLE) {
+    return { status: "idle", source: "agent", identity: true, agentId: "copilot" };
+  }
+  if (title.endsWith(COPILOT_TITLE_SUFFIX)) {
+    return {
+      status: "working",
+      source: "agent",
+      timer: "schedule-agent",
+      agentId: "copilot",
+    };
+  }
+  return null;
+}
+
 export function detectCopilotCLI(
   code: number,
   payload: string,

--- a/packages/extension-host/src/extension-host/agent-osc-detectors.ts
+++ b/packages/extension-host/src/extension-host/agent-osc-detectors.ts
@@ -388,7 +388,12 @@ export function detectCopilotTitle(
   if (code !== 0) return null;
   const title = payload.trim();
   if (title === COPILOT_TITLE) {
-    return { status: "idle", source: "agent", identity: true, agentId: "copilot" };
+    return {
+      status: "idle",
+      source: "agent",
+      identity: true,
+      agentId: "copilot",
+    };
   }
   if (title.endsWith(COPILOT_TITLE_SUFFIX)) {
     return {

--- a/packages/extension-host/src/extension-host/agents-service.test.ts
+++ b/packages/extension-host/src/extension-host/agents-service.test.ts
@@ -149,6 +149,70 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe("AgentsService — promotion from the foreground leader alone", () => {
+  // Windows has no hooks (the script is POSIX shell) and no guarantee of an
+  // OSC promotion, so the foreground leader is the only evidence available.
+  // Before this, such a terminal was tracked and correctly named but stayed
+  // isAgent: false — and every consumer that shows "agent terminals" filters
+  // on isAgent, so a working Copilot session was invisible.
+  it("promotes a shell to an agent when a known agent is the foreground leader", async () => {
+    const id = "t-fg-promote";
+    const sessionId = "sess-fg-promote";
+
+    await attachTerminal(id, sessionId);
+    expect(svc.getByTerminalId(id)?.isAgent).toBe(false);
+
+    // No hook event, no OSC — just the leader, as on Windows.
+    foreground(sessionId, {
+      pgid: 9560,
+      atPrompt: false,
+      leader: "copilot.exe",
+      cwd: "",
+    });
+
+    const info = svc.getByTerminalId(id);
+    expect(info?.isAgent).toBe(true);
+    expect(info?.agentId).toBe("copilot");
+    expect(info?.agentName).toBe("GitHub Copilot CLI");
+  });
+
+  it("leaves a plain shell alone", async () => {
+    const id = "t-fg-shell";
+    const sessionId = "sess-fg-shell";
+
+    await attachTerminal(id, sessionId);
+    foreground(sessionId, {
+      pgid: 3732,
+      atPrompt: true,
+      leader: "cmd.exe",
+      cwd: "",
+    });
+
+    expect(svc.getByTerminalId(id)?.isAgent).toBe(false);
+  });
+
+  it("does not re-promote on every tick once it is already an agent", async () => {
+    // The Windows walk reports a new leader roughly once a second while an
+    // agent shells out (git, where, powershell), so this path is hot.
+    const id = "t-fg-repeat";
+    const sessionId = "sess-fg-repeat";
+
+    await attachTerminal(id, sessionId);
+    for (let i = 0; i < 3; i++) {
+      foreground(sessionId, {
+        pgid: 9560,
+        atPrompt: false,
+        leader: "copilot.exe",
+        cwd: "",
+      });
+    }
+
+    const info = svc.getByTerminalId(id);
+    expect(info?.isAgent).toBe(true);
+    expect(info?.agentId).toBe("copilot");
+  });
+});
+
 describe("AgentsService — Grok session-file resume", () => {
   it("resolves grok --resume from the session file when the foreground is grok", async () => {
     const id = "t-grok";

--- a/packages/extension-host/src/extension-host/agents-service.ts
+++ b/packages/extension-host/src/extension-host/agents-service.ts
@@ -72,6 +72,9 @@ type TrackedAgent = {
    * / reset. `null` until a known agent leader has been seen.
    */
   agentPgid: number | null;
+  /** Last `<code>\0<payload>` logged for this terminal, to collapse the
+   * repeats that title sequences produce. Diagnostics only. */
+  lastOscKey?: string;
   /**
    * Sticky catalog id (`"claude"`, `"grok"`, …) of the leader that set
    * {@link agentPgid}. Used to reject foreign SessionStart hooks that share a
@@ -688,6 +691,41 @@ function applyDetection(terminalId: string, result: DetectionResult) {
 /** Attach catalog identity from an OSC identity signal. Does not invent a
  * session id — only names the agent so shell-integration noise can't wipe
  * the promotion. */
+
+/**
+ * Record every OSC sequence a tracked terminal emits, and whether any detector
+ * claimed it.
+ *
+ * This is the signal that answers "why is my agent's status not updating?" —
+ * a question that otherwise requires capturing the raw PTY stream, which is
+ * impractical on Windows (no `script`, and redirecting to a file makes the
+ * agent non-TTY so it stops emitting sequences at all).
+ *
+ * Deliberately logs the *undetected* ones too: an agent whose activity never
+ * changes is emitting something we don't understand, and the payload is the
+ * only way to find out what. Consecutive identical events are collapsed —
+ * title sequences repeat heavily — so a busy terminal doesn't drown the
+ * channel.
+ */
+function logOscEvent(
+  entry: TrackedAgent,
+  terminalId: string,
+  code: number,
+  payload: string,
+): void {
+  const key = `${code}\u0000${payload}`;
+  if (entry.lastOscKey === key) return;
+  entry.lastOscKey = key;
+  const detected = detectFromOsc(code, payload);
+  const trimmed = payload.length > 120 ? `${payload.slice(0, 120)}…` : payload;
+  agentsChannel.debug(
+    `terminal ${terminalId} osc ${code} payload=${JSON.stringify(trimmed)} → ` +
+      (detected
+        ? `${detected.status} (source=${detected.source})`
+        : "no detector matched"),
+  );
+}
+
 function stampDetectedAgentIdentity(terminalId: string, agentId: string) {
   const entry = trackedAgents.get(terminalId);
   const agent = agentById(agentId);
@@ -1020,6 +1058,7 @@ function attachSession(terminalId: string) {
   entry.cleanupOsc = getTerminalService().subscribeOsc(
     terminalId,
     ({ code, payload }) => {
+      logOscEvent(entry, terminalId, code, payload);
       const detected = detectFromOsc(code, payload);
       if (detected) {
         const wasAgent = entry.state.isAgent;

--- a/packages/extension-host/src/extension-host/agents-service.ts
+++ b/packages/extension-host/src/extension-host/agents-service.ts
@@ -820,6 +820,16 @@ function stickKnownAgentForeground(
   const becameAgent = prevAgentPgid !== fg.pgid;
   entry.agentPgid = fg.pgid;
   entry.agentCatalogId = agent.id;
+  // A known agent is the foreground process — that *is* an agent terminal,
+  // and it's stronger evidence than the OSC heuristics that normally promote
+  // one. `applyHookMatch` already promotes on the same reasoning; this path
+  // never did, because on macOS/Linux a hook or an OSC signal always got
+  // there first. On Windows neither exists, so a correctly-identified agent
+  // stayed `isAgent: false` and was filtered out of every consumer that shows
+  // "agent terminals" — tracked, named, and invisible.
+  if (!entry.state.isAgent && entry.state.kind === "shell") {
+    applyEvent(terminalId, detectedEvent(terminalId, "idle", "agent"));
+  }
   if (becameAgent) {
     if (prevAgentPgid != null) {
       resetSessionIdentityForNewInstance(entry, terminalId);

--- a/packages/extension-host/src/extension-host/agents-service.ts
+++ b/packages/extension-host/src/extension-host/agents-service.ts
@@ -919,8 +919,14 @@ function bindForeground(
     sessionId,
   }).then((fg) => {
     if (!fg) {
+      // "not yet" is only true where a foreground stream exists at all. Where
+      // the backend has none, this fires for every terminal forever and the
+      // wording sends anyone reading the log looking for a race that isn't
+      // there — which is exactly what happened on Windows.
       agentsChannel.debug(
-        `terminal ${terminalId} foreground seed: no snapshot available yet`,
+        `terminal ${terminalId} foreground seed: no snapshot ` +
+          `(none yet, or this backend reports no foreground process — see the ` +
+          `capability line logged at startup)`,
       );
       return;
     }
@@ -994,7 +1000,21 @@ function attachSession(terminalId: string) {
     ({ code, payload }) => {
       const detected = detectFromOsc(code, payload);
       if (detected) {
+        const wasAgent = entry.state.isAgent;
         applyDetection(terminalId, detected);
+        if (!wasAgent && entry.state.isAgent) {
+          // Promotion from OSC alone. On Windows this is the *only* way a
+          // terminal becomes an agent, so silence here meant an unexplained
+          // "nothing appears" with no trace to follow.
+          agentsChannel.debug(
+            `terminal ${terminalId} promoted to agent by OSC ${code} ` +
+              `(${detected.status}, source=${detected.source})` +
+              (entry.state.agentId
+                ? ` — identified as ${entry.state.agentId}`
+                : " — no identity yet (needs a foreground leader or an " +
+                  "identity-carrying signal)"),
+          );
+        }
         return;
       }
       // Contextual fallback (Codex's plain-title idle): only meaningful when

--- a/packages/extension-host/src/extension-host/agents-service.ts
+++ b/packages/extension-host/src/extension-host/agents-service.ts
@@ -995,6 +995,18 @@ function attachSession(terminalId: string) {
   };
   trackedAgents.set(terminalId, entry);
 
+  // Which workspace a tracked terminal is filed under decides whether it is
+  // ever visible: `ctx.agents.getState()` filters on
+  // `info.workspaceId === activeWorkspaceId`, and the all-workspaces view is
+  // filtered by the caller the same way. A mismatch here means a terminal that
+  // is tracked, ticking, and completely invisible — with nothing in the log to
+  // say why.
+  agentsChannel.debug(
+    `terminal ${terminalId} tracked in workspace ${ctx.wsId} ` +
+      `(active workspace ${store.activeWorkspaceId ?? "none"}, ` +
+      `${trackedAgents.size} tracked total)`,
+  );
+
   entry.cleanupOsc = getTerminalService().subscribeOsc(
     terminalId,
     ({ code, payload }) => {

--- a/packages/extension-host/src/extension-host/agents-service.ts
+++ b/packages/extension-host/src/extension-host/agents-service.ts
@@ -712,11 +712,11 @@ function logOscEvent(
   terminalId: string,
   code: number,
   payload: string,
+  detected: DetectionResult | null,
 ): void {
   const key = `${code}\u0000${payload}`;
   if (entry.lastOscKey === key) return;
   entry.lastOscKey = key;
-  const detected = detectFromOsc(code, payload);
   const trimmed = payload.length > 120 ? `${payload.slice(0, 120)}…` : payload;
   agentsChannel.debug(
     `terminal ${terminalId} osc ${code} payload=${JSON.stringify(trimmed)} → ` +
@@ -1058,8 +1058,8 @@ function attachSession(terminalId: string) {
   entry.cleanupOsc = getTerminalService().subscribeOsc(
     terminalId,
     ({ code, payload }) => {
-      logOscEvent(entry, terminalId, code, payload);
       const detected = detectFromOsc(code, payload);
+      logOscEvent(entry, terminalId, code, payload, detected);
       if (detected) {
         const wasAgent = entry.state.isAgent;
         applyDetection(terminalId, detected);
@@ -1084,7 +1084,12 @@ function attachSession(terminalId: string) {
       const wasAgentWorking =
         entry.state.activity === "working" &&
         entry.state.workingSource === "agent";
-      const idle = detectIdleAfterWorking(code, payload, wasAgentWorking);
+      const idle = detectIdleAfterWorking(
+        code,
+        payload,
+        wasAgentWorking,
+        entry.agentCatalogId,
+      );
       if (idle) applyDetection(terminalId, idle);
     },
   ).dispose;

--- a/packages/extension-host/src/extension-host/keybindings.test.ts
+++ b/packages/extension-host/src/extension-host/keybindings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { dispatchKey, keybindingRegistry } from "./keybindings";
+import { dispatchKey, keybindingRegistry, parseKeySpec } from "./keybindings";
 import { commandRegistry } from "./commands";
 import { menuItemRegistry } from "./menu-items";
 import { setUserBindings } from "./keymap";
@@ -35,6 +35,57 @@ function keyEvent(init: {
   } as unknown as KeyboardEvent;
 }
 
+describe("parseKeySpec", () => {
+  // The stored `cmd` token means CmdOrCtrl — Cmd on macOS, Ctrl elsewhere —
+  // matching what displayKey renders and what the native menu accelerator
+  // resolves to. Parsing it as a literal metaKey off-Mac made every
+  // JS-dispatched default (tab cycling, Cmd+`, Cmd+Shift+F) require the
+  // physical Windows key, so none of them could fire on Windows or Linux.
+  it("maps the primary modifier to Cmd on macOS", () => {
+    const p = parseKeySpec("cmd+alt+right", true);
+    expect(p).toMatchObject({ meta: true, ctrl: false, alt: true });
+  });
+
+  it("maps the primary modifier to Ctrl off macOS", () => {
+    const p = parseKeySpec("cmd+alt+right", false);
+    expect(p).toMatchObject({ meta: false, ctrl: true, alt: true });
+  });
+
+  it("treats every primary spelling alike", () => {
+    for (const spec of [
+      "cmd+k",
+      "command+k",
+      "cmdorctrl+k",
+      "meta+k",
+      "super+k",
+    ]) {
+      expect(parseKeySpec(spec, true)).toMatchObject({
+        meta: true,
+        ctrl: false,
+      });
+      expect(parseKeySpec(spec, false)).toMatchObject({
+        meta: false,
+        ctrl: true,
+      });
+    }
+  });
+
+  it("keeps ctrl literal on both platforms", () => {
+    // A macOS user who binds Ctrl+K means Ctrl, not Cmd — and the Shortcuts
+    // page records exactly what was pressed.
+    expect(parseKeySpec("ctrl+k", true)).toMatchObject({
+      meta: false,
+      ctrl: true,
+    });
+    expect(parseKeySpec("ctrl+k", false)).toMatchObject({
+      meta: false,
+      ctrl: true,
+    });
+  });
+});
+
+// jsdom reports `navigator.platform === ""`, so these run the off-Mac branch:
+// a `cmd+…` binding is pressed as Ctrl.
 describe("dispatchKey", () => {
   let run: ReturnType<typeof vi.fn>;
   const disposables: Array<{ dispose: () => void }> = [];
@@ -56,7 +107,7 @@ describe("dispatchKey", () => {
         key: "cmd+alt+g",
       }),
     );
-    const e = keyEvent({ code: "KeyG", meta: true, alt: true });
+    const e = keyEvent({ code: "KeyG", ctrl: true, alt: true });
 
     expect(dispatchKey(e)).toBe(true);
     expect(run).toHaveBeenCalledTimes(1);
@@ -68,7 +119,7 @@ describe("dispatchKey", () => {
     // never called registerKeybinding and has no menu item — keybindings.json
     // is then the only record of the chord.
     setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
-    const e = keyEvent({ code: "KeyG", meta: true, alt: true });
+    const e = keyEvent({ code: "KeyG", ctrl: true, alt: true });
 
     expect(dispatchKey(e)).toBe(true);
     expect(run).toHaveBeenCalledTimes(1);
@@ -79,7 +130,7 @@ describe("dispatchKey", () => {
   it("ignores an override whose chord does not match", () => {
     setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
 
-    expect(dispatchKey(keyEvent({ code: "KeyG", meta: true }))).toBe(false);
+    expect(dispatchKey(keyEvent({ code: "KeyG", ctrl: true }))).toBe(false);
     expect(run).not.toHaveBeenCalled();
   });
 
@@ -96,7 +147,7 @@ describe("dispatchKey", () => {
     );
     setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
 
-    expect(dispatchKey(keyEvent({ code: "KeyG", meta: true, alt: true }))).toBe(
+    expect(dispatchKey(keyEvent({ code: "KeyG", ctrl: true, alt: true }))).toBe(
       false,
     );
     expect(run).not.toHaveBeenCalled();
@@ -104,7 +155,7 @@ describe("dispatchKey", () => {
 
   it("fires an override-only command exactly once", () => {
     setUserBindings([{ command: "ext.toggle", key: "cmd+alt+g" }]);
-    dispatchKey(keyEvent({ code: "KeyG", meta: true, alt: true }));
+    dispatchKey(keyEvent({ code: "KeyG", ctrl: true, alt: true }));
 
     expect(run).toHaveBeenCalledTimes(1);
   });
@@ -122,7 +173,7 @@ describe("dispatchKey", () => {
       { command: "-ext.toggle", key: "" },
     ]);
 
-    expect(dispatchKey(keyEvent({ code: "KeyG", meta: true, alt: true }))).toBe(
+    expect(dispatchKey(keyEvent({ code: "KeyG", ctrl: true, alt: true }))).toBe(
       false,
     );
     expect(run).not.toHaveBeenCalled();

--- a/packages/extension-host/src/extension-host/keybindings.ts
+++ b/packages/extension-host/src/extension-host/keybindings.ts
@@ -87,30 +87,48 @@ const isMac =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad/.test(navigator.platform);
 
+/**
+ * Every spelling of the **primary** modifier — Cmd on macOS, Ctrl everywhere
+ * else. `normalizeKey` (keymap.ts) folds all of these to the single stored
+ * token `cmd`, `displayKey` renders that token as "Cmd"/"Ctrl" per platform,
+ * and `toTauriAccelerator` emits it as `CmdOrCtrl` for the native menu — so the
+ * parser has to make the same platform choice. Reading `cmd` as a literal
+ * metaKey off-Mac is what left every JS-dispatched default (tab cycling,
+ * workspace cycling, Find in Files) demanding the physical **Windows key**,
+ * while the Shortcuts page advertised the Ctrl chord that could never fire.
+ * `ctrl` stays literal on every platform — Ctrl is its own modifier on macOS.
+ */
+const PRIMARY_MODIFIERS = [
+  "cmd",
+  "command",
+  "cmdorctrl",
+  "commandorcontrol",
+  "meta",
+  "super",
+];
+
 const parseCache = new Map<string, ParsedKey>();
 
-function parseKey(spec: string): ParsedKey {
-  const cached = parseCache.get(spec);
-  if (cached) return cached;
+/** @internal — exported for tests, which pin `mac` to cover both platforms. */
+export function parseKeySpec(spec: string, mac: boolean): ParsedKey {
   const parts = spec.toLowerCase().split("+");
   // The last token is the key; everything before is a modifier.
   const key = parts.pop() ?? "";
-  const primaryAlias =
-    parts.includes("cmdorctrl") || parts.includes("commandorcontrol");
-  const parsed: ParsedKey = {
-    meta:
-      parts.includes("cmd") ||
-      parts.includes("meta") ||
-      parts.includes("super") ||
-      (isMac && primaryAlias),
+  const primary = PRIMARY_MODIFIERS.some((m) => parts.includes(m));
+  return {
+    meta: mac && primary,
     ctrl:
-      parts.includes("ctrl") ||
-      parts.includes("control") ||
-      (!isMac && primaryAlias),
+      parts.includes("ctrl") || parts.includes("control") || (!mac && primary),
     shift: parts.includes("shift"),
     alt: parts.includes("alt") || parts.includes("option"),
     code: tokenToCode(key),
   };
+}
+
+function parseKey(spec: string): ParsedKey {
+  const cached = parseCache.get(spec);
+  if (cached) return cached;
+  const parsed = parseKeySpec(spec, isMac);
   parseCache.set(spec, parsed);
   return parsed;
 }

--- a/packages/extensions-silo/src/file-explorer/Tree.tsx
+++ b/packages/extensions-silo/src/file-explorer/Tree.tsx
@@ -25,8 +25,19 @@ import { findWorktreeFor } from "../git/worktree-utils";
 // Module-level file clipboard (cut/copy) — reserved for future Paste implementation
 const fileCb = { current: null as { path: string; op: "cut" | "copy" } | null };
 
+// Sync platform read, mirroring how the host itself decides (keymap.ts): the
+// row chords need an answer inside a keydown handler, and `ctx.system.getInfo()`
+// is async.
 const isMac = /Mac|iPhone|iPad/.test(navigator.platform);
+const isWindows = /Win/.test(navigator.platform);
 const ACCEL = rowAccelerators(isMac);
+// Name the OS file manager the way that platform names it — "Reveal in Finder"
+// is meaningless on Windows.
+const REVEAL_LABEL = isMac
+  ? "Reveal in Finder"
+  : isWindows
+    ? "Reveal in File Explorer"
+    : "Reveal in File Manager";
 
 export function Tree({
   ctx,
@@ -392,7 +403,7 @@ export function Tree({
       });
     }
     items.push({
-      label: "Reveal in Finder",
+      label: REVEAL_LABEL,
       accelerator: ACCEL.reveal,
       run: () => ctxReveal(path),
     });

--- a/packages/extensions-silo/src/file-explorer/Tree.tsx
+++ b/packages/extensions-silo/src/file-explorer/Tree.tsx
@@ -11,13 +11,22 @@ import {
   type NewItem,
   type RowFocusProps,
 } from "./tree-types";
-import { collapseAllExpanded, flattenVisible, treeArrowNav } from "./tree-nav";
+import {
+  collapseAllExpanded,
+  flattenVisible,
+  matchRowShortcut,
+  rowAccelerators,
+  treeArrowNav,
+} from "./tree-nav";
 import { DirNode } from "./TreeNodes";
 import type { GitAPI, GitWorktree } from "../git/git-api";
 import { findWorktreeFor } from "../git/worktree-utils";
 
 // Module-level file clipboard (cut/copy) — reserved for future Paste implementation
 const fileCb = { current: null as { path: string; op: "cut" | "copy" } | null };
+
+const isMac = /Mac|iPhone|iPad/.test(navigator.platform);
+const ACCEL = rowAccelerators(isMac);
 
 export function Tree({
   ctx,
@@ -157,47 +166,36 @@ export function Tree({
       return true;
     }
     const name = path.split("/").pop() ?? path;
-    if (e.key === "Enter" && e.metaKey) {
-      e.preventDefault();
-      if (!isDir) editors.open(path, { workspaceId });
-      return true;
+    const shortcut = matchRowShortcut(e, isMac);
+    if (!shortcut) return false;
+    e.preventDefault();
+    switch (shortcut) {
+      case "open":
+        if (!isDir) editors.open(path, { workspaceId });
+        break;
+      case "rename":
+        setRenaming(path);
+        break;
+      case "delete":
+        void ctxDelete(path, name);
+        break;
+      case "reveal":
+        void ctxReveal(path);
+        break;
+      case "cut":
+        ctxCut(path);
+        break;
+      case "copy":
+        ctxCopy(path);
+        break;
+      case "copyPath":
+        ctxCopyPath(path);
+        break;
+      case "copyRelPath":
+        ctxCopyRelPath(path);
+        break;
     }
-    if (e.key === "Enter" && !e.metaKey && !e.shiftKey) {
-      e.preventDefault();
-      setRenaming(path);
-      return true;
-    }
-    if (e.key === "Backspace" && e.metaKey) {
-      e.preventDefault();
-      void ctxDelete(path, name);
-      return true;
-    }
-    if (e.key === "r" && e.altKey && e.metaKey) {
-      e.preventDefault();
-      void ctxReveal(path);
-      return true;
-    }
-    if (e.key === "x" && e.metaKey) {
-      e.preventDefault();
-      ctxCut(path);
-      return true;
-    }
-    if (e.key === "c" && e.metaKey && !e.altKey && !e.shiftKey) {
-      e.preventDefault();
-      ctxCopy(path);
-      return true;
-    }
-    if (e.key === "c" && e.metaKey && e.altKey && !e.shiftKey) {
-      e.preventDefault();
-      ctxCopyPath(path);
-      return true;
-    }
-    if (e.key === "c" && e.metaKey && e.altKey && e.shiftKey) {
-      e.preventDefault();
-      ctxCopyRelPath(path);
-      return true;
-    }
-    return false;
+    return true;
   }
 
   // Focus-group props for a row, composing the group's handlers with the tree's:
@@ -367,7 +365,7 @@ export function Tree({
     if (!isDir) {
       items.push({
         label: "Open",
-        accelerator: "⌘↩",
+        accelerator: ACCEL.open,
         run: () => ctxOpenToSide(path),
       });
       // "Open With" — only when the file has more than one matching view
@@ -395,39 +393,43 @@ export function Tree({
     }
     items.push({
       label: "Reveal in Finder",
-      accelerator: "⌥⌘R",
+      accelerator: ACCEL.reveal,
       run: () => ctxReveal(path),
     });
     if (!rootArea) {
       items.push({ type: "separator" });
-      items.push({ label: "Cut", accelerator: "⌘X", run: () => ctxCut(path) });
+      items.push({
+        label: "Cut",
+        accelerator: ACCEL.cut,
+        run: () => ctxCut(path),
+      });
       items.push({
         label: "Copy",
-        accelerator: "⌘C",
+        accelerator: ACCEL.copy,
         run: () => ctxCopy(path),
       });
     }
     items.push({ type: "separator" });
     items.push({
       label: "Copy Path",
-      accelerator: "⌥⌘C",
+      accelerator: ACCEL.copyPath,
       run: () => ctxCopyPath(path),
     });
     items.push({
       label: "Copy Relative Path",
-      accelerator: "⌥⇧⌘C",
+      accelerator: ACCEL.copyRelPath,
       run: () => ctxCopyRelPath(path),
     });
     if (!rootArea) {
       items.push({ type: "separator" });
       items.push({
         label: "Rename…",
-        accelerator: "↵",
+        accelerator: ACCEL.rename,
         run: () => ctxRename(path),
       });
       items.push({
         label: "Delete",
-        accelerator: "⌘⌫",
+        accelerator: ACCEL.delete,
         danger: true,
         run: () => ctxDelete(path, name),
       });

--- a/packages/extensions-silo/src/file-explorer/tree-nav.test.ts
+++ b/packages/extensions-silo/src/file-explorer/tree-nav.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { collapseAllExpanded, flattenVisible, treeArrowNav } from "./tree-nav";
+import {
+  collapseAllExpanded,
+  flattenVisible,
+  matchRowShortcut,
+  rowAccelerators,
+  treeArrowNav,
+  type RowKeyChord,
+} from "./tree-nav";
 import type { Listing } from "./tree-types";
 
 const root = "/ws";
@@ -196,5 +203,100 @@ describe("collapseAllExpanded", () => {
     expect(collapseAllExpanded({ "/ws": true }, root)).toEqual({
       "/ws": true,
     });
+  });
+});
+
+describe("matchRowShortcut", () => {
+  const chord = (
+    init: Partial<RowKeyChord> & { key: string },
+  ): RowKeyChord => ({
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...init,
+  });
+
+  // The row shortcuts bypass the keybinding registry, so they carry their own
+  // platform mapping: Cmd on macOS, Ctrl everywhere else. Matching `metaKey`
+  // on both platforms left all of them requiring the Windows key off-Mac.
+  it("takes the primary modifier as Cmd on macOS", () => {
+    expect(matchRowShortcut(chord({ key: "c", metaKey: true }), true)).toBe(
+      "copy",
+    );
+    expect(
+      matchRowShortcut(chord({ key: "c", ctrlKey: true }), true),
+    ).toBeNull();
+  });
+
+  it("takes the primary modifier as Ctrl off macOS", () => {
+    expect(matchRowShortcut(chord({ key: "c", ctrlKey: true }), false)).toBe(
+      "copy",
+    );
+    expect(
+      matchRowShortcut(chord({ key: "c", metaKey: true }), false),
+    ).toBeNull();
+  });
+
+  it("opens on primary+Enter and renames on plain Enter", () => {
+    expect(matchRowShortcut(chord({ key: "Enter", metaKey: true }), true)).toBe(
+      "open",
+    );
+    expect(matchRowShortcut(chord({ key: "Enter" }), true)).toBe("rename");
+    // Shift+Enter is the focus group's to handle, not the tree's.
+    expect(
+      matchRowShortcut(chord({ key: "Enter", shiftKey: true }), true),
+    ).toBeNull();
+  });
+
+  it("separates the three copy chords by Alt and Shift", () => {
+    const c = (init: Partial<RowKeyChord>) =>
+      matchRowShortcut(chord({ key: "c", metaKey: true, ...init }), true);
+    expect(c({})).toBe("copy");
+    expect(c({ altKey: true })).toBe("copyPath");
+    // Shift uppercases the reported key — the match folds case.
+    expect(
+      matchRowShortcut(
+        chord({ key: "C", metaKey: true, altKey: true, shiftKey: true }),
+        true,
+      ),
+    ).toBe("copyRelPath");
+  });
+
+  it("requires Alt for reveal and rejects decorated cut", () => {
+    expect(
+      matchRowShortcut(chord({ key: "r", metaKey: true, altKey: true }), true),
+    ).toBe("reveal");
+    expect(
+      matchRowShortcut(chord({ key: "r", metaKey: true }), true),
+    ).toBeNull();
+    expect(matchRowShortcut(chord({ key: "x", metaKey: true }), true)).toBe(
+      "cut",
+    );
+    expect(
+      matchRowShortcut(chord({ key: "x", metaKey: true, altKey: true }), true),
+    ).toBeNull();
+  });
+
+  it("deletes only with the primary modifier", () => {
+    expect(
+      matchRowShortcut(chord({ key: "Backspace", metaKey: true }), true),
+    ).toBe("delete");
+    expect(matchRowShortcut(chord({ key: "Backspace" }), true)).toBeNull();
+  });
+
+  it("ignores keys the tree does not bind", () => {
+    expect(
+      matchRowShortcut(chord({ key: "v", metaKey: true }), true),
+    ).toBeNull();
+    expect(matchRowShortcut(chord({ key: "a" }), true)).toBeNull();
+  });
+});
+
+describe("rowAccelerators", () => {
+  it("labels chords with Mac glyphs and spelled-out chords elsewhere", () => {
+    expect(rowAccelerators(true).delete).toBe("⌘⌫");
+    expect(rowAccelerators(false).delete).toBe("Ctrl+Backspace");
+    expect(rowAccelerators(false).copyRelPath).toBe("Ctrl+Alt+Shift+C");
   });
 });

--- a/packages/extensions-silo/src/file-explorer/tree-nav.ts
+++ b/packages/extensions-silo/src/file-explorer/tree-nav.ts
@@ -95,3 +95,93 @@ export function collapseAllExpanded(
   }
   return next;
 }
+
+/** A row action the tree binds to a keyboard chord. */
+export type RowShortcut =
+  | "open"
+  | "rename"
+  | "delete"
+  | "reveal"
+  | "cut"
+  | "copy"
+  | "copyPath"
+  | "copyRelPath";
+
+/** The parts of a keydown the row chords look at. */
+export interface RowKeyChord {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * True when the chord carries the platform's **primary** modifier — Cmd on
+ * macOS, Ctrl everywhere else. These row shortcuts are hand-rolled rather than
+ * registered through `ctx.registerKeybinding`, so they never inherit the host
+ * dispatcher's platform mapping and have to make the same choice themselves.
+ * Testing `metaKey` directly left every one of them demanding the physical
+ * Windows key off-Mac.
+ */
+function hasPrimaryMod(e: RowKeyChord, isMac: boolean): boolean {
+  return isMac ? e.metaKey : e.ctrlKey;
+}
+
+/**
+ * The row action a chord invokes, or null when the tree doesn't own the key
+ * (the caller then defers to the focus group's own movement handling).
+ *
+ * Order matters: plain Enter renames, so the Cmd/Ctrl+Enter "open" case has to
+ * be tested first.
+ */
+export function matchRowShortcut(
+  e: RowKeyChord,
+  isMac: boolean,
+): RowShortcut | null {
+  const primary = hasPrimaryMod(e, isMac);
+  if (e.key === "Enter") {
+    if (primary) return "open";
+    return e.shiftKey ? null : "rename";
+  }
+  if (e.key === "Backspace") return primary ? "delete" : null;
+  if (!primary) return null;
+  // Shift uppercases `key` ("C" for Ctrl+Alt+Shift+C), so fold the case — the
+  // chord is about which letter, not how the OS reported it.
+  const letter = e.key.toLowerCase();
+  if (letter === "r") return e.altKey ? "reveal" : null;
+  if (letter === "x") return e.altKey || e.shiftKey ? null : "cut";
+  if (letter !== "c") return null;
+  if (!e.altKey) return e.shiftKey ? null : "copy";
+  return e.shiftKey ? "copyRelPath" : "copyPath";
+}
+
+/**
+ * Context-menu accelerator labels for the row shortcuts. macOS uses its glyph
+ * vocabulary; elsewhere the chords spell out in the modifier order `displayKey`
+ * uses for the Keyboard Shortcuts page (Ctrl, Alt, Shift) — so a Windows user
+ * sees "Ctrl+Backspace" next to Delete rather than "⌘⌫".
+ */
+export function rowAccelerators(isMac: boolean): Record<RowShortcut, string> {
+  return isMac
+    ? {
+        open: "⌘↩",
+        rename: "↵",
+        delete: "⌘⌫",
+        reveal: "⌥⌘R",
+        cut: "⌘X",
+        copy: "⌘C",
+        copyPath: "⌥⌘C",
+        copyRelPath: "⌥⇧⌘C",
+      }
+    : {
+        open: "Ctrl+Enter",
+        rename: "Enter",
+        delete: "Ctrl+Backspace",
+        reveal: "Ctrl+Alt+R",
+        cut: "Ctrl+X",
+        copy: "Ctrl+C",
+        copyPath: "Ctrl+Alt+C",
+        copyRelPath: "Ctrl+Alt+Shift+C",
+      };
+}


### PR DESCRIPTION
## Summary

Agents were invisible on Windows. A terminal running GitHub Copilot showed as a
plain shell — no name, no icon, no activity — while the same terminal on a Mac
showed everything. Windows is ~38% of Silo's downloads, and agent awareness is
what Silo is for, so this was the largest gap in the product.

Windows now identifies the agent running in a terminal, shows its icon, and
tracks its activity. This isn't Copilot-specific: the fix feeds the same
identification path every platform uses, so Claude, Codex, Cursor, Copilot and
Grok are all recognised there for the first time.

Found and fixed by testing on a real Windows machine — five distinct bugs, each
surfaced by the previous fix revealing the next.

**Still not available on Windows:** exact resume (`--resume <id>`), which needs
a hook, and Silo's hook is a POSIX shell script. And one honest caveat, now
documented: activity depends on the agent emitting a per-turn signal, and
Copilot only announces when a task *starts*, never when it ends — so its
busy/idle can lag. Which agent is running is always correct.

## Details

### The chain

Windows' console API can't answer "what is running in this terminal?" — there
are no process groups and no `tcgetpgrp`. `subscribe_foreground` returned
`None`, so `agentByLeader` (the only thing that names an agent) never ran. OSC
detectors carry *status*, not identity — `DetectionResult` has no `agentId`,
and pi's title detector was the only one supplying one.

Each fix uncovered the next:

1. **No foreground at all** → `process_tree.rs` walks the process tree from the
   shell the daemon spawned and reports the deepest descendant.
2. **`copilot.exe` didn't match `leaderNames: ["copilot"]`** → `leaderBasename`
   split on `/` only. Now strips `.exe`/`.cmd`/`.bat`/`.com` and handles `\`.
3. **`conhost.exe` won the walk** — a real child of the shell in a ConPTY
   session, competing on depth with the agent. It only lost by luck of pid
   ordering. The walk now descends *through* console infrastructure without
   reporting it.
4. **Identity resolved but `isAgent` stayed false** → `stickKnownAgentForeground`
   never promoted. `applyHookMatch` always had, but on macOS a hook or OSC got
   there first; Windows has neither. A correctly-named agent was filtered out of
   every consumer that shows "agent terminals".
5. **Copilot emitted no OSC 9;4 at all** — zero, across a whole session. Its
   real signal is an OSC 0 title (`Implement Quick Task - GitHub Copilot`), so
   it gets a title detector, tried before the progress one.

### Design notes

- `process_tree.rs` splits the Win32 snapshot (`CreateToolhelp32Snapshot`, via
  `extern "system"` like `kill_child` already does) from `resolve_leader`, which
  is **pure and unit-tested on any platform** — every bug here lives in the tree
  walk, not the FFI.
- Transport reuses the Windows TCP protocol with two tags mirroring the Unix
  host. A foreground subscriber is intercepted **before** joining `clients` —
  under `MAX_DATA_CLIENTS = 1` it would evict the live data client, the
  regression RFC 0026 hit on Unix.
- Polling is adaptive (500 ms for 5 s after a change, then 2.5 s) because the
  snapshot enumerates every process on the machine.
- The Copilot title detector carries `agentId`; the OSC 9;4 detector must not,
  since that protocol is generic to Windows consoles and would label any
  `winget` install as Copilot.

### Not Windows-only

Two changes affect every platform and deserve review as such:

- **`leaderBasename`** now strips executable extensions and backslashes.
- **Promotion timing** — a terminal whose foreground leader is a known agent is
  marked `isAgent` immediately, rather than waiting for a hook or OSC. More
  correct, but it *is* a behavior change on macOS/Linux.

Copilot was re-tested on macOS after the detector change: unchanged.

### Observability

Working out why agents failed here took an afternoon of reading source, because
the Agents channel was verbose about the machinery that works and silent about
the machinery that doesn't. Now it logs a startup capability line, every OSC
sequence with the detector's verdict (including "no detector matched" — the
interesting case), and which workspace each terminal is filed under. The last
two bugs were found by reading these lines instead of guessing.

### Test plan

- 10 unit tests for `resolve_leader` (nesting, sibling ties, `conhost`, cycles
  from pid reuse, missing root), running on macOS.
- Detector tests use the **exact payloads captured on Windows**, including the
  subprocess titles that overwrite Copilot's mid-task and the OSC 4/10/11
  colour queries in the same stream.
- Promotion tests: 2 of the 3 fail without the fix (verified by reverting it).
- `pnpm lint`, `tsc --noEmit`, `pnpm test`, `cargo test`, `cargo clippy`,
  `pnpm docs:build` all clean. `rust-windows` CI green.
- **Manually verified on Windows**: identity, icon, and first-turn activity.

### Follow-ups (deliberately not here)

- **Activity from process-tree churn.** A tool subprocess running under the
  agent means "working" — precise, per-turn, and needs no cooperation from the
  agent. It would fix Copilot's lag and any future agent with no signal, but it
  changes activity semantics on every platform and has three real design
  problems (an agent thinking with no tools looks idle; a long-lived subprocess
  looks permanently busy; the Windows poll samples rather than observes). Wants
  its own design pass.
- **`resolveNodeWrappedAgent` shells out to `ps`**, so it can't work on Windows.
  Copilot resolves anyway via `copilot.exe`, but an agent that only ever
  presents as `node.exe` would stay unidentified there.
- **Exact resume on Windows** — needs a PowerShell hook script and a
  terminal-id-keyed hook event (now possible since `SILO_TERMINAL_ID` shipped in
  RFC 0028).

Supersedes #411, which documented the pre-fix behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTNr2wgiuarrFe91MdZVG2
