### PR TITLE
fix(navigator): drop view row font size by 1px

### DIFF
--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -37,10 +37,10 @@
   border-radius: var(--silo-radius-sm);
   color: var(--silo-color-text-hi);
   font-family: var(--silo-font-ui);
-  /* A pixel over the surrounding left-panel size (SideColumn.css sets that to
-     base + 1px) so the destinations read a step louder than the view bodies
-     they lead to. The icon column and `size={19}` glyphs are scaled to match. */
-  font-size: calc(var(--silo-font-size-base) + 2px);
+  /* Matches the surrounding left-panel size (SideColumn.css sets that to
+     base + 1px) so the destinations sit level with the view bodies they lead
+     to. The icon column and `size={19}` glyphs are scaled to match. */
+  font-size: calc(var(--silo-font-size-base) + 1px);
   cursor: pointer;
   user-select: none;
 }


### PR DESCRIPTION
## Summary

The Navigator's list of destinations (Workspaces, Agents) was rendering a touch larger than the rest of the left sidebar. This drops it by one pixel so it sits level with the surrounding panel text.

Visual only — no behavior change.

## Details

`packages/extensions-core/src/navigator/NavigatorPanel.css` — `.nav-view-row` `font-size` goes from `calc(var(--silo-font-size-base) + 2px)` to `+ 1px`, matching what `SideColumn.css` sets for the left panel. The explanatory comment above it was updated to describe the new intent (level with, rather than a step louder than, the view bodies below).

Icon sizing (the 19px icon column and `size={19}` glyphs) is left as-is; it still reads fine against the slightly smaller label.

### Test plan

No tests added — pure CSS token change with no logic. `pnpm lint` and `pnpm test` ran green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)