### PR TITLE
fix(terminal): read clipboard via Tauri plugin for context-menu Paste

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,14 +15,15 @@
     "test:it": "vitest run --project integration --no-file-parallelism"
   },
   "dependencies": {
-    "@silo-code/sdk": "workspace:*",
+    "@monaco-editor/react": "^4.7.0",
+    "@phosphor-icons/react": "^2.1.10",
     "@silo-code/extension-host": "workspace:*",
     "@silo-code/extensions-core": "workspace:*",
     "@silo-code/extensions-silo": "workspace:*",
+    "@silo-code/sdk": "workspace:*",
     "@silo-code/ui": "workspace:*",
-    "@monaco-editor/react": "^4.7.0",
-    "@phosphor-icons/react": "^2.1.10",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -73,6 +73,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +610,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +753,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1191,6 +1227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1258,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1262,6 +1310,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1551,6 +1605,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1851,6 +1915,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2194,6 +2269,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -3407,6 +3483,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,6 +3791,12 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4578,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "silo"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -4607,6 +4700,7 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-process",
@@ -5055,6 +5149,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5385,6 +5494,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5720,6 +5843,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
 ]
 
 [[package]]
@@ -6265,6 +6399,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "widestring"
@@ -7014,6 +7154,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7083,6 +7241,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -7323,6 +7498,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-fs = "2"
+tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-store = "2"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -36,6 +36,7 @@
         }
       ]
     },
+    "clipboard-manager:allow-read-text",
     "dialog:default",
     "shell:default",
     "store:default",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
 
     let builder = builder
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_store::Builder::default().build())

--- a/packages/extension-host/package.json
+++ b/packages/extension-host/package.json
@@ -12,10 +12,11 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@silo-code/sdk": "workspace:*",
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
+    "@silo-code/sdk": "workspace:*",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",

--- a/packages/extension-host/src/extension-host/clipboard.test.ts
+++ b/packages/extension-host/src/extension-host/clipboard.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { readTextMock } = vi.hoisted(() => ({
+  readTextMock: vi.fn(async () => "clipboard"),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: readTextMock,
+}));
+
+import { readClipboardText } from "./clipboard";
+
+describe("readClipboardText", () => {
+  it("reads via the Tauri clipboard plugin", async () => {
+    readTextMock.mockResolvedValueOnce("hello");
+    await expect(readClipboardText()).resolves.toBe("hello");
+    expect(readTextMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/extension-host/src/extension-host/clipboard.ts
+++ b/packages/extension-host/src/extension-host/clipboard.ts
@@ -1,0 +1,12 @@
+import { readText } from "@tauri-apps/plugin-clipboard-manager";
+
+// Host-mediated clipboard read for core UI. WebKit in WKWebView treats
+// `navigator.clipboard.readText()` as privacy-sensitive and shows a native
+// "Paste" permission bubble that loses user-activation by the time it's
+// clicked (e.g. terminal context-menu Paste). The Tauri plugin reads straight
+// from the OS pasteboard via Rust instead.
+
+/** Plain-text clipboard contents, or `""` when empty. */
+export function readClipboardText(): Promise<string> {
+  return readText();
+}

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -132,6 +132,12 @@ export { EXTENSIONS_SETTINGS_GROUP } from "./settings-pages";
 // mechanical swap would risk regressing. See platform.ts.
 export { homeDir } from "./platform";
 
+// Clipboard read — privileged because WKWebView's `navigator.clipboard.readText()`
+// shows a native permission bubble that silently fails from custom menus; the
+// Tauri plugin reads the OS pasteboard directly. Only `core.terminal` needs this
+// today (context-menu Paste + paste-on-right-click).
+export { readClipboardText } from "./clipboard";
+
 // Workspace section registry — exposed here (rather than on the public
 // WorkspaceService type) because reading back the full provider list, including
 // React component references, is a core-extension-only concern. The *write* side

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -41,6 +41,7 @@ import {
   notifyTerminalSessionRecreated,
   stripAgentStatusMarkers,
   spawnTerminalSession,
+  readClipboardText,
   type TerminalForeground,
 } from "@silo-code/extension-host/internal";
 import { xtermThemeFor } from "./xterm-theme";
@@ -497,8 +498,8 @@ export function TerminalPanel(
     hostEl?.addEventListener("mouseup", onMouseUp);
     disposers.push(() => hostEl?.removeEventListener("mouseup", onMouseUp));
 
-    // Paste on right-click: do it from `auxclick` (a real click gesture WebKit
-    // allows clipboard reads from) rather than `contextmenu` (which it doesn't).
+    // Paste on right-click: do it from `auxclick` (a real click gesture) rather
+    // than `contextmenu` (which doesn't carry the same user-activation semantics).
     const onAuxClick = (e: MouseEvent) => {
       if (e.button === 2 && store.terminalSettings.pasteOnRightClick) {
         void ctxPaste();
@@ -1144,8 +1145,7 @@ export function TerminalPanel(
     }
 
     // When enabled, right-click pastes instead of opening the context menu. The
-    // paste itself happens in the `auxclick` handler — WebKit grants clipboard
-    // read only on a real click gesture, not on a `contextmenu` event.
+    // paste itself happens in the `auxclick` handler (a real click gesture).
     if (store.terminalSettings.pasteOnRightClick) {
       return;
     }
@@ -1183,11 +1183,9 @@ export function TerminalPanel(
   async function ctxPaste() {
     const live = liveRef.current;
     if (!live) return;
-    // Focus first so the webview clipboard read has document focus (the
-    // right-click path otherwise reads with the window unfocused).
     live.term.focus();
     try {
-      const text = await navigator.clipboard.readText();
+      const text = await readClipboardText();
       if (text) live.term.paste(text);
     } catch (err) {
       console.warn("[terminal] paste failed", err);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.0
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -592,6 +595,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.0
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -2508,6 +2514,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -6595,6 +6604,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:


### PR DESCRIPTION
## Summary

- Fixes #276 — terminal right-click **Paste** (and paste-on-right-click) no longer calls `navigator.clipboard.readText()`, which triggers a WKWebView permission bubble that silently fails once the custom menu closes.
- Adds `@tauri-apps/plugin-clipboard-manager` and routes paste through `readClipboardText()` on the host internal surface, reading the OS pasteboard via Rust instead of the DOM clipboard API.

## Test plan

- [ ] Copy text to the system clipboard
- [ ] Right-click in a terminal → **Paste** — text appears, no native permission bubble
- [ ] Enable **Paste on right-click** in terminal settings — right-click pastes without opening the menu
- [ ] Confirm **Cmd+V** and **Edit → Paste** still work (unchanged paths)
- [ ] `pnpm --filter @silo-code/extension-host exec vitest run src/extension-host/clipboard.test.ts`


Made with [Cursor](https://cursor.com)