### PR TITLE
feat(agents): bundle Agent Monitor as built-in silo.agents

### DIFF
--- a/apps/desktop/src/builtins.ts
+++ b/apps/desktop/src/builtins.ts
@@ -25,6 +25,7 @@ import {
   fileSearch,
   git,
   gitExplorer,
+  agents,
   themePresets,
 } from "@silo-code/extensions-silo";
 
@@ -58,6 +59,7 @@ const builtins: Extension[] = [
   // consume its published GitAPI.
   git,
   gitExplorer,
+  agents,
   // Register presets before the themes UI so the picker has them on first paint.
   themePresets,
   themes,

--- a/apps/website/src/demo-config.ts
+++ b/apps/website/src/demo-config.ts
@@ -517,11 +517,10 @@ export const SETTINGS_PAGES = [
   { id: "terminal", title: "Terminal" },
   { id: "layout", title: "Layout" },
   { id: "extensions", title: "Extensions", group: "extensions" },
-  { id: "agent-monitor", title: "Agent Monitor" },
+  { id: "agents", title: "Agents" },
   { id: "system-monitor", title: "System Monitor" },
   { id: "github-actions", title: "GitHub Actions" },
   { id: "github-prs", title: "GitHub Pull Requests" },
-  { id: "agents", title: "Agents", group: "agents" },
   { id: "about", title: "About Silo", group: "about" },
 ];
 
@@ -544,7 +543,7 @@ export const REGISTRY_CATEGORIES = [
  */
 export const REGISTRY_ENTRIES: RegistryEntry[] = [
   {
-    id: "silo.agent-monitor",
+    id: "silo.agents",
     name: "Agent Monitor",
     version: "0.2.3",
     state: "update-available",

--- a/packages/extension-host/src/extension-host/extension-manager.test.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.test.ts
@@ -96,6 +96,7 @@ import {
   updateNeedsConsent,
 } from "./extension-manager";
 import { registerBuiltins } from "./builtins-registry";
+import { toastStore } from "./ui-service";
 import type { Extension } from "@silo-code/sdk";
 
 const INSTALLED = "/cfg/extensions/installed.json";
@@ -122,6 +123,7 @@ beforeEach(() => {
   loaderMock.needsReload.mockReturnValue(false);
   invokeMock.mockClear().mockResolvedValue(undefined);
   fsDeleteSpy.mockClear();
+  toastStore.toasts.splice(0, toastStore.toasts.length);
   // Reset the built-in registry so merged rows / dispatch start clean.
   registerBuiltins([], new Set());
 });
@@ -223,6 +225,62 @@ describe("loadInstalled", () => {
       main: "dist/index.js",
       permissions: ["fs:write"],
     });
+  });
+
+  it("retires an on-disk install when its id matches a built-in", async () => {
+    registerBuiltins([fakeBuiltin("silo.agents", "Agents")], new Set());
+    fsMap.set(
+      INSTALLED,
+      JSON.stringify({
+        version: 1,
+        extensions: [
+          {
+            id: "silo.agent-monitor",
+            dir: "silo.agent-monitor",
+            enabled: true,
+            permissions: [],
+          },
+        ],
+      }),
+    );
+    fsMap.set(
+      "/cfg/extensions/silo.agent-monitor/package.json",
+      JSON.stringify({
+        name: "Agent Monitor",
+        version: "0.2.10",
+        silo: { id: "silo.agent-monitor", main: "dist/index.js" },
+      }),
+    );
+    fsMap.set(
+      "/cfg/extensions/silo.agent-monitor/dist/index.js",
+      "third-party",
+    );
+
+    await mgr.loadInstalled();
+
+    expect(loaderMock.loadExtension).not.toHaveBeenCalled();
+    expect(JSON.parse(fsMap.get(INSTALLED)!).extensions).toEqual([]);
+    expect(fsMap.has("/cfg/extensions/silo.agent-monitor/dist/index.js")).toBe(
+      false,
+    );
+    const rows = mgr
+      .getState()
+      .extensions.filter((e) => e.id === "silo.agents");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      name: "Agents",
+      builtin: true,
+      publisher: "Silo",
+    });
+    expect(toastStore.toasts).toEqual([
+      expect.objectContaining({
+        level: "info",
+        title: "Agent Monitor extension is now built-in to Silo",
+        message:
+          "Your settings were kept; the separately installed copy was removed.",
+        dedupKey: "builtin-migrate:silo.agents",
+      }),
+    ]);
   });
 });
 

--- a/packages/extension-host/src/extension-host/extension-manager.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.ts
@@ -35,6 +35,13 @@ import {
   disableBuiltin,
   builtinRows,
 } from "./builtins-registry";
+import {
+  migrateDisabledBuiltins,
+  isSupersededOnDiskId,
+  SUPERSEDED_BUILTIN_IDS,
+  SUPERSEDED_BUILTIN_TOAST_TITLES,
+} from "../state/extension-id-migration";
+import { pushToast } from "./ui-service";
 import { appVersion } from "../services/tauri-app";
 import { isEngineCompatible } from "./engine-compat";
 import {
@@ -423,6 +430,11 @@ async function readInstalledFile(): Promise<InstalledFile> {
     if (!Array.isArray(parsed.extensions)) {
       return { version: REGISTRY_VERSION, extensions: [] };
     }
+    const disabled = migrateDisabledBuiltins(parsed.disabledBuiltins);
+    if (disabled.changed) {
+      parsed.disabledBuiltins = disabled.ids;
+      await writeInstalledFile(parsed);
+    }
     return parsed;
   } catch {
     return { version: REGISTRY_VERSION, extensions: [] };
@@ -432,6 +444,20 @@ async function readInstalledFile(): Promise<InstalledFile> {
 async function writeInstalledFile(file: InstalledFile): Promise<void> {
   const path = `${await extensionsRoot()}/installed.json`;
   await fsWriteText(path, JSON.stringify(file, null, 2));
+}
+
+/**
+ * Remove an on-disk third-party install whose id now matches a built-in (or was
+ * superseded by one). Settings in `globalExtensionState` migrate separately.
+ */
+async function retireOnDiskInstall(id: string, dir: string): Promise<void> {
+  if (isLoaded(id)) unloadExtension(id);
+  const root = await extensionsRoot();
+  const destDir = `${root}/${dir}`;
+  if (await fsPathExists(destDir)) await fsDelete(destDir);
+  await upsertRecord((file) => {
+    file.extensions = file.extensions.filter((e) => e.id !== id);
+  });
 }
 
 // ---- reactive state ----------------------------------------------------------
@@ -457,6 +483,9 @@ async function refresh(): Promise<void> {
   const hostVersion = await appVersion().catch(() => "");
   const rows: InstalledExtension[] = [];
   for (const rec of file.extensions) {
+    // A built-in with the same id owns the extension — skip the retired on-disk
+    // row so Settings → Extensions never lists the id twice.
+    if (isBuiltin(rec.id) || isSupersededOnDiskId(rec.id, isBuiltin)) continue;
     const dir = `${root}/${rec.dir}`;
     try {
       const m = await readManifest(dir);
@@ -768,7 +797,33 @@ export function getExtensionManager(): ExtensionManager {
     async loadInstalled() {
       const file = await readInstalledFile();
       const root = await extensionsRoot();
+      // Transparent migration: a third-party install whose id is now built-in
+      // is retired on disk instead of loaded alongside the in-process copy.
+      const migrated: { oldId: string; newId: string }[] = [];
       for (const rec of file.extensions) {
+        if (isBuiltin(rec.id) || isSupersededOnDiskId(rec.id, isBuiltin)) {
+          await retireOnDiskInstall(rec.id, rec.dir);
+          migrated.push({
+            oldId: rec.id,
+            newId: SUPERSEDED_BUILTIN_IDS[rec.id] ?? rec.id,
+          });
+        }
+      }
+      for (const { oldId, newId } of migrated) {
+        const name = builtinRows().find((b) => b.id === newId)?.name ?? newId;
+        const title =
+          SUPERSEDED_BUILTIN_TOAST_TITLES[oldId] ?? `${name} is now built in`;
+        pushToast(
+          "info",
+          "Your settings were kept; the separately installed copy was removed.",
+          {
+            title,
+            dedupKey: `builtin-migrate:${newId}`,
+          },
+        );
+      }
+      const current = await readInstalledFile();
+      for (const rec of current.extensions) {
         if (!rec.enabled) continue;
         try {
           const dir = `${root}/${rec.dir}`;

--- a/packages/extension-host/src/state/extension-id-migration.test.ts
+++ b/packages/extension-host/src/state/extension-id-migration.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  migrateDisabledBuiltins,
+  migrateGlobalExtensionState,
+  isSupersededOnDiskId,
+} from "./extension-id-migration";
+
+describe("migrateGlobalExtensionState", () => {
+  it("moves the old extension bag to the new id", () => {
+    const state = {
+      "silo.agent-monitor": { iconMode: "color", soundEnabled: true },
+    };
+    expect(migrateGlobalExtensionState(state)).toBe(true);
+    expect(state["silo.agents"]).toEqual({
+      iconMode: "color",
+      soundEnabled: true,
+    });
+    expect(state["silo.agent-monitor"]).toBeUndefined();
+  });
+
+  it("preserves newer keys when both bags exist", () => {
+    const state = {
+      "silo.agent-monitor": { iconMode: "color" },
+      "silo.agents": { iconMode: "none", groupBy: "status" },
+    };
+    migrateGlobalExtensionState(state);
+    expect(state["silo.agents"]).toEqual({
+      iconMode: "none",
+      groupBy: "status",
+    });
+  });
+
+  it("rewrites the navigator active view prefix", () => {
+    const state = {
+      "core.navigator": { activeView: "silo.agent-monitor.by-status" },
+    };
+    migrateGlobalExtensionState(state);
+    expect(state["core.navigator"].activeView).toBe("silo.agents.by-status");
+  });
+
+  it("maps retired navigator views to their replacement", () => {
+    const state = {
+      "core.navigator": { activeView: "silo.agent-monitor.by-workspace" },
+    };
+    migrateGlobalExtensionState(state);
+    expect(state["core.navigator"].activeView).toBe("silo.agents.by-status");
+  });
+
+  it("is a no-op when nothing to migrate", () => {
+    const state = { "silo.agents": { iconMode: "color" } };
+    expect(migrateGlobalExtensionState(state)).toBe(false);
+  });
+});
+
+describe("migrateDisabledBuiltins", () => {
+  it("replaces superseded ids", () => {
+    const { ids, changed } = migrateDisabledBuiltins([
+      "silo.agent-monitor",
+      "silo.file-explorer",
+    ]);
+    expect(changed).toBe(true);
+    expect(ids.sort()).toEqual(["silo.agents", "silo.file-explorer"].sort());
+  });
+});
+
+describe("isSupersededOnDiskId", () => {
+  it("is true only when the replacement is a registered built-in", () => {
+    const isBuiltin = (id: string) => id === "silo.agents";
+    expect(isSupersededOnDiskId("silo.agent-monitor", isBuiltin)).toBe(true);
+    expect(isSupersededOnDiskId("silo.agent-monitor", () => false)).toBe(false);
+    expect(isSupersededOnDiskId("acme.other", isBuiltin)).toBe(false);
+  });
+});

--- a/packages/extension-host/src/state/extension-id-migration.ts
+++ b/packages/extension-host/src/state/extension-id-migration.ts
@@ -1,0 +1,84 @@
+/**
+ * One-time migrations when a third-party extension id becomes a built-in under
+ * a new id. Keeps settings (`globalExtensionState`), navigator view choice, and
+ * `disabledBuiltins` aligned without manual cleanup.
+ */
+
+/** Former extension id → id Silo now ships as a built-in. */
+export const SUPERSEDED_BUILTIN_IDS: Readonly<Record<string, string>> = {
+  "silo.agent-monitor": "silo.agents",
+};
+
+/** Optional toast title when retiring a superseded on-disk install. */
+export const SUPERSEDED_BUILTIN_TOAST_TITLES: Readonly<Record<string, string>> =
+  {
+    "silo.agent-monitor": "Agent Monitor extension is now built-in to Silo",
+  };
+
+/** Retired navigator view ids rewritten on migration. */
+const RETIRED_VIEW_IDS: Readonly<Record<string, string>> = {
+  "silo.agent-monitor.by-workspace": "silo.agents.by-status",
+};
+
+function rewriteNavigatorViewId(activeView: string): string | null {
+  if (activeView in RETIRED_VIEW_IDS) {
+    return RETIRED_VIEW_IDS[activeView];
+  }
+  for (const [oldId, newId] of Object.entries(SUPERSEDED_BUILTIN_IDS)) {
+    if (activeView.startsWith(`${oldId}.`)) {
+      return newId + activeView.slice(oldId.length);
+    }
+  }
+  return null;
+}
+
+/** Migrate extension global storage bags and navigator view ids. */
+export function migrateGlobalExtensionState(
+  state: Record<string, Record<string, unknown>>,
+): boolean {
+  let changed = false;
+  for (const [oldId, newId] of Object.entries(SUPERSEDED_BUILTIN_IDS)) {
+    const oldBag = state[oldId];
+    if (!oldBag) continue;
+    state[newId] = { ...oldBag, ...state[newId] };
+    delete state[oldId];
+    changed = true;
+  }
+  const nav = state["core.navigator"];
+  if (nav) {
+    const activeView = nav.activeView;
+    if (typeof activeView === "string") {
+      const rewritten = rewriteNavigatorViewId(activeView);
+      if (rewritten && rewritten !== activeView) {
+        nav.activeView = rewritten;
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
+/** Rewrite persisted built-in disable choices to the new ids. */
+export function migrateDisabledBuiltins(ids: readonly string[] | undefined): {
+  ids: string[];
+  changed: boolean;
+} {
+  const set = new Set(ids ?? []);
+  let changed = false;
+  for (const [oldId, newId] of Object.entries(SUPERSEDED_BUILTIN_IDS)) {
+    if (set.delete(oldId)) {
+      set.add(newId);
+      changed = true;
+    }
+  }
+  return { ids: [...set], changed };
+}
+
+/** Whether an on-disk install id was superseded by a now-built-in extension. */
+export function isSupersededOnDiskId(
+  id: string,
+  isBuiltinId: (id: string) => boolean,
+): boolean {
+  const target = SUPERSEDED_BUILTIN_IDS[id];
+  return target !== undefined && isBuiltinId(target);
+}

--- a/packages/extension-host/src/state/persistence.ts
+++ b/packages/extension-host/src/state/persistence.ts
@@ -13,6 +13,7 @@ import {
 } from "./types";
 import type { WorkspaceInternal } from "./types";
 import { migratePanelIds } from "./panel-id-migration";
+import { migrateGlobalExtensionState } from "./extension-id-migration";
 import { loadPanelStateFromWorkspace } from "./workspaces";
 import {
   capturePanelState,
@@ -135,6 +136,7 @@ export async function hydrate(configDir: string): Promise<void> {
   // Merge settings over defaults so settings added in later versions hydrate
   // sanely from an older blob. (Order/active are reconciled below, after we know
   // which workspace files actually loaded.)
+  let extensionStateMigrated = false;
   if (index) {
     store.uiFontSize = index.uiFontSize ?? DEFAULT_UI_FONT_SIZE;
     store.activeThemeId = index.activeThemeId ?? "dark";
@@ -156,6 +158,9 @@ export async function hydrate(configDir: string): Promise<void> {
     store.globalExtensionState = index.globalExtensionState
       ? cloneExtensionState(index.globalExtensionState)
       : {};
+    if (migrateGlobalExtensionState(store.globalExtensionState)) {
+      extensionStateMigrated = true;
+    }
     store.agentState = index.agentState
       ? cloneAgentState(index.agentState)
       : {};
@@ -255,6 +260,9 @@ export async function hydrate(configDir: string): Promise<void> {
 
   store.hydrated = true;
   subscribe(store, schedulePersist);
+  if (extensionStateMigrated) {
+    void persistImmediately();
+  }
 }
 
 async function doPersist(): Promise<void> {

--- a/packages/extensions-core/src/agents-settings/AgentsHooksPanel.tsx
+++ b/packages/extensions-core/src/agents-settings/AgentsHooksPanel.tsx
@@ -1,0 +1,402 @@
+/**
+ * Session-hook install UI for the Agents settings page (Hooks tab).
+ *
+ * Kept in its own module so `agent-catalog-modularization` can land
+ * {@link AgentExtraSettingsToggle} changes here without fighting tab/options
+ * composition work in `index.tsx`.
+ */
+import {
+  useCallback,
+  useEffect,
+  useState,
+  Fragment,
+  type ReactNode,
+} from "react";
+import type { ExtensionContext } from "@silo-code/sdk";
+import {
+  Badge,
+  Section,
+  Callout,
+  Button,
+  SettingRow,
+  Switch,
+} from "@silo-code/sdk";
+import {
+  hookInstallableAgents,
+  sessionFileAgents,
+  buildTrackSessionScript,
+  TRACK_SCRIPT_REL,
+  type AgentDefinition,
+  type AgentHookResume,
+} from "@silo-code/extension-host/internal";
+import { installerFor } from "./install-strategy";
+import {
+  getTerminalProgress,
+  PI_AGENT_SETTINGS_REL,
+  withTerminalProgress,
+  type PiAgentSettings,
+} from "./pi-settings";
+import {
+  parseSettingsJsonText,
+  writableSettingsOrThrow,
+  type SettingsJsonRead,
+} from "./settings-json";
+import "./AgentsSettingsPage.css";
+
+type HookAgent = AgentDefinition & { resume: AgentHookResume };
+
+interface AgentRow {
+  agent: HookAgent;
+  installed: boolean;
+  loaded: boolean;
+  error?: string;
+}
+
+async function resolveHomeDir(ctx: ExtensionContext): Promise<string | null> {
+  try {
+    const { code, stdout } = await ctx.process.exec("sh", [
+      "-c",
+      "printf '%s' \"$HOME\"",
+    ]);
+    return code === 0 ? stdout.trim() || null : null;
+  } catch {
+    return null;
+  }
+}
+
+function settingsPathFor(agent: HookAgent, home: string): string {
+  return `${home}/${agent.resume.configPath}`;
+}
+
+async function ensureTrackScript(
+  ctx: ExtensionContext,
+  home: string,
+): Promise<boolean> {
+  const path = `${home}/${TRACK_SCRIPT_REL}`;
+  const body = buildTrackSessionScript();
+  const existing = (await ctx.files.pathExists(path))
+    ? await ctx.files.readText(path).catch(() => null)
+    : null;
+  if (existing === body) return false;
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  if (dir) await ctx.files.createDir(dir);
+  await ctx.files.writeText(path, body);
+  return true;
+}
+
+async function refreshConfigIfDrifted(
+  ctx: ExtensionContext,
+  agent: HookAgent,
+  path: string,
+): Promise<boolean> {
+  return installerFor(agent.resume).refreshIfDrifted(ctx, agent.resume, path);
+}
+
+async function writeInstalled(
+  ctx: ExtensionContext,
+  agent: HookAgent,
+  path: string,
+  home: string,
+  install: boolean,
+): Promise<void> {
+  if (install) await ensureTrackScript(ctx, home);
+  await installerFor(agent.resume).write(ctx, agent.resume, path, install);
+}
+
+async function readPiAgentSettings(
+  ctx: ExtensionContext,
+  home: string,
+): Promise<SettingsJsonRead<PiAgentSettings>> {
+  const path = `${home}/${PI_AGENT_SETTINGS_REL}`;
+  if (!(await ctx.files.pathExists(path))) return { kind: "missing" };
+  const text = await ctx.files.readText(path).catch(() => null);
+  return parseSettingsJsonText<PiAgentSettings>(text, path);
+}
+
+async function writePiTerminalProgress(
+  ctx: ExtensionContext,
+  home: string,
+  enabled: boolean,
+): Promise<void> {
+  const path = `${home}/${PI_AGENT_SETTINGS_REL}`;
+  const read = await readPiAgentSettings(ctx, home);
+  const current = writableSettingsOrThrow(read, path);
+  const next = withTerminalProgress(current, enabled);
+  const body = JSON.stringify(next, null, 2) + "\n";
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  if (dir) await ctx.files.createDir(dir);
+  await ctx.files.writeText(path, body);
+}
+
+function AgentSettingsRow({
+  label,
+  hint,
+  docsUrl,
+  onOpenDocs,
+  control,
+}: {
+  label: string;
+  hint: string;
+  docsUrl: string;
+  onOpenDocs: (url: string) => void;
+  control?: ReactNode;
+}) {
+  return (
+    <div className="silo-setting-row">
+      <div className="silo-setting-row-text">
+        <div className="silo-setting-row-label">{label}</div>
+        <div className="silo-setting-row-hint">{hint}</div>
+        <button
+          type="button"
+          className="agents-settings-docs-link"
+          onClick={() => onOpenDocs(docsUrl)}
+        >
+          Setup details
+        </button>
+      </div>
+      {control != null && (
+        <div className="silo-setting-row-control">{control}</div>
+      )}
+    </div>
+  );
+}
+
+export function AgentsHooksPanel({ ctx }: { ctx: ExtensionContext }) {
+  const [home, setHome] = useState<string | null | undefined>(undefined);
+  const [rows, setRows] = useState<AgentRow[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [piTerminalProgress, setPiTerminalProgress] = useState<boolean | null>(
+    null,
+  );
+  const [piProgressError, setPiProgressError] = useState<string | null>(null);
+  const [windows, setWindows] = useState(false);
+
+  const load = useCallback(async () => {
+    const agents = hookInstallableAgents();
+    const { os } = await ctx.system.getInfo();
+    const isWindows = os === "windows";
+    setWindows(isWindows);
+    if (isWindows) {
+      setHome(null);
+      setRows(
+        agents.map((agent) => ({ agent, installed: false, loaded: true })),
+      );
+      return;
+    }
+    const h = await resolveHomeDir(ctx);
+    setHome(h);
+    if (!h) {
+      setRows(
+        agents.map((agent) => ({
+          agent,
+          installed: false,
+          loaded: false,
+          error: "Could not resolve $HOME",
+        })),
+      );
+      return;
+    }
+    const next: AgentRow[] = [];
+    for (const agent of agents) {
+      try {
+        const installed = await installerFor(agent.resume).isInstalled(
+          ctx,
+          agent.resume,
+          settingsPathFor(agent, h),
+        );
+        next.push({ agent, installed, loaded: true });
+      } catch (err) {
+        next.push({
+          agent,
+          installed: false,
+          loaded: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    try {
+      const installedAgents = next.filter((r) => r.installed);
+      if (installedAgents.length > 0) {
+        const scriptWrote = await ensureTrackScript(ctx, h);
+        const healed: string[] = [];
+        for (const r of installedAgents) {
+          const wrote = await refreshConfigIfDrifted(
+            ctx,
+            r.agent,
+            settingsPathFor(r.agent, h),
+          );
+          if (wrote) healed.push(r.agent.displayName);
+        }
+        if (scriptWrote || healed.length > 0) {
+          ctx.log.info(
+            "Refreshed Silo session hook to the shell-script runtime" +
+              (healed.length > 0 ? ` (config: ${healed.join(", ")})` : "") +
+              (scriptWrote ? " (wrote track-session.sh)" : "") +
+              ".",
+          );
+        }
+      }
+    } catch (err) {
+      ctx.log.warn(
+        "Agent hook self-heal skipped: " +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
+
+    setPiProgressError(null);
+    try {
+      const read = await readPiAgentSettings(ctx, h);
+      if (read.kind === "invalid") {
+        setPiTerminalProgress(false);
+        setPiProgressError(read.message);
+      } else {
+        setPiTerminalProgress(
+          getTerminalProgress(read.kind === "ok" ? read.value : {}),
+        );
+      }
+    } catch (err) {
+      setPiTerminalProgress(false);
+      setPiProgressError(err instanceof Error ? err.message : String(err));
+    }
+
+    setRows(next);
+  }, [ctx]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function toggle(row: AgentRow, install: boolean) {
+    if (!home) return;
+    setBusy(row.agent.id);
+    const path = settingsPathFor(row.agent, home);
+    try {
+      await writeInstalled(ctx, row.agent, path, home, install);
+      await load();
+    } catch (err) {
+      setRows((prev) =>
+        prev.map((r) =>
+          r.agent.id === row.agent.id
+            ? { ...r, error: err instanceof Error ? err.message : String(err) }
+            : r,
+        ),
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function togglePiTerminalProgress(enabled: boolean) {
+    if (!home) return;
+    setBusy("pi-terminal-progress");
+    setPiProgressError(null);
+    try {
+      await writePiTerminalProgress(ctx, home, enabled);
+      setPiTerminalProgress(enabled);
+    } catch (err) {
+      setPiProgressError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const autoAgents = sessionFileAgents();
+
+  return (
+    <>
+      <p className="agents-settings-banner">
+        <Badge tone="warn">Work in progress</Badge> Session hooks and exact
+        resume are still evolving. Expect rough edges — feedback welcome.{" "}
+        <button
+          type="button"
+          className="agents-settings-banner-link"
+          onClick={() =>
+            void ctx.ui.openExternal("https://getsilo.dev/guide/agent-sessions")
+          }
+        >
+          Learn more
+        </button>
+      </p>
+
+      {windows && (
+        <Callout>
+          Exact resume via session hooks is macOS and Linux only for now —
+          Windows doesn&rsquo;t yet support the POSIX-shell hook and
+          process-group tracking it relies on. Silo still detects these agents
+          and shows a best-effort resume hint.
+        </Callout>
+      )}
+
+      <Section label="Session hooks">
+        {rows.map((row) => (
+          <Fragment key={row.agent.id}>
+            <AgentSettingsRow
+              label={row.agent.displayName}
+              hint={
+                row.error
+                  ? `Error: ${row.error}`
+                  : windows
+                    ? "Detection only on this platform"
+                    : row.installed
+                      ? (row.agent.resume.postInstallNote ??
+                        "Hook installed — exact resume enabled.")
+                      : "Install Silo's session hook for exact resume."
+              }
+              docsUrl={row.agent.docsUrl}
+              onOpenDocs={(url) => void ctx.ui.openExternal(url)}
+              control={
+                windows ? undefined : (
+                  <Button
+                    size="sm"
+                    variant={row.installed ? "normal" : "primary"}
+                    disabled={busy === row.agent.id || !row.loaded}
+                    onClick={() => void toggle(row, !row.installed)}
+                  >
+                    {row.installed ? "Uninstall" : "Install"}
+                  </Button>
+                )
+              }
+            />
+            {row.agent.id === "pi" && !windows && (
+              <SettingRow
+                label="Terminal progress"
+                hint={
+                  piProgressError
+                    ? `Error: ${piProgressError}`
+                    : "Emit OSC 9;4 progress so Silo can show pi working/idle. Restart pi after changing."
+                }
+              >
+                <Switch
+                  checked={piTerminalProgress ?? false}
+                  disabled={
+                    piTerminalProgress === null ||
+                    busy === "pi-terminal-progress" ||
+                    !home
+                  }
+                  onChange={(checked) => void togglePiTerminalProgress(checked)}
+                  aria-label="pi terminal progress"
+                />
+              </SettingRow>
+            )}
+          </Fragment>
+        ))}
+      </Section>
+
+      {autoAgents.length > 0 && (
+        <Section label="Works automatically">
+          {autoAgents.map((agent) => (
+            <AgentSettingsRow
+              key={agent.id}
+              label={agent.displayName}
+              hint="Uses its native session registry — no hook to install."
+              docsUrl={agent.docsUrl}
+              onOpenDocs={(url) => void ctx.ui.openExternal(url)}
+              control={<Badge tone="ok">Automatic</Badge>}
+            />
+          ))}
+        </Section>
+      )}
+    </>
+  );
+}

--- a/packages/extensions-core/src/agents-settings/AgentsSettingsPage.css
+++ b/packages/extensions-core/src/agents-settings/AgentsSettingsPage.css
@@ -1,6 +1,7 @@
 /* Agents settings uses the shared settings page chrome (`.es-page` /
- * `.es-header` / `.es-scroll` from SettingsPage.css) and SDK primitives
- * (Section, Callout, Badge, Button). Keep this file for the unboxed WIP
+ * `.es-header` from SettingsPage.css) and SDK primitives (Section, Callout,
+ * Badge, Button). Tab content scrolls via `.silo-scroll` inside TabPanel,
+ * matching system-monitor settings spacing. Keep this file for the unboxed WIP
  * banner and the per-row docs link under the SettingRow hint. */
 
 .agents-settings-banner {
@@ -43,4 +44,35 @@
 
 .agents-settings-banner-link:hover {
   color: var(--silo-color-text-hi);
+}
+
+/* Tabs + TabPanel below the title — same pattern as system-monitor settings
+ * (page-level strip attached to its panel, not header-inline SegmentedTabs). */
+.agents-settings-page {
+  gap: 12px;
+}
+
+.agents-settings-tabs {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.agents-settings-tabs > .silo-tab-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.agents-settings-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+  /* TabPanel already pads 14px; extra inset below the tab strip (+10px vs system-monitor). */
+  padding-top: 20px;
 }

--- a/packages/extensions-core/src/agents-settings/index.tsx
+++ b/packages/extensions-core/src/agents-settings/index.tsx
@@ -1,485 +1,85 @@
 /**
- * Agents settings page — Install / Uninstall per agent CLI that exposes a
- * session hook (`hookInstallableAgents()` from the agent catalog, the single
- * source of truth). Install writes Silo's hook into that CLI's **default**
- * config location. No per-account (e.g. `CLAUDE_CONFIG_DIR`) differentiation —
- * assumes the CLI's standard setup; the linked "Setup details" docs page
- * covers a non-default setup manually. Installing the hook is what gives
- * `ctx.agents` an exact, PID-correlated session id instead of the
- * honest-but-vague generic hint (see RFC 0018's hook-based resolution). The
- * actual hook-event reading and PID correlation is host-internal, sealed,
- * same as the rest of `ctx.agents`.
+ * Agents settings page — the single Application-rail entry (`id: "agents"`).
  *
- * Installing does two things (RFC 0019): write the shared POSIX-shell capture
- * script (`~/.silo/agent-hooks/track-session.sh`, catalog-templated), then add
- * a one-line hook entry pointing at it. On load the page also **self-heals** —
- * any install still carrying the legacy inline `python3`/base64 command (which
- * tripped endpoint-security tools) is rewritten to the shell runtime, silently
- * unless it actually changes something.
+ * **Options** tab composes host display prefs with `silo.agents`' published
+ * {@link AgentsExtensionAPI.OptionsPanel} via `ctx.getExtension` — the same
+ * bundled-only pattern as `silo.git-explorer` → `silo.git` (no general SDK for
+ * extending built-in settings pages).
  *
- * On-disk schemas are selected via `resume.installStrategy` through
- * {@link installerFor} (Claude/Codex, Cursor, Copilot). The whole feature is
- * macOS/Linux only — on Windows the page is detection-only (no Install, no
- * self-heal), since a shell hook can neither run nor correlate there.
+ * **Hooks** tab lives in {@link AgentsHooksPanel} so agent-catalog modularization
+ * can evolve hook/extra-settings UI independently.
  */
-import {
-  useCallback,
-  useEffect,
-  useState,
-  Fragment,
-  type ReactNode,
-} from "react";
+import { useState, type ComponentType } from "react";
 import { useSnapshot } from "valtio";
 import type { Extension, ExtensionContext } from "@silo-code/sdk";
-import {
-  Badge,
-  Section,
-  Callout,
-  Button,
-  SettingRow,
-  Switch,
-} from "@silo-code/sdk";
-import {
-  hookInstallableAgents,
-  sessionFileAgents,
-  buildTrackSessionScript,
-  TRACK_SCRIPT_REL,
-  store,
-  setTerminalSetting,
-  type AgentDefinition,
-  type AgentHookResume,
-} from "@silo-code/extension-host/internal";
-import { installerFor } from "./install-strategy";
-import {
-  getTerminalProgress,
-  PI_AGENT_SETTINGS_REL,
-  withTerminalProgress,
-  type PiAgentSettings,
-} from "./pi-settings";
-import {
-  parseSettingsJsonText,
-  writableSettingsOrThrow,
-  type SettingsJsonRead,
-} from "./settings-json";
+import { Section, Tabs, TabPanel, SettingRow, Switch } from "@silo-code/sdk";
+import { store, setTerminalSetting } from "@silo-code/extension-host/internal";
+import { AgentsHooksPanel } from "./AgentsHooksPanel";
 import "./AgentsSettingsPage.css";
 
-type HookAgent = AgentDefinition & { resume: AgentHookResume };
-
-interface AgentRow {
-  agent: HookAgent;
-  installed: boolean;
-  loaded: boolean;
-  error?: string;
+/** Mirror of `silo.agents`' {@link AgentsExtensionAPI} — core cannot import silo. */
+interface SiloAgentsSettingsAPI {
+  OptionsPanel: ComponentType;
 }
 
-async function resolveHomeDir(ctx: ExtensionContext): Promise<string | null> {
-  try {
-    const { code, stdout } = await ctx.process.exec("sh", [
-      "-c",
-      "printf '%s' \"$HOME\"",
-    ]);
-    return code === 0 ? stdout.trim() || null : null;
-  } catch {
-    return null;
-  }
-}
+type AgentsSettingsTab = "options" | "hooks";
 
-/** Absolute settings-file path for an agent under the user's home dir. */
-function settingsPathFor(agent: HookAgent, home: string): string {
-  return `${home}/${agent.resume.configPath}`;
-}
+function AgentsOptionsTab({ ctx }: { ctx: ExtensionContext }) {
+  const hideGlyphs = useSnapshot(store).terminalSettings.hideAgentStatusGlyphs;
+  const siloAgents = ctx.getExtension<SiloAgentsSettingsAPI>("silo.agents");
+  const OptionsPanel =
+    siloAgents?.active && siloAgents.api?.OptionsPanel
+      ? siloAgents.api.OptionsPanel
+      : null;
 
-/**
- * Ensure the shared capture script exists at `~/.silo/agent-hooks/
- * track-session.sh` and matches the current catalog-templated body (RFC 0019).
- * Every installed agent's hook command invokes this one script, so it's written
- * once, not per-agent. Idempotent: writes only when absent or drifted (e.g. the
- * catalog's known-agent list changed), and returns whether it wrote.
- */
-async function ensureTrackScript(
-  ctx: ExtensionContext,
-  home: string,
-): Promise<boolean> {
-  const path = `${home}/${TRACK_SCRIPT_REL}`;
-  const body = buildTrackSessionScript();
-  const existing = (await ctx.files.pathExists(path))
-    ? await ctx.files.readText(path).catch(() => null)
-    : null;
-  if (existing === body) return false;
-  const dir = path.slice(0, path.lastIndexOf("/"));
-  if (dir) await ctx.files.createDir(dir);
-  await ctx.files.writeText(path, body);
-  return true;
-}
-
-/**
- * Rewrite an already-installed agent's hook config **only if** its stored
- * command differs from what the catalog now produces — the migration path for
- * legacy base64/`python3` commands (RFC 0019). Relies on the per-strategy
- * installers returning the *same* object by reference when nothing changed, so
- * an already-current install writes nothing. Returns whether it wrote.
- */
-async function refreshConfigIfDrifted(
-  ctx: ExtensionContext,
-  agent: HookAgent,
-  path: string,
-): Promise<boolean> {
-  return installerFor(agent.resume).refreshIfDrifted(ctx, agent.resume, path);
-}
-
-async function writeInstalled(
-  ctx: ExtensionContext,
-  agent: HookAgent,
-  path: string,
-  home: string,
-  install: boolean,
-): Promise<void> {
-  // The config command references the shared capture script, so the script has
-  // to exist before anything points at it.
-  if (install) await ensureTrackScript(ctx, home);
-  await installerFor(agent.resume).write(ctx, agent.resume, path, install);
-}
-
-async function readPiAgentSettings(
-  ctx: ExtensionContext,
-  home: string,
-): Promise<SettingsJsonRead<PiAgentSettings>> {
-  const path = `${home}/${PI_AGENT_SETTINGS_REL}`;
-  if (!(await ctx.files.pathExists(path))) return { kind: "missing" };
-  const text = await ctx.files.readText(path).catch(() => null);
-  return parseSettingsJsonText<PiAgentSettings>(text, path);
-}
-
-async function writePiTerminalProgress(
-  ctx: ExtensionContext,
-  home: string,
-  enabled: boolean,
-): Promise<void> {
-  const path = `${home}/${PI_AGENT_SETTINGS_REL}`;
-  const read = await readPiAgentSettings(ctx, home);
-  const current = writableSettingsOrThrow(read, path);
-  const next = withTerminalProgress(current, enabled);
-  const body = JSON.stringify(next, null, 2) + "\n";
-  const dir = path.slice(0, path.lastIndexOf("/"));
-  if (dir) await ctx.files.createDir(dir);
-  await ctx.files.writeText(path, body);
-}
-
-/** Label + hint + docs link on the left; a single control on the right —
- * matches other settings pages (Install / Uninstall alone), instead of cramming badge +
- * link + switch into the control slot. */
-function AgentSettingsRow({
-  label,
-  hint,
-  docsUrl,
-  onOpenDocs,
-  control,
-}: {
-  label: string;
-  hint: string;
-  docsUrl: string;
-  onOpenDocs: (url: string) => void;
-  control?: ReactNode;
-}) {
   return (
-    <div className="silo-setting-row">
-      <div className="silo-setting-row-text">
-        <div className="silo-setting-row-label">{label}</div>
-        <div className="silo-setting-row-hint">{hint}</div>
-        <button
-          type="button"
-          className="agents-settings-docs-link"
-          onClick={() => onOpenDocs(docsUrl)}
+    <>
+      {OptionsPanel != null && <OptionsPanel />}
+      <Section label="Display">
+        <SettingRow
+          label="Hide status glyphs in tab titles"
+          hint="Strips agent status markers (Claude's ◐/✳, Codex's spinner, Cursor's “ - Working…”) from terminal tab titles."
         >
-          Setup details
-        </button>
-      </div>
-      {control != null && (
-        <div className="silo-setting-row-control">{control}</div>
-      )}
-    </div>
+          <Switch
+            checked={hideGlyphs}
+            onChange={(checked) =>
+              setTerminalSetting("hideAgentStatusGlyphs", checked)
+            }
+            aria-label="Hide status glyphs in tab titles"
+          />
+        </SettingRow>
+      </Section>
+    </>
   );
 }
 
 function AgentsSettingsPage({ ctx }: { ctx: ExtensionContext }) {
-  const [home, setHome] = useState<string | null | undefined>(undefined);
-  const [rows, setRows] = useState<AgentRow[]>([]);
-  const [busy, setBusy] = useState<string | null>(null);
-  const [piTerminalProgress, setPiTerminalProgress] = useState<boolean | null>(
-    null,
-  );
-  const [piProgressError, setPiProgressError] = useState<string | null>(null);
-  // Exact resume needs a POSIX-shell hook that Windows can neither run nor
-  // correlate against (RFC 0019 / RFC 0010's ConPTY gap) — the toggles are
-  // hidden there and the page is detection-only.
-  const [windows, setWindows] = useState(false);
-  // A terminal-display setting, surfaced here because this is where a user
-  // looks for how agents present themselves (see TerminalSettings).
-  const hideGlyphs = useSnapshot(store).terminalSettings.hideAgentStatusGlyphs;
-
-  const load = useCallback(async () => {
-    const agents = hookInstallableAgents();
-    const { os } = await ctx.system.getInfo();
-    const isWindows = os === "windows";
-    setWindows(isWindows);
-    if (isWindows) {
-      // Detection-only: no home resolution (there's no `sh`), no toggles, and
-      // never any self-heal — a pre-existing hook synced from another machine
-      // is left inert as-is rather than rewritten to a form that still can't
-      // run here.
-      setHome(null);
-      setRows(
-        agents.map((agent) => ({ agent, installed: false, loaded: true })),
-      );
-      return;
-    }
-    const h = await resolveHomeDir(ctx);
-    setHome(h);
-    if (!h) {
-      setRows(
-        agents.map((agent) => ({
-          agent,
-          installed: false,
-          loaded: false,
-          error: "Could not resolve $HOME",
-        })),
-      );
-      return;
-    }
-    const next: AgentRow[] = [];
-    for (const agent of agents) {
-      try {
-        const installed = await installerFor(agent.resume).isInstalled(
-          ctx,
-          agent.resume,
-          settingsPathFor(agent, h),
-        );
-        next.push({ agent, installed, loaded: true });
-      } catch (err) {
-        next.push({
-          agent,
-          installed: false,
-          loaded: false,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-
-    // Self-heal on load: migrate any legacy base64/python install to the
-    // shell-script runtime just by opening this page. Idempotent — writes only
-    // on drift — and silent unless it actually heals, in which case it logs to
-    // the extension's Output channel for a diagnostic trail.
-    try {
-      const installedAgents = next.filter((r) => r.installed);
-      if (installedAgents.length > 0) {
-        const scriptWrote = await ensureTrackScript(ctx, h);
-        const healed: string[] = [];
-        for (const r of installedAgents) {
-          const wrote = await refreshConfigIfDrifted(
-            ctx,
-            r.agent,
-            settingsPathFor(r.agent, h),
-          );
-          if (wrote) healed.push(r.agent.displayName);
-        }
-        if (scriptWrote || healed.length > 0) {
-          ctx.log.info(
-            "Refreshed Silo session hook to the shell-script runtime" +
-              (healed.length > 0 ? ` (config: ${healed.join(", ")})` : "") +
-              (scriptWrote ? " (wrote track-session.sh)" : "") +
-              ".",
-          );
-        }
-      }
-    } catch (err) {
-      ctx.log.warn(
-        "Agent hook self-heal skipped: " +
-          (err instanceof Error ? err.message : String(err)),
-      );
-    }
-
-    setPiProgressError(null);
-    try {
-      const read = await readPiAgentSettings(ctx, h);
-      if (read.kind === "invalid") {
-        setPiTerminalProgress(false);
-        setPiProgressError(read.message);
-      } else {
-        setPiTerminalProgress(
-          getTerminalProgress(read.kind === "ok" ? read.value : {}),
-        );
-      }
-    } catch (err) {
-      setPiTerminalProgress(false);
-      setPiProgressError(err instanceof Error ? err.message : String(err));
-    }
-
-    setRows(next);
-  }, [ctx]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  async function toggle(row: AgentRow, install: boolean) {
-    if (!home) return;
-    setBusy(row.agent.id);
-    const path = settingsPathFor(row.agent, home);
-    try {
-      await writeInstalled(ctx, row.agent, path, home, install);
-      await load();
-    } catch (err) {
-      setRows((prev) =>
-        prev.map((r) =>
-          r.agent.id === row.agent.id
-            ? { ...r, error: err instanceof Error ? err.message : String(err) }
-            : r,
-        ),
-      );
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  async function togglePiTerminalProgress(enabled: boolean) {
-    if (!home) return;
-    setBusy("pi-terminal-progress");
-    setPiProgressError(null);
-    try {
-      await writePiTerminalProgress(ctx, home, enabled);
-      setPiTerminalProgress(enabled);
-    } catch (err) {
-      setPiProgressError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  const autoAgents = sessionFileAgents();
+  const [tab, setTab] = useState<AgentsSettingsTab>("options");
 
   return (
-    <div className="es-page">
+    <div className="es-page agents-settings-page">
       <div className="es-header">
         <h2>Agents</h2>
       </div>
 
-      <div className="es-scroll silo-scroll">
-        <Section label="Display">
-          <SettingRow
-            label="Hide status glyphs in tab titles"
-            hint="Strips agent status markers (Claude's ◐/✳, Codex's spinner, Cursor's “ - Working…”) from terminal tab titles."
-          >
-            <Switch
-              checked={hideGlyphs}
-              onChange={(checked) =>
-                setTerminalSetting("hideAgentStatusGlyphs", checked)
-              }
-              aria-label="Hide status glyphs in tab titles"
-            />
-          </SettingRow>
-        </Section>
-
-        {/* Both of these scope to session hooks specifically — the WIP caveat is
-            about hook-based exact resume, and the Windows gap is that a
-            POSIX-shell hook can't run there. Kept adjacent to the hooks section
-            rather than at the top of the page, where they read as applying to
-            every agent setting. */}
-        <p className="agents-settings-banner">
-          <Badge tone="warn">Work in progress</Badge> Session hooks and exact
-          resume are still evolving. Expect rough edges — feedback welcome.{" "}
-          <button
-            type="button"
-            className="agents-settings-banner-link"
-            onClick={() =>
-              void ctx.ui.openExternal(
-                "https://getsilo.dev/guide/agent-sessions",
-              )
-            }
-          >
-            Learn more
-          </button>
-        </p>
-
-        {windows && (
-          <Callout>
-            Exact resume via session hooks is macOS and Linux only for now —
-            Windows doesn&rsquo;t yet support the POSIX-shell hook and
-            process-group tracking it relies on. Silo still detects these agents
-            and shows a best-effort resume hint.
-          </Callout>
-        )}
-
-        <Section label="Session hooks">
-          {rows.map((row) => (
-            <Fragment key={row.agent.id}>
-              <AgentSettingsRow
-                label={row.agent.displayName}
-                hint={
-                  row.error
-                    ? `Error: ${row.error}`
-                    : windows
-                      ? "Detection only on this platform"
-                      : row.installed
-                        ? (row.agent.resume.postInstallNote ??
-                          "Hook installed — exact resume enabled.")
-                        : "Install Silo's session hook for exact resume."
-                }
-                docsUrl={row.agent.docsUrl}
-                onOpenDocs={(url) => void ctx.ui.openExternal(url)}
-                control={
-                  windows ? undefined : (
-                    <Button
-                      size="sm"
-                      variant={row.installed ? "normal" : "primary"}
-                      disabled={busy === row.agent.id || !row.loaded}
-                      onClick={() => void toggle(row, !row.installed)}
-                    >
-                      {row.installed ? "Uninstall" : "Install"}
-                    </Button>
-                  )
-                }
-              />
-              {row.agent.id === "pi" && !windows && (
-                <SettingRow
-                  label="Terminal progress"
-                  hint={
-                    piProgressError
-                      ? `Error: ${piProgressError}`
-                      : "Emit OSC 9;4 progress so Silo can show pi working/idle. Restart pi after changing."
-                  }
-                >
-                  <Switch
-                    checked={piTerminalProgress ?? false}
-                    disabled={
-                      piTerminalProgress === null ||
-                      busy === "pi-terminal-progress" ||
-                      !home
-                    }
-                    onChange={(checked) =>
-                      void togglePiTerminalProgress(checked)
-                    }
-                    aria-label="pi terminal progress"
-                  />
-                </SettingRow>
-              )}
-            </Fragment>
-          ))}
-        </Section>
-
-        {autoAgents.length > 0 && (
-          <Section label="Works automatically">
-            {autoAgents.map((agent) => (
-              <AgentSettingsRow
-                key={agent.id}
-                label={agent.displayName}
-                hint="Uses its native session registry — no hook to install."
-                docsUrl={agent.docsUrl}
-                onOpenDocs={(url) => void ctx.ui.openExternal(url)}
-                control={<Badge tone="ok">Automatic</Badge>}
-              />
-            ))}
-          </Section>
-        )}
+      <div className="agents-settings-tabs">
+        <Tabs
+          tabs={[
+            { id: "options", label: "Options" },
+            { id: "hooks", label: "Hooks" },
+          ]}
+          active={tab}
+          onSelect={setTab}
+        />
+        <TabPanel>
+          <div className="silo-scroll agents-settings-scroll">
+            {tab === "options" ? (
+              <AgentsOptionsTab ctx={ctx} />
+            ) : (
+              <AgentsHooksPanel ctx={ctx} />
+            )}
+          </div>
+        </TabPanel>
       </div>
     </div>
   );
@@ -491,7 +91,6 @@ export const extension: Extension = {
     ctx.registerSettingsPage({
       id: "agents",
       title: "Agents",
-      // Just above About Silo (9_about): after Extensions (5_*), before About.
       group: "8_agents",
       order: 1,
       component: () => <AgentsSettingsPage ctx={ctx} />,

--- a/packages/extensions-core/src/extensions/browse-model.test.ts
+++ b/packages/extensions-core/src/extensions/browse-model.test.ts
@@ -79,6 +79,23 @@ describe("filterRegistry", () => {
       filterRegistry(entries, { query: "weather", category: "monitoring" }),
     ).toHaveLength(0);
   });
+
+  it("hides built-in ids the host now ships (until the registry drops them)", () => {
+    const withBuiltin = [
+      ...entries,
+      entry("silo.agent-monitor", { description: "Agent Monitor" }),
+      entry("silo.agents", { description: "Agents" }),
+    ];
+    expect(
+      filterRegistry(withBuiltin, { query: "", category: "" }).map((e) => e.id),
+    ).toEqual(["acme.weather", "acme.clock"]);
+    expect(
+      filterRegistry(withBuiltin, {
+        query: "agent monitor",
+        category: "",
+      }),
+    ).toHaveLength(0);
+  });
 });
 
 describe("registryCategories", () => {

--- a/packages/extensions-core/src/extensions/browse-model.ts
+++ b/packages/extensions-core/src/extensions/browse-model.ts
@@ -30,6 +30,16 @@ export interface BrowseFilter {
   category: string;
 }
 
+/**
+ * Registry ids Silo now ships as built-ins — hidden from Browse until the
+ * external registry index drops them (avoids offering a separate install).
+ */
+const HIDDEN_FROM_BROWSE = new Set(["silo.agent-monitor", "silo.agents"]);
+
+function visibleInBrowse(entry: Pick<RegistryExtension, "id">): boolean {
+  return !HIDDEN_FROM_BROWSE.has(entry.id);
+}
+
 /** Filter registry entries by search text and category facet. */
 export function filterRegistry(
   entries: readonly RegistryExtension[],
@@ -37,6 +47,7 @@ export function filterRegistry(
 ): RegistryExtension[] {
   const q = query.trim().toLowerCase();
   return entries.filter((e) => {
+    if (!visibleInBrowse(e)) return false;
     if (e.status === "removed") return false;
     if (category && !e.categories.includes(category)) return false;
     if (!q) return true;
@@ -52,7 +63,9 @@ export function filterRegistry(
 export function registryCategories(
   entries: readonly RegistryExtension[],
 ): string[] {
-  return [...new Set(entries.flatMap((e) => e.categories))].sort();
+  return [
+    ...new Set(entries.filter(visibleInBrowse).flatMap((e) => e.categories)),
+  ].sort();
 }
 
 /** How a registry entry relates to this install of Silo. */

--- a/packages/extensions-core/src/extensions/extension-icons.test.ts
+++ b/packages/extensions-core/src/extensions/extension-icons.test.ts
@@ -5,6 +5,7 @@ describe("extensionIconFor", () => {
   it("gives a bundled extension its own glyph", () => {
     expect(extensionIconFor("core.terminal")).not.toBeNull();
     expect(extensionIconFor("silo.git-explorer")).not.toBeNull();
+    expect(extensionIconFor("silo.agents")).not.toBeNull();
   });
 
   it("has nothing for an extension the user installed themselves", () => {

--- a/packages/extensions-core/src/extensions/extension-icons.ts
+++ b/packages/extensions-core/src/extensions/extension-icons.ts
@@ -19,6 +19,7 @@ import {
   MagnifyingGlass,
   MarkdownLogo,
   Palette,
+  PlugsConnected,
   PuzzlePiece,
   Robot,
   SidebarSimple,
@@ -94,7 +95,7 @@ const BUILTIN_ICONS = new Map<string, ExtensionIconSpec>(
   Object.entries({
     // Core — the workbench itself.
     "core.about": spec(Info, TINT.slate),
-    "core.agents-settings": spec(Robot, TINT.teal),
+    "core.agents-settings": spec(PlugsConnected, TINT.teal),
     "core.cli-install": spec(Command, TINT.slate),
     "core.editor": spec(Code, TINT.indigo),
     "core.extensions": spec(PuzzlePiece, TINT.purple),
@@ -116,6 +117,7 @@ const BUILTIN_ICONS = new Map<string, ExtensionIconSpec>(
     "silo.file-search": spec(MagnifyingGlass, TINT.amber),
     "silo.git": spec(GitCommit, TINT.orange),
     "silo.git-explorer": spec(GitBranch, TINT.orange),
+    "silo.agents": spec(Robot, TINT.teal),
     "silo.image-viewer": spec(Image, TINT.rose),
     "silo.markdown-preview": spec(MarkdownLogo, TINT.blue),
     "silo.theme-presets": spec(Swatches, TINT.purple),

--- a/packages/extensions-silo/src/agents/AgentIconGlyph.tsx
+++ b/packages/extensions-silo/src/agents/AgentIconGlyph.tsx
@@ -1,0 +1,44 @@
+import type { IconMode } from "./settings-store";
+import { agentIconFor } from "./agent-icons";
+
+/**
+ * A row/tab's agent brand icon, or `null` when `mode` is `"none"` or no icon
+ * is known for this agent (see `agent-icons.ts`). Shared between the Agents
+ * panel's rows and the CenterDock terminal-tab leading icon (`ctx.terminals
+ * .bindIcon`) so both read the same setting the same way.
+ *
+ * "color" tints the glyph with the brand's own hex via inline `style`;
+ * "monotone" leaves `color` unset so it inherits whatever the caller's CSS
+ * sets on an ancestor (the Agents panel points it at `--silo-color-text-hi`;
+ * the CenterDock tab is sized/positioned entirely by host chrome, which also
+ * supplies its own icon color via `currentColor` inheritance).
+ */
+export function AgentIconGlyph({
+  agentId,
+  mode,
+  colorScheme,
+  className,
+}: {
+  agentId: string | undefined;
+  mode: IconMode;
+  /** The host's active light/dark base — "color" mode picks the icon's
+   * {@link AgentIcon.hexLight}/{@link AgentIcon.hexDark} accordingly, since a
+   * single hex can't have enough contrast against both. */
+  colorScheme: "dark" | "light";
+  className?: string;
+}) {
+  if (mode === "none") return null;
+  const icon = agentIconFor(agentId);
+  if (!icon) return null;
+  const hex = colorScheme === "light" ? icon.hexLight : icon.hexDark;
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      style={mode === "color" ? { color: `#${hex}` } : undefined}
+      aria-hidden="true"
+    >
+      <path d={icon.path} fill="currentColor" fillRule={icon.fillRule} />
+    </svg>
+  );
+}

--- a/packages/extensions-silo/src/agents/agent-icons.test.ts
+++ b/packages/extensions-silo/src/agents/agent-icons.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { agentIconFor } from "./agent-icons";
+
+describe("agentIconFor", () => {
+  it("returns the brand icon for every catalog agent id", () => {
+    expect(agentIconFor("claude")).toMatchObject({
+      title: "Claude Code",
+      hexLight: "D97757",
+      hexDark: "D97757",
+    });
+    expect(agentIconFor("cursor")).toMatchObject({ title: "Cursor" });
+    expect(agentIconFor("copilot")).toMatchObject({ title: "GitHub Copilot" });
+    expect(agentIconFor("codex")).toMatchObject({ title: "Codex" });
+    expect(agentIconFor("grok")).toMatchObject({ title: "Grok" });
+    expect(agentIconFor("pi")).toMatchObject({ title: "pi" });
+  });
+
+  it("flips genuinely-black marks to white for dark themes, but not colors with real contrast on both", () => {
+    for (const id of ["cursor", "copilot", "grok", "pi"]) {
+      const icon = agentIconFor(id);
+      expect(icon?.hexLight).toBe("000000");
+      expect(icon?.hexDark).toBe("FFFFFF");
+    }
+    for (const id of ["claude", "codex"]) {
+      const icon = agentIconFor(id);
+      expect(icon?.hexLight).toBe(icon?.hexDark);
+    }
+  });
+
+  it("marks the icons whose path assumes evenodd fill, and only those", () => {
+    expect(agentIconFor("codex")?.fillRule).toBe("evenodd");
+    expect(agentIconFor("grok")?.fillRule).toBe("evenodd");
+    expect(agentIconFor("claude")?.fillRule).toBeUndefined();
+    expect(agentIconFor("cursor")?.fillRule).toBeUndefined();
+    expect(agentIconFor("copilot")?.fillRule).toBeUndefined();
+    expect(agentIconFor("pi")?.fillRule).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown or missing id", () => {
+    expect(agentIconFor("not-a-real-agent")).toBeUndefined();
+    expect(agentIconFor(undefined)).toBeUndefined();
+  });
+});

--- a/packages/extensions-silo/src/agents/agent-icons.ts
+++ b/packages/extensions-silo/src/agents/agent-icons.ts
@@ -1,0 +1,91 @@
+/**
+ * Per-agent brand marks for the Agents panel's icon column. Path + hex data
+ * copied from icon packs rather than taken as a runtime dependency — each
+ * icon is a single small SVG path, and inlining it avoids pulling in a
+ * multi-thousand-icon package for six entries. Sources, per entry:
+ *
+ * - claude, cursor, copilot: simple-icons (CC0-1.0, https://simpleicons.org).
+ * - codex, grok: simple-icons has no OpenAI/xAI marks (both were pulled from
+ *   that project after trademark requests — see its DISCLAIMER.md), so these
+ *   two come from `@lobehub/icons-static-svg` (MIT,
+ *   https://github.com/lobehub/lobe-icons), a set curated specifically for
+ *   AI-model/agent brand logos.
+ * - pi: no icon pack carries a mark for it. Reuses the geometric π glyph
+ *   already drawn for it on the marketing site (`apps/website/src/App.tsx`,
+ *   xerro-edit) — three bars/legs plus a curled tail, combined into one path.
+ */
+
+export interface AgentIcon {
+  /** Display name, for the glyph's accessible label. */
+  title: string;
+  /**
+   * The brand's color against a light background, no leading `#`.
+   * "color" mode uses this or {@link hexDark} depending on the host's active
+   * theme — a single hex can't have enough contrast against both a white and
+   * a near-black tab strip. Claude and Codex have one color that already
+   * reads fine on both, so their `hexLight`/`hexDark` match; cursor, copilot,
+   * grok, and pi are genuinely black-or-nothing marks (real marks for the
+   * first three, `currentColor` for pi), so those flip to white for
+   * {@link hexDark} rather than going invisible against a dark background.
+   */
+  hexLight: string;
+  /** The brand's color against a dark background, no leading `#`. See
+   * {@link hexLight}. */
+  hexDark: string;
+  /** SVG path data, `viewBox="0 0 24 24"`. */
+  path: string;
+  /** Set when the source path was authored assuming `fill-rule: evenodd`
+   * (codex, grok) — omit for the simple-icons paths, which assume the SVG
+   * default (`nonzero`). Getting this wrong renders solid over what should be
+   * a cut-out hole in the glyph. */
+  fillRule?: "evenodd";
+}
+
+const AGENT_ICONS: Record<string, AgentIcon> = {
+  claude: {
+    title: "Claude Code",
+    hexLight: "D97757",
+    hexDark: "D97757",
+    path: "M21 10.5h3v3h-3v3h-1.5v3H18v-3h-1.5v3H15v-3H9v3H7.5v-3H6v3H4.5v-3H3v-3H0v-3h3v-6h18Zm-15 0h1.5v-3H6Zm10.5 0H18v-3h-1.5z",
+  },
+  cursor: {
+    title: "Cursor",
+    hexLight: "000000",
+    hexDark: "FFFFFF",
+    path: "M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23",
+  },
+  copilot: {
+    title: "GitHub Copilot",
+    hexLight: "000000",
+    hexDark: "FFFFFF",
+    path: "M23.922 16.997C23.061 18.492 18.063 22.02 12 22.02 5.937 22.02.939 18.492.078 16.997A.641.641 0 0 1 0 16.741v-2.869a.883.883 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.098 10.098 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952C7.255 2.937 9.248 1.98 11.978 1.98c2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.841.841 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256Zm-11.75-5.992h-.344a4.359 4.359 0 0 1-.355.508c-.77.947-1.918 1.492-3.508 1.492-1.725 0-2.989-.359-3.782-1.259a2.137 2.137 0 0 1-.085-.104L4 11.746v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.359 4.359 0 0 1-.355-.508Zm2.328 3.25c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm-5 0c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm3.313-6.185c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z",
+  },
+  codex: {
+    title: "Codex",
+    hexLight: "7A9DFF",
+    hexDark: "7A9DFF",
+    fillRule: "evenodd",
+    path: "M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z",
+  },
+  grok: {
+    title: "Grok",
+    hexLight: "000000",
+    hexDark: "FFFFFF",
+    fillRule: "evenodd",
+    path: "M9.27 15.29l7.978-5.897c.391-.29.95-.177 1.137.272.98 2.369.542 5.215-1.41 7.169-1.951 1.954-4.667 2.382-7.149 1.406l-2.711 1.257c3.889 2.661 8.611 2.003 11.562-.953 2.341-2.344 3.066-5.539 2.388-8.42l.006.007c-.983-4.232.242-5.924 2.75-9.383.06-.082.12-.164.179-.248l-3.301 3.305v-.01L9.267 15.292M7.623 16.723c-2.792-2.67-2.31-6.801.071-9.184 1.761-1.763 4.647-2.483 7.166-1.425l2.705-1.25a7.808 7.808 0 00-1.829-1A8.975 8.975 0 005.984 5.83c-2.533 2.536-3.33 6.436-1.962 9.764 1.022 2.487-.653 4.246-2.34 6.022-.599.63-1.199 1.259-1.682 1.925l7.62-6.815",
+  },
+  pi: {
+    title: "pi",
+    hexLight: "000000",
+    hexDark: "FFFFFF",
+    path: "M4.5,5.4 H19.5 A1.3,1.3 0 0 1 20.8,6.7 A1.3,1.3 0 0 1 19.5,8 H4.5 A1.3,1.3 0 0 1 3.2,6.7 A1.3,1.3 0 0 1 4.5,5.4 Z M7.9,8 A1.3,1.3 0 0 1 9.2,9.3 V18.1 A1.3,1.3 0 0 1 7.9,19.4 A1.3,1.3 0 0 1 6.6,18.1 V9.3 A1.3,1.3 0 0 1 7.9,8 Z M16.1,8 A1.3,1.3 0 0 1 17.4,9.3 V15.9 A1.3,1.3 0 0 1 16.1,17.2 A1.3,1.3 0 0 1 14.8,15.9 V9.3 A1.3,1.3 0 0 1 16.1,8 Z M14.8 15.6h2.6a2.6 2.6 0 0 0 2.6 2.6v2.6a5.2 5.2 0 0 1-5.2-5.2z",
+  },
+};
+
+/** The brand icon for an {@link AgentInfo.agentId}, or `undefined` if none is
+ * known (unrecognized id). */
+export function agentIconFor(
+  agentId: string | undefined,
+): AgentIcon | undefined {
+  return agentId ? AGENT_ICONS[agentId] : undefined;
+}

--- a/packages/extensions-silo/src/agents/agent-view.test.ts
+++ b/packages/extensions-silo/src/agents/agent-view.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import type { AgentInfo } from "@silo-code/sdk";
+import {
+  deriveStatusRow,
+  deriveTab,
+  stoppedWorking,
+  staleSuffix,
+  stripStatusMarker,
+} from "./agent-view";
+
+/** Build an AgentInfo with sensible defaults; override just the fields a test
+ * cares about. Mirrors the host's shape at `ctx.agents`. */
+function agent(over: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    terminalId: "t1",
+    workspaceId: "w1",
+    kind: "claude",
+    isAgent: true,
+    activity: "none",
+    needsAttention: false,
+    stale: false,
+    ...over,
+  };
+}
+
+describe("deriveStatusRow", () => {
+  it("returns null for non-agent terminals whatever their activity", () => {
+    expect(
+      deriveStatusRow(agent({ isAgent: false, activity: "working" })),
+    ).toBeNull();
+    expect(
+      deriveStatusRow(agent({ isAgent: false, activity: "idle" })),
+    ).toBeNull();
+  });
+
+  it("returns null for an agent that has never run", () => {
+    expect(deriveStatusRow(agent({ activity: "none" }))).toBeNull();
+  });
+
+  it("shows a working row carrying workingSince for elapsed time", () => {
+    expect(
+      deriveStatusRow(
+        agent({ activity: "working", workingSince: "2026-01-01T00:00:00Z" }),
+      ),
+    ).toEqual({ activity: "working", startedAt: "2026-01-01T00:00:00Z" });
+  });
+
+  it("shows a green ready row (with attentionSince) when finished + unseen", () => {
+    expect(
+      deriveStatusRow(
+        agent({
+          activity: "idle",
+          needsAttention: true,
+          attentionSince: "2026-01-01T00:05:00Z",
+        }),
+      ),
+    ).toEqual({ activity: "ready", startedAt: "2026-01-01T00:05:00Z" });
+  });
+
+  it("shows a neutral (grey) row once an idle finish is acknowledged", () => {
+    expect(
+      deriveStatusRow(agent({ activity: "idle", needsAttention: false })),
+    ).toEqual({});
+  });
+
+  it("shows an error row for an errored agent", () => {
+    expect(deriveStatusRow(agent({ activity: "error" }))).toEqual({
+      activity: "error",
+    });
+  });
+
+  it("holds an acknowledged idle row green when forcedAttentionSince is given", () => {
+    // "Keep it until the next run" mode: a watched finish the host never
+    // flagged still shows green, carrying the local finish timestamp.
+    expect(
+      deriveStatusRow(
+        agent({ activity: "idle", needsAttention: false }),
+        "2026-01-01T00:09:00Z",
+      ),
+    ).toEqual({ activity: "ready", startedAt: "2026-01-01T00:09:00Z" });
+  });
+
+  it("prefers the host's attentionSince over a forced timestamp", () => {
+    expect(
+      deriveStatusRow(
+        agent({
+          activity: "idle",
+          needsAttention: true,
+          attentionSince: "2026-01-01T00:05:00Z",
+        }),
+        "2026-01-01T00:09:00Z",
+      ),
+    ).toEqual({ activity: "ready", startedAt: "2026-01-01T00:05:00Z" });
+  });
+
+  it("does not force non-idle states green", () => {
+    expect(
+      deriveStatusRow(agent({ activity: "working", workingSince: "x" }), "y"),
+    ).toEqual({
+      activity: "working",
+      startedAt: "x",
+    });
+    expect(deriveStatusRow(agent({ isAgent: false }), "y")).toBeNull();
+    expect(deriveStatusRow(agent({ activity: "none" }), "y")).toBeNull();
+  });
+
+  it("shows a warn row for a dead (backend-gone) agent", () => {
+    expect(deriveStatusRow(agent({ activity: "dead" }))).toEqual({
+      activity: "warn",
+    });
+  });
+});
+
+describe("deriveTab", () => {
+  it("returns null for non-agents and never-ran agents", () => {
+    expect(
+      deriveTab(agent({ isAgent: false, activity: "working" })),
+    ).toBeNull();
+    expect(deriveTab(agent({ activity: "none" }))).toBeNull();
+  });
+
+  it("badges a working agent with a spinner", () => {
+    expect(deriveTab(agent({ activity: "working" }))).toEqual({
+      activity: "working",
+      tooltip: "Agent working",
+    });
+  });
+
+  it("badges a finished-unseen agent as ready/Finished", () => {
+    expect(
+      deriveTab(agent({ activity: "idle", needsAttention: true })),
+    ).toEqual({
+      activity: "ready",
+      tooltip: "Finished",
+    });
+  });
+
+  it("drops the badge once the finish is acknowledged", () => {
+    expect(
+      deriveTab(agent({ activity: "idle", needsAttention: false })),
+    ).toBeNull();
+  });
+
+  it("holds the Finished badge when forceAttention is set (kept-until-next-run mode)", () => {
+    expect(
+      deriveTab(agent({ activity: "idle", needsAttention: false }), true),
+    ).toEqual({
+      activity: "ready",
+      tooltip: "Finished",
+    });
+  });
+
+  it("forceAttention does not conjure a badge for non-idle states", () => {
+    expect(deriveTab(agent({ activity: "none" }), true)).toBeNull();
+    expect(
+      deriveTab(agent({ isAgent: false, activity: "idle" }), true),
+    ).toBeNull();
+  });
+
+  it("badges an errored agent", () => {
+    expect(deriveTab(agent({ activity: "error" }))).toEqual({
+      activity: "error",
+      tooltip: "Agent error",
+    });
+  });
+
+  it("surfaces the resume command in a dead agent's tooltip when one is known", () => {
+    expect(
+      deriveTab(
+        agent({ activity: "dead", resumeCommand: "claude --resume 01abc" }),
+      ),
+    ).toEqual({
+      activity: "warn",
+      tooltip: "Agent session ended — claude --resume 01abc",
+    });
+  });
+
+  it("falls back to a session-id-less dead tooltip", () => {
+    expect(deriveTab(agent({ activity: "dead" }))).toEqual({
+      activity: "warn",
+      tooltip: "Agent session ended",
+    });
+  });
+
+  it("appends the stale suffix to live-state tooltips", () => {
+    expect(
+      deriveTab(agent({ activity: "working", stale: true }))?.tooltip,
+    ).toBe("Agent working (unconfirmed since restart)");
+    expect(
+      deriveTab(agent({ activity: "idle", needsAttention: true, stale: true }))
+        ?.tooltip,
+    ).toBe("Finished (unconfirmed since restart)");
+  });
+});
+
+describe("stoppedWorking", () => {
+  it("is true on a working → idle transition for an agent", () => {
+    expect(
+      stoppedWorking(
+        agent({ activity: "working" }),
+        agent({ activity: "idle" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("never fires on the first snapshot (undefined prev)", () => {
+    expect(stoppedWorking(undefined, agent({ activity: "idle" }))).toBe(false);
+  });
+
+  it("does not fire on idle → idle (e.g. acknowledgement) or repeated frames", () => {
+    expect(
+      stoppedWorking(agent({ activity: "idle" }), agent({ activity: "idle" })),
+    ).toBe(false);
+    expect(
+      stoppedWorking(
+        agent({ activity: "working" }),
+        agent({ activity: "working" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not fire on working → error or working → dead (clean-finish only)", () => {
+    expect(
+      stoppedWorking(
+        agent({ activity: "working" }),
+        agent({ activity: "error" }),
+      ),
+    ).toBe(false);
+    expect(
+      stoppedWorking(
+        agent({ activity: "working" }),
+        agent({ activity: "dead" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not fire when the terminal isn't an agent", () => {
+    expect(
+      stoppedWorking(
+        agent({ activity: "working" }),
+        agent({ activity: "idle", isAgent: false }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("staleSuffix", () => {
+  it("is empty when not stale", () => {
+    expect(staleSuffix(false, "label")).toBe("");
+    expect(staleSuffix(false, "tooltip")).toBe("");
+  });
+
+  it("uses terse wording for labels and a fuller one for tooltips", () => {
+    expect(staleSuffix(true, "label")).toBe(" (unconfirmed)");
+    expect(staleSuffix(true, "tooltip")).toBe(" (unconfirmed since restart)");
+  });
+});
+
+describe("stripStatusMarker", () => {
+  it("strips a leading Claude/Codex braille spinner glyph", () => {
+    expect(stripStatusMarker("⠋ my-project")).toBe("my-project");
+  });
+
+  it("strips Claude's ✳ idle marker", () => {
+    expect(stripStatusMarker("✳ my-project")).toBe("my-project");
+  });
+
+  it("strips Codex's [ ! ] / [ . ] action markers", () => {
+    expect(stripStatusMarker("[ ! ] my-project")).toBe("my-project");
+    expect(stripStatusMarker("[ . ] my-project")).toBe("my-project");
+  });
+
+  it("strips a trailing Cursor Agent status suffix", () => {
+    expect(stripStatusMarker("my-chat - ⏳ Working on it")).toBe("my-chat");
+    expect(stripStatusMarker("my-chat - ✅ Ready")).toBe("my-chat");
+    expect(stripStatusMarker("my-chat - Waiting for you (2 items)")).toBe(
+      "my-chat",
+    );
+  });
+
+  it("leaves an unmarked title untouched", () => {
+    expect(stripStatusMarker("plain-title")).toBe("plain-title");
+  });
+});

--- a/packages/extensions-silo/src/agents/agent-view.ts
+++ b/packages/extensions-silo/src/agents/agent-view.ts
@@ -1,0 +1,163 @@
+/**
+ * The pure, unit-tested projection layer: turns a host-computed
+ * {@link AgentInfo} (from `ctx.agents`) into the Workspaces-panel status row
+ * and terminal-tab badge this extension renders. Since Silo 0.39 the host
+ * owns *all* detection, persistence, stale-gap tracking, and reboot recovery —
+ * so this module carries none of that; it only decides how the shared agent
+ * state should *look*.
+ *
+ * The visual vocabulary it maps onto:
+ *
+ * - **working** → a working Activity row (with `workingSince` so the host
+ *   renders elapsed time) and a spinner tab badge.
+ * - **idle + needsAttention** → the "finished, unseen" state: a green `ready`
+ *   row + check tab badge, sticky until the user views the terminal (at which
+ *   point the host clears `needsAttention` via `ctx.agents.acknowledge`).
+ * - **idle + acknowledged** → a neutral/grey row (no activity glyph) and no
+ *   tab badge — the run finished and has been seen.
+ * - **error** → a red `error` row + badge.
+ * - **dead** → a `warn` row + badge: the terminal's backend was confirmed gone
+ *   after an unclean shutdown (new in `ctx.agents`). The tab tooltip surfaces
+ *   the agent's `resumeCommand` when the host resolved one.
+ * - **none** (never ran, or a plain non-agent shell) → no row, no badge.
+ */
+
+import type { AgentInfo, Activity } from "@silo-code/sdk";
+
+/** The Workspaces-panel row for a terminal, or `null` for no row. An empty
+ * object is a row with no activity glyph — the host's neutral/grey "done"
+ * fallback (ADR 0030). */
+export type StatusRowView = { activity?: Activity; startedAt?: string };
+
+/**
+ * `forcedAttentionSince` keeps an idle agent green even though the host cleared
+ * (or never raised) `needsAttention`: the "Keep it until the next run" focus
+ * mode wants a finish to stay flagged even when you were *watching* the
+ * terminal — a case the host deliberately treats as already-seen. When present,
+ * it's the timestamp of that finish, so the row still renders elapsed time.
+ * `index.tsx` supplies it only in that mode; host `needsAttention` always wins
+ * when both are set. See {@link stoppedWorking}.
+ */
+export function deriveStatusRow(
+  a: AgentInfo,
+  forcedAttentionSince?: string,
+): StatusRowView | null {
+  if (!a.isAgent) return null;
+  switch (a.activity) {
+    case "working":
+      return { activity: "working", startedAt: a.workingSince };
+    case "error":
+      return { activity: "error" };
+    case "dead":
+      return { activity: "warn" };
+    case "idle":
+      // Finished-unseen shows the green "go look" row; once acknowledged
+      // (needsAttention cleared, and not force-held) it settles into the
+      // neutral grey row — which never disappears while the agent terminal is
+      // open, only greys out.
+      if (a.needsAttention)
+        return { activity: "ready", startedAt: a.attentionSince };
+      if (forcedAttentionSince !== undefined)
+        return { activity: "ready", startedAt: forcedAttentionSince };
+      return {};
+    case "none":
+    default:
+      return null;
+  }
+}
+
+/** The terminal-tab badge (Activity glyph + tooltip) for a terminal, or `null`
+ * for none. Acknowledged-idle and never-ran agents show nothing. */
+export interface TabView {
+  activity: Activity;
+  tooltip: string;
+}
+
+/** `forceAttention` mirrors {@link deriveStatusRow}'s `forcedAttentionSince`:
+ * hold the "Finished" badge on an idle agent whose finish should stay flagged
+ * even though the host cleared/never raised `needsAttention`. */
+export function deriveTab(
+  a: AgentInfo,
+  forceAttention = false,
+): TabView | null {
+  if (!a.isAgent) return null;
+  switch (a.activity) {
+    case "working":
+      return { activity: "working", tooltip: withStale(a, "Agent working") };
+    case "error":
+      return { activity: "error", tooltip: withStale(a, "Agent error") };
+    case "dead":
+      return {
+        activity: "warn",
+        tooltip: a.resumeCommand
+          ? `Agent session ended — ${a.resumeCommand}`
+          : "Agent session ended",
+      };
+    case "idle":
+      return a.needsAttention || forceAttention
+        ? { activity: "ready", tooltip: withStale(a, "Finished") }
+        : null;
+    case "none":
+    default:
+      return null;
+  }
+}
+
+/**
+ * Whether this snapshot represents an agent that just *stopped working* —
+ * the working → idle transition the notification chime fires on. Compares the
+ * previous {@link AgentInfo} for the same terminal against the next; `undefined`
+ * `prev` (a terminal seen for the first time) never counts, so seeding the
+ * initial snapshot can't ring. Error/dead deliberately don't chime here — they
+ * mirror the pre-`ctx.agents` behavior, which only sounded on a clean finish.
+ */
+export function stoppedWorking(
+  prev: AgentInfo | undefined,
+  next: AgentInfo,
+): boolean {
+  return (
+    next.isAgent && prev?.activity === "working" && next.activity === "idle"
+  );
+}
+
+/**
+ * The "(unconfirmed…)" suffix appended to a status-row label or tab tooltip
+ * when {@link AgentInfo.stale} is set — a restored busy/attention state that
+ * followed a long-enough gap that the agent may have finished unobserved.
+ * `variant` picks the wording: the row label is terse; the tooltip has room.
+ */
+export function staleSuffix(
+  stale: boolean,
+  variant: "label" | "tooltip",
+): string {
+  if (!stale) return "";
+  return variant === "label"
+    ? " (unconfirmed)"
+    : " (unconfirmed since restart)";
+}
+
+function withStale(a: AgentInfo, base: string): string {
+  return `${base}${staleSuffix(a.stale, "tooltip")}`;
+}
+
+// Matches a leading agent-status glyph an OSC title may carry: the Claude/
+// Codex braille spinner (U+2800-U+28FF), Claude's ✳ idle signal, or Codex's
+// "[ ! ]"/"[ . ]" action-required marker — plus any following whitespace.
+const LEADING_MARKER_RE = /^(?:[⠀-⣿]|✳|\[ [!.] \])\s*/;
+
+// Cursor Agent encodes status as a trailing " - <emoji?> <status>" segment
+// (optionally with a worktree suffix on the full title). Strip that so the
+// row label is just the chat/agent name.
+const CURSOR_STATUS_SUFFIX_RE =
+  / - (?:[📤📂🔄⌨️🧭⏳📋❓🔐📝✅]\s*)?(?:Moving to cloud|Loading conversation|Reconnecting|Running shell command|Planning|Working.*|Queued|Reviewing changes|Waiting for you|Waiting for confirmation|Ready)(?: \([^)]+\))?$/;
+
+/**
+ * Strip agent-status glyphs/suffixes from a terminal title before showing it
+ * as a Workspaces-panel status-row label. The host detects agent activity from
+ * these markers, but they're redundant — and visually noisy — next to the
+ * row's own status dot. (The tab title keeps them, paired with its spinner.)
+ */
+export function stripStatusMarker(title: string): string {
+  const withoutCursor = title.replace(CURSOR_STATUS_SUFFIX_RE, "");
+  return withoutCursor.replace(LEADING_MARKER_RE, "");
+}

--- a/packages/extensions-silo/src/agents/agents-api.ts
+++ b/packages/extensions-silo/src/agents/agents-api.ts
@@ -1,0 +1,6 @@
+import type { ComponentType } from "react";
+
+/** Published by `silo.agents` for `core.agents-settings` (bundled-only composition). */
+export interface AgentsExtensionAPI {
+  OptionsPanel: ComponentType;
+}

--- a/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRow } from "./agents-panel-view";
+import {
+  buildAgeSections,
+  buildStatusSections,
+  staleSectionStartsExpanded,
+} from "./agents-panel";
+
+function row(over: Partial<AgentRow> = {}): AgentRow {
+  return {
+    terminalId: "t1",
+    workspaceId: "w1",
+    section: "working",
+    title: "agent",
+    workspaceName: "ws",
+    activity: "working",
+    ...over,
+  };
+}
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+describe("buildStatusSections (staleDoneEnabled: true)", () => {
+  it("always returns the ready/working/done/N+ hours old headings, even with no agents at all", () => {
+    const sections = buildStatusSections([], true, 8);
+    expect(sections.map((s) => s.header)).toEqual([
+      "Ready",
+      "Working",
+      "Idle",
+      "8+ hours old",
+    ]);
+    expect(sections.every((s) => s.rows.length === 0)).toBe(true);
+  });
+
+  it("only marks the 'N+ hours old' heading as collapsible", () => {
+    const sections = buildStatusSections([], true, 8);
+    expect(sections.find((s) => s.header === "8+ hours old")?.collapsible).toBe(
+      true,
+    );
+    expect(
+      sections
+        .filter((s) => s.header !== "8+ hours old")
+        .every((s) => !s.collapsible),
+    ).toBe(true);
+  });
+
+  it("keeps sections with no matching agents empty rather than dropping them", () => {
+    const sections = buildStatusSections(
+      [row({ terminalId: "t1", section: "working", activity: "working" })],
+      true,
+      8,
+    );
+    expect(sections.find((s) => s.header === "Ready")?.rows).toEqual([]);
+    expect(
+      sections
+        .find((s) => s.header === "Working")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["t1"]);
+    expect(sections.find((s) => s.header === "Idle")?.rows).toEqual([]);
+    expect(sections.find((s) => s.header === "8+ hours old")?.rows).toEqual([]);
+  });
+
+  it("splits done rows older than the configured threshold into their own heading", () => {
+    const sections = buildStatusSections(
+      [
+        row({
+          terminalId: "recent",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(1),
+        }),
+        row({
+          terminalId: "stale",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(9),
+        }),
+      ],
+      true,
+      8,
+    );
+    expect(
+      sections.find((s) => s.header === "Idle")?.rows.map((r) => r.terminalId),
+    ).toEqual(["recent"]);
+    expect(
+      sections
+        .find((s) => s.header === "8+ hours old")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["stale"]);
+  });
+
+  it("treats a done row exactly at the threshold as stale", () => {
+    const sections = buildStatusSections(
+      [
+        row({
+          terminalId: "boundary",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(8),
+        }),
+      ],
+      true,
+      8,
+    );
+    expect(sections.find((s) => s.header === "Idle")?.rows).toEqual([]);
+    expect(
+      sections
+        .find((s) => s.header === "8+ hours old")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["boundary"]);
+  });
+
+  it("keeps a done row with no since timestamp in Done, not N+ hours old", () => {
+    const sections = buildStatusSections(
+      [
+        row({
+          terminalId: "no-since",
+          section: "done",
+          activity: "idle",
+          since: undefined,
+        }),
+      ],
+      true,
+      8,
+    );
+    expect(
+      sections.find((s) => s.header === "Idle")?.rows.map((r) => r.terminalId),
+    ).toEqual(["no-since"]);
+    expect(sections.find((s) => s.header === "8+ hours old")?.rows).toEqual([]);
+  });
+
+  it("uses the configured threshold, not a hardcoded 8 hours", () => {
+    const sections = buildStatusSections(
+      [
+        row({
+          terminalId: "t1",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(5),
+        }),
+      ],
+      true,
+      4,
+    );
+    expect(sections.map((s) => s.header)).toContain("4+ hours old");
+    expect(sections.find((s) => s.header === "Idle")?.rows).toEqual([]);
+    expect(
+      sections
+        .find((s) => s.header === "4+ hours old")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["t1"]);
+  });
+});
+
+describe("buildStatusSections (staleDoneEnabled: false)", () => {
+  it("omits the 'N+ hours old' heading entirely", () => {
+    const sections = buildStatusSections([], false, 8);
+    expect(sections.map((s) => s.header)).toEqual(["Ready", "Working", "Idle"]);
+  });
+
+  it("keeps old done rows in Done instead of splitting them out", () => {
+    const sections = buildStatusSections(
+      [
+        row({
+          terminalId: "recent",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(1),
+        }),
+        row({
+          terminalId: "stale",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(9),
+        }),
+      ],
+      false,
+      8,
+    );
+    expect(
+      sections
+        .find((s) => s.header === "Idle")
+        ?.rows.map((r) => r.terminalId)
+        .sort(),
+    ).toEqual(["recent", "stale"]);
+  });
+});
+
+describe("buildAgeSections (staleDoneEnabled: true)", () => {
+  it("returns one unheaded flat section plus the 'N+ hours old' heading, even with no agents at all", () => {
+    const sections = buildAgeSections([], true, 8, []);
+    expect(sections.map((s) => s.header)).toEqual(["", "8+ hours old"]);
+    expect(sections.every((s) => s.rows.length === 0)).toBe(true);
+  });
+
+  it("only marks the 'N+ hours old' heading as collapsible", () => {
+    const sections = buildAgeSections([], true, 8, []);
+    expect(sections.find((s) => s.header === "8+ hours old")?.collapsible).toBe(
+      true,
+    );
+    expect(sections.find((s) => s.header === "")?.collapsible).toBeUndefined();
+  });
+
+  it("mixes ready, working and recent done rows into one list, ordered by since (most recent first), not by status", () => {
+    const sections = buildAgeSections(
+      [
+        row({
+          terminalId: "oldest",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(3),
+        }),
+        row({
+          terminalId: "newest",
+          section: "ready",
+          activity: "idle",
+          since: hoursAgo(1),
+        }),
+        row({
+          terminalId: "middle",
+          section: "working",
+          activity: "working",
+          since: hoursAgo(2),
+        }),
+      ],
+      true,
+      8,
+      [],
+    );
+    expect(
+      sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
+    ).toEqual(["newest", "middle", "oldest"]);
+  });
+
+  it("splits only done rows older than the configured threshold into their own heading", () => {
+    const sections = buildAgeSections(
+      [
+        row({
+          terminalId: "recent-done",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(1),
+        }),
+        row({
+          terminalId: "stale-done",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(9),
+        }),
+        row({
+          terminalId: "long-working",
+          section: "working",
+          activity: "working",
+          since: hoursAgo(9),
+        }),
+      ],
+      true,
+      8,
+      [],
+    );
+    expect(
+      sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
+    ).toEqual(["recent-done", "long-working"]);
+    expect(
+      sections
+        .find((s) => s.header === "8+ hours old")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["stale-done"]);
+  });
+
+  it("puts undragged rows above dragged ones, and honors manualOrder's relative order for the dragged ones", () => {
+    const sections = buildAgeSections(
+      [
+        row({ terminalId: "a", since: hoursAgo(1) }),
+        row({ terminalId: "b", since: hoursAgo(2) }),
+        row({ terminalId: "c", since: hoursAgo(3) }),
+      ],
+      true,
+      8,
+      ["c", "a"], // dragged, in this order — "b" was never touched
+    );
+    expect(
+      sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
+    ).toEqual([
+      "b", // undragged, floats to the top
+      "c", // dragged, first in manualOrder
+      "a", // dragged, second in manualOrder
+    ]);
+  });
+
+  it("ignores manualOrder ids with no matching row instead of erroring", () => {
+    const sections = buildAgeSections(
+      [row({ terminalId: "a", since: hoursAgo(1) })],
+      true,
+      8,
+      ["closed-terminal", "a"],
+    );
+    expect(
+      sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
+    ).toEqual(["a"]);
+  });
+});
+
+describe("buildAgeSections (staleDoneEnabled: false)", () => {
+  it("omits the 'N+ hours old' heading entirely", () => {
+    const sections = buildAgeSections([], false, 8, []);
+    expect(sections.map((s) => s.header)).toEqual([""]);
+  });
+
+  it("keeps old done rows in the flat list instead of splitting them out", () => {
+    const sections = buildAgeSections(
+      [
+        row({
+          terminalId: "recent",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(1),
+        }),
+        row({
+          terminalId: "stale",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(9),
+        }),
+      ],
+      false,
+      8,
+      [],
+    );
+    expect(
+      sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
+    ).toEqual(["recent", "stale"]);
+  });
+});
+
+describe("staleSectionStartsExpanded", () => {
+  it("opens the old heading when nothing is ready, working or idle", () => {
+    const sections = buildStatusSections(
+      [row({ section: "done", since: hoursAgo(9) })],
+      true,
+      8,
+    );
+    expect(staleSectionStartsExpanded(sections)).toBe(true);
+  });
+
+  it("stays collapsed while any other heading has rows", () => {
+    const sections = buildStatusSections(
+      [
+        row({ section: "working" }),
+        row({ terminalId: "t2", section: "done", since: hoursAgo(9) }),
+      ],
+      true,
+      8,
+    );
+    expect(staleSectionStartsExpanded(sections)).toBe(false);
+  });
+
+  it("is true when the view is completely empty", () => {
+    // Nothing to reveal either way, but the rule shouldn't special-case it.
+    expect(staleSectionStartsExpanded(buildStatusSections([], true, 8))).toBe(
+      true,
+    );
+  });
+
+  it("ignores the old heading's own rows when deciding", () => {
+    // Two stale rows and nothing else still counts as "everything else empty".
+    const sections = buildStatusSections(
+      [
+        row({ section: "done", since: hoursAgo(9) }),
+        row({ terminalId: "t2", section: "done", since: hoursAgo(20) }),
+      ],
+      true,
+      8,
+    );
+    expect(staleSectionStartsExpanded(sections)).toBe(true);
+  });
+});

--- a/packages/extensions-silo/src/agents/agents-panel-view.test.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-view.test.ts
@@ -1,0 +1,585 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AgentInfo, Workspace } from "@silo-code/sdk";
+import {
+  buildAgentRows,
+  groupAgentRows,
+  groupAgentRowsByWorkspace,
+  formatElapsed,
+  isAtLeastHoursOld,
+  moveItem,
+  orderAgeRows,
+  updateDoneSince,
+  type AgentRow,
+} from "./agents-panel-view";
+
+function agent(over: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    terminalId: "t1",
+    workspaceId: "w1",
+    kind: "claude",
+    isAgent: true,
+    activity: "none",
+    needsAttention: false,
+    stale: false,
+    ...over,
+  };
+}
+
+function workspace(over: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "w1",
+    name: "my-project",
+    folder: "/tmp/my-project",
+    createdAt: "2026-01-01T00:00:00Z",
+    lastOpenedAt: "2026-01-01T00:00:00Z",
+    terminals: [{ id: "t1", sessionId: "s1", kind: "claude", title: "claude" }],
+    editors: [],
+    ...over,
+  };
+}
+
+describe("buildAgentRows", () => {
+  it("drops non-agent terminals and agents that have never run", () => {
+    expect(buildAgentRows([agent({ isAgent: false })], [workspace()])).toEqual(
+      [],
+    );
+    expect(
+      buildAgentRows([agent({ activity: "none" })], [workspace()]),
+    ).toEqual([]);
+  });
+
+  it("sections a needs-attention agent as ready regardless of activity", () => {
+    const rows = buildAgentRows(
+      [
+        agent({
+          activity: "idle",
+          needsAttention: true,
+          attentionSince: "2026-01-01T00:05:00Z",
+        }),
+      ],
+      [workspace()],
+    );
+    expect(rows).toEqual([
+      {
+        terminalId: "t1",
+        workspaceId: "w1",
+        section: "ready",
+        title: "claude",
+        workspaceName: "my-project",
+        activity: "idle",
+        since: "2026-01-01T00:05:00Z",
+      },
+    ]);
+  });
+
+  it("sections a working agent as working, carrying workingSince", () => {
+    const rows = buildAgentRows(
+      [agent({ activity: "working", workingSince: "2026-01-01T00:00:00Z" })],
+      [workspace()],
+    );
+    expect(rows[0]).toMatchObject({
+      section: "working",
+      since: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("sections an acknowledged idle agent as done with no since", () => {
+    const rows = buildAgentRows(
+      [agent({ activity: "idle", needsAttention: false })],
+      [workspace()],
+    );
+    expect(rows[0]).toMatchObject({ section: "done", since: undefined });
+  });
+
+  it("sections error and dead agents as done", () => {
+    expect(
+      buildAgentRows([agent({ activity: "error" })], [workspace()])[0],
+    ).toMatchObject({
+      section: "done",
+    });
+    expect(
+      buildAgentRows([agent({ activity: "dead" })], [workspace()])[0],
+    ).toMatchObject({
+      section: "done",
+    });
+  });
+
+  it("passes agentId through for the icon column, undefined when unresolved", () => {
+    expect(
+      buildAgentRows(
+        [agent({ activity: "working", agentId: "claude" })],
+        [workspace()],
+      )[0].agentId,
+    ).toBe("claude");
+    expect(
+      buildAgentRows([agent({ activity: "working" })], [workspace()])[0]
+        .agentId,
+    ).toBeUndefined();
+  });
+
+  it("prefers customName over the OSC title, and strips status markers from the OSC title", () => {
+    const ws = workspace({
+      terminals: [
+        { id: "t1", sessionId: "s1", kind: "claude", title: "⠋ raw-title" },
+      ],
+    });
+    expect(
+      buildAgentRows([agent({ activity: "working" })], [ws])[0].title,
+    ).toBe("raw-title");
+
+    const wsNamed = workspace({
+      terminals: [
+        {
+          id: "t1",
+          sessionId: "s1",
+          kind: "claude",
+          title: "⠋ raw-title",
+          customName: "My Agent",
+        },
+      ],
+    });
+    expect(
+      buildAgentRows([agent({ activity: "working" })], [wsNamed])[0].title,
+    ).toBe("My Agent");
+  });
+
+  it("drops rows whose workspace or terminal can no longer be found", () => {
+    expect(
+      buildAgentRows(
+        [agent({ activity: "working", workspaceId: "missing" })],
+        [workspace()],
+      ),
+    ).toEqual([]);
+    expect(
+      buildAgentRows(
+        [agent({ activity: "working", terminalId: "missing" })],
+        [workspace()],
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("groupAgentRows", () => {
+  it("buckets rows into ready/working/done", () => {
+    const rows = buildAgentRows(
+      [
+        agent({
+          terminalId: "t1",
+          activity: "idle",
+          needsAttention: true,
+          attentionSince: "x",
+        }),
+        agent({ terminalId: "t2", activity: "working", workingSince: "y" }),
+        agent({ terminalId: "t3", activity: "idle" }),
+      ],
+      [
+        workspace({
+          terminals: [
+            { id: "t1", sessionId: "s1", kind: "claude", title: "a" },
+            { id: "t2", sessionId: "s2", kind: "claude", title: "b" },
+            { id: "t3", sessionId: "s3", kind: "claude", title: "c" },
+          ],
+        }),
+      ],
+    );
+    const groups = groupAgentRows(rows);
+    expect(groups.ready.map((r) => r.terminalId)).toEqual(["t1"]);
+    expect(groups.working.map((r) => r.terminalId)).toEqual(["t2"]);
+    expect(groups.done.map((r) => r.terminalId)).toEqual(["t3"]);
+  });
+
+  it("sorts rows with a since timestamp most-recent-first", () => {
+    const rows = buildAgentRows(
+      [
+        agent({
+          terminalId: "t1",
+          activity: "idle",
+          needsAttention: true,
+          attentionSince: "2026-01-01T00:00:00Z",
+        }),
+        agent({
+          terminalId: "t2",
+          activity: "idle",
+          needsAttention: true,
+          attentionSince: "2026-01-01T00:10:00Z",
+        }),
+      ],
+      [
+        workspace({
+          terminals: [
+            { id: "t1", sessionId: "s1", kind: "claude", title: "a" },
+            { id: "t2", sessionId: "s2", kind: "claude", title: "b" },
+          ],
+        }),
+      ],
+    );
+    expect(groupAgentRows(rows).ready.map((r) => r.terminalId)).toEqual([
+      "t2",
+      "t1",
+    ]);
+  });
+
+  it("sorts done rows (no since) alphabetically by title", () => {
+    const rows = buildAgentRows(
+      [
+        agent({ terminalId: "t1", activity: "idle" }),
+        agent({ terminalId: "t2", activity: "idle" }),
+      ],
+      [
+        workspace({
+          terminals: [
+            { id: "t1", sessionId: "s1", kind: "claude", title: "zebra" },
+            { id: "t2", sessionId: "s2", kind: "claude", title: "apple" },
+          ],
+        }),
+      ],
+    );
+    expect(groupAgentRows(rows).done.map((r) => r.title)).toEqual([
+      "apple",
+      "zebra",
+    ]);
+  });
+});
+
+describe("groupAgentRowsByWorkspace", () => {
+  const wsA = workspace({
+    id: "wA",
+    name: "beta-project",
+    terminals: [
+      { id: "t1", sessionId: "s1", kind: "claude", title: "a" },
+      { id: "t2", sessionId: "s2", kind: "claude", title: "b" },
+    ],
+  });
+  const wsB = workspace({
+    id: "wB",
+    name: "alpha-project",
+    terminals: [{ id: "t3", sessionId: "s3", kind: "claude", title: "c" }],
+  });
+
+  it("buckets rows by workspace and sorts workspace groups alphabetically by name", () => {
+    const rows = buildAgentRows(
+      [
+        agent({ terminalId: "t1", workspaceId: "wA", activity: "working" }),
+        agent({ terminalId: "t3", workspaceId: "wB", activity: "working" }),
+      ],
+      [wsA, wsB],
+    );
+    const groups = groupAgentRowsByWorkspace(rows);
+    expect(groups.map((g) => g.workspaceName)).toEqual([
+      "alpha-project",
+      "beta-project",
+    ]);
+    expect(groups.map((g) => g.rows.map((r) => r.terminalId))).toEqual([
+      ["t3"],
+      ["t1"],
+    ]);
+  });
+
+  it("orders rows within a workspace ready-before-working-before-done", () => {
+    const rows = buildAgentRows(
+      [
+        agent({ terminalId: "t1", workspaceId: "wA", activity: "idle" }),
+        agent({
+          terminalId: "t2",
+          workspaceId: "wA",
+          activity: "idle",
+          needsAttention: true,
+          attentionSince: "x",
+        }),
+      ],
+      [wsA],
+    );
+    const groups = groupAgentRowsByWorkspace(rows);
+    expect(groups[0].rows.map((r) => r.terminalId)).toEqual(["t2", "t1"]);
+  });
+
+  it("omits workspaces with no agent rows", () => {
+    const rows = buildAgentRows(
+      [agent({ terminalId: "t1", workspaceId: "wA", activity: "working" })],
+      [wsA, wsB],
+    );
+    expect(groupAgentRowsByWorkspace(rows).map((g) => g.workspaceId)).toEqual([
+      "wA",
+    ]);
+  });
+});
+
+describe("formatElapsed", () => {
+  const now = new Date("2026-01-01T00:10:00Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows whole seconds under a minute", () => {
+    expect(formatElapsed(new Date(now.getTime() - 45_000).toISOString())).toBe(
+      "45s",
+    );
+  });
+
+  it("shows whole minutes under an hour", () => {
+    expect(
+      formatElapsed(new Date(now.getTime() - 12 * 60_000).toISOString()),
+    ).toBe("12m");
+  });
+
+  it("shows whole hours under a day", () => {
+    expect(
+      formatElapsed(new Date(now.getTime() - 3 * 3_600_000).toISOString()),
+    ).toBe("3h");
+  });
+
+  it("shows whole days beyond that", () => {
+    expect(
+      formatElapsed(new Date(now.getTime() - 2 * 86_400_000).toISOString()),
+    ).toBe("2d");
+  });
+
+  it("clamps a future timestamp (clock skew) to 0s rather than negative", () => {
+    expect(formatElapsed(new Date(now.getTime() + 5_000).toISOString())).toBe(
+      "0s",
+    );
+  });
+});
+
+describe("isAtLeastHoursOld", () => {
+  const now = new Date("2026-01-01T00:00:00Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is false for a timestamp under the threshold", () => {
+    expect(
+      isAtLeastHoursOld(
+        new Date(now.getTime() - 7 * 3_600_000).toISOString(),
+        8,
+      ),
+    ).toBe(false);
+  });
+
+  it("is true at exactly the threshold", () => {
+    expect(
+      isAtLeastHoursOld(
+        new Date(now.getTime() - 8 * 3_600_000).toISOString(),
+        8,
+      ),
+    ).toBe(true);
+  });
+
+  it("is true past the threshold", () => {
+    expect(
+      isAtLeastHoursOld(
+        new Date(now.getTime() - 9 * 3_600_000).toISOString(),
+        8,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("updateDoneSince", () => {
+  it("stamps a newly-done terminal with the given now", () => {
+    const next = updateDoneSince(
+      new Map(),
+      [agent({ activity: "idle" })],
+      "t0",
+    );
+    expect(next.get("t1")).toBe("t0");
+  });
+
+  it("keeps the original timestamp while a terminal stays done across calls", () => {
+    const first = updateDoneSince(
+      new Map(),
+      [agent({ activity: "idle" })],
+      "t0",
+    );
+    const second = updateDoneSince(first, [agent({ activity: "idle" })], "t1");
+    expect(second.get("t1")).toBe("t0");
+  });
+
+  it("does not track terminals outside the done section", () => {
+    const next = updateDoneSince(
+      new Map(),
+      [agent({ activity: "working" })],
+      "t0",
+    );
+    expect(next.has("t1")).toBe(false);
+    expect(
+      updateDoneSince(
+        new Map(),
+        [
+          agent({
+            activity: "idle",
+            needsAttention: true,
+            attentionSince: "x",
+          }),
+        ],
+        "t0",
+      ).has("t1"),
+    ).toBe(false);
+  });
+
+  it("drops a terminal once it's no longer in the snapshot (closed)", () => {
+    const first = updateDoneSince(
+      new Map(),
+      [agent({ activity: "idle" })],
+      "t0",
+    );
+    const second = updateDoneSince(first, [], "t1");
+    expect(second.has("t1")).toBe(false);
+  });
+
+  it("re-stamps a terminal that leaves done and later returns to it", () => {
+    const done = updateDoneSince(
+      new Map(),
+      [agent({ activity: "idle" })],
+      "t0",
+    );
+    const working = updateDoneSince(
+      done,
+      [agent({ activity: "working" })],
+      "t1",
+    );
+    expect(working.has("t1")).toBe(false); // gone while working — not "done"
+    const doneAgain = updateDoneSince(
+      working,
+      [agent({ activity: "idle" })],
+      "t2",
+    );
+    expect(doneAgain.get("t1")).toBe("t2"); // fresh stamp, not the original t0
+  });
+});
+
+describe("buildAgentRows + groupAgentRows with a doneSince map", () => {
+  it("gives done rows a since, sorted shortest-duration-first like the other sections", () => {
+    const ws = workspace({
+      terminals: [
+        { id: "t1", sessionId: "s1", kind: "claude", title: "a" },
+        { id: "t2", sessionId: "s2", kind: "claude", title: "b" },
+      ],
+    });
+    const doneSince = new Map([
+      ["t1", "2026-01-01T00:00:00Z"], // done longer ago
+      ["t2", "2026-01-01T00:05:00Z"], // done more recently — shorter duration
+    ]);
+    const rows = buildAgentRows(
+      [
+        agent({ terminalId: "t1", activity: "idle" }),
+        agent({ terminalId: "t2", activity: "idle" }),
+      ],
+      [ws],
+      doneSince,
+    );
+    expect(rows.map((r) => r.since)).toEqual([
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:05:00Z",
+    ]);
+    expect(groupAgentRows(rows).done.map((r) => r.terminalId)).toEqual([
+      "t2",
+      "t1",
+    ]);
+  });
+});
+
+function row(over: Partial<AgentRow> = {}): AgentRow {
+  return {
+    terminalId: "t1",
+    workspaceId: "w1",
+    section: "working",
+    title: "agent",
+    workspaceName: "ws",
+    activity: "working",
+    ...over,
+  };
+}
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+describe("moveItem", () => {
+  it("moves an item forward", () => {
+    expect(moveItem(["a", "b", "c", "d"], 0, 2)).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("moves an item backward", () => {
+    expect(moveItem(["a", "b", "c", "d"], 3, 1)).toEqual(["a", "d", "b", "c"]);
+  });
+
+  it("is a no-op when from equals to", () => {
+    expect(moveItem(["a", "b", "c"], 1, 1)).toEqual(["a", "b", "c"]);
+  });
+
+  it("clamps an out-of-range from into bounds", () => {
+    expect(moveItem(["a", "b", "c"], 99, 0)).toEqual(["c", "a", "b"]);
+  });
+
+  it("clamps an out-of-range to into bounds", () => {
+    expect(moveItem(["a", "b", "c"], 0, 99)).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns an empty array unchanged", () => {
+    expect(moveItem([], 0, 0)).toEqual([]);
+  });
+
+  it("doesn't mutate the input array", () => {
+    const input = ["a", "b", "c"];
+    moveItem(input, 0, 2);
+    expect(input).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("orderAgeRows", () => {
+  it("with an empty manualOrder, sorts every row by since (most recent first)", () => {
+    const rows = [
+      row({ terminalId: "oldest", since: hoursAgo(3) }),
+      row({ terminalId: "newest", since: hoursAgo(1) }),
+      row({ terminalId: "middle", since: hoursAgo(2) }),
+    ];
+    expect(orderAgeRows(rows, []).map((r) => r.terminalId)).toEqual([
+      "newest",
+      "middle",
+      "oldest",
+    ]);
+  });
+
+  it("puts every undragged row above every dragged row", () => {
+    const rows = [
+      row({ terminalId: "dragged-1", since: hoursAgo(1) }),
+      row({ terminalId: "undragged", since: hoursAgo(9) }),
+      row({ terminalId: "dragged-2", since: hoursAgo(2) }),
+    ];
+    expect(
+      orderAgeRows(rows, ["dragged-1", "dragged-2"]).map((r) => r.terminalId),
+    ).toEqual(["undragged", "dragged-1", "dragged-2"]);
+  });
+
+  it("orders dragged rows by their position in manualOrder, not by since", () => {
+    const rows = [
+      row({ terminalId: "a", since: hoursAgo(1) }),
+      row({ terminalId: "b", since: hoursAgo(9) }),
+    ];
+    // "b" is older but listed first in manualOrder — manualOrder wins.
+    expect(orderAgeRows(rows, ["b", "a"]).map((r) => r.terminalId)).toEqual([
+      "b",
+      "a",
+    ]);
+  });
+
+  it("silently ignores a manualOrder id with no matching row", () => {
+    const rows = [row({ terminalId: "a", since: hoursAgo(1) })];
+    expect(orderAgeRows(rows, ["gone", "a"]).map((r) => r.terminalId)).toEqual([
+      "a",
+    ]);
+  });
+});

--- a/packages/extensions-silo/src/agents/agents-panel-view.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-view.ts
@@ -1,0 +1,302 @@
+/**
+ * The pure, unit-tested projection layer for the Agents side panel: turns the
+ * host-computed {@link AgentInfo} snapshot (`ctx.agents`, unscoped across every
+ * loaded workspace) plus the current {@link Workspace} list into the row
+ * groups the panel renders, in either of its two views — by status
+ * ({@link groupAgentRows}: "ready"/needs-attention, then "working", then
+ * "done") or by workspace ({@link groupAgentRowsByWorkspace}). `agents-panel.tsx`
+ * is the thin component layer that wires this to React state, the view
+ * toggle, and `ctx.terminals.focus`.
+ */
+
+import type { AgentActivity, AgentInfo, Workspace } from "@silo-code/sdk";
+import { stripStatusMarker } from "./agent-view";
+
+export type AgentSection = "ready" | "working" | "done";
+
+export interface AgentRow {
+  terminalId: string;
+  workspaceId: string;
+  section: AgentSection;
+  /** The tab's title (customName, or the OSC title with status markers stripped). */
+  title: string;
+  workspaceName: string;
+  /** Raw host activity, kept so the component can pick a glyph within "done" (idle/error/dead). */
+  activity: AgentActivity;
+  /** Stable catalog key (e.g. `"claude"`, `"codex"`) for the icon column, or
+   * undefined before the host has resolved which agent this is. */
+  agentId?: string;
+  /**
+   * When this row entered its current section — `attentionSince` for "ready",
+   * `workingSince` for "working" (both host-owned and restart-durable). For
+   * "done", the host doesn't track an equivalent (acknowledged idle, error,
+   * dead all clear their own timestamps) — worse, `TerminalRecord
+   * .lastActiveAt` looks like a stand-in (its doc says "last output") but
+   * isn't actually updated on PTY output; the only write site is
+   * `recreateTerminal` (a backend reconnect), so it resets to "now" for
+   * reasons unrelated to the agent finishing, which is why using it here
+   * briefly produced rows whose duration jumped around. So this comes from
+   * {@link updateDoneSince}'s own local tracking instead — see its
+   * persistence note for how the "resets on every extension reload" version
+   * of that problem is handled.
+   */
+  since?: string;
+}
+
+/**
+ * Which section an agent belongs in, or `null` for no row at all — mirrors
+ * {@link deriveStatusRow}'s "no row" cases (non-agents, and agents that have
+ * never run). `needsAttention` wins regardless of `activity` (an idle agent
+ * with a pending finish is "ready", not "done"); everything else that isn't
+ * actively `"working"` — acknowledged idle, `error`, `dead` — settles into
+ * "done".
+ */
+function sectionFor(a: AgentInfo): AgentSection | null {
+  if (!a.isAgent || a.activity === "none") return null;
+  if (a.needsAttention) return "ready";
+  if (a.activity === "working") return "working";
+  return "done";
+}
+
+/**
+ * Build the flat row list for every tracked agent that should appear in the
+ * panel. Rows whose workspace or terminal record can no longer be found
+ * (closed since the agent snapshot was taken) are silently dropped rather
+ * than shown with placeholder text. `doneSince` supplies the locally-tracked
+ * timestamp for "done" rows (see {@link updateDoneSince}); omit it only where
+ * a duration for "done" rows isn't needed.
+ */
+export function buildAgentRows(
+  agents: readonly AgentInfo[],
+  workspaces: readonly Workspace[],
+  doneSince: ReadonlyMap<string, string> = new Map(),
+): AgentRow[] {
+  const workspaceById = new Map(workspaces.map((ws) => [ws.id, ws]));
+  const rows: AgentRow[] = [];
+  for (const a of agents) {
+    const section = sectionFor(a);
+    if (!section) continue;
+    const ws = workspaceById.get(a.workspaceId);
+    if (!ws) continue;
+    const terminal = ws.terminals.find((t) => t.id === a.terminalId);
+    if (!terminal) continue;
+    rows.push({
+      terminalId: a.terminalId,
+      workspaceId: a.workspaceId,
+      section,
+      title: terminal.customName ?? stripStatusMarker(terminal.title),
+      workspaceName: ws.name,
+      activity: a.activity,
+      agentId: a.agentId,
+      since:
+        section === "ready"
+          ? a.attentionSince
+          : section === "working"
+            ? a.workingSince
+            : doneSince.get(a.terminalId),
+    });
+  }
+  return rows;
+}
+
+/**
+ * Track "how long has this row been done" locally, since the host doesn't
+ * expose an equivalent to `attentionSince`/`workingSince` for "done", and
+ * `TerminalRecord.lastActiveAt` isn't a safe substitute (see the caveat on
+ * {@link AgentRow.since}). Call on every new {@link AgentInfo} snapshot,
+ * threading the previous call's result back in as `prev`: a terminal keeps
+ * its first-seen timestamp for as long as it stays "done" *continuously*,
+ * and gets re-stamped at `nowIso` the moment it re-enters "done" from another
+ * section (ready or working) — including the very first time this extension
+ * observes it, since `prev` starts empty.
+ *
+ * That first-seen moment would be a real gap on its own — a terminal that
+ * was already done before this extension started watching would show a
+ * duration counted from then, not from whenever it actually finished, and
+ * every reload would reset every row to that same freshly-observed instant.
+ * `agents-panel.tsx` closes it by persisting this map to `ctx.storage.global`
+ * and seeding `prev` from that on mount, so `updateDoneSince` only "starts
+ * over" for a row the very first time it's ever seen done, not on every
+ * reload.
+ */
+export function updateDoneSince(
+  prev: ReadonlyMap<string, string>,
+  agents: readonly AgentInfo[],
+  nowIso: string,
+): Map<string, string> {
+  const next = new Map<string, string>();
+  for (const a of agents) {
+    if (sectionFor(a) !== "done") continue;
+    next.set(a.terminalId, prev.get(a.terminalId) ?? nowIso);
+  }
+  return next;
+}
+
+export const SECTION_ORDER: readonly AgentSection[] = [
+  "ready",
+  "working",
+  "done",
+];
+
+/**
+ * Compact duration since an ISO timestamp — `"45s"`, `"12m"`, `"3h"`, `"2d"` —
+ * for the elapsed-time label next to a ready/working row's subtitle (mirrors
+ * the host's own `formatElapsed` in the Workspaces panel, reimplemented here
+ * since it isn't part of the public SDK surface). Negative durations (clock
+ * skew) clamp to `0s` rather than showing a negative number.
+ */
+export function formatElapsed(isoDate: string): string {
+  const ms = Date.now() - new Date(isoDate).getTime();
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${Math.max(0, sec)}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+/**
+ * Whether an ISO timestamp is at least `hours` old — used to split the
+ * panel's "done" section into a further "N+ hours old" heading once a
+ * finished agent has sat unacknowledged long enough that it reads as clutter
+ * rather than something to act on.
+ */
+export function isAtLeastHoursOld(isoDate: string, hours: number): boolean {
+  return Date.now() - new Date(isoDate).getTime() >= hours * 60 * 60 * 1000;
+}
+
+/**
+ * Order two rows within a single section: rows with a `since` timestamp sort
+ * most-recent-first — i.e. shortest duration first, since a smaller elapsed
+ * time means a more recent `since`. (Every row normally carries one once
+ * `buildAgentRows` is given a `doneSince` map; the alphabetical-by-title
+ * fallback only matters for a caller that omits it.)
+ *
+ * Ordering is driven purely by the fixed ISO `since` string, never by an
+ * elapsed duration computed against `Date.now()` — so a row's position never
+ * shifts on its own as time passes between renders, only the elapsed label
+ * next to it does. Exported so the "Recent" grouping (`buildAgeSections` in
+ * `agents-panel.tsx`) can sort its flat, cross-section list with the same
+ * jitter-free rule instead of drifting from this one.
+ */
+export function compareRows(x: AgentRow, y: AgentRow): number {
+  if (x.since && y.since) return y.since.localeCompare(x.since);
+  if (x.since) return -1;
+  if (y.since) return 1;
+  return x.title.localeCompare(y.title);
+}
+
+/**
+ * Group rows by section (ready, working, done — in that fixed display order),
+ * sorted within each by {@link compareRows}.
+ */
+export function groupAgentRows(
+  rows: readonly AgentRow[],
+): Record<AgentSection, AgentRow[]> {
+  const groups: Record<AgentSection, AgentRow[]> = {
+    ready: [],
+    working: [],
+    done: [],
+  };
+  for (const row of rows) groups[row.section].push(row);
+  for (const section of SECTION_ORDER) {
+    groups[section].sort(compareRows);
+  }
+  return groups;
+}
+
+export interface WorkspaceGroup {
+  workspaceId: string;
+  workspaceName: string;
+  rows: AgentRow[];
+}
+
+/**
+ * Group rows by workspace instead of by section — the alternate "Workspace"
+ * view. Workspace groups sort alphabetically by name (the SDK's
+ * `WorkspaceService` doesn't expose the host's user-dragged panel order to
+ * extensions, so alphabetical is the only stable, predictable choice here).
+ * Within a workspace, rows still sort ready-before-working-before-done (via
+ * {@link SECTION_ORDER}), then by {@link compareRows} — so the state that
+ * needs your attention most doesn't get buried under an unrelated grouping.
+ */
+export function groupAgentRowsByWorkspace(
+  rows: readonly AgentRow[],
+): WorkspaceGroup[] {
+  const byWorkspace = new Map<string, WorkspaceGroup>();
+  for (const row of rows) {
+    let group = byWorkspace.get(row.workspaceId);
+    if (!group) {
+      group = {
+        workspaceId: row.workspaceId,
+        workspaceName: row.workspaceName,
+        rows: [],
+      };
+      byWorkspace.set(row.workspaceId, group);
+    }
+    group.rows.push(row);
+  }
+  const groups = [...byWorkspace.values()];
+  for (const group of groups) {
+    group.rows.sort(
+      (x, y) =>
+        SECTION_ORDER.indexOf(x.section) - SECTION_ORDER.indexOf(y.section) ||
+        compareRows(x, y),
+    );
+  }
+  groups.sort((a, b) => a.workspaceName.localeCompare(b.workspaceName));
+  return groups;
+}
+
+/**
+ * Move the item at `from` so it sits at `to`, clamping both into range. The
+ * pure array-splice math behind the "Recent" view's drag-to-reorder, kept
+ * free of any DOM/React drag machinery so it's trivial to unit test on its
+ * own (see `manual-order.test.ts`).
+ */
+export function moveItem<T>(
+  items: readonly T[],
+  from: number,
+  to: number,
+): T[] {
+  const next = items.slice();
+  if (next.length === 0) return next;
+  const clampedFrom = Math.max(0, Math.min(from, next.length - 1));
+  const [moved] = next.splice(clampedFrom, 1);
+  const clampedTo = Math.max(0, Math.min(to, next.length));
+  next.splice(clampedTo, 0, moved);
+  return next;
+}
+
+/**
+ * Final row order for the "Recent" view's flat, non-stale section. A row the
+ * user has never dragged sorts by {@link compareRows} (most recent first)
+ * and floats above every dragged row — a freshly-started or freshly-finished
+ * agent should read as "new" without the user having to go drag it there
+ * themselves. A row present in `manualOrder` (the id sequence a previous drag
+ * left behind, persisted by `./manual-order`) instead keeps that exact
+ * relative order, below the undragged rows.
+ *
+ * Nothing here prunes `manualOrder` — an id that's dropped out of `rows`
+ * entirely (terminal closed, or the row aged into the stale section) simply
+ * has no matching row to place, so it's silently inert. `agents-panel.tsx`
+ * is the one persisting a trimmed `manualOrder` back once that happens, so
+ * storage doesn't accumulate ids forever.
+ */
+export function orderAgeRows(
+  rows: readonly AgentRow[],
+  manualOrder: readonly string[],
+): AgentRow[] {
+  const manualIndex = new Map(manualOrder.map((id, i) => [id, i]));
+  const undragged: AgentRow[] = [];
+  const dragged: AgentRow[] = [];
+  for (const row of rows) {
+    (manualIndex.has(row.terminalId) ? dragged : undragged).push(row);
+  }
+  undragged.sort(compareRows);
+  dragged.sort(
+    (a, b) => manualIndex.get(a.terminalId)! - manualIndex.get(b.terminalId)!,
+  );
+  return [...undragged, ...dragged];
+}

--- a/packages/extensions-silo/src/agents/agents-panel.tsx
+++ b/packages/extensions-silo/src/agents/agents-panel.tsx
@@ -1,0 +1,729 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { CaretRight, DotsSixVertical } from "@phosphor-icons/react";
+import type { Activity, ExtensionContext, MenuEntry } from "@silo-code/sdk";
+import { ActivityGlyph, Badge, useServiceState } from "@silo-code/sdk";
+import {
+  buildAgentRows,
+  compareRows,
+  formatElapsed,
+  groupAgentRows,
+  groupAgentRowsByWorkspace,
+  isAtLeastHoursOld,
+  moveItem,
+  orderAgeRows,
+  SECTION_ORDER,
+  type AgentRow,
+  type AgentSection,
+} from "./agents-panel-view";
+import { getDoneSince } from "./done-since";
+import { manualOrderService } from "./manual-order";
+import { AgentIconGlyph } from "./AgentIconGlyph";
+import { settingsService, type IconMode } from "./settings-store";
+
+/** Ticks the panel so a rendered `formatElapsed` duration stays live. 1s
+ * matches the host's own Workspaces-panel elapsed-time refresh. */
+function useNow(intervalMs: number): void {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (intervalMs <= 0) return;
+    const id = setInterval(() => setTick((t) => t + 1), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+}
+
+const SECTION_LABELS: Record<AgentSection, string> = {
+  ready: "Ready",
+  working: "Working",
+  // The host's own term for the state is idle — an agent that has stopped
+  // working and isn't waiting on you. "Done" implied a finished task rather
+  // than a session sitting there.
+  done: "Idle",
+};
+
+/** A section as the render below wants it, regardless of which grouping
+ * produced it: a heading, its rows, and where each row's subtitle (the line
+ * under the title) comes from — whichever axis isn't already the heading. */
+export interface PanelSection {
+  key: string;
+  header: string;
+  rows: AgentRow[];
+  subtitle: (row: AgentRow) => string;
+  /** Whether the render below collapses this heading's rows by default,
+   * revealing them only while the section is hovered — only the "N+ hours
+   * old" heading does, since it's the one that piles up with rows you're
+   * least likely to still care about. */
+  collapsible?: boolean;
+}
+
+// Stable key for the "N+ hours old" section — both what buildStatusSections
+// tags it with and what the render below checks to apply the hover reveal.
+const STALE_DONE_SECTION_KEY = "stale-done";
+
+/**
+ * Whether the "N+ hours old" heading should start open rather than waiting for
+ * a hover. With nothing ready, working or idle it is the only content the view
+ * has, and a panel showing three empty headings plus a collapsed one reads as
+ * empty — the user shouldn't have to hover to discover it isn't.
+ */
+export function staleSectionStartsExpanded(
+  sections: readonly PanelSection[],
+): boolean {
+  return sections.every(
+    (s) => s.key === STALE_DONE_SECTION_KEY || s.rows.length === 0,
+  );
+}
+
+function isStaleDone(row: AgentRow, staleDoneHours: number): boolean {
+  return (
+    row.since !== undefined && isAtLeastHoursOld(row.since, staleDoneHours)
+  );
+}
+
+/**
+ * `staleDoneEnabled`/`staleDoneHours` are the settings-configurable split
+ * (see `DEFAULT_STALE_DONE_ENABLED`/`DEFAULT_STALE_DONE_HOURS`/
+ * `MIN_STALE_DONE_HOURS` in `./settings-store`): while enabled, a "done" row
+ * sitting for at least `staleDoneHours` drops out of the Done heading into
+ * its own "N+ hours old" one, clearing space in Done for finishes still
+ * worth a glance without losing the older ones entirely. Disabled, every
+ * done row just stays in Done and the extra heading doesn't appear at all.
+ */
+export function buildStatusSections(
+  rows: readonly AgentRow[],
+  staleDoneEnabled: boolean,
+  staleDoneHours: number,
+): PanelSection[] {
+  const groups = groupAgentRows(rows);
+  const subtitle = (row: AgentRow) => row.workspaceName;
+  const statusSections = SECTION_ORDER.map((section) => ({
+    key: section,
+    header: SECTION_LABELS[section],
+    rows:
+      section === "done" && staleDoneEnabled
+        ? groups.done.filter((row) => !isStaleDone(row, staleDoneHours))
+        : groups[section],
+    subtitle,
+  }));
+  if (!staleDoneEnabled) return statusSections;
+  return [
+    ...statusSections,
+    {
+      key: STALE_DONE_SECTION_KEY,
+      header: `${staleDoneHours}+ hours old`,
+      rows: groups.done.filter((row) => isStaleDone(row, staleDoneHours)),
+      subtitle,
+      collapsible: true,
+    },
+  ];
+}
+
+export function buildWorkspaceSections(
+  rows: readonly AgentRow[],
+): PanelSection[] {
+  return groupAgentRowsByWorkspace(rows).map((group) => ({
+    key: group.workspaceId,
+    header: group.workspaceName,
+    rows: group.rows,
+    subtitle: (row) => SECTION_LABELS[row.section],
+  }));
+}
+
+/**
+ * The "Recent" view (internal `groupBy` value `"age"`): unlike status or
+ * workspace grouping, every row sits in one flat, unheaded-by-status list —
+ * no status or workspace bucketing above it. Rows the user hasn't
+ * drag-reordered sort by {@link compareRows} (most recently changed first);
+ * `manualOrder` (see `./manual-order`) carries whatever order a drag left
+ * behind for the rest — see {@link orderAgeRows} for exactly how the two mix.
+ * The one exception, drag or no drag, is the same "N+ hours old" split
+ * `buildStatusSections` uses: a done row that's sat past `staleDoneHours`
+ * still peels off into its own collapsible heading (tagged with the same
+ * `STALE_DONE_SECTION_KEY`, so the panel's existing hover-to-reveal behavior
+ * applies unchanged, and it stays un-reorderable — see `agents-panel.tsx`'s
+ * render, which only wires drag handlers for `key === "age"`), since burying
+ * genuinely stale rows among fresh ones defeats the point of this view.
+ *
+ * Because {@link compareRows} orders by the fixed `since` timestamp rather
+ * than an elapsed duration recomputed on every render, an undragged row's
+ * position never shifts on its own as time passes — only its displayed
+ * elapsed label does — so a row stays put unless its actual state changes or
+ * the user drags it.
+ */
+export function buildAgeSections(
+  rows: readonly AgentRow[],
+  staleDoneEnabled: boolean,
+  staleDoneHours: number,
+  manualOrder: readonly string[],
+): PanelSection[] {
+  const subtitle = (row: AgentRow) =>
+    `${SECTION_LABELS[row.section]} · ${row.workspaceName}`;
+  const isStale = (row: AgentRow) =>
+    staleDoneEnabled &&
+    row.section === "done" &&
+    isStaleDone(row, staleDoneHours);
+  const activeRows = orderAgeRows(
+    rows.filter((row) => !isStale(row)),
+    manualOrder,
+  );
+  // No heading: the view's own title already says "Agents" — a heading here
+  // would just restate it, unlike the by-status/by-workspace views where the
+  // heading carries real information (which status, which workspace).
+  const ageSection: PanelSection = {
+    key: "age",
+    header: "",
+    rows: activeRows,
+    subtitle,
+  };
+  if (!staleDoneEnabled) return [ageSection];
+  return [
+    ageSection,
+    {
+      key: STALE_DONE_SECTION_KEY,
+      header: `${staleDoneHours}+ hours old`,
+      rows: rows.filter(isStale).slice().sort(compareRows),
+      subtitle,
+      collapsible: true,
+    },
+  ];
+}
+
+/** The glyph for a row's section — "done" still distinguishes error/dead from
+ * a plain acknowledged-idle finish (which gets the neutral gray dot). */
+function glyphFor(row: AgentRow): Activity | undefined {
+  switch (row.section) {
+    case "ready":
+      return "ready";
+    case "working":
+      return "working";
+    case "done":
+      if (row.activity === "error") return "error";
+      if (row.activity === "dead") return "warn";
+      return undefined;
+  }
+}
+
+/** Drag affordance for a row, wired only in the "Recent" view's flat,
+ * non-stale section (see `AgentsPanel`'s render — the stale section and the
+ * status/workspace views never pass this). Pointer-based rather than native
+ * HTML5 drag-and-drop — see the comment on `handleAgePointerDown` in
+ * `AgentsPanel` for why. */
+interface RowDrag {
+  /** This row's position within the flat section — both for the checks
+   * below and as the `data-drag-index` `AgentsPanel` uses to scope its
+   * pointermove rect-measuring to just the draggable rows. */
+  index: number;
+  dragging: boolean;
+  /** The drop indicator goes on whichever row edge is adjacent to the
+   * insertion point: `insertBefore` draws it above this row (the common
+   * case — every insertion point except the very last has a "next row" to
+   * anchor to), `insertAfter` draws it below this row instead, and only the
+   * section's last row ever gets it (there's no row after the very last
+   * insertion point to be "before"). */
+  insertBefore: boolean;
+  insertAfter: boolean;
+  onPointerDown: (e: ReactPointerEvent<HTMLSpanElement>) => void;
+}
+
+function AgentRowItem({
+  row,
+  subtitle,
+  active,
+  iconMode,
+  colorScheme,
+  onFocus,
+  onContextMenu,
+  drag,
+}: {
+  row: AgentRow;
+  /** Workspace name in the "by status" view; status label in the "by
+   * workspace" view — whichever isn't already the enclosing section header. */
+  subtitle: string;
+  active: boolean;
+  iconMode: IconMode;
+  colorScheme: "dark" | "light";
+  onFocus: (terminalId: string) => void;
+  onContextMenu: (row: AgentRow, at: { x: number; y: number }) => void;
+  drag?: RowDrag;
+}) {
+  const classNames = ["ap-row"];
+  if (active) classNames.push("active");
+  if (drag?.dragging) classNames.push("ap-row-dragging");
+  if (drag?.insertBefore) classNames.push("ap-row-drop-target-before");
+  if (drag?.insertAfter) classNames.push("ap-row-drop-target-after");
+  return (
+    <div
+      className={classNames.join(" ")}
+      role="option"
+      aria-selected={active}
+      tabIndex={0}
+      data-drag-index={drag?.index}
+      onClick={() => onFocus(row.terminalId)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onFocus(row.terminalId);
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu(row, { x: e.clientX, y: e.clientY });
+      }}
+    >
+      <ActivityGlyph activity={glyphFor(row)} className="ap-row-glyph" />
+      <div className="ap-row-text">
+        <span className="ap-row-title-line">
+          <AgentIconGlyph
+            agentId={row.agentId}
+            mode={iconMode}
+            colorScheme={colorScheme}
+            className="ap-row-icon"
+          />
+          <span className="ap-row-title">{row.title}</span>
+        </span>
+        <span className="ap-row-subtitle">
+          <span className="ap-row-workspace">{subtitle}</span>
+          {row.since && (
+            <>
+              <span className="ap-row-sep">·</span>
+              <span className="ap-row-elapsed">{formatElapsed(row.since)}</span>
+            </>
+          )}
+        </span>
+      </div>
+      {/* Hover-only affordance on the row's right edge — and, since this is a
+          pointer-driven drag rather than native HTML5 drag-and-drop, the
+          actual drag gesture starts here too (not from anywhere on the row):
+          full control over the pointer means there's no need for the old
+          "draggable has to be the whole row or the drag image is a tiny
+          glyph" tradeoff. */}
+      {drag && (
+        <span
+          className="ap-row-grip"
+          title="Drag to reorder"
+          onPointerDown={drag.onPointerDown}
+        >
+          <DotsSixVertical size={14} weight="bold" />
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function AgentsPanel({
+  ctx,
+  active,
+}: {
+  ctx: ExtensionContext;
+  /** False while this view is mounted but off screen — the 1s elapsed-time
+   * tick is the only per-second work here, so parking it is the whole win. */
+  active: boolean;
+}) {
+  // 1s so formatElapsed's seconds-resolution display (<1 minute) ticks live;
+  // rows past a minute don't strictly need it, but the tick is cheap.
+  useNow(active ? 1_000 : 0);
+
+  const [, setTick] = useState(0);
+  useEffect(
+    () =>
+      ctx.agents.subscribe(() => setTick((t) => t + 1), { allWorkspaces: true })
+        .dispose,
+    [ctx.agents],
+  );
+  useEffect(
+    () => ctx.workspaces.subscribe(() => setTick((t) => t + 1)).dispose,
+    [ctx.workspaces],
+  );
+
+  // The terminal currently focused in the center dock, wherever its
+  // workspace — `getActive`/`subscribeActive` return a single, globally
+  // unique terminal id, so a plain equality check is enough to mark its row.
+  const [activeTerminalId, setActiveTerminalId] = useState(() =>
+    ctx.terminals.getActive(),
+  );
+  useEffect(
+    () => ctx.terminals.subscribeActive(setActiveTerminalId).dispose,
+    [ctx.terminals],
+  );
+
+  // `groupBy` is a setting rather than a prop now: the two groupings were two
+  // registered Navigator views until SDK 0.34, and are one view with a
+  // "View by" header control since.
+  const { iconMode, groupBy, staleDoneEnabled, staleDoneHours } =
+    useServiceState(settingsService);
+
+  // "color" mode picks a brand hex that has to have contrast against the
+  // host's actual active background, not just against Silo's dark theme —
+  // see AgentIconGlyph. `ctx.theme` matches ReactiveService's getState/
+  // subscribe shape directly, so useServiceState works without adapting it.
+  const themeState = useServiceState(ctx.theme);
+  const colorScheme = ctx.theme.resolve(themeState.activeId).base;
+
+  // The "Recent" view's persisted drag order (see ./manual-order) — reactive
+  // for the same reason `groupBy` above is: a drag anywhere in this
+  // component has to show up immediately, not just on the next unrelated
+  // re-render.
+  const manualOrder = useServiceState(manualOrderService);
+
+  // Drag-to-reorder for the "Recent" view's flat section only, driven by raw
+  // Pointer Events rather than native HTML5 drag-and-drop. Native drag was
+  // the first cut here, but WebKit (Silo's Tauri webview) only rasterizes
+  // *some* of a row into its automatic drag image — the status dot came
+  // through, the flex/ellipsis-heavy text column and the row's own
+  // background didn't — and that held even after switching to an explicit
+  // `setDragImage` call. Pointer Events sidestep the browser's drag-image
+  // machinery entirely: `handleAgePointerDown` below clones the row into a
+  // plain `position: fixed` element we move ourselves on every
+  // `pointermove`, so what follows the cursor is guaranteed to be a real,
+  // fully-painted copy of the row, not a browser-generated snapshot.
+  //
+  // `dragIndexRef`/`dropTargetIndexRef` are refs because the move/up
+  // listeners below are plain `window.addEventListener` callbacks (outside
+  // React's render cycle) — they need a synchronously-current value, not
+  // whatever `dropTargetIndex` closed over back when the drag started.
+  // `setDropTargetIndex` keeps the ref and the state (which the row-map below
+  // reads, to rerender the drop-target styling as the drag crosses rows) in
+  // lockstep.
+  //
+  // `dropTargetIndex` is an *insertion point*, not "which row is hovered" —
+  // it ranges from `0` (before the first row) through `sectionRows.length`
+  // (after the last row) inclusive. That extra value past the last row's own
+  // index is what makes "drop at the very bottom" representable at all: a
+  // hit-test keyed on "which row am I over" has no row to report once the
+  // cursor passes the last one, so it went stale there and both the border
+  // and the final drop position silently fell back to a smaller row instead.
+  const dragIndexRef = useRef<number | null>(null);
+  const dropTargetIndexRef = useRef<number | null>(null);
+  const [dropTargetIndex, setDropTargetIndexState] = useState<number | null>(
+    null,
+  );
+  function setDropTargetIndex(index: number | null) {
+    dropTargetIndexRef.current = index;
+    setDropTargetIndexState(index);
+  }
+  const dragGhostRef = useRef<HTMLDivElement | null>(null);
+  const dragOffsetRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  // Set only while a drag is in flight, so the panel can tear down its ghost
+  // element and window listeners if it unmounts mid-drag (e.g. the user
+  // switches Navigator views without releasing the pointer).
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => dragCleanupRef.current?.(), []);
+
+  function handleAgePointerDown(
+    e: ReactPointerEvent<HTMLSpanElement>,
+    index: number,
+    sectionRows: readonly AgentRow[],
+  ) {
+    const rowEl = e.currentTarget.closest<HTMLDivElement>(".ap-row");
+    if (!rowEl) return;
+    e.preventDefault();
+
+    const rect = rowEl.getBoundingClientRect();
+    dragOffsetRef.current = {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+    dragIndexRef.current = index;
+    setDropTargetIndex(index);
+
+    const ghost = rowEl.cloneNode(true) as HTMLDivElement;
+    ghost.classList.add("ap-row-ghost");
+    ghost.style.width = `${rect.width}px`;
+    ghost.style.left = `${rect.left}px`;
+    ghost.style.top = `${rect.top}px`;
+    document.body.appendChild(ghost);
+    dragGhostRef.current = ghost;
+
+    // Every row still in the DOM for this section, in display order —
+    // measured once here rather than re-queried on every `pointermove`. Rows
+    // don't reorder mid-drag (`manualOrder` only changes on drop), so their
+    // relative order stays valid for the whole gesture; each row's *rect* is
+    // still re-read live below, so scrolling mid-drag is accounted for.
+    const rowEls = Array.from(
+      rowEl.parentElement?.querySelectorAll<HTMLElement>(
+        ":scope > .ap-row[data-drag-index]",
+      ) ?? [],
+    );
+
+    // Cursor-relative-to-row-midpoints hit-testing, not
+    // `elementFromPoint`-on-a-row: the cursor spends plenty of time over
+    // blank space below the last row (or between rows, given the row
+    // spacing) where no row element exists to hit-test against at all, and
+    // that blank space is exactly where "insert at the very end" lives.
+    // Comparing against midpoints instead means every cursor position maps
+    // to *some* insertion point, all the way through `rowEls.length`.
+    function insertionIndexAt(clientY: number): number {
+      for (let i = 0; i < rowEls.length; i++) {
+        const r = rowEls[i].getBoundingClientRect();
+        if (clientY < r.top + r.height / 2) return i;
+      }
+      return rowEls.length;
+    }
+
+    function handleMove(ev: PointerEvent) {
+      const g = dragGhostRef.current;
+      if (g) {
+        g.style.left = `${ev.clientX - dragOffsetRef.current.x}px`;
+        g.style.top = `${ev.clientY - dragOffsetRef.current.y}px`;
+      }
+      const idx = insertionIndexAt(ev.clientY);
+      if (idx !== dropTargetIndexRef.current) setDropTargetIndex(idx);
+    }
+
+    function cleanup() {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      window.removeEventListener("pointercancel", cleanup);
+      dragGhostRef.current?.remove();
+      dragGhostRef.current = null;
+      dragIndexRef.current = null;
+      setDropTargetIndex(null);
+      dragCleanupRef.current = null;
+    }
+
+    function handleUp() {
+      const from = dragIndexRef.current;
+      const insertAt = dropTargetIndexRef.current;
+      if (from !== null && insertAt !== null && insertAt !== from) {
+        // `insertAt` is expressed in the *original* (pre-removal) row order
+        // — "insert before whichever row used to sit at this index" — but
+        // `moveItem`'s `to` means "the moved item's index in the final
+        // array". Those only coincide when `insertAt <= from`: dragging
+        // downward past `from` shifts everything between `from` and
+        // `insertAt` up by one once the dragged row is removed, so the
+        // final index is one less than the original insertion point.
+        const finalIndex = insertAt > from ? insertAt - 1 : insertAt;
+        // The whole visible order becomes the new manual order, not just the
+        // two swapped rows — so a row that was sorting purely by recency
+        // (not yet in `manualOrder`) gets carried into it too, exactly where
+        // it was sitting when the drag happened.
+        manualOrderService.set(
+          moveItem(
+            sectionRows.map((r) => r.terminalId),
+            from,
+            finalIndex,
+          ),
+        );
+      }
+      cleanup();
+    }
+
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    window.addEventListener("pointercancel", cleanup);
+    dragCleanupRef.current = cleanup;
+  }
+
+  // The "N+ hours old" section starts collapsed and reveals its rows only
+  // while the mouse is over it — attached to the section's own container
+  // (not the heading), so a click on a row inside it (which doesn't move the
+  // mouse) never collapses it mid-click; only actually leaving the section
+  // does.
+  //
+  // Collapse is debounced rather than instant: WebKit (and Chromium) re-hit-test
+  // and fire mouseleave/mouseenter transitions on scroll, not just on real
+  // pointer movement, so scrolling the panel with the cursor sitting still over
+  // this section can momentarily "leave" it mid-scroll. Without the delay that
+  // collapsed the section — and shrank ap-body's scroll height — before the
+  // user could ever scroll down into the rows they'd just revealed. A leave
+  // that's immediately followed by a re-enter (the common case while scrolling
+  // through the section's own rows) cancels the pending collapse; only a leave
+  // that sticks around actually collapses it.
+  const [staleHovered, setStaleHovered] = useState(false);
+  const staleCollapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  useEffect(
+    () => () => {
+      if (staleCollapseTimeoutRef.current !== null) {
+        clearTimeout(staleCollapseTimeoutRef.current);
+      }
+    },
+    [],
+  );
+  function handleStaleMouseEnter() {
+    if (staleCollapseTimeoutRef.current !== null) {
+      clearTimeout(staleCollapseTimeoutRef.current);
+      staleCollapseTimeoutRef.current = null;
+    }
+    setStaleHovered(true);
+  }
+  function handleStaleMouseLeave() {
+    staleCollapseTimeoutRef.current = setTimeout(() => {
+      staleCollapseTimeoutRef.current = null;
+      setStaleHovered(false);
+    }, 300);
+  }
+
+  const agentsSnapshot = ctx.agents.getState({ allWorkspaces: true });
+  // "Done since" is tracked at extension scope (see ./done-since) rather than
+  // here: both views read the same stamps, and tracking has to keep running
+  // whichever view — if any — the user has open.
+  const rows = buildAgentRows(
+    agentsSnapshot,
+    ctx.workspaces.getState().all,
+    getDoneSince(),
+  );
+
+  const sections =
+    groupBy === "workspace"
+      ? buildWorkspaceSections(rows)
+      : groupBy === "age"
+        ? buildAgeSections(rows, staleDoneEnabled, staleDoneHours, manualOrder)
+        : buildStatusSections(rows, staleDoneEnabled, staleDoneHours);
+
+  const staleStartsExpanded = staleSectionStartsExpanded(sections);
+
+  // Trim `manualOrder` once a dragged row drops out of the flat section for
+  // good (terminal closed, or it aged into "N+ hours old") — otherwise
+  // storage would carry that id forever. `orderAgeRows` already treats a
+  // manual-order id with no matching row as inert, so this is pure
+  // housekeeping, not correctness: it only ever removes ids, never changes
+  // display order.
+  useEffect(() => {
+    if (groupBy !== "age") return;
+    const flatIds = new Set(
+      sections.find((s) => s.key === "age")?.rows.map((r) => r.terminalId),
+    );
+    const trimmed = manualOrder.filter((id) => flatIds.has(id));
+    if (trimmed.length !== manualOrder.length) manualOrderService.set(trimmed);
+  });
+
+  function openRowMenu(row: AgentRow, at: { x: number; y: number }) {
+    const items: MenuEntry[] = [];
+    // Only a row that's actually flagged has anything to acknowledge —
+    // `acknowledge` is a host-side no-op otherwise, and an always-present row
+    // that usually does nothing is worse than one that comes and goes.
+    if (row.section === "ready") {
+      items.push({
+        label: "Mark as seen",
+        run: () => ctx.agents.acknowledge(row.terminalId),
+      });
+      items.push({ type: "separator" });
+    }
+
+    // Rename… and any `terminal/tab` contributions — the same rows the
+    // terminal's own tab offers, rather than a menu that drifts from it.
+    items.push(...ctx.terminals.getTabMenuItems(row.terminalId));
+
+    // The workspace this agent is running in. A submenu rather than inline
+    // because rows span every workspace in the Agents view, so the actions
+    // need to say which one they apply to.
+    const workspaceItems = ctx.workspaces.getWorkspaceMenuItems(
+      row.workspaceId,
+    );
+    if (workspaceItems.length > 0) {
+      if (items.length > 0) items.push({ type: "separator" });
+      items.push({ label: row.workspaceName, submenu: workspaceItems });
+    }
+
+    if (items.length > 0) items.push({ type: "separator" });
+    items.push({
+      label: "Close terminal",
+      danger: true,
+      run: () => {
+        void (async () => {
+          const ok = await ctx.ui.confirm({
+            title: "Close terminal?",
+            body: `"${row.title}" and anything running in it will be stopped.`,
+            confirmLabel: "Close",
+            danger: true,
+          });
+          if (ok) ctx.terminals.close(row.terminalId);
+        })();
+      },
+    });
+
+    void ctx.ui.showMenu({ items, at, toggle: false });
+  }
+
+  // Only the workspace grouping can produce zero sections (no workspace to
+  // group by) — the status grouping always has its three fixed headings, even
+  // with no agents at all, so it never hits this.
+  if (sections.length === 0) {
+    return (
+      <div className="ap-panel">
+        <div className="ap-body">
+          <div className="ap-empty">
+            <p>No agents running.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ap-panel">
+      <div className="ap-body">
+        {sections.map((section) => {
+          const isStaleSection = section.key === STALE_DONE_SECTION_KEY;
+          const isDraggableSection = section.key === "age";
+          const expanded =
+            !isStaleSection || staleHovered || staleStartsExpanded;
+          return (
+            <div
+              key={section.key}
+              className="ap-section"
+              onMouseEnter={isStaleSection ? handleStaleMouseEnter : undefined}
+              onMouseLeave={isStaleSection ? handleStaleMouseLeave : undefined}
+            >
+              {/* Every heading carries its row count. The status grouping's
+                  three headings are fixed and so are often empty — a `0` says
+                  "nothing ready" in less space than a placeholder row. An
+                  empty `header` (the "Recent" view's flat list) skips the
+                  heading row entirely — "Agents" would only restate the
+                  view's own title. */}
+              {section.header !== "" && (
+                <div className="ap-section-title">
+                  {isStaleSection && (
+                    <CaretRight
+                      size="0.7em"
+                      weight="bold"
+                      className={
+                        expanded
+                          ? "ap-section-caret expanded"
+                          : "ap-section-caret"
+                      }
+                    />
+                  )}
+                  {section.header}
+                  <Badge size="sm" className="ap-section-count">
+                    {section.rows.length}
+                  </Badge>
+                </div>
+              )}
+              {expanded &&
+                section.rows.map((row, i) => (
+                  <AgentRowItem
+                    key={row.terminalId}
+                    row={row}
+                    subtitle={section.subtitle(row)}
+                    active={row.terminalId === activeTerminalId}
+                    iconMode={iconMode}
+                    colorScheme={colorScheme}
+                    onFocus={(terminalId) => ctx.terminals.focus(terminalId)}
+                    onContextMenu={openRowMenu}
+                    drag={
+                      isDraggableSection
+                        ? {
+                            index: i,
+                            dragging: dragIndexRef.current === i,
+                            insertBefore: dropTargetIndex === i,
+                            insertAfter:
+                              i === section.rows.length - 1 &&
+                              dropTargetIndex === section.rows.length,
+                            onPointerDown: (e) =>
+                              handleAgePointerDown(e, i, section.rows),
+                          }
+                        : undefined
+                    }
+                  />
+                ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/extensions-silo/src/agents/done-since.test.ts
+++ b/packages/extensions-silo/src/agents/done-since.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { AgentInfo, ExtensionStorage } from "@silo-code/sdk";
+import {
+  getDoneSince,
+  initDoneSince,
+  recordDoneSince,
+  resetDoneSince,
+} from "./done-since";
+
+/** In-memory ExtensionStorage stand-in that counts writes, so the tests can
+ * assert the steady state doesn't persist on every snapshot. */
+function fakeStorage(initial: Record<string, unknown> = {}) {
+  const data = new Map<string, unknown>(Object.entries(initial));
+  let writes = 0;
+  let listener: (() => void) | null = null;
+  const storage: ExtensionStorage & { writes(): number; hydrate(): void } = {
+    get: ((key: string, fallback?: unknown) =>
+      data.has(key) ? data.get(key) : fallback) as ExtensionStorage["get"],
+    set(key, value) {
+      writes++;
+      if (value === undefined) data.delete(key);
+      else data.set(key, value);
+    },
+    keys: () => [...data.keys()],
+    subscribe(l) {
+      listener = l;
+      return {
+        dispose: () => {
+          listener = null;
+        },
+      };
+    },
+    writes: () => writes,
+    hydrate() {
+      listener?.();
+    },
+  };
+  return storage;
+}
+
+/** An agent `sectionFor` classifies as "done": idle and acknowledged. */
+function doneAgent(terminalId: string): AgentInfo {
+  return {
+    terminalId,
+    workspaceId: "w1",
+    kind: "claude",
+    isAgent: true,
+    activity: "idle",
+    needsAttention: false,
+    stale: false,
+  };
+}
+
+function workingAgent(terminalId: string): AgentInfo {
+  return { ...doneAgent(terminalId), activity: "working" };
+}
+
+// The module holds its state in a singleton (it's extension-scoped by
+// design), so each test starts from a clean one.
+beforeEach(() => resetDoneSince());
+
+describe("initDoneSince", () => {
+  it("seeds from persisted storage", () => {
+    initDoneSince(
+      fakeStorage({ agentsDoneSince: { t1: "2026-01-01T00:00:00Z" } }),
+    );
+    expect(getDoneSince().get("t1")).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("starts empty when nothing is persisted", () => {
+    initDoneSince(fakeStorage());
+    expect(getDoneSince().size).toBe(0);
+  });
+
+  it("re-reads when storage notifies after async hydrate", () => {
+    const storage = fakeStorage();
+    initDoneSince(storage);
+    expect(getDoneSince().size).toBe(0);
+    storage.set("agentsDoneSince", { t1: "2026-01-01T00:00:00Z" });
+    storage.hydrate();
+    expect(getDoneSince().get("t1")).toBe("2026-01-01T00:00:00Z");
+  });
+});
+
+describe("recordDoneSince", () => {
+  it("stamps a newly done agent and persists it", () => {
+    const storage = fakeStorage();
+    initDoneSince(storage);
+    recordDoneSince([doneAgent("t1")]);
+    expect(getDoneSince().has("t1")).toBe(true);
+    expect(storage.get<Record<string, string>>("agentsDoneSince")?.t1).toBe(
+      getDoneSince().get("t1"),
+    );
+  });
+
+  it("keeps an existing stamp rather than refreshing it", () => {
+    initDoneSince(
+      fakeStorage({ agentsDoneSince: { t1: "2026-01-01T00:00:00Z" } }),
+    );
+    recordDoneSince([doneAgent("t1")]);
+    expect(getDoneSince().get("t1")).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("drops a row that is no longer done", () => {
+    initDoneSince(
+      fakeStorage({ agentsDoneSince: { t1: "2026-01-01T00:00:00Z" } }),
+    );
+    recordDoneSince([workingAgent("t1")]);
+    expect(getDoneSince().has("t1")).toBe(false);
+  });
+
+  it("drops a row whose terminal the host no longer reports", () => {
+    initDoneSince(
+      fakeStorage({ agentsDoneSince: { t1: "2026-01-01T00:00:00Z" } }),
+    );
+    recordDoneSince([]);
+    expect(getDoneSince().size).toBe(0);
+  });
+
+  it("does not write when the contents are unchanged", () => {
+    const storage = fakeStorage();
+    initDoneSince(storage);
+    recordDoneSince([doneAgent("t1")]);
+    const afterFirst = storage.writes();
+    recordDoneSince([doneAgent("t1")]);
+    recordDoneSince([doneAgent("t1")]);
+    expect(storage.writes()).toBe(afterFirst);
+  });
+
+  it("tracks each terminal independently", () => {
+    initDoneSince(
+      fakeStorage({ agentsDoneSince: { t1: "2026-01-01T00:00:00Z" } }),
+    );
+    recordDoneSince([doneAgent("t1"), doneAgent("t2")]);
+    expect(getDoneSince().get("t1")).toBe("2026-01-01T00:00:00Z");
+    expect(getDoneSince().get("t2")).not.toBe("2026-01-01T00:00:00Z");
+    expect(getDoneSince().size).toBe(2);
+  });
+});

--- a/packages/extensions-silo/src/agents/done-since.ts
+++ b/packages/extensions-silo/src/agents/done-since.ts
@@ -1,0 +1,65 @@
+import type { AgentInfo, ExtensionStorage } from "@silo-code/sdk";
+import { updateDoneSince } from "./agents-panel-view";
+
+// "How long has this row been done" — the one piece of state the host doesn't
+// expose a timestamp for (unlike ready/working), so the extension tracks it
+// itself. It lives here, at extension scope, rather than inside a panel
+// component: both agent views read the same timestamps, and tracking must keep
+// running whichever view (if any) the user currently has open.
+//
+// Persisted so the stamps survive an extension reload or app restart —
+// without that, every reload would re-stamp every currently-done row as "just
+// now" (see the caveat on `AgentRow.since`). A plain object, not a Map:
+// storage values round-trip through JSON.
+const STORAGE_KEY = "agentsDoneSince";
+
+let storage: ExtensionStorage | null = null;
+let doneSince: ReadonlyMap<string, string> = new Map();
+
+/** Seed from persisted storage. Re-reads on every storage change (hydrate /
+ * id migration) so a value saved under a retired extension id is picked up
+ * once the host rewrites the bag. Call once from `activate()`. */
+export function initDoneSince(s: ExtensionStorage): { dispose(): void } {
+  storage = s;
+  function read() {
+    doneSince = new Map(
+      Object.entries(s.get<Record<string, string>>(STORAGE_KEY, {})),
+    );
+  }
+  read();
+  const sub = s.subscribe(read);
+  return { dispose: () => sub.dispose() };
+}
+
+function sameContents(
+  a: ReadonlyMap<string, string>,
+  b: ReadonlyMap<string, string>,
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) if (b.get(k) !== v) return false;
+  return true;
+}
+
+/**
+ * Fold a fresh agents snapshot in. An id already present keeps its original
+ * stamp, so this only ever adds a new one or drops a row that's no longer
+ * done — it never overwrites. Writes to storage only when the contents
+ * actually changed, so the steady state costs nothing.
+ */
+export function recordDoneSince(agents: readonly AgentInfo[]): void {
+  const next = updateDoneSince(doneSince, agents, new Date().toISOString());
+  if (sameContents(next, doneSince)) return;
+  doneSince = next;
+  storage?.set(STORAGE_KEY, Object.fromEntries(next));
+}
+
+/** The current stamps, for building rows. */
+export function getDoneSince(): ReadonlyMap<string, string> {
+  return doneSince;
+}
+
+/** Drop all state — tests only, so one case can't leak into the next. */
+export function resetDoneSince(): void {
+  storage = null;
+  doneSince = new Map();
+}

--- a/packages/extensions-silo/src/agents/index.tsx
+++ b/packages/extensions-silo/src/agents/index.tsx
@@ -1,0 +1,334 @@
+import type {
+  AgentInfo,
+  Extension,
+  ExtensionContext,
+  WorkspaceStatusRow,
+} from "@silo-code/sdk";
+import type { AgentsExtensionAPI } from "./agents-api";
+import { Robot } from "@phosphor-icons/react";
+import {
+  deriveStatusRow,
+  deriveTab,
+  stripStatusMarker,
+  staleSuffix,
+  stoppedWorking,
+} from "./agent-view";
+import { maybePlayTransitionSound } from "./sound";
+import {
+  initSettings,
+  clearSettingsListeners,
+  AgentsOptionsPanel,
+  settingsService,
+} from "./settings";
+import { AgentsPanel } from "./agents-panel";
+import { initDoneSince, recordDoneSince } from "./done-since";
+import { initManualOrder } from "./manual-order";
+import { AgentIconGlyph } from "./AgentIconGlyph";
+import styles from "./styles.css?inline";
+
+const STYLE_ID = "silo-agents-styles";
+
+function activate(ctx: ExtensionContext): AgentsExtensionAPI {
+  ctx.subscriptions.push(initSettings(ctx.storage.global));
+  ctx.subscriptions.push(initDoneSince(ctx.storage.global));
+  ctx.subscriptions.push(initManualOrder(ctx.storage.global));
+
+  // Latest host-computed agent state, keyed by terminal record id. Since Silo
+  // 0.39 the host (`ctx.agents`) owns every hard part — OSC detection, the
+  // working/idle/dead state machine, cross-restart persistence, and stale-gap
+  // recovery — so this extension only *projects* that shared state into rows,
+  // tab badges, and a chime. The map is read synchronously by the three
+  // binder `provide` callbacks below, so it's kept current on every agents
+  // change.
+  const agents = new Map<string, AgentInfo>();
+  // Terminals that have finished a run and not yet started another, mapped to
+  // when they finished. This is the extension's own "finished, unseen" record,
+  // used *only* by the "Keep it until the next run" focus mode: the host clears
+  // (or never raises) `needsAttention` for a finish you were watching live, so
+  // this local flag is what keeps such a finish green until the agent works
+  // again. The `clear`/`hide` modes ignore it and rely on host `needsAttention`.
+  const finishedUnseen = new Map<string, string>();
+  let activeTerminalId = ctx.terminals.getActive();
+
+  // "color" icon mode needs to know the host's actual active light/dark base
+  // to pick a hex with contrast — see AgentIconGlyph. Tracked imperatively
+  // (like `agents` above) since bindIcon's provide() isn't a React component.
+  let colorScheme = ctx.theme.resolve(ctx.theme.getState().activeId).base;
+  ctx.subscriptions.push(
+    ctx.theme.subscribe(() => {
+      colorScheme = ctx.theme.resolve(ctx.theme.getState().activeId).base;
+      ctx.terminals.invalidateTabAdornments();
+    }),
+  );
+
+  function applySnapshot(state: AgentInfo[]) {
+    let ring = false;
+    const next = new Map<string, AgentInfo>();
+    const liveIds = new Set<string>();
+    for (const a of state) {
+      liveIds.add(a.terminalId);
+      // Chime once when any agent finishes a run, whether or not its terminal
+      // is focused — the host lands watched finishes straight on idle too, so
+      // this covers both. maybePlayTransitionSound debounces simultaneous ones.
+      if (stoppedWorking(agents.get(a.terminalId), a)) {
+        ring = true;
+        finishedUnseen.set(a.terminalId, new Date().toISOString());
+      }
+      // A new run clears the finished flag — "until the next run" ends here.
+      if (a.activity === "working") finishedUnseen.delete(a.terminalId);
+      next.set(a.terminalId, a);
+    }
+    // Drop flags for terminals the host no longer tracks (closed).
+    for (const id of [...finishedUnseen.keys()]) {
+      if (!liveIds.has(id)) finishedUnseen.delete(id);
+    }
+    agents.clear();
+    for (const [id, a] of next) agents.set(id, a);
+    // Stamp newly-done rows here rather than during a panel render, so the
+    // "done for 3h" durations keep accruing even with no agent view open.
+    recordDoneSince(state);
+    if (ring) maybePlayTransitionSound();
+    ctx.workspaces.invalidateStatus();
+    ctx.terminals.invalidateTabDecorations();
+    // Refreshes bindActivity too, but that's already covered above — added
+    // for bindIcon (agentId can newly resolve after the terminal's already
+    // been seen once, e.g. once a hook confirms the session).
+    ctx.terminals.invalidateTabAdornments();
+  }
+
+  ctx.subscriptions.push(
+    ctx.agents.subscribe((state) => applySnapshot(state), {
+      allWorkspaces: true,
+    }),
+  );
+  // subscribe() only fires on change, so seed the current state now — the
+  // first render must already have it. Seeding compares against an empty map,
+  // so it never rings the chime.
+  applySnapshot(ctx.agents.getState({ allWorkspaces: true }));
+
+  ctx.subscriptions.push(
+    ctx.workspaces.bindStatus({
+      id: "silo.agents.status",
+      provide(workspaceId): WorkspaceStatusRow[] {
+        const ws = ctx.workspaces.get(workspaceId);
+        if (!ws) return [];
+        const rows: WorkspaceStatusRow[] = [];
+        const behavior = settingsService.getState().focusBehavior;
+        const hideFocusedRow = behavior === "hide";
+        for (const t of ws.terminals) {
+          const a = agents.get(t.id);
+          if (!a) continue;
+          if (hideFocusedRow && t.id === activeTerminalId) continue;
+          // Only "none" mode holds a watched finish green (see finishedUnseen).
+          const forcedSince =
+            behavior === "none" ? finishedUnseen.get(t.id) : undefined;
+          const row = deriveStatusRow(a, forcedSince);
+          if (!row) continue;
+          const label = t.customName ?? stripStatusMarker(t.title);
+          rows.push({
+            id: t.id,
+            // A restored busy/attention duration the host couldn't confirm
+            // after a long app-closed gap is flagged rather than shown as if
+            // freshly observed.
+            label: `${label}${staleSuffix(a.stale, "label")}`,
+            activity: row.activity,
+            startedAt: row.startedAt,
+          });
+        }
+        return rows;
+      },
+    }),
+  );
+
+  ctx.subscriptions.push(
+    ctx.terminals.bindActivity({
+      id: "silo.agents.tab",
+      provide(terminalId) {
+        const a = agents.get(terminalId);
+        if (!a) return null;
+        const forceAttention =
+          settingsService.getState().focusBehavior === "none" &&
+          finishedUnseen.has(terminalId);
+        const tab = deriveTab(a, forceAttention);
+        if (!tab) return null;
+        return { activity: tab.activity, tooltip: tab.tooltip };
+      },
+    }),
+  );
+
+  ctx.subscriptions.push(
+    ctx.terminals.bindIcon({
+      id: "silo.agents.tab-icon",
+      provide(terminalId) {
+        const a = agents.get(terminalId);
+        if (!a) return null;
+        // Called as a plain function (not JSX) so `icon` is the component's
+        // *actual* return value now — AgentIconGlyph renders null for "none"
+        // mode or an unknown agent, and that has to gate whether a
+        // contribution is returned at all. Constructing `<AgentIconGlyph/>`
+        // instead would give a truthy element descriptor even when the
+        // component ultimately renders nothing, tricking the host into
+        // reserving tab space (margin, flex gap) for an empty icon slot.
+        const icon = AgentIconGlyph({
+          agentId: a.agentId,
+          mode: settingsService.getState().iconMode,
+          colorScheme,
+        });
+        return icon ? { icon } : null;
+      },
+    }),
+  );
+
+  ctx.subscriptions.push(
+    ctx.terminals.subscribeActive((terminalId) => {
+      activeTerminalId = terminalId;
+      // Viewing a terminal acknowledges a pending finish (clears the green
+      // "needs attention" flag) — unless the user chose "none", where focus
+      // never touches status. `acknowledge` is a host-side no-op when the
+      // terminal wasn't pending, so calling it unconditionally is safe.
+      if (terminalId && settingsService.getState().focusBehavior !== "none") {
+        ctx.agents.acknowledge(terminalId);
+      }
+      // Re-render rows on every focus change so the "hide focused row" setting
+      // tracks the active terminal even when the acknowledge above was a no-op.
+      ctx.workspaces.invalidateStatus();
+    }),
+  );
+
+  ctx.subscriptions.push(
+    ctx.workspaces.subscribe(() => {
+      // Terminal titles/customNames live on workspace state, so status-row
+      // labels can change even when the agent state itself hasn't.
+      ctx.workspaces.invalidateStatus();
+    }),
+  );
+
+  let lastGroupBy = settingsService.getState().groupBy;
+  ctx.subscriptions.push(
+    settingsService.subscribe((s) => {
+      // Toggling "hide focused row" changes which rows render.
+      ctx.workspaces.invalidateStatus();
+      // Toggling iconMode changes what silo.agents.tab-icon returns.
+      ctx.terminals.invalidateTabAdornments();
+      // The View by control's closed-state label names the active mode, so
+      // it has to be re-registered (title isn't a function like when/checked)
+      // whenever the mode actually flips — not on every unrelated setting.
+      if (s.groupBy !== lastGroupBy) {
+        lastGroupBy = s.groupBy;
+        registerGroupByToolbarItem();
+      }
+    }),
+  );
+
+  // A view *of the Navigator*, not a panel of its own (RFC 0023). A second
+  // side panel would be a second navigator sitting beside the first, which
+  // leaves no rule for which one to trust — and side-panel state is
+  // per-workspace, so which navigator you were looking at could change as you
+  // switched workspaces. As a view, agents are another way to read the one
+  // panel. It reads `ctx.agents`/`ctx.workspaces` directly rather than the
+  // `agents` map above, since it needs its own re-render subscriptions.
+  // registerNavigatorView is auto-tracked on ctx.subscriptions, so no push.
+  //
+  // One view, not two. Status and workspace grouping were separate registered
+  // views while the Navigator's selector was a dropdown; now that every view
+  // is listed in the panel, two entries for one list cost a permanent row and
+  // made "which Agents view am I in" a question worth asking. Grouping is a
+  // preference of this view (see `groupBy` in ./settings-store), flipped from
+  // the View by control below.
+  //
+  // The id keeps its by-status suffix: it's the persisted key for "which view
+  // is active", so renaming it would drop the choice of everyone already on
+  // it. `silo.agents.by-workspace` is retired — anyone parked on it
+  // falls back to the Workspaces view once, and picks Agents out of the
+  // Navigator's list to come back.
+  ctx.registerNavigatorView({
+    id: "silo.agents.by-status",
+    title: "Agents",
+    order: 1,
+    icon: <Robot size={19} weight="duotone" />,
+    component: ({ active }) => <AgentsPanel ctx={ctx} active={active} />,
+  });
+
+  // Grouping lives in the Navigator header rather than inside the list: it's
+  // chrome for the view, and putting it here gets the host's button + dropdown
+  // chrome, `when` scoping, and menu anchoring for free instead of spending a
+  // row of the panel on a control that's flipped occasionally.
+  //
+  // `title` is a plain string in the SDK, not a function like `when`/`checked`,
+  // so the closed-state label can't just read `groupBy` live — the control is
+  // re-registered under the same id whenever the mode changes (see the
+  // settingsService subscriber above) to keep the label in sync.
+  let groupByToolbarItem: { dispose(): void } | undefined;
+  function registerGroupByToolbarItem() {
+    groupByToolbarItem?.dispose();
+    const { groupBy } = settingsService.getState();
+    groupByToolbarItem = ctx.registerToolbarItem({
+      id: "silo.agents.group-by",
+      surface: "navigator",
+      // The closed-state label is the picked menu item's own label verbatim
+      // (no "By ..." transform) — one string to keep in sync with the menu
+      // below instead of two.
+      title:
+        groupBy === "age"
+          ? "Recent"
+          : groupBy === "workspace"
+            ? "Workspace"
+            : "Status",
+      tooltip: "View agents by status, workspace, or recent activity",
+      order: -1,
+      when: (_keys, target) => target.viewId === "silo.agents.by-status",
+      menu: () => {
+        const { groupBy } = settingsService.getState();
+        return [
+          { type: "header", label: "View by" },
+          {
+            label: "Recent",
+            checked: groupBy === "age",
+            run: () => settingsService.set({ groupBy: "age" }),
+          },
+          {
+            label: "Status",
+            checked: groupBy === "status",
+            run: () => settingsService.set({ groupBy: "status" }),
+          },
+          {
+            label: "Workspace",
+            checked: groupBy === "workspace",
+            run: () => settingsService.set({ groupBy: "workspace" }),
+          },
+        ];
+      },
+    });
+  }
+  registerGroupByToolbarItem();
+  ctx.subscriptions.push({ dispose: () => groupByToolbarItem?.dispose() });
+
+  injectStyles();
+
+  return { OptionsPanel: AgentsOptionsPanel };
+}
+
+function deactivate() {
+  document.getElementById(STYLE_ID)?.remove();
+  clearSettingsListeners();
+}
+
+function injectStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = styles;
+  document.head.appendChild(style);
+}
+
+export const extension: Extension<AgentsExtensionAPI> = {
+  id: "silo.agents",
+  manifest: {
+    name: "Agents",
+    description:
+      "At-a-glance agent status: an Agents view in the Navigator groupable by status or workspace, status rows on each workspace, and terminal tab badges/icons, cleared when you view the terminal.",
+    version: "0.2.10",
+  },
+  activate,
+  deactivate,
+};

--- a/packages/extensions-silo/src/agents/manual-order.test.ts
+++ b/packages/extensions-silo/src/agents/manual-order.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { ExtensionStorage } from "@silo-code/sdk";
+import {
+  initManualOrder,
+  manualOrderService,
+  resetManualOrder,
+} from "./manual-order";
+
+function fakeStorage(
+  initial: Record<string, unknown> = {},
+): ExtensionStorage & {
+  hydrate(): void;
+} {
+  const data = new Map<string, unknown>(Object.entries(initial));
+  let listener: (() => void) | null = null;
+  return {
+    get: ((key: string, fallback?: unknown) =>
+      data.has(key) ? data.get(key) : fallback) as ExtensionStorage["get"],
+    set(key, value) {
+      if (value === undefined) data.delete(key);
+      else data.set(key, value);
+    },
+    keys: () => [...data.keys()],
+    subscribe(l) {
+      listener = l;
+      return {
+        dispose: () => {
+          listener = null;
+        },
+      };
+    },
+    hydrate() {
+      listener?.();
+    },
+  };
+}
+
+// The module holds its state in a singleton (it's extension-scoped, like
+// ./done-since), so each test starts from a clean one.
+beforeEach(() => resetManualOrder());
+
+describe("initManualOrder", () => {
+  it("seeds from persisted storage", () => {
+    initManualOrder(fakeStorage({ agentsRecentManualOrder: ["b", "a"] }));
+    expect(manualOrderService.getState()).toEqual(["b", "a"]);
+  });
+
+  it("starts empty when nothing is persisted", () => {
+    initManualOrder(fakeStorage());
+    expect(manualOrderService.getState()).toEqual([]);
+  });
+
+  it("re-reads when storage notifies after async hydrate", () => {
+    const storage = fakeStorage();
+    initManualOrder(storage);
+    expect(manualOrderService.getState()).toEqual([]);
+    storage.set("agentsRecentManualOrder", ["b", "a"]);
+    storage.hydrate();
+    expect(manualOrderService.getState()).toEqual(["b", "a"]);
+  });
+});
+
+describe("manualOrderService.set", () => {
+  it("updates state and persists the new order", () => {
+    const storage = fakeStorage();
+    initManualOrder(storage);
+    manualOrderService.set(["c", "a", "b"]);
+    expect(manualOrderService.getState()).toEqual(["c", "a", "b"]);
+    expect(storage.get<string[]>("agentsRecentManualOrder")).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("notifies subscribers", () => {
+    initManualOrder(fakeStorage());
+    const seen: (readonly string[])[] = [];
+    const sub = manualOrderService.subscribe((order) => seen.push(order));
+    manualOrderService.set(["a"]);
+    expect(seen).toEqual([["a"]]);
+    sub.dispose();
+  });
+
+  it("stops notifying a disposed subscriber", () => {
+    initManualOrder(fakeStorage());
+    const seen: (readonly string[])[] = [];
+    const sub = manualOrderService.subscribe((order) => seen.push(order));
+    sub.dispose();
+    manualOrderService.set(["a"]);
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/extensions-silo/src/agents/manual-order.ts
+++ b/packages/extensions-silo/src/agents/manual-order.ts
@@ -1,0 +1,63 @@
+/**
+ * The persisted drag order for the "Recent" view's flat section — a plain
+ * list of terminal ids in the order the user last left them via drag. Empty
+ * by default, which reduces `orderAgeRows` to its unmodified
+ * most-recent-first sort, so nobody who's never dragged a row sees any
+ * change in behavior.
+ *
+ * A `ReactiveService` like `./settings-store`, rather than folded into that
+ * store directly: it's read the same way (`useServiceState` in
+ * `agents-panel.tsx`) but changes for a different reason — a user drag, not a
+ * settings-page edit — and keeping it separate means a settings change never
+ * has to reason about drag state or vice versa.
+ */
+
+import type { ExtensionStorage, ReactiveService } from "@silo-code/sdk";
+
+const STORAGE_KEY = "agentsRecentManualOrder";
+
+let order: readonly string[] = [];
+let backingStorage: ExtensionStorage | null = null;
+const listeners = new Set<(order: readonly string[]) => void>();
+
+export const manualOrderService: ReactiveService<readonly string[]> & {
+  set(next: readonly string[]): void;
+} = {
+  getState: () => order,
+  subscribe(listener) {
+    listeners.add(listener);
+    return { dispose: () => listeners.delete(listener) };
+  },
+  set(next) {
+    order = next;
+    backingStorage?.set(STORAGE_KEY, [...next]);
+    for (const l of listeners) l(order);
+  },
+};
+
+function sameOrder(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
+}
+
+/** Seed from persisted storage — re-reads on hydrate / id migration. */
+export function initManualOrder(storage: ExtensionStorage): {
+  dispose(): void;
+} {
+  backingStorage = storage;
+  function read() {
+    const next = storage.get<string[]>(STORAGE_KEY, []);
+    if (sameOrder(next, order)) return;
+    order = next;
+    for (const l of listeners) l(order);
+  }
+  read();
+  const sub = storage.subscribe(read);
+  return { dispose: () => sub.dispose() };
+}
+
+/** Drop all state — tests only, so one case can't leak into the next. */
+export function resetManualOrder(): void {
+  backingStorage = null;
+  order = [];
+  listeners.clear();
+}

--- a/packages/extensions-silo/src/agents/settings-store.ts
+++ b/packages/extensions-silo/src/agents/settings-store.ts
@@ -1,0 +1,248 @@
+/**
+ * The extension's own settings — a tiny reactive store implementing the SDK's
+ * ReactiveService, mirroring the pattern used by the clock-extension example
+ * (and, for the host's own settings pages, the terminal/editor settings
+ * stores). `index.tsx` reads `settingsService.getState()` when deciding what
+ * focusing a terminal does to its status (whether to `ctx.agents.acknowledge`
+ * it, and whether to hide its row).
+ *
+ * Persisted via `ctx.storage.global` (shared across workspaces — this is a
+ * general behavior preference, not per-project) so it survives an app
+ * restart. `initSettings()` must be called once from `activate()`.
+ *
+ * Kept free of any *runtime* `@silo-code/sdk` import (types only) so this
+ * module — and `settings.test.ts`, which exercises it directly — never needs
+ * to load the SDK package at all. `settings.tsx` is the thin component layer
+ * that adds the one runtime import (`useServiceState`).
+ */
+
+import type { ExtensionStorage, ReactiveService } from "@silo-code/sdk";
+import { sounds, type SoundName } from "./synth";
+
+/**
+ * What focusing an agent's terminal does to its status.
+ *
+ * - `"clear"` (default): viewing a finished terminal acknowledges the run —
+ *   the green check and green status dot become the neutral grey "done" dot.
+ * - `"hide"`: as `"clear"`, and additionally the workspace status row is
+ *   hidden entirely for whichever terminal is currently focused.
+ * - `"none"`: focus never changes status — the green finished indicator
+ *   stays until the agent starts its next run.
+ */
+export type FocusBehavior = "clear" | "hide" | "none";
+
+/** Whether/how the Agents panel shows each row's agent brand icon —
+ * `"none"`, the official brand color, or a single monotone color. */
+export type IconMode = "none" | "color" | "monotone";
+
+/**
+ * Which axis the Agents view sections its rows by. Until SDK 0.34 these were
+ * two separately registered Navigator views ("Agents" and "Agents by
+ * workspace"); they are one view and one persisted preference now, flipped
+ * from the "View by" control in the Navigator's header. `"age"` is labeled
+ * "Recent" in that control — the setting value keeps the shorter internal
+ * name.
+ */
+export type GroupMode = "status" | "workspace" | "age";
+
+export interface AgentMonitorSettings {
+  focusBehavior: FocusBehavior;
+  /** Whether a sound plays when an agent transitions working → waiting. */
+  soundEnabled: boolean;
+  /** Which synthesized sound to play. */
+  soundId: SoundName;
+  /** How the Agents panel shows each row's agent icon. */
+  iconMode: IconMode;
+  /** Which axis the Agents view groups its rows by. */
+  groupBy: GroupMode;
+  /** Whether the Agents panel segments long-done agents out of the Done
+   * heading into a collapsible "N+ hours old" one at all. */
+  staleDoneEnabled: boolean;
+  /** How long a "done" row sits before the Agents panel moves it out of the
+   * Done heading into its own "N+ hours old" one. Whole hours, minimum 1.
+   * Only takes effect while {@link staleDoneEnabled} is on. */
+  staleDoneHours: number;
+}
+
+// Keys renamed on each shape change ("hideStatusWhenFocused" → "clearOnFocus"
+// → this) so stale persisted values from older versions are simply ignored
+// and the new default applies.
+const STORAGE_KEY_FOCUS = "focusBehavior";
+const STORAGE_KEY_SOUND_ENABLED = "soundEnabled";
+const STORAGE_KEY_SOUND_ID = "soundId";
+const STORAGE_KEY_ICON_MODE = "agentsIconMode";
+const STORAGE_KEY_GROUP_BY = "agentsGroupBy";
+const STORAGE_KEY_STALE_DONE_ENABLED = "agentsStaleDoneEnabled";
+const STORAGE_KEY_STALE_DONE_HOURS = "agentsStaleDoneHours";
+
+const DEFAULT_BEHAVIOR: FocusBehavior = "clear";
+const DEFAULT_SOUND_ENABLED = true;
+const DEFAULT_SOUND_ID: SoundName = "chime";
+const DEFAULT_ICON_MODE: IconMode = "color";
+const DEFAULT_GROUP_BY: GroupMode = "age";
+export const DEFAULT_STALE_DONE_ENABLED = true;
+export const DEFAULT_STALE_DONE_HOURS = 4;
+export const MIN_STALE_DONE_HOURS = 1;
+
+const VALID_BEHAVIORS: readonly FocusBehavior[] = ["clear", "hide", "none"];
+const VALID_ICON_MODES: readonly IconMode[] = ["none", "color", "monotone"];
+const VALID_GROUP_MODES: readonly GroupMode[] = ["status", "workspace", "age"];
+// The synth's raw UI-feedback sounds (press/release/toggle) read as click
+// acknowledgements, not "come look at this" — excluded from the curated
+// list offered here. Everything else is `sounds`' own names, reused
+// directly rather than hand-copied, so the list can't drift from what
+// `play()` actually accepts.
+const EXCLUDED_SOUND_IDS: readonly SoundName[] = ["press", "release", "toggle"];
+export const SOUND_IDS: readonly SoundName[] = sounds.filter(
+  (name) => !EXCLUDED_SOUND_IDS.includes(name),
+);
+
+/** Guard against garbage in storage (or values from a future version). */
+function coerceBehavior(v: unknown): FocusBehavior {
+  return VALID_BEHAVIORS.includes(v as FocusBehavior)
+    ? (v as FocusBehavior)
+    : DEFAULT_BEHAVIOR;
+}
+
+function coerceSoundEnabled(v: unknown): boolean {
+  return typeof v === "boolean" ? v : DEFAULT_SOUND_ENABLED;
+}
+
+function coerceSoundId(v: unknown): SoundName {
+  return SOUND_IDS.includes(v as SoundName)
+    ? (v as SoundName)
+    : DEFAULT_SOUND_ID;
+}
+
+function coerceIconMode(v: unknown): IconMode {
+  return VALID_ICON_MODES.includes(v as IconMode)
+    ? (v as IconMode)
+    : DEFAULT_ICON_MODE;
+}
+
+function coerceGroupBy(v: unknown): GroupMode {
+  return VALID_GROUP_MODES.includes(v as GroupMode)
+    ? (v as GroupMode)
+    : DEFAULT_GROUP_BY;
+}
+
+function coerceStaleDoneEnabled(v: unknown): boolean {
+  return typeof v === "boolean" ? v : DEFAULT_STALE_DONE_ENABLED;
+}
+
+/** Whole hours, at least {@link MIN_STALE_DONE_HOURS} — anything else
+ * (garbage in storage, a fractional or sub-minimum value) falls back to the
+ * default rather than being clamped, since a silently-clamped stored value
+ * would drift from what the settings field displays. */
+function coerceStaleDoneHours(v: unknown): number {
+  return typeof v === "number" &&
+    Number.isInteger(v) &&
+    v >= MIN_STALE_DONE_HOURS
+    ? v
+    : DEFAULT_STALE_DONE_HOURS;
+}
+
+let settings: AgentMonitorSettings = {
+  focusBehavior: DEFAULT_BEHAVIOR,
+  soundEnabled: DEFAULT_SOUND_ENABLED,
+  soundId: DEFAULT_SOUND_ID,
+  iconMode: DEFAULT_ICON_MODE,
+  groupBy: DEFAULT_GROUP_BY,
+  staleDoneEnabled: DEFAULT_STALE_DONE_ENABLED,
+  staleDoneHours: DEFAULT_STALE_DONE_HOURS,
+};
+let backingStorage: ExtensionStorage | null = null;
+const listeners = new Set<(s: AgentMonitorSettings) => void>();
+
+export const settingsService: ReactiveService<AgentMonitorSettings> & {
+  set(patch: Partial<AgentMonitorSettings>): void;
+} = {
+  getState: () => settings,
+  subscribe(listener) {
+    listeners.add(listener);
+    return { dispose: () => listeners.delete(listener) };
+  },
+  set(patch) {
+    settings = { ...settings, ...patch };
+    backingStorage?.set(STORAGE_KEY_FOCUS, settings.focusBehavior);
+    backingStorage?.set(STORAGE_KEY_SOUND_ENABLED, settings.soundEnabled);
+    backingStorage?.set(STORAGE_KEY_SOUND_ID, settings.soundId);
+    backingStorage?.set(STORAGE_KEY_ICON_MODE, settings.iconMode);
+    backingStorage?.set(STORAGE_KEY_GROUP_BY, settings.groupBy);
+    backingStorage?.set(
+      STORAGE_KEY_STALE_DONE_ENABLED,
+      settings.staleDoneEnabled,
+    );
+    backingStorage?.set(STORAGE_KEY_STALE_DONE_HOURS, settings.staleDoneHours);
+    for (const l of listeners) l(settings);
+  },
+};
+
+/**
+ * Bind persisted storage to the settings service — call once from
+ * `activate()`. Reads the persisted value immediately and re-reads on every
+ * storage change, since `ctx.storage` hydrates asynchronously and a value
+ * saved last session may not be present at the instant `activate` runs.
+ */
+export function initSettings(storage: ExtensionStorage): {
+  dispose(): void;
+} {
+  backingStorage = storage;
+  function read() {
+    const focusBehavior = coerceBehavior(
+      storage.get<string>(STORAGE_KEY_FOCUS, settings.focusBehavior),
+    );
+    const soundEnabled = coerceSoundEnabled(
+      storage.get<boolean>(STORAGE_KEY_SOUND_ENABLED, settings.soundEnabled),
+    );
+    const soundId = coerceSoundId(
+      storage.get<string>(STORAGE_KEY_SOUND_ID, settings.soundId),
+    );
+    const iconMode = coerceIconMode(
+      storage.get<string>(STORAGE_KEY_ICON_MODE, settings.iconMode),
+    );
+    const groupBy = coerceGroupBy(
+      storage.get<string>(STORAGE_KEY_GROUP_BY, settings.groupBy),
+    );
+    const staleDoneEnabled = coerceStaleDoneEnabled(
+      storage.get<boolean>(
+        STORAGE_KEY_STALE_DONE_ENABLED,
+        settings.staleDoneEnabled,
+      ),
+    );
+    const staleDoneHours = coerceStaleDoneHours(
+      storage.get<number>(
+        STORAGE_KEY_STALE_DONE_HOURS,
+        settings.staleDoneHours,
+      ),
+    );
+    if (
+      focusBehavior !== settings.focusBehavior ||
+      soundEnabled !== settings.soundEnabled ||
+      soundId !== settings.soundId ||
+      iconMode !== settings.iconMode ||
+      groupBy !== settings.groupBy ||
+      staleDoneEnabled !== settings.staleDoneEnabled ||
+      staleDoneHours !== settings.staleDoneHours
+    ) {
+      settings = {
+        ...settings,
+        focusBehavior,
+        soundEnabled,
+        soundId,
+        iconMode,
+        groupBy,
+        staleDoneEnabled,
+        staleDoneHours,
+      };
+      for (const l of listeners) l(settings);
+    }
+  }
+  read();
+  const sub = storage.subscribe(read);
+  return { dispose: () => sub.dispose() };
+}
+
+export function clearSettingsListeners(): void {
+  listeners.clear();
+}

--- a/packages/extensions-silo/src/agents/settings.test.ts
+++ b/packages/extensions-silo/src/agents/settings.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { ExtensionStorage } from "@silo-code/sdk";
+import {
+  settingsService,
+  initSettings,
+  clearSettingsListeners,
+  SOUND_IDS,
+  DEFAULT_STALE_DONE_ENABLED,
+  DEFAULT_STALE_DONE_HOURS,
+  type FocusBehavior,
+} from "./settings-store";
+
+/** In-memory ExtensionStorage stand-in, mirroring the host's real contract. */
+function fakeStorage(
+  initial: Record<string, unknown> = {},
+): ExtensionStorage & {
+  emit(): void;
+} {
+  const data = new Map<string, unknown>(Object.entries(initial));
+  const listeners = new Set<() => void>();
+  return {
+    get: ((key: string, fallback?: unknown) =>
+      data.has(key) ? data.get(key) : fallback) as ExtensionStorage["get"],
+    set(key, value) {
+      if (value === undefined) data.delete(key);
+      else data.set(key, value);
+    },
+    keys: () => [...data.keys()],
+    subscribe(listener) {
+      listeners.add(listener);
+      return { dispose: () => listeners.delete(listener) };
+    },
+    emit() {
+      for (const l of listeners) l();
+    },
+  };
+}
+
+// settings-store.ts holds its state in a module-level singleton (mirrors the
+// host's own ReactiveService pattern), so each test pins a known starting
+// value via a throwaway storage before exercising the behavior under test.
+function resetTo(focusBehavior: FocusBehavior) {
+  clearSettingsListeners();
+  initSettings(fakeStorage({ focusBehavior })).dispose();
+}
+
+describe("agent-monitor settings persistence", () => {
+  beforeEach(() => {
+    resetTo("none");
+  });
+
+  it('defaults to "clear" with empty storage', () => {
+    resetTo("clear"); // restore module to compiled default before testing empty storage
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().focusBehavior).toBe("clear");
+    sub.dispose();
+  });
+
+  it("hydrates from a value already persisted (restart case)", () => {
+    const storage = fakeStorage({ focusBehavior: "hide" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().focusBehavior).toBe("hide");
+    sub.dispose();
+  });
+
+  it("coerces an invalid stored value to the default", () => {
+    // e.g. a boolean left over from an older settings shape, or garbage.
+    const storage = fakeStorage({ focusBehavior: true });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().focusBehavior).toBe("clear");
+    sub.dispose();
+  });
+
+  it("persists a change through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ focusBehavior: "hide" });
+    expect(storage.get<string>("focusBehavior")).toBe("hide");
+    sub.dispose();
+  });
+
+  it("picks up a value that arrives after activation (async hydration)", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().focusBehavior).toBe("none");
+    storage.set("focusBehavior", "hide");
+    storage.emit();
+    expect(settingsService.getState().focusBehavior).toBe("hide");
+    sub.dispose();
+  });
+
+  it("dispose stops reacting to further storage changes", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    sub.dispose();
+    storage.set("focusBehavior", "hide");
+    storage.emit();
+    expect(settingsService.getState().focusBehavior).toBe("none");
+  });
+});
+
+describe("agent-monitor sound settings", () => {
+  beforeEach(() => {
+    clearSettingsListeners();
+    initSettings(
+      fakeStorage({ soundEnabled: false, soundId: "chime" }),
+    ).dispose();
+  });
+
+  it('defaults to enabled with "chime" when nothing is persisted', () => {
+    // Restore module to compiled defaults before testing empty storage —
+    // initSettings falls back to the in-memory singleton when a key is missing.
+    initSettings(
+      fakeStorage({ soundEnabled: true, soundId: "chime" }),
+    ).dispose();
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().soundEnabled).toBe(true);
+    expect(settingsService.getState().soundId).toBe("chime");
+    sub.dispose();
+  });
+
+  it("hydrates a persisted enabled/soundId pair", () => {
+    const storage = fakeStorage({ soundEnabled: true, soundId: "sparkle" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().soundEnabled).toBe(true);
+    expect(settingsService.getState().soundId).toBe("sparkle");
+    sub.dispose();
+  });
+
+  it("coerces an invalid persisted soundId to the default", () => {
+    const storage = fakeStorage({ soundId: "not-a-real-sound" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().soundId).toBe("chime");
+    sub.dispose();
+  });
+
+  it.each(["press", "release", "toggle"])(
+    "coerces the excluded UI-feedback sound %j to the default",
+    (soundId) => {
+      const storage = fakeStorage({ soundId });
+      const sub = initSettings(storage);
+      expect(settingsService.getState().soundId).toBe("chime");
+      sub.dispose();
+    },
+  );
+
+  it("coerces a non-boolean persisted soundEnabled to the default", () => {
+    const storage = fakeStorage({ soundEnabled: "yes" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().soundEnabled).toBe(true);
+    sub.dispose();
+  });
+
+  it("persists soundEnabled/soundId through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ soundEnabled: true, soundId: "bloom" });
+    expect(storage.get<boolean>("soundEnabled")).toBe(true);
+    expect(storage.get<string>("soundId")).toBe("bloom");
+    sub.dispose();
+  });
+
+  it("excludes the UI-feedback sounds from the offered list", () => {
+    expect(SOUND_IDS).not.toContain("press");
+    expect(SOUND_IDS).not.toContain("release");
+    expect(SOUND_IDS).not.toContain("toggle");
+    expect(SOUND_IDS).toContain("chime");
+  });
+});
+
+describe("agent-monitor iconMode setting", () => {
+  beforeEach(() => {
+    clearSettingsListeners();
+    initSettings(fakeStorage({ agentsIconMode: "color" })).dispose();
+  });
+
+  it('defaults to "color" with empty storage', () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().iconMode).toBe("color");
+    sub.dispose();
+  });
+
+  it('hydrates a persisted "monotone" value', () => {
+    const storage = fakeStorage({ agentsIconMode: "monotone" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().iconMode).toBe("monotone");
+    sub.dispose();
+  });
+
+  it('hydrates a persisted "none" value', () => {
+    const storage = fakeStorage({ agentsIconMode: "none" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().iconMode).toBe("none");
+    sub.dispose();
+  });
+
+  it("coerces an invalid persisted value to the default", () => {
+    const storage = fakeStorage({ agentsIconMode: "nonsense" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().iconMode).toBe("color");
+    sub.dispose();
+  });
+
+  it("persists a change through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ iconMode: "monotone" });
+    expect(storage.get<string>("agentsIconMode")).toBe("monotone");
+    sub.dispose();
+  });
+});
+
+describe("agent-monitor groupBy setting", () => {
+  beforeEach(() => {
+    clearSettingsListeners();
+    initSettings(fakeStorage({ agentsGroupBy: "status" })).dispose();
+  });
+
+  it('defaults to "age" with empty storage', () => {
+    // Restore module state to the compiled default before testing empty
+    // storage — `beforeEach` above seeds "status", and `read()` falls back to
+    // the *current* in-memory value when storage has nothing persisted, so
+    // without this reset the test would just reflect that seed rather than
+    // DEFAULT_GROUP_BY. Mirrors the `resetTo("clear")` pattern for
+    // focusBehavior above.
+    initSettings(fakeStorage({ agentsGroupBy: "age" })).dispose();
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().groupBy).toBe("age");
+    sub.dispose();
+  });
+
+  it('hydrates a persisted "workspace" value (restart case)', () => {
+    const storage = fakeStorage({ agentsGroupBy: "workspace" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().groupBy).toBe("workspace");
+    sub.dispose();
+  });
+
+  it("coerces an invalid persisted value to the default", () => {
+    const storage = fakeStorage({ agentsGroupBy: "by-project" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().groupBy).toBe("age");
+    sub.dispose();
+  });
+
+  it("persists a change through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ groupBy: "workspace" });
+    expect(storage.get<string>("agentsGroupBy")).toBe("workspace");
+    sub.dispose();
+  });
+
+  it("notifies subscribers so the open view regroups", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    const seen: string[] = [];
+    const listener = settingsService.subscribe((s) => seen.push(s.groupBy));
+    settingsService.set({ groupBy: "workspace" });
+    expect(seen).toEqual(["workspace"]);
+    listener.dispose();
+    sub.dispose();
+  });
+});
+
+describe("agent-monitor staleDoneEnabled setting", () => {
+  beforeEach(() => {
+    clearSettingsListeners();
+    initSettings(
+      fakeStorage({ agentsStaleDoneEnabled: DEFAULT_STALE_DONE_ENABLED }),
+    ).dispose();
+  });
+
+  it(`defaults to ${DEFAULT_STALE_DONE_ENABLED} with empty storage`, () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneEnabled).toBe(
+      DEFAULT_STALE_DONE_ENABLED,
+    );
+    sub.dispose();
+  });
+
+  it("hydrates a persisted false value", () => {
+    const storage = fakeStorage({ agentsStaleDoneEnabled: false });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneEnabled).toBe(false);
+    sub.dispose();
+  });
+
+  it("coerces a non-boolean persisted value to the default", () => {
+    const storage = fakeStorage({ agentsStaleDoneEnabled: "nope" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneEnabled).toBe(
+      DEFAULT_STALE_DONE_ENABLED,
+    );
+    sub.dispose();
+  });
+
+  it("persists a change through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ staleDoneEnabled: false });
+    expect(storage.get<boolean>("agentsStaleDoneEnabled")).toBe(false);
+    sub.dispose();
+  });
+});
+
+describe("agent-monitor staleDoneHours setting", () => {
+  beforeEach(() => {
+    clearSettingsListeners();
+    initSettings(
+      fakeStorage({ agentsStaleDoneHours: DEFAULT_STALE_DONE_HOURS }),
+    ).dispose();
+  });
+
+  it(`defaults to ${DEFAULT_STALE_DONE_HOURS} with empty storage`, () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneHours).toBe(
+      DEFAULT_STALE_DONE_HOURS,
+    );
+    sub.dispose();
+  });
+
+  it("hydrates a persisted value", () => {
+    const storage = fakeStorage({ agentsStaleDoneHours: 12 });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneHours).toBe(12);
+    sub.dispose();
+  });
+
+  it("coerces the minimum boundary value (1) as valid", () => {
+    const storage = fakeStorage({ agentsStaleDoneHours: 1 });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneHours).toBe(1);
+    sub.dispose();
+  });
+
+  it("coerces a value below the minimum to the default", () => {
+    const storage = fakeStorage({ agentsStaleDoneHours: 0 });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneHours).toBe(
+      DEFAULT_STALE_DONE_HOURS,
+    );
+    sub.dispose();
+  });
+
+  it("coerces a fractional value to the default", () => {
+    const storage = fakeStorage({ agentsStaleDoneHours: 4.5 });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneHours).toBe(
+      DEFAULT_STALE_DONE_HOURS,
+    );
+    sub.dispose();
+  });
+
+  it("coerces a non-number persisted value to the default", () => {
+    const storage = fakeStorage({ agentsStaleDoneHours: "8" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleDoneHours).toBe(
+      DEFAULT_STALE_DONE_HOURS,
+    );
+    sub.dispose();
+  });
+
+  it("persists a change through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ staleDoneHours: 6 });
+    expect(storage.get<number>("agentsStaleDoneHours")).toBe(6);
+    sub.dispose();
+  });
+});

--- a/packages/extensions-silo/src/agents/settings.tsx
+++ b/packages/extensions-silo/src/agents/settings.tsx
@@ -1,0 +1,195 @@
+/**
+ * The Agent Monitor settings page component. Split from `settings-store.ts`
+ * so the pure store (and its unit tests) never has to load the real
+ * `@silo-code/sdk` runtime — this file is the only place that does, via
+ * `useServiceState`.
+ */
+
+import {
+  useServiceState,
+  IconButton,
+  Input,
+  RadioCard,
+  RadioGroup,
+  Section,
+  Select,
+  SettingRow,
+  Switch,
+} from "@silo-code/sdk";
+import type { SoundName } from "./synth";
+import {
+  settingsService,
+  SOUND_IDS,
+  MIN_STALE_DONE_HOURS,
+  type FocusBehavior,
+  type IconMode,
+} from "./settings-store";
+import { previewSound } from "./sound";
+
+export {
+  settingsService,
+  initSettings,
+  clearSettingsListeners,
+  DEFAULT_STALE_DONE_ENABLED,
+  DEFAULT_STALE_DONE_HOURS,
+  MIN_STALE_DONE_HOURS,
+  type AgentMonitorSettings,
+  type FocusBehavior,
+  type IconMode,
+} from "./settings-store";
+
+function soundLabel(name: SoundName): string {
+  return name[0].toUpperCase() + name.slice(1);
+}
+
+const FOCUS_OPTIONS: { value: FocusBehavior; label: string; hint: string }[] = [
+  {
+    value: "clear",
+    label: "Clear the finished indicator",
+    hint: "Viewing the terminal acknowledges the run — the green check disappears and the status dot turns grey.",
+  },
+  {
+    value: "hide",
+    label: "Clear it, and hide the focused terminal's status row",
+    hint: "As above, plus the workspace status row is hidden entirely for whichever terminal you're currently viewing.",
+  },
+  {
+    value: "none",
+    label: "Keep it until the next run",
+    hint: "Viewing changes nothing — the green check and status stay until the agent starts working again.",
+  },
+];
+
+const ICON_MODE_OPTIONS: { value: IconMode; label: string }[] = [
+  { value: "none", label: "No icons" },
+  { value: "color", label: "Color" },
+  { value: "monotone", label: "Monotone" },
+];
+
+/** Embeddable options block — composed into core.agents-settings via getExtension. */
+export function AgentsOptionsPanel() {
+  const s = useServiceState(settingsService);
+  return (
+    <div className="am-options-panel">
+      <div className="am-intro">
+        <span className="am-intro-title">
+          When you view a finished agent's terminal
+        </span>
+        <span className="am-hint">
+          An agent that finishes a run shows a green check on its tab and a
+          green dot in the workspace status until you look at it. Choose what
+          viewing its terminal should do.
+        </span>
+        <div className="am-options">
+          <RadioGroup
+            value={s.focusBehavior}
+            onChange={(value) =>
+              settingsService.set({ focusBehavior: value as FocusBehavior })
+            }
+          >
+            {FOCUS_OPTIONS.map((opt) => (
+              <RadioCard
+                key={opt.value}
+                value={opt.value}
+                title={opt.label}
+                description={opt.hint}
+              />
+            ))}
+          </RadioGroup>
+        </div>
+      </div>
+      <Section label="Agent icons">
+        <SettingRow label="Show agent app icons in the agent views">
+          <Select
+            value={s.iconMode}
+            onChange={(e) =>
+              settingsService.set({ iconMode: e.target.value as IconMode })
+            }
+            aria-label="Show agent app icons in the agent views"
+          >
+            {ICON_MODE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </Select>
+        </SettingRow>
+      </Section>
+      <Section label="Agent views">
+        <SettingRow
+          label="Set old finished agents aside"
+          hint="Keeps Done focused on recent finishes — older ones collapse into their own section that expands on hover."
+        >
+          <Switch
+            checked={s.staleDoneEnabled}
+            onChange={(staleDoneEnabled) =>
+              settingsService.set({ staleDoneEnabled })
+            }
+            aria-label="Set old finished agents aside"
+          />
+        </SettingRow>
+        {s.staleDoneEnabled && (
+          <SettingRow label="Consider an agent old after">
+            <div className="am-hours-control">
+              <Input
+                className="am-hours-input"
+                type="number"
+                min={MIN_STALE_DONE_HOURS}
+                step={1}
+                value={s.staleDoneHours}
+                onChange={(e) => {
+                  const hours = Math.trunc(Number(e.target.value));
+                  if (!Number.isFinite(hours) || hours < MIN_STALE_DONE_HOURS)
+                    return;
+                  settingsService.set({ staleDoneHours: hours });
+                }}
+                aria-label="Consider an agent old after this many hours"
+              />
+              <span className="am-hours-unit">hours</span>
+            </div>
+          </SettingRow>
+        )}
+      </Section>
+      <Section label="Sound">
+        <span className="am-hint">
+          Play a sound whenever an agent stops working, whether or not you're
+          watching its terminal.
+        </span>
+        <SettingRow label="Play a sound when an agent stops working">
+          <Switch
+            checked={s.soundEnabled}
+            onChange={(soundEnabled) => settingsService.set({ soundEnabled })}
+            aria-label="Play a sound when an agent stops working"
+          />
+        </SettingRow>
+        <SettingRow label="Notification sound">
+          <div className="am-sound-control">
+            <Select
+              value={s.soundId}
+              onChange={(e) =>
+                settingsService.set({ soundId: e.target.value as SoundName })
+              }
+              aria-label="Notification sound"
+            >
+              {SOUND_IDS.map((name) => (
+                <option key={name} value={name}>
+                  {soundLabel(name)}
+                </option>
+              ))}
+            </Select>
+            <IconButton
+              size="sm"
+              onClick={() => previewSound(s.soundId)}
+              aria-label={`Preview ${soundLabel(s.soundId)} sound`}
+            >
+              ▶
+            </IconButton>
+          </div>
+        </SettingRow>
+      </Section>
+    </div>
+  );
+}
+
+/** @deprecated Use {@link AgentsOptionsPanel}. */
+export const AgentMonitorSettingsPage = AgentsOptionsPanel;

--- a/packages/extensions-silo/src/agents/sound.test.ts
+++ b/packages/extensions-silo/src/agents/sound.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ExtensionStorage } from "@silo-code/sdk";
+import { clearSettingsListeners, initSettings } from "./settings-store";
+import { maybePlayTransitionSound, previewSound } from "./sound";
+
+const playMock = vi.hoisted(() => vi.fn());
+vi.mock("./synth", () => ({
+  play: playMock,
+  sounds: [
+    "chime",
+    "sparkle",
+    "droplet",
+    "bloom",
+    "whisper",
+    "tick",
+    "press",
+    "release",
+    "toggle",
+    "success",
+    "error",
+    "page",
+    "loading",
+    "ready",
+  ],
+}));
+
+/** In-memory ExtensionStorage stand-in, mirroring settings.test.ts's. */
+function fakeStorage(initial: Record<string, unknown> = {}): ExtensionStorage {
+  const data = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: ((key: string, fallback?: unknown) =>
+      data.has(key) ? data.get(key) : fallback) as ExtensionStorage["get"],
+    set(key, value) {
+      if (value === undefined) data.delete(key);
+      else data.set(key, value);
+    },
+    keys: () => [...data.keys()],
+    subscribe: () => ({ dispose: () => {} }),
+  };
+}
+
+// sound.ts's debounce timestamp is module-level state, so each test below
+// uses its own well-separated block of timestamps rather than resetting it
+// directly — cheaper than exporting a test-only reset hook.
+describe("maybePlayTransitionSound", () => {
+  beforeEach(() => {
+    playMock.mockClear();
+    clearSettingsListeners();
+    initSettings(
+      fakeStorage({ soundEnabled: true, soundId: "chime" }),
+    ).dispose();
+  });
+
+  it("does nothing when sound is disabled", () => {
+    initSettings(
+      fakeStorage({ soundEnabled: false, soundId: "chime" }),
+    ).dispose();
+    maybePlayTransitionSound(10_000);
+    expect(playMock).not.toHaveBeenCalled();
+  });
+
+  it("plays the configured sound when enabled", () => {
+    maybePlayTransitionSound(20_000);
+    expect(playMock).toHaveBeenCalledWith("chime");
+  });
+
+  it("debounces a second call inside the window", () => {
+    maybePlayTransitionSound(30_000);
+    maybePlayTransitionSound(30_200);
+    expect(playMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("plays again once the debounce window has passed", () => {
+    maybePlayTransitionSound(40_000);
+    maybePlayTransitionSound(40_800);
+    expect(playMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("previewSound", () => {
+  beforeEach(() => playMock.mockClear());
+
+  it("always plays, bypassing the enabled flag", () => {
+    clearSettingsListeners();
+    initSettings(
+      fakeStorage({ soundEnabled: false, soundId: "chime" }),
+    ).dispose();
+    previewSound("bloom");
+    expect(playMock).toHaveBeenCalledWith("bloom");
+  });
+});

--- a/packages/extensions-silo/src/agents/sound.ts
+++ b/packages/extensions-silo/src/agents/sound.ts
@@ -1,0 +1,28 @@
+/**
+ * Plays the working → waiting notification sound, gated on the user's
+ * settings and debounced so several terminals finishing at once don't stack
+ * overlapping tones. Kept separate from `index.tsx` so the debounce logic is
+ * unit-testable without the SDK.
+ */
+
+import { play, type SoundName } from "./synth";
+import { settingsService } from "./settings-store";
+
+const DEBOUNCE_MS = 750;
+let lastPlayedAt = 0;
+
+/** Called from `dispatch()` whenever an agent stops working, regardless of
+ * whether its terminal is currently focused. */
+export function maybePlayTransitionSound(now: number = Date.now()): void {
+  const { soundEnabled, soundId } = settingsService.getState();
+  if (!soundEnabled) return;
+  if (now - lastPlayedAt < DEBOUNCE_MS) return;
+  lastPlayedAt = now;
+  play(soundId);
+}
+
+/** Called from the settings page's preview button — bypasses the enabled
+ * flag and debounce so every click is audible. */
+export function previewSound(soundId: SoundName): void {
+  play(soundId);
+}

--- a/packages/extensions-silo/src/agents/styles.css
+++ b/packages/extensions-silo/src/agents/styles.css
@@ -1,0 +1,296 @@
+/* Tab decoration icons — colors come from the host via `currentColor`
+   (the decoration's semantic `color` maps to --silo-color-* tokens). */
+.am-spinner {
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: am-spin 0.7s linear infinite;
+}
+@keyframes am-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.am-waiting-icon {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+.am-waiting-icon span {
+  display: block;
+  width: 2.5px;
+  height: 8px;
+  background: currentColor;
+  border-radius: 1px;
+}
+
+/* Settings page — mirrors the host's Editor / Keyboard Shortcuts pages so a
+   third-party page reads as one family. */
+.am-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 12px;
+}
+.am-header {
+  display: flex;
+  align-items: center;
+  min-height: var(--settings-header-height);
+  flex-shrink: 0;
+}
+.am-header h2 {
+  margin: 0;
+  font-size: 1.1em;
+  color: var(--silo-color-text-hi);
+}
+/* Scrolls independently of the header once the sections (focus behavior,
+   agent icons, sound) run taller than the settings pane. Scroll behavior and
+   scrollbar appearance come from the host's `.silo-scroll` class (applied in
+   settings.tsx) — no overflow/scrollbar rules needed here. */
+.am-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+/* Embedded in core.agents-settings Options tab — parent owns scroll chrome. */
+.am-options-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+/* The intro block above the first proper Section — a page-level question
+   ("When you view a finished agent's terminal"), not a labeled group, so it
+   keeps its own larger, non-uppercase title instead of the SDK Section
+   label. */
+.am-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.am-intro-title {
+  font-weight: 600;
+  color: var(--silo-color-text-hi);
+}
+.am-hint {
+  font-size: calc(var(--settings-font) - 2px);
+  color: var(--silo-color-text-lo);
+  line-height: 1.35;
+}
+/* A plain block wrapper — no flex/gap of its own. RadioCard (SDK) spaces
+   itself via `.silo-radio-card + .silo-radio-card`; adding a flex gap here
+   would double up on that. */
+.am-options {
+  margin-top: 8px;
+}
+
+.am-sound-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.am-hours-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.am-hours-input {
+  width: 4em;
+}
+.am-hours-unit {
+  color: var(--silo-color-text-lo);
+}
+
+/* Agent views in the Navigator — all classes prefixed ap-; tokens
+   only. Root inherits the column font size from `.side-pane`, so no absolute
+   font-size here. Deliberately NOT its own scroll container: the host's
+   `.tab-pane` (the panel's scrolling ancestor) already scrolls, persists, and
+   styles scroll position for whatever renders inside it. Giving `.ap-body`
+   its own nested `overflow-y: auto` stacked TWO scrollable regions at the
+   same screen position — the outer `.tab-pane` (normally zero scroll range,
+   so its thumb renders full-track, looking "already at the bottom") and the
+   real one one level deeper that a real mouse/trackpad drag never reliably
+   reached. Letting `.tab-pane` be the sole scroller fixes that outright. */
+.ap-body {
+  padding: 4px 0;
+}
+.ap-empty {
+  padding: 12px;
+  color: var(--silo-color-text-lo);
+}
+.ap-section + .ap-section {
+  margin-top: 20px;
+}
+.ap-section-title {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  /* Left inset matches the view header's own padding (same base 12px as
+     `.ap-empty`), not `.ap-row`'s extra 4px hover-pill margin — headings
+     aren't interactive rows, so they align with the chrome above them
+     instead of with the rows below. */
+  padding: 4px 12px;
+  font-size: var(--silo-font-size-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--silo-color-text-lo);
+}
+.ap-section-caret {
+  flex-shrink: 0;
+  transition: transform 0.1s ease-out;
+}
+.ap-section-caret.expanded {
+  transform: rotate(90deg);
+}
+/* The heading is uppercase + letter-spaced; a count inside it isn't. Geometry
+   and color come from the kit's `size="sm"` chip. */
+.ap-section-count {
+  text-transform: none;
+  letter-spacing: normal;
+}
+.ap-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 12px;
+  /* Match WorkspacesView `.ws-item` inset so hover/active backgrounds don't
+     flush to the pane edges. */
+  margin: 0 4px 2px;
+  cursor: pointer;
+  border-radius: var(--silo-radius-sm);
+}
+.ap-row:hover {
+  background: var(--silo-color-bg-hover);
+}
+.ap-row.active {
+  background: var(--silo-color-bg-active);
+}
+.ap-row-glyph {
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+.ap-row-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.ap-row-title-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.ap-row-icon {
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  /* "Monotone" mode's color (unset when "color" mode overrides it inline) —
+     the middle text tier: lighter than text-hi (the title's own color, which
+     read too heavy for a small glyph) but still darker/more solid than
+     text-lo (the dimmer subtitle line, which read washed out). */
+  color: var(--silo-color-text);
+}
+.ap-row-title {
+  min-width: 0;
+  color: var(--silo-color-text-hi);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ap-row-subtitle {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+}
+.ap-row-workspace {
+  min-width: 0;
+  flex-shrink: 1;
+  color: var(--silo-color-text-lo);
+  font-size: var(--silo-font-size-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ap-row-sep {
+  flex-shrink: 0;
+  color: var(--silo-color-text-lo);
+  font-size: var(--silo-font-size-sm);
+}
+.ap-row-elapsed {
+  flex-shrink: 0;
+  color: var(--silo-color-text-lo);
+  font-size: var(--silo-font-size-sm);
+}
+/* The "Recent" view's drag affordance — only that view passes `drag` to
+   AgentRowItem, so this only ever appears there. Hidden until the row is
+   hovered, and pinned to the row's right edge via the auto margin rather
+   than a fixed position, so it still lines up if the row's content is
+   short. */
+.ap-row-grip {
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-left: 4px;
+  display: flex;
+  align-items: center;
+  color: var(--silo-color-text-lo);
+  opacity: 0;
+  cursor: grab;
+  /* The drag gesture starts here (pointerdown) rather than on the row as a
+     whole — without this, touch/trackpad input can try to scroll or
+     gesture-navigate before our own pointermove handler gets a chance. */
+  touch-action: none;
+}
+.ap-row:hover .ap-row-grip {
+  opacity: 1;
+}
+.ap-row-grip:active {
+  cursor: grabbing;
+}
+.ap-row-dragging {
+  opacity: 0.4;
+}
+/* Square corners deliberately, on both — a rounded border reads as another
+   row's outline; a plain straight rule reads as an insertion point.
+   `-before` is the common case (every insertion point except "at the very
+   end" has a next row to draw it above); `-after` only ever applies to the
+   section's last row, for that one remaining case — see the `insertAfter`
+   comment on `RowDrag` in agents-panel.tsx. */
+.ap-row-drop-target-before {
+  border-radius: 0;
+  border-top: 2px solid var(--silo-color-accent);
+  margin-top: -1px;
+}
+.ap-row-drop-target-after {
+  border-radius: 0;
+  border-bottom: 2px solid var(--silo-color-accent);
+  margin-bottom: -1px;
+}
+/* The floating "card" that follows the cursor during a drag — a cloned copy
+   of the real row (see `handleAgePointerDown` in agents-panel.tsx), repositioned
+   on every pointermove via inline `left`/`top` rather than a CSS transition,
+   since it needs to track the cursor exactly, not ease toward it. Needs its
+   own solid background because `.ap-row` itself only paints one on
+   hover/active — floating over the panel with no fill would look like
+   see-through text rather than a lifted card. `pointer-events: none` keeps
+   it out of the way of the row-rect hit-testing that drives the drop-target
+   detection. */
+.ap-row-ghost {
+  position: fixed;
+  z-index: 1000;
+  margin: 0;
+  pointer-events: none;
+  background: var(--silo-color-bg);
+  border-radius: var(--silo-radius-sm);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  opacity: 0.5;
+  cursor: grabbing;
+}
+.ap-row-ghost .ap-row-grip {
+  opacity: 1;
+}

--- a/packages/extensions-silo/src/agents/synth.ts
+++ b/packages/extensions-silo/src/agents/synth.ts
@@ -1,0 +1,595 @@
+/**
+ * A tiny self-contained Web Audio synth — no asset files, no dependencies.
+ * Replaces the `cuelume` package, which cached one `AudioContext` for the
+ * page's lifetime; in Silo's WKWebView shell that context can get stuck
+ * reporting "running" while producing no output once the window backgrounds
+ * (https://bugs.webkit.org/show_bug.cgi?id=231105), with no reliable way to
+ * detect or recover from outside the library. Creating a fresh, short-lived
+ * `AudioContext` per call and closing it when done sidesteps the bug by
+ * construction — there's no long-lived context left around to go stale.
+ *
+ * The recipe data and rendering approach (layered tone/noise sources into a
+ * shared soft delay/feedback "shimmer" send) are ported from cuelume
+ * (MIT licensed, https://github.com/Danilaa1/cuelume) — that curated palette
+ * is what actually sounds good; only the AudioContext lifecycle changed.
+ */
+
+export type SoundName =
+  | "chime"
+  | "sparkle"
+  | "droplet"
+  | "bloom"
+  | "whisper"
+  | "tick"
+  | "press"
+  | "release"
+  | "toggle"
+  | "success"
+  | "error"
+  | "page"
+  | "loading"
+  | "ready";
+
+interface ToneLayer {
+  kind: "tone";
+  waveform: OscillatorType;
+  frequency: number;
+  offset?: number;
+  attack: number;
+  decay: number;
+  peak: number;
+  detune?: number;
+  glideTo?: number;
+  glideTime?: number;
+}
+
+interface NoiseLayer {
+  kind: "noise";
+  filterType: BiquadFilterType;
+  filterFrequency: number;
+  filterQ?: number;
+  offset?: number;
+  attack: number;
+  decay: number;
+  peak: number;
+}
+
+type Layer = ToneLayer | NoiseLayer;
+
+interface Shimmer {
+  delay: number;
+  feedback: number;
+  wet: number;
+  lowpass: number;
+}
+
+interface Recipe {
+  masterGain: number;
+  layers: Layer[];
+  shimmer?: Shimmer;
+}
+
+const RECIPES: Record<SoundName, Recipe> = {
+  chime: {
+    masterGain: 0.5,
+    layers: [
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 1046.5,
+        attack: 0.006,
+        decay: 0.22,
+        peak: 0.09,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 1568,
+        offset: 0.09,
+        attack: 0.006,
+        decay: 0.26,
+        peak: 0.08,
+      },
+    ],
+    shimmer: { delay: 0.12, feedback: 0.25, wet: 0.18, lowpass: 4000 },
+  },
+  sparkle: {
+    masterGain: 0.5,
+    layers: [
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 1760,
+        offset: 0,
+        attack: 0.003,
+        decay: 0.09,
+        peak: 0.045,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 2217,
+        offset: 0.045,
+        attack: 0.003,
+        decay: 0.09,
+        peak: 0.04,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 2637,
+        offset: 0.09,
+        attack: 0.003,
+        decay: 0.1,
+        peak: 0.038,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 3520,
+        offset: 0.135,
+        attack: 0.003,
+        decay: 0.12,
+        peak: 0.032,
+      },
+    ],
+    shimmer: { delay: 0.07, feedback: 0.35, wet: 0.22, lowpass: 6000 },
+  },
+  droplet: {
+    masterGain: 0.55,
+    layers: [
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 1200,
+        glideTo: 550,
+        glideTime: 0.14,
+        attack: 0.004,
+        decay: 0.2,
+        peak: 0.075,
+      },
+    ],
+    shimmer: { delay: 0.09, feedback: 0.2, wet: 0.15, lowpass: 3000 },
+  },
+  bloom: {
+    masterGain: 0.5,
+    layers: [
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 528,
+        attack: 0.06,
+        decay: 0.32,
+        peak: 0.06,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 528,
+        detune: 12,
+        attack: 0.06,
+        decay: 0.34,
+        peak: 0.05,
+      },
+    ],
+    shimmer: { delay: 0.15, feedback: 0.2, wet: 0.12, lowpass: 2500 },
+  },
+  whisper: {
+    masterGain: 0.5,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "lowpass",
+        filterFrequency: 1200,
+        filterQ: 0.7,
+        attack: 0.04,
+        decay: 0.16,
+        peak: 0.05,
+      },
+    ],
+  },
+  tick: {
+    masterGain: 0.4,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 5400,
+        filterQ: 1.8,
+        attack: 0.001,
+        decay: 0.018,
+        peak: 0.14,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 2600,
+        attack: 0.001,
+        decay: 0.012,
+        peak: 0.018,
+      },
+    ],
+  },
+  press: {
+    masterGain: 0.4,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 1700,
+        filterQ: 1.4,
+        attack: 0.001,
+        decay: 0.02,
+        peak: 0.13,
+      },
+    ],
+  },
+  release: {
+    masterGain: 0.4,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 4600,
+        filterQ: 1.8,
+        attack: 0.001,
+        decay: 0.016,
+        peak: 0.12,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 3200,
+        offset: 0.006,
+        attack: 0.001,
+        decay: 0.05,
+        peak: 0.02,
+      },
+    ],
+  },
+  toggle: {
+    masterGain: 0.4,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 2200,
+        filterQ: 1.6,
+        attack: 0.001,
+        decay: 0.016,
+        peak: 0.12,
+      },
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 3800,
+        filterQ: 1.6,
+        offset: 0.024,
+        attack: 0.001,
+        decay: 0.02,
+        peak: 0.1,
+      },
+    ],
+  },
+  success: {
+    masterGain: 0.5,
+    layers: [
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 880,
+        attack: 0.004,
+        decay: 0.09,
+        peak: 0.06,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 1108.73,
+        offset: 0.06,
+        attack: 0.004,
+        decay: 0.1,
+        peak: 0.06,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 1318.51,
+        offset: 0.12,
+        attack: 0.004,
+        decay: 0.18,
+        peak: 0.07,
+      },
+    ],
+    shimmer: { delay: 0.1, feedback: 0.22, wet: 0.16, lowpass: 4500 },
+  },
+  error: {
+    masterGain: 0.42,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 850,
+        filterQ: 1.1,
+        attack: 0.001,
+        decay: 0.035,
+        peak: 0.13,
+      },
+      {
+        kind: "tone",
+        waveform: "triangle",
+        frequency: 440,
+        offset: 0.025,
+        attack: 0.004,
+        decay: 0.09,
+        peak: 0.045,
+      },
+      {
+        kind: "tone",
+        waveform: "triangle",
+        frequency: 349.23,
+        offset: 0.1,
+        attack: 0.004,
+        decay: 0.14,
+        peak: 0.04,
+      },
+    ],
+  },
+  page: {
+    masterGain: 0.38,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "lowpass",
+        filterFrequency: 1800,
+        filterQ: 0.7,
+        attack: 0.006,
+        decay: 0.08,
+        peak: 0.11,
+      },
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 4200,
+        filterQ: 1.2,
+        offset: 0.04,
+        attack: 0.004,
+        decay: 0.065,
+        peak: 0.08,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 2400,
+        offset: 0.075,
+        attack: 0.002,
+        decay: 0.045,
+        peak: 0.02,
+      },
+    ],
+  },
+  loading: {
+    masterGain: 0.42,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "lowpass",
+        filterFrequency: 1400,
+        filterQ: 0.6,
+        attack: 0.035,
+        decay: 0.14,
+        peak: 0.035,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 420,
+        glideTo: 630,
+        glideTime: 0.18,
+        attack: 0.025,
+        decay: 0.18,
+        peak: 0.05,
+      },
+    ],
+    shimmer: { delay: 0.11, feedback: 0.18, wet: 0.12, lowpass: 2800 },
+  },
+  ready: {
+    masterGain: 0.45,
+    layers: [
+      {
+        kind: "noise",
+        filterType: "bandpass",
+        filterFrequency: 3200,
+        filterQ: 1.7,
+        attack: 0.001,
+        decay: 0.018,
+        peak: 0.1,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 659.25,
+        offset: 0.025,
+        attack: 0.012,
+        decay: 0.2,
+        peak: 0.05,
+      },
+      {
+        kind: "tone",
+        waveform: "sine",
+        frequency: 987.77,
+        offset: 0.025,
+        attack: 0.012,
+        decay: 0.22,
+        peak: 0.035,
+      },
+    ],
+    shimmer: { delay: 0.13, feedback: 0.2, wet: 0.13, lowpass: 3600 },
+  },
+};
+
+const SOURCE_STOP_PADDING = 0.05;
+const CLEANUP_MARGIN = 0.05;
+const INAUDIBLE_GAIN = 0.001;
+
+export const sounds: readonly SoundName[] = Object.keys(RECIPES) as SoundName[];
+
+export function isSoundName(value: unknown): value is SoundName {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(RECIPES, value)
+  );
+}
+
+function renderTone(
+  context: AudioContext,
+  destination: AudioNode,
+  layer: ToneLayer,
+  startTime: number,
+): void {
+  const oscillator = context.createOscillator();
+  oscillator.type = layer.waveform;
+  oscillator.frequency.setValueAtTime(layer.frequency, startTime);
+  if (layer.detune) oscillator.detune.value = layer.detune;
+  if (layer.glideTo !== undefined) {
+    const glideTime = layer.glideTime ?? layer.attack + layer.decay;
+    oscillator.frequency.exponentialRampToValueAtTime(
+      layer.glideTo,
+      startTime + glideTime,
+    );
+  }
+  const gain = context.createGain();
+  gain.gain.setValueAtTime(0.0001, startTime);
+  gain.gain.exponentialRampToValueAtTime(layer.peak, startTime + layer.attack);
+  gain.gain.exponentialRampToValueAtTime(
+    0.0001,
+    startTime + layer.attack + layer.decay,
+  );
+  oscillator.connect(gain).connect(destination);
+  oscillator.start(startTime);
+  oscillator.stop(startTime + layer.attack + layer.decay + SOURCE_STOP_PADDING);
+}
+
+function renderNoise(
+  context: AudioContext,
+  destination: AudioNode,
+  layer: NoiseLayer,
+  startTime: number,
+): void {
+  const duration = layer.attack + layer.decay + SOURCE_STOP_PADDING;
+  const length = Math.max(1, Math.floor(duration * context.sampleRate));
+  const buffer = context.createBuffer(1, length, context.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < length; i++) data[i] = 2 * Math.random() - 1;
+  const source = context.createBufferSource();
+  source.buffer = buffer;
+  const filter = context.createBiquadFilter();
+  filter.type = layer.filterType;
+  filter.frequency.value = layer.filterFrequency;
+  if (layer.filterQ !== undefined) filter.Q.value = layer.filterQ;
+  const gain = context.createGain();
+  gain.gain.setValueAtTime(0.0001, startTime);
+  gain.gain.exponentialRampToValueAtTime(layer.peak, startTime + layer.attack);
+  gain.gain.exponentialRampToValueAtTime(
+    0.0001,
+    startTime + layer.attack + layer.decay,
+  );
+  source.connect(filter).connect(gain).connect(destination);
+  source.start(startTime);
+  source.stop(startTime + duration);
+}
+
+function attachShimmer(
+  context: AudioContext,
+  source: AudioNode,
+  destination: AudioNode,
+  shimmer: Shimmer,
+): void {
+  const delay = context.createDelay(1);
+  delay.delayTime.value = shimmer.delay;
+  const feedbackFilter = context.createBiquadFilter();
+  feedbackFilter.type = "lowpass";
+  feedbackFilter.frequency.value = shimmer.lowpass;
+  const feedbackGain = context.createGain();
+  feedbackGain.gain.value = shimmer.feedback;
+  const wetGain = context.createGain();
+  wetGain.gain.value = shimmer.wet;
+  source.connect(delay);
+  delay.connect(feedbackFilter);
+  feedbackFilter.connect(feedbackGain);
+  feedbackGain.connect(delay);
+  feedbackFilter.connect(wetGain);
+  wetGain.connect(destination);
+}
+
+function sourceEnd(recipe: Recipe): number {
+  return Math.max(
+    ...recipe.layers.map(
+      (layer) =>
+        (layer.offset ?? 0) + layer.attack + layer.decay + SOURCE_STOP_PADDING,
+    ),
+  );
+}
+
+function shimmerTail(shimmer: Shimmer | undefined): number {
+  if (!shimmer || shimmer.feedback <= 0) return 0;
+  if (shimmer.feedback >= 1) return shimmer.delay;
+  return (
+    shimmer.delay *
+    (1 + Math.ceil(Math.log(INAUDIBLE_GAIN) / Math.log(shimmer.feedback)))
+  );
+}
+
+/** Renders the recipe and returns how many ms to wait before it's safe to
+ * close the context (last source stopped, shimmer tail decayed below
+ * audibility). */
+function renderRecipe(context: AudioContext, recipe: Recipe): number {
+  const now = context.currentTime;
+  const master = context.createGain();
+  master.gain.value = recipe.masterGain;
+  master.connect(context.destination);
+  if (recipe.shimmer)
+    attachShimmer(context, master, context.destination, recipe.shimmer);
+
+  for (const layer of recipe.layers) {
+    const startTime = now + (layer.offset ?? 0);
+    if (layer.kind === "tone") renderTone(context, master, layer, startTime);
+    else renderNoise(context, master, layer, startTime);
+  }
+
+  return (
+    (sourceEnd(recipe) + shimmerTail(recipe.shimmer) + CLEANUP_MARGIN) * 1000
+  );
+}
+
+/**
+ * Plays a sound immediately on a fresh `AudioContext`, closed once it's done
+ * rendering. Safe to call from anywhere, including a still-backgrounded
+ * window — a no-op when Web Audio is unavailable (SSR, old browsers) or the
+ * sound name is unknown.
+ */
+export function play(soundId: SoundName): void {
+  if (typeof window === "undefined" || !isSoundName(soundId)) return;
+  const Ctor =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+  if (!Ctor) return;
+
+  let ctx: AudioContext;
+  try {
+    ctx = new Ctor();
+  } catch {
+    return;
+  }
+  const recipe = RECIPES[soundId];
+  const start = (): void => {
+    const cleanupAfterMs = renderRecipe(ctx, recipe);
+    setTimeout(() => void ctx.close().catch(() => {}), cleanupAfterMs);
+  };
+  if (ctx.state === "running") {
+    start();
+  } else {
+    ctx.resume().then(start, () => void ctx.close().catch(() => {}));
+  }
+}

--- a/packages/extensions-silo/src/index.ts
+++ b/packages/extensions-silo/src/index.ts
@@ -17,3 +17,4 @@ export { extension as fileSearch } from "./file-search";
 export { extension as git } from "./git";
 export { extension as gitExplorer } from "./git-explorer";
 export { extension as themePresets } from "./theme-presets";
+export { extension as agents } from "./agents";


### PR DESCRIPTION
## Summary

- Bundle the former third-party Agent Monitor as built-in `silo.agents` (Navigator view, status rows, tab badges/icons, sound).
- Migrate `silo.agent-monitor` transparently: `globalExtensionState`, navigator view ids, disabled builtins, and on-disk installs (with toast).
- Merge Agents settings into one Application-rail page with **Options** + **Hooks** tabs; `silo.agents` publishes `OptionsPanel` via `getExtension` (git-explorer pattern). Hooks live in `AgentsHooksPanel.tsx` for the upcoming agent-catalog merge.

## Test plan

- [ ] Fresh install: Agents Navigator view, status rows, and tab decorations work
- [ ] Settings → Agents: Options | Hooks tabs; Options shows focus/icons/sound + hide-glyphs at bottom
- [ ] Upgrade path: existing `silo.agent-monitor` on-disk install retires with toast; settings preserved
- [ ] Extensions Browse: neither `silo.agent-monitor` nor `silo.agents` offered for install
- [ ] `silo.agents` disabled: Options tab shows hide-glyphs only; Hooks unchanged


Made with [Cursor](https://cursor.com)