### PR TITLE
fix(terminal): persist mouse-reporting encoding so restore recovers it

### DIFF
--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -11,6 +11,11 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { SearchAddon } from "@xterm/addon-search";
 import {
+  nextMouseEncoding,
+  withRestoredMouseEncoding,
+  type MouseEncoding,
+} from "./terminal-mouse-encoding";
+import {
   DND_MIME,
   type DockPanelProps,
   type Disposable,
@@ -456,6 +461,27 @@ export function TerminalPanel(
 
     const disposers: Array<() => void> = [];
 
+    // See terminal-mouse-encoding.ts: xterm's SerializeAddon can't capture
+    // which mouse-reporting encoding a TUI selected, so track it ourselves
+    // via the public CSI-handler API for persistBuffer() below to fold in.
+    let mouseEncoding: MouseEncoding = null;
+    const decsetSub = term.parser.registerCsiHandler(
+      { prefix: "?", final: "h" },
+      (params) => {
+        mouseEncoding = nextMouseEncoding(mouseEncoding, params, true);
+        return false; // don't suppress xterm's own DECSET handling
+      },
+    );
+    const decrstSub = term.parser.registerCsiHandler(
+      { prefix: "?", final: "l" },
+      (params) => {
+        mouseEncoding = nextMouseEncoding(mouseEncoding, params, false);
+        return false; // don't suppress xterm's own DECRST handling
+      },
+    );
+    disposers.push(() => decsetSub.dispose());
+    disposers.push(() => decrstSub.dispose());
+
     // Copy-on-select: on mouse release (so we don't fire mid-drag), copy the
     // selection and clear it. Reads the setting live so the toggle takes effect
     // without a remount.
@@ -618,7 +644,11 @@ export function TerminalPanel(
         let saveDirty = false;
         const persistBuffer = () => {
           try {
-            const data = serializeAddon.serialize({ scrollback: 2000 });
+            const data = withRestoredMouseEncoding(
+              serializeAddon.serialize({ scrollback: 2000 }),
+              mouseEncoding,
+              term.modes.mouseTrackingMode,
+            );
             session.saveBuffer(data);
           } catch (err) {
             console.warn("[terminal] serialize failed", err);

--- a/packages/extensions-core/src/terminal/terminal-mouse-encoding.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-mouse-encoding.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  nextMouseEncoding,
+  withRestoredMouseEncoding,
+} from "./terminal-mouse-encoding";
+
+describe("nextMouseEncoding", () => {
+  it("adopts an encoding on DECSET", () => {
+    expect(nextMouseEncoding(null, [1006], true)).toBe(1006);
+  });
+
+  it("ignores non-encoding params, e.g. a combined tracking-mode DECSET", () => {
+    expect(nextMouseEncoding(null, [1000, 1006], true)).toBe(1006);
+  });
+
+  it("switches encoding when the app re-selects a different one", () => {
+    expect(nextMouseEncoding(1006, [1005], true)).toBe(1005);
+  });
+
+  it("clears the encoding on a matching DECRST", () => {
+    expect(nextMouseEncoding(1006, [1006], false)).toBe(null);
+  });
+
+  it("leaves the encoding alone on a DECRST for a different mode", () => {
+    expect(nextMouseEncoding(1006, [1000], false)).toBe(1006);
+  });
+
+  it("ignores an unrelated DECSET/DECRST entirely", () => {
+    expect(nextMouseEncoding(1006, [2004], true)).toBe(1006);
+    expect(nextMouseEncoding(1006, [2004], false)).toBe(1006);
+  });
+});
+
+describe("withRestoredMouseEncoding", () => {
+  it("appends the encoding's DECSET when tracking is on", () => {
+    expect(withRestoredMouseEncoding("SCREEN", 1006, "vt200")).toBe(
+      "SCREEN\x1b[?1006h",
+    );
+  });
+
+  it("is a no-op when no encoding was ever selected", () => {
+    expect(withRestoredMouseEncoding("SCREEN", null, "vt200")).toBe("SCREEN");
+  });
+
+  it("is a no-op when tracking mode is off, even with a remembered encoding", () => {
+    expect(withRestoredMouseEncoding("SCREEN", 1006, "none")).toBe("SCREEN");
+  });
+});

--- a/packages/extensions-core/src/terminal/terminal-mouse-encoding.ts
+++ b/packages/extensions-core/src/terminal/terminal-mouse-encoding.ts
@@ -1,0 +1,48 @@
+/**
+ * xterm.js's public `IModes` exposes whether mouse reporting is *on*
+ * (`mouseTrackingMode`) but not which encoding a TUI switched it to — SGR
+ * (1006), UTF-8 (1005), or urxvt (1015). `SerializeAddon` inherits that gap:
+ * its buffer dump replays tracking mode but never the encoding switch, so a
+ * modern TUI (which sends the switch once at startup, not on every redraw)
+ * comes back from a restore stuck reporting in the legacy default encoding.
+ *
+ * TerminalPanel tracks the encoding itself via xterm's public CSI-handler API
+ * and uses these pure helpers to fold it into the persisted buffer — the same
+ * way SerializeAddon already folds in tracking mode — so a plain
+ * `term.write()` on restore recovers both.
+ */
+
+export type MouseEncoding = 1005 | 1006 | 1015 | null;
+
+/**
+ * Reduces one DECSET (`enabled: true`) / DECRST (`enabled: false`) CSI call's
+ * params into the next tracked encoding. Non-encoding params (e.g. the
+ * tracking-mode params in a combined `?1000;1006h`) are ignored.
+ */
+export function nextMouseEncoding(
+  current: MouseEncoding,
+  params: readonly (number | number[])[],
+  enabled: boolean,
+): MouseEncoding {
+  let next = current;
+  for (const p of params) {
+    if (p !== 1005 && p !== 1006 && p !== 1015) continue;
+    if (enabled) next = p;
+    else if (next === p) next = null;
+  }
+  return next;
+}
+
+/**
+ * Appends the tracked encoding's DECSET to a SerializeAddon dump, unless
+ * there's no app-selected encoding or tracking itself isn't currently on
+ * (nothing for the encoding to apply to).
+ */
+export function withRestoredMouseEncoding(
+  serialized: string,
+  encoding: MouseEncoding,
+  mouseTrackingMode: string,
+): string {
+  if (encoding === null || mouseTrackingMode === "none") return serialized;
+  return `${serialized}\x1b[?${encoding}h`;
+}


### PR DESCRIPTION
## Summary

Some full-screen terminal apps (Grok, Claude Code, Codex, etc.) enable a
richer mouse-reporting format when they start up. Detaching and reattaching
a terminal running one of these apps lost that setting, so the app stopped
receiving usable mouse-wheel/scroll input — scrolling through its history
appeared "stuck" until the app itself was restarted.

Fixes the same bug as #420, at the point where the setting actually gets
lost, rather than guessing what to restore afterward — see the review
discussion on #420 for why.

## Details

### Root cause

`session.getBuffer()` is backed by xterm.js's `SerializeAddon`, which
persists whether mouse tracking is *on* but never which encoding (SGR
1006 / UTF-8 1005 / urxvt 1015) the app selected — that's not part of
xterm's public `IModes`, so the addon has no way to capture it. On
restore, xterm falls back to the legacy default encoding, and reports
sent in that format go unread by apps expecting the one they asked for.

### Fix

`TerminalPanel.tsx` tracks the live encoding itself via xterm's public
CSI-handler API (`term.parser.registerCsiHandler`) and folds it into the
buffer at *save* time (`persistBuffer`), the same way `SerializeAddon`
already folds in tracking mode. Restore is untouched — a plain
`term.write(restored)`, since the encoding is now just part of the
persisted string.

Extracted to pure, unit-tested helpers in `terminal-mouse-encoding.ts`
(`nextMouseEncoding`, `withRestoredMouseEncoding`) per the repo's testing
convention — 9 new test cases.

### Verification

- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all pass.
- Manually reproduced in the dev app with a fresh Grok terminal: detach/
  reattach preserved wheel-scroll. Confirmed via temporary tracing that a
  Grok session already running *before* this fix was loaded doesn't
  retroactively pick up its encoding until restarted — expected, since
  the app only announces the switch once at its own startup, and this fix
  can only observe it while live.

### Test plan

- [x] Unit tests for `nextMouseEncoding` / `withRestoredMouseEncoding`
- [x] Manual repro: fresh Grok terminal, detach/reattach, mouse-wheel scroll