### PR TITLE
fix(terminal): wire Cmd+K clear shortcut and persist buffer on clear

### DIFF
--- a/apps/docs/api/types/interfaces/ContextKeys.md
+++ b/apps/docs/api/types/interfaces/ContextKeys.md
@@ -54,3 +54,17 @@ Defined in: [packages/sdk/src/context-keys.ts:32](https://github.com/silo-code/s
 Use [ContextKeys.activeEditorViewId](#activeeditorviewid) instead.
 Kept for one release so extensions compiled against the old SDK continue
 to receive the correct value at runtime without a silent break.
+
+***
+
+### terminalFocused
+
+```ts
+terminalFocused: boolean;
+```
+
+Defined in: [packages/sdk/src/context-keys.ts:38](https://github.com/silo-code/silo/blob/main/packages/sdk/src/context-keys.ts#L38)
+
+True when an xterm textarea in a terminal panel owns DOM focus — the user
+is typing into (or has just typed into) a terminal. Used to scope terminal-
+local keybindings such as Clear (`cmd+k`).

--- a/packages/extension-host/src/extension-host/context-keys.test.ts
+++ b/packages/extension-host/src/extension-host/context-keys.test.ts
@@ -5,6 +5,7 @@ import { contextKeys, setContextKey, onContextChange } from "./context-keys";
 beforeEach(() => {
   setContextKey("activeEditorId", null);
   setContextKey("activeEditorViewId", null);
+  setContextKey("terminalFocused", false);
 });
 
 describe("setContextKey", () => {

--- a/packages/extension-host/src/extension-host/context-keys.ts
+++ b/packages/extension-host/src/extension-host/context-keys.ts
@@ -10,6 +10,7 @@ export const contextKeys: ContextKeys = {
   activeEditorViewId: null,
   activeEditorId: null,
   activeViewerId: null, // deprecated alias — mirrored automatically by setContextKey
+  terminalFocused: false,
 };
 
 const listeners = new Set<() => void>();

--- a/packages/extension-host/src/extension-host/keybindings.test.ts
+++ b/packages/extension-host/src/extension-host/keybindings.test.ts
@@ -190,7 +190,7 @@ describe("dispatchKey", () => {
         when: (keys) => keys.terminalFocused,
       }),
     );
-    const e = keyEvent({ code: "KeyK", meta: true });
+    const e = keyEvent({ code: "KeyK", ctrl: true });
 
     expect(dispatchKey(e)).toBe(false);
     expect(run).not.toHaveBeenCalled();

--- a/packages/extension-host/src/extension-host/keybindings.test.ts
+++ b/packages/extension-host/src/extension-host/keybindings.test.ts
@@ -3,6 +3,7 @@ import { dispatchKey, keybindingRegistry, parseKeySpec } from "./keybindings";
 import { commandRegistry } from "./commands";
 import { menuItemRegistry } from "./menu-items";
 import { setUserBindings } from "./keymap";
+import { setContextKey } from "./context-keys";
 
 // Registering a menu item / changing user bindings rebuilds the native menu;
 // stub the Tauri menu API so that stays inert under the test environment.
@@ -93,6 +94,7 @@ describe("dispatchKey", () => {
   beforeEach(() => {
     for (const d of disposables.splice(0)) d.dispose();
     setUserBindings([]);
+    setContextKey("terminalFocused", false);
     run = vi.fn();
     disposables.push(
       commandRegistry.register({ id: "ext.toggle", label: "Toggle", run }),
@@ -177,5 +179,24 @@ describe("dispatchKey", () => {
       false,
     );
     expect(run).not.toHaveBeenCalled();
+  });
+
+  it("honors a when clause on the binding", () => {
+    disposables.push(
+      keybindingRegistry.register({
+        id: "ext.terminal.clear.key",
+        command: "ext.toggle",
+        key: "cmd+k",
+        when: (keys) => keys.terminalFocused,
+      }),
+    );
+    const e = keyEvent({ code: "KeyK", meta: true });
+
+    expect(dispatchKey(e)).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+
+    setContextKey("terminalFocused", true);
+    expect(dispatchKey(e)).toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/extension-host/src/extension-host/menu-accelerator.test.ts
+++ b/packages/extension-host/src/extension-host/menu-accelerator.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { menuAcceleratorForCommand } from "./menu-accelerator";
+import {
+  displayKey,
+  effectiveKey,
+  recordKeybindingDefault,
+  setUserBindings,
+} from "./keymap";
+
+describe("menuAcceleratorForCommand", () => {
+  beforeEach(() => {
+    setUserBindings([]);
+    recordKeybindingDefault("core.terminal.clear", "cmd+k");
+  });
+
+  it("returns the display label for a command's default key", () => {
+    const key = effectiveKey("core.terminal.clear");
+    expect(menuAcceleratorForCommand("core.terminal.clear")).toBe(
+      key ? displayKey(key) : undefined,
+    );
+  });
+
+  it("reflects a user override", () => {
+    setUserBindings([{ command: "core.terminal.clear", key: "cmd+shift+k" }]);
+    const key = effectiveKey("core.terminal.clear");
+    expect(menuAcceleratorForCommand("core.terminal.clear")).toBe(
+      key ? displayKey(key) : undefined,
+    );
+  });
+
+  it("returns undefined when the command is unbound", () => {
+    setUserBindings([{ command: "-core.terminal.clear", key: "" }]);
+    expect(menuAcceleratorForCommand("core.terminal.clear")).toBeUndefined();
+  });
+});

--- a/packages/extension-host/src/extension-host/menu-accelerator.ts
+++ b/packages/extension-host/src/extension-host/menu-accelerator.ts
@@ -1,0 +1,8 @@
+import { displayKey, effectiveKey, isRemoved } from "./keymap";
+
+/** Context-menu accelerator label for a command's effective key, if bound. */
+export function menuAcceleratorForCommand(command: string): string | undefined {
+  if (isRemoved(command)) return undefined;
+  const key = effectiveKey(command);
+  return key ? displayKey(key) : undefined;
+}

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -362,6 +362,7 @@ export {
   isRemoved,
   setKeybindingCaptureActive,
 } from "./keymap";
+export { menuAcceleratorForCommand } from "./menu-accelerator";
 
 // Foreground-process updates for a terminal session (RFC 0010 N1) — consumed by
 // the built-in terminal for tab titles. Core-only; not public SDK surface.
@@ -370,6 +371,12 @@ export {
   terminalForegroundSnapshot,
 } from "./terminal-foreground";
 export type { TerminalForeground } from "./terminal-foreground";
+
+export {
+  clearFocusedTerminal,
+  registerTerminalClear,
+  setTerminalFocus,
+} from "./terminal-clear-registry";
 
 // `ctx.agents`'s death/reset hooks (RFC 0018) — called by the built-in
 // terminal panel at the exact moment it observes SESSION_GONE on reattach

--- a/packages/extension-host/src/extension-host/terminal-clear-registry.test.ts
+++ b/packages/extension-host/src/extension-host/terminal-clear-registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  clearFocusedTerminal,
+  registerTerminalClear,
+  setTerminalFocus,
+} from "./terminal-clear-registry";
+import { contextKeys, setContextKey } from "./context-keys";
+
+beforeEach(() => {
+  setContextKey("activeEditorId", null);
+  setContextKey("activeEditorViewId", null);
+  setTerminalFocus(null);
+});
+
+describe("terminal-clear-registry", () => {
+  it("clears the focused terminal when its handler is registered", () => {
+    const clear = vi.fn();
+    const sub = registerTerminalClear("term_1", clear);
+    setTerminalFocus("term_1");
+
+    expect(clearFocusedTerminal()).toBe(true);
+    expect(clear).toHaveBeenCalledTimes(1);
+
+    sub.dispose();
+  });
+
+  it("no-ops when no terminal textarea is focused", () => {
+    const clear = vi.fn();
+    registerTerminalClear("term_1", clear);
+
+    expect(clearFocusedTerminal()).toBe(false);
+    expect(clear).not.toHaveBeenCalled();
+    expect(contextKeys.terminalFocused).toBe(false);
+  });
+
+  it("no-ops when focus moved elsewhere before clear", () => {
+    const clear = vi.fn();
+    registerTerminalClear("term_1", clear);
+    setTerminalFocus("term_1");
+    setTerminalFocus(null);
+
+    expect(clearFocusedTerminal()).toBe(false);
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("clears focus state when the focused panel unmounts", () => {
+    const sub = registerTerminalClear("term_1", vi.fn());
+    setTerminalFocus("term_1");
+
+    sub.dispose();
+
+    expect(contextKeys.terminalFocused).toBe(false);
+  });
+});

--- a/packages/extension-host/src/extension-host/terminal-clear-registry.ts
+++ b/packages/extension-host/src/extension-host/terminal-clear-registry.ts
@@ -1,0 +1,40 @@
+import type { Disposable } from "@silo-code/sdk";
+import { contextKeys, setContextKey } from "./context-keys";
+
+type ClearFn = () => void;
+
+const clearHandlers = new Map<string, ClearFn>();
+let focusedTerminalId: string | null = null;
+
+/**
+ * Publish terminal textarea focus for the given record id (or `null` on blur).
+ * Drives the `terminalFocused` context key used by the Clear keybinding's
+ * `when` clause.
+ */
+export function setTerminalFocus(terminalId: string | null): void {
+  focusedTerminalId = terminalId;
+  setContextKey("terminalFocused", terminalId !== null);
+}
+
+/** Register a terminal panel's clear action. Disposed on unmount. */
+export function registerTerminalClear(
+  terminalId: string,
+  clear: ClearFn,
+): Disposable {
+  clearHandlers.set(terminalId, clear);
+  return {
+    dispose: () => {
+      clearHandlers.delete(terminalId);
+      if (focusedTerminalId === terminalId) setTerminalFocus(null);
+    },
+  };
+}
+
+/** Clear the terminal whose xterm textarea is focused, if any. */
+export function clearFocusedTerminal(): boolean {
+  if (!contextKeys.terminalFocused || !focusedTerminalId) return false;
+  const clear = clearHandlers.get(focusedTerminalId);
+  if (!clear) return false;
+  clear();
+  return true;
+}

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -41,6 +41,9 @@ import {
   notifyTerminalSessionRecreated,
   stripAgentStatusMarkers,
   spawnTerminalSession,
+  registerTerminalClear,
+  setTerminalFocus,
+  menuAcceleratorForCommand,
   type TerminalForeground,
 } from "@silo-code/extension-host/internal";
 import { xtermThemeFor } from "./xterm-theme";
@@ -114,6 +117,15 @@ interface LiveRefs {
   search: SearchAddon;
   session: ProcessSession;
   sessionId: string;
+  /**
+   * Serialize the current buffer and persist it immediately, bypassing the
+   * throttle timer below. Set once `persistBuffer` exists, just after this ref
+   * is populated — undefined only in the brief window before that. Without
+   * this, `ctxClear`'s screen clear was invisible to the persisted snapshot
+   * until the next throttle tick, so a restart in that window (or a tick that
+   * lost the race) resurrected the pre-clear scrollback.
+   */
+  persistNow?: () => void;
 }
 
 async function openFileFromTerminal(
@@ -614,18 +626,24 @@ export function TerminalPanel(
           search: searchAddon,
           session,
           sessionId,
+          persistNow: () => {
+            saveDirty = false;
+            persistBuffer();
+          },
         };
 
         // Publish the terminal's selection to the active-selection registry
         // while it has focus, so `ctx.ui.getActiveSelectionText()` (e.g. the
         // Search panel's Cmd+Shift+F) can read it. Cleared on blur / teardown.
         const onTermFocus = () => {
+          setTerminalFocus(terminalId);
           selSourceRef.current?.dispose();
           selSourceRef.current = registerSelectionSource(
             () => liveRef.current?.term.getSelection() || null,
           );
         };
         const onTermBlur = () => {
+          setTerminalFocus(null);
           selSourceRef.current?.dispose();
           selSourceRef.current = null;
         };
@@ -1094,7 +1112,11 @@ export function TerminalPanel(
       { label: "Paste", accelerator: `${cmdKey}V`, run: ctxPaste },
       { label: "Select All", accelerator: `${cmdKey}A`, run: ctxSelectAll },
       { type: "separator" },
-      { label: "Clear", accelerator: `${cmdKey}K`, run: ctxClear },
+      {
+        label: "Clear",
+        accelerator: menuAcceleratorForCommand("core.terminal.clear"),
+        run: ctxClear,
+      },
       { label: "New Terminal Here", run: ctxNewTerminalHere },
       { type: "separator" },
       { label: "Kill Terminal", danger: true, run: ctxKill },
@@ -1205,8 +1227,14 @@ export function TerminalPanel(
     const live = liveRef.current;
     if (!live) return;
     live.term.clear();
+    live.persistNow?.();
     live.term.focus();
   }
+
+  useEffect(() => {
+    if (lifecycle.kind !== "ready") return;
+    return registerTerminalClear(terminalId, ctxClear).dispose;
+  }, [lifecycle.kind, terminalId]);
 
   function ctxKill() {
     const live = liveRef.current;

--- a/packages/extensions-core/src/terminal/index.tsx
+++ b/packages/extensions-core/src/terminal/index.tsx
@@ -3,6 +3,7 @@ import {
   isStartupStatusActive,
   startupTerminalRestoreBegin,
   startupTerminalRestoreEnd,
+  clearFocusedTerminal,
 } from "@silo-code/extension-host/internal";
 import { TerminalPanel, type TerminalPanelParams } from "./TerminalPanel";
 import { TerminalSettingsPage } from "./TerminalSettingsPage";
@@ -15,6 +16,19 @@ export const extension: Extension = {
       isStartupActive: isStartupStatusActive,
       onRestoreBegin: startupTerminalRestoreBegin,
       onRestoreEnd: startupTerminalRestoreEnd,
+    });
+    ctx.registerCommand({
+      id: "core.terminal.clear",
+      label: "Clear Terminal",
+      run: () => {
+        clearFocusedTerminal();
+      },
+    });
+    ctx.registerKeybinding({
+      id: "core.terminal.clear.key",
+      key: "cmd+k",
+      command: "core.terminal.clear",
+      when: (keys) => keys.terminalFocused,
     });
     ctx.registerDockPanelKind({
       id: "terminal",

--- a/packages/sdk/src/context-keys.ts
+++ b/packages/sdk/src/context-keys.ts
@@ -30,4 +30,10 @@ export interface ContextKeys {
    * to receive the correct value at runtime without a silent break.
    */
   activeViewerId: string | null;
+  /**
+   * True when an xterm textarea in a terminal panel owns DOM focus — the user
+   * is typing into (or has just typed into) a terminal. Used to scope terminal-
+   * local keybindings such as Clear (`cmd+k`).
+   */
+  terminalFocused: boolean;
 }


### PR DESCRIPTION
## Summary
- Register `core.terminal.clear` with a `cmd+k` keybinding scoped to `terminalFocused`, so Clear works from the keyboard (Mac: Cmd+K, Windows/Linux: Ctrl+K) without firing in other surfaces.
- Context menu Clear label now reads the effective key from the keymap, so user remaps show up on the next open.
- Flush the persisted terminal buffer immediately on clear so a restart in the throttle window does not resurrect pre-clear scrollback.

## Test plan
- [ ] Focus a terminal, run a command to produce output, press Cmd+K (Ctrl+K on Windows/Linux) — screen clears
- [ ] Clear via context menu — same behavior
- [ ] Remap **Clear Terminal** in Settings → Keyboard Shortcuts — context menu shows the new chord
- [ ] With focus in an editor, Cmd+K does nothing
- [ ] Clear, then restart Silo before the 2s persist tick — scrollback stays cleared


Made with [Cursor](https://cursor.com)