### PR TITLE
fix(terminal): correctly restore scrolling for TUI apps after a buffer restore

### DIFF
--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -653,7 +653,25 @@ export function TerminalPanel(
         if (!needsCreate) {
           const restored = await session.getBuffer();
           if (restored.length > 0) {
-            term.write(restored);
+            // Terminals deliver mouse events in one of several formats: a
+            // legacy default and the modern one (SGR), which every modern
+            // TUI (grok, Claude Code, codex, etc.) uses and switches to.
+            // Restoring the saved buffer re-enables "the CLI app running in
+            // this terminal wants mouse events" but Silo doesn't restore the
+            // format switch, so the CLI app gets events in the legacy format
+            // it can't read and ignores them — wheel scrolling does nothing
+            // until that CLI app itself is restarted. Fix: after restoring
+            // the buffer, always switch mouse events back to SGR format (the
+            // one agent TUIs actually use).
+            term.write(restored, () => {
+              // Tab was closed or moved to another session mid-restore.
+              if (liveRef.current?.sessionId !== sessionId) return;
+              // Skip terminals where no app asked for mouse events (a plain
+              // shell prompt) — those scroll fine, nothing to fix.
+              if (term.modes.mouseTrackingMode !== "none") {
+                term.write("\x1b[?1006h"); // = use SGR format
+              }
+            });
           }
           replayed = true;
           for (const d of pendingLive) writeLive(d);


### PR DESCRIPTION
## What & why

The terminal tab with an agent ( for example grok ) would become stuck 
and unscrollabe after quitting and reopening the app.

Sometimes a terminal tab running an agent CLI (grok, Claude Code, codex, …)
just stops scrolling: the mouse wheel does nothing, the keyboard still works,
and the only way out is to kill the agent and resume it. 

Here's the chain. When Silo restarts, the PTY — and the agent inside it —
survives, and Silo replays a saved snapshot of the terminal's contents into
the fresh xterm so the tab picks up where it left off. That snapshot (made by
xterm's SerializeAddon) remembers that the agent turned **mouse reporting on**,
but not that the agent also switched mouse reports to the **modern SGR
format**. Every TUI uses to SGR (grok, Claude Code, codex, …)

So after the restore the terminal is in a state no real program ever asks for:
mouse reporting on, but in the legacy format. Two things then go wrong at
once:

- The cli agent receives mouse reports in a format its parser doesn't accept, so
  it silently ignores them.
- xterm, seeing mouse reporting on, hands every wheel event to the program
  instead of scrolling its own viewport.

Wheel events go to the agent, the agent drops them, nothing scrolls — until
the agent restarts and asks for SGR again. That's the "stuck" tab.

The fix is just sending the SGR write after a restore if the current cli app  is tracking the mouse.

## Steps to verify

0. Open Silo
1. Create new workspace
2. Open new terminal
3. Launch grok build
4. Have a conversation in the session
5. Open a new terminal tab in the same workspace
6. Do a big `ls -la` or something that makes it scrollable
7. Quit the app
8. Open it again
9. **Grok tab will be stuck and unscrollable**
10. **Regular tab will be scrollabe** 

Attaching video with bug reproduction and the fix working

https://github.com/user-attachments/assets/e678a1c4-b0cd-4eaa-83a4-78ea5a028abf