### PR TITLE
feat(git-explorer): auto-refresh commits list and add manual refresh

### DIFF
--- a/packages/extensions-silo/src/git-explorer/CommitDetailView.tsx
+++ b/packages/extensions-silo/src/git-explorer/CommitDetailView.tsx
@@ -7,6 +7,7 @@ import type {
   GitAPI,
 } from "@silo-code/git-api";
 import { resolveDiffBase } from "../git/parse-commit-files";
+import { formatAuthorDate } from "./commit-list-model";
 import { ICON_OPEN } from "./git-icons";
 
 function statusGlyph(status: CommitFileChange["status"]): string {
@@ -103,7 +104,9 @@ export function CommitDetailView({
         )}
         <div className="git-commit-detail-meta">
           <span>{detail.author}</span>
-          <span>{detail.relativeDate}</span>
+          <Tooltip content={formatAuthorDate(detail.authorDate)}>
+            <span>{detail.relativeDate}</span>
+          </Tooltip>
           <code>{detail.shortHash}</code>
         </div>
       </div>

--- a/packages/extensions-silo/src/git-explorer/CommitListView.tsx
+++ b/packages/extensions-silo/src/git-explorer/CommitListView.tsx
@@ -5,6 +5,7 @@ import type { GitAPI, GitLogEntry, GitStatus } from "@silo-code/git-api";
 import {
   dividerIndex,
   displayDividerIndex,
+  formatAuthorDate,
   orderedCommits,
   type CommitOrder,
   type UnpushedSet,
@@ -20,23 +21,36 @@ const PAGE_SIZE = 50;
  * parent (its toggle button lives in `GitView`'s shared subview header, next
  * to Back/title). Reads `status` live from the parent (not a snapshot taken
  * when the view opened), so a branch switch underfoot just re-fetches in
- * place. */
+ * place.
+ *
+ * Also refetches when `status.headSha` moves — a new commit, pull, rebase, or
+ * checkout on this folder — so the list stays current without polling `log`
+ * on every status refresh (see `GitStatus.headSha`'s doc comment). `refreshKey`
+ * is the manual escape hatch: bump it (e.g. from a "Refresh" button) to force
+ * a refetch even when `headSha` hasn't changed. */
 export function CommitListView({
   ctx,
   folder,
   status,
   order,
+  refreshKey,
   onTotalCountChange,
+  onLoadingChange,
   onSelectCommit,
 }: {
   ctx: ExtensionContext;
   folder: string;
   status: GitStatus;
   order: CommitOrder;
+  /** Bump to force a refetch regardless of whether `status.headSha` changed. */
+  refreshKey: number;
   /** Reports the exact total once resolved (see `GitAPI.commitCount`), for
    * the parent's "Commits (N)" header — independent of how many rows are
    * currently paged in. */
   onTotalCountChange?: (count: number | null) => void;
+  /** Mirrors the main fetch's loading state, for a parent "Refresh" button's
+   * spin indicator. */
+  onLoadingChange?: (loading: boolean) => void;
   onSelectCommit: (hash: string) => void;
 }) {
   const [commits, setCommits] = useState<GitLogEntry[]>([]);
@@ -88,7 +102,15 @@ export function CommitListView({
     return () => {
       cancelled = true;
     };
-  }, [ctx, folder, branchBase, baseResolved, onTotalCountChange]);
+  }, [
+    ctx,
+    folder,
+    branchBase,
+    baseResolved,
+    status.headSha,
+    refreshKey,
+    onTotalCountChange,
+  ]);
 
   useEffect(() => {
     const api = ctx.getExtension<GitAPI>("silo.git")?.api;
@@ -133,9 +155,15 @@ export function CommitListView({
     limit,
     status.branch,
     status.upstream,
+    status.headSha,
+    refreshKey,
     branchBase,
     baseResolved,
   ]);
+
+  useEffect(() => {
+    onLoadingChange?.(loading);
+  }, [loading, onLoadingChange]);
 
   function copyHash(hash: string) {
     void navigator.clipboard.writeText(hash);
@@ -199,7 +227,9 @@ export function CommitListView({
             </div>
             <div className="git-commit-meta">
               <span className="git-commit-author">{c.author}</span>
-              <span className="git-commit-date">{c.relativeDate}</span>
+              <Tooltip content={formatAuthorDate(c.authorDate)}>
+                <span className="git-commit-date">{c.relativeDate}</span>
+              </Tooltip>
               <span className="git-commit-files">
                 {c.filesChanged} file{c.filesChanged === 1 ? "" : "s"}
               </span>

--- a/packages/extensions-silo/src/git-explorer/CommitsTakeover.tsx
+++ b/packages/extensions-silo/src/git-explorer/CommitsTakeover.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useState } from "react";
 import {
+  ArrowsClockwise,
   CaretLeft,
   SortAscending,
   SortDescending,
@@ -45,6 +46,10 @@ export function CommitsTakeover({
   // Exact total for the tools-row count — reported by CommitListView once it
   // resolves (see GitAPI.commitCount), independent of how many rows are paged in.
   const [commitsTotal, setCommitsTotal] = useState<number | null>(null);
+  // Bumped by the "Refresh" button to force CommitListView to refetch even
+  // when status.headSha hasn't moved (e.g. retrying after an error).
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
   // The detail pane needs a hash to render even while it's parked off-screen
   // (e.g. sliding out after Back) — keep the last one shown so it doesn't
   // blank mid-animation.
@@ -98,6 +103,16 @@ export function CommitsTakeover({
               {commitsTotal !== null && (
                 <span className="git-takeover-count">{commitsTotal}</span>
               )}
+              <Tooltip content="Refresh">
+                <button
+                  className={`row-action refresh-btn${refreshing ? " working" : ""}`}
+                  onClick={
+                    refreshing ? undefined : () => setRefreshKey((k) => k + 1)
+                  }
+                >
+                  <ArrowsClockwise size={14} />
+                </button>
+              </Tooltip>
               <Tooltip
                 content={
                   commitOrder === "oldestFirst"
@@ -138,7 +153,9 @@ export function CommitsTakeover({
               folder={folder}
               status={status}
               order={commitOrder}
+              refreshKey={refreshKey}
               onTotalCountChange={setCommitsTotal}
+              onLoadingChange={setRefreshing}
               onSelectCommit={(hash) =>
                 viewStack.push({ kind: "commit-detail", hash })
               }

--- a/packages/extensions-silo/src/git-explorer/commit-list-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/commit-list-model.test.ts
@@ -3,6 +3,7 @@ import type { GitLogEntry } from "../git/git-api";
 import {
   dividerIndex,
   displayDividerIndex,
+  formatAuthorDate,
   orderedCommits,
 } from "./commit-list-model";
 
@@ -12,6 +13,7 @@ function entry(hash: string): GitLogEntry {
     shortHash: hash.slice(0, 7),
     author: "a",
     relativeDate: "now",
+    authorDate: "2026-01-01T00:00:00Z",
     subject: hash,
   };
 }
@@ -75,5 +77,18 @@ describe("displayDividerIndex", () => {
   it("stays -1 (no divider) regardless of order", () => {
     expect(displayDividerIndex(-1, commits.length, "newestFirst")).toBe(-1);
     expect(displayDividerIndex(-1, commits.length, "oldestFirst")).toBe(-1);
+  });
+});
+
+describe("formatAuthorDate", () => {
+  it("formats a valid ISO date into a locale date/time string", () => {
+    const formatted = formatAuthorDate("2026-03-05T14:30:00Z");
+    expect(formatted).not.toBe("2026-03-05T14:30:00Z");
+    expect(formatted).toContain("2026");
+  });
+
+  it("returns the raw string unchanged when it doesn't parse as a date", () => {
+    expect(formatAuthorDate("")).toBe("");
+    expect(formatAuthorDate("not-a-date")).toBe("not-a-date");
   });
 });

--- a/packages/extensions-silo/src/git-explorer/commit-list-model.ts
+++ b/packages/extensions-silo/src/git-explorer/commit-list-model.ts
@@ -46,3 +46,20 @@ export function displayDividerIndex(
   if (canonicalIndex === -1) return -1;
   return order === "oldestFirst" ? total - canonicalIndex : canonicalIndex;
 }
+
+/**
+ * Formats a commit's {@link GitLogEntry.authorDate} (ISO 8601) into a
+ * locale-formatted absolute date/time — the tooltip counterpart to
+ * {@link GitLogEntry.relativeDate}, which is only accurate as of when it was
+ * fetched and reads increasingly wrong sitting in a list between refreshes.
+ * Returns the raw string unchanged if it doesn't parse as a date (e.g. a
+ * hand-built `GitAPI` test stub that leaves it empty).
+ */
+export function formatAuthorDate(authorDate: string): string {
+  const date = new Date(authorDate);
+  if (Number.isNaN(date.getTime())) return authorDate;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}

--- a/packages/extensions-silo/src/git/git-service.test.ts
+++ b/packages/extensions-silo/src/git/git-service.test.ts
@@ -942,6 +942,7 @@ describe("GitService.status against a rejecting exec (e.g. missing cwd)", () => 
       files: [],
       inRepo: false,
       missing: true,
+      headSha: null,
     });
   });
 
@@ -973,6 +974,7 @@ describe("GitService.status against a rejecting exec (e.g. missing cwd)", () => 
       files: [],
       inRepo: false,
       missing: true,
+      headSha: null,
     });
   });
 

--- a/packages/extensions-silo/src/git/git-service.ts
+++ b/packages/extensions-silo/src/git/git-service.ts
@@ -51,6 +51,7 @@ function missingStatus(): GitStatus {
     files: [],
     inRepo: false,
     missing: true,
+    headSha: null,
   };
 }
 
@@ -63,23 +64,27 @@ function notARepoStatus(): GitStatus {
     behind: 0,
     files: [],
     inRepo: false,
+    headSha: null,
   };
 }
 
-/** Parses `git log --pretty=format:%H%x09%h%x09%an%x09%ar%x09%s --numstat
- * [--diff-merges=first-parent]` output — the file lines under each header
- * count that commit's `filesChanged`, with no extra request per commit. */
+/** Parses `git log --pretty=format:%H%x09%h%x09%an%x09%ar%x09%aI%x09%s
+ * --numstat [--diff-merges=first-parent]` output — the file lines under each
+ * header count that commit's `filesChanged`, with no extra request per
+ * commit. */
 function parseLog(raw: string): GitLogEntry[] {
   const entries: GitLogEntry[] = [];
   let current: GitLogEntry | null = null;
   for (const line of raw.split("\n")) {
     if (LOG_HEADER_RE.test(line)) {
-      const [hash, shortHash, author, relativeDate, ...rest] = line.split(TAB);
+      const [hash, shortHash, author, relativeDate, authorDate, ...rest] =
+        line.split(TAB);
       current = {
         hash: hash ?? "",
         shortHash: shortHash ?? "",
         author: author ?? "",
         relativeDate: relativeDate ?? "",
+        authorDate: authorDate ?? "",
         subject: rest.join(TAB),
         filesChanged: 0,
       };
@@ -145,7 +150,7 @@ export function createGitService(exec: ExecFn): Omit<GitAPI, "watchRepo"> {
     async log(cwd, limit = 50, base) {
       const { stdout, code } = await git(cwd, [
         "log",
-        "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%s",
+        "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%aI%x09%s",
         "--numstat",
         "--diff-merges=first-parent",
         `-${limit}`,
@@ -280,7 +285,7 @@ export function createGitService(exec: ExecFn): Omit<GitAPI, "watchRepo"> {
       for (const range of ranges) {
         const { stdout, code } = await git(cwd, [
           "log",
-          "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%s",
+          "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%aI%x09%s",
           range,
         ]);
         if (code === 0) return parseLog(stdout);
@@ -343,7 +348,7 @@ export function createGitService(exec: ExecFn): Omit<GitAPI, "watchRepo"> {
       const { stdout: metaLine, code: metaCode } = await git(cwd, [
         "show",
         "-s",
-        "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%P%x09%s%x09%b",
+        "--pretty=format:%H%x09%h%x09%an%x09%ar%x09%aI%x09%P%x09%s%x09%b",
         hash,
       ]);
       if (metaCode !== 0 || !metaLine) return null;
@@ -352,6 +357,7 @@ export function createGitService(exec: ExecFn): Omit<GitAPI, "watchRepo"> {
         shortHash,
         author,
         relativeDate,
+        authorDate,
         parentsRaw,
         subject,
         ...bodyParts
@@ -388,6 +394,7 @@ export function createGitService(exec: ExecFn): Omit<GitAPI, "watchRepo"> {
         shortHash: shortHash ?? "",
         author: author ?? "",
         relativeDate: relativeDate ?? "",
+        authorDate: authorDate ?? "",
         subject: subject ?? "",
         filesChanged: files.length,
         body: bodyParts.join(TAB).trim(),

--- a/packages/extensions-silo/src/git/parse-status.test.ts
+++ b/packages/extensions-silo/src/git/parse-status.test.ts
@@ -23,7 +23,13 @@ describe("parseGitStatus", () => {
       behind: 0,
       files: [],
       inRepo: true,
+      headSha: "393176cf9883e90ad8c21384332b312aa7c736aa",
     });
+  });
+
+  it("reports headSha as null for a fresh repo with no commits yet", () => {
+    const raw = ["# branch.oid (initial)", "# branch.head main", ""].join("\n");
+    expect(parseGitStatus(raw).headSha).toBeNull();
   });
 
   it("decodes staged, modified, untracked, and renamed entries together", () => {

--- a/packages/extensions-silo/src/git/parse-status.ts
+++ b/packages/extensions-silo/src/git/parse-status.ts
@@ -24,11 +24,16 @@ export function parseGitStatus(raw: string): GitStatus {
   let upstream: string | null = null;
   let ahead = 0;
   let behind = 0;
+  let headSha: string | null = null;
   const files: GitFileStatus[] = [];
 
   for (const line of raw.split("\n")) {
     if (!line) continue;
-    if (line.startsWith("# branch.head")) {
+    if (line.startsWith("# branch.oid")) {
+      // `(initial)` on a fresh repo with no commits — HEAD resolves to nothing.
+      const oid = line.replace("# branch.oid ", "").trim();
+      headSha = oid === "(initial)" ? null : oid;
+    } else if (line.startsWith("# branch.head")) {
       branch = line.replace("# branch.head ", "").trim();
     } else if (line.startsWith("# branch.upstream")) {
       upstream = line.replace("# branch.upstream ", "").trim();
@@ -83,5 +88,5 @@ export function parseGitStatus(raw: string): GitStatus {
       });
     }
   }
-  return { branch, upstream, ahead, behind, files, inRepo: true };
+  return { branch, upstream, ahead, behind, files, inRepo: true, headSha };
 }

--- a/packages/git-api/src/git-api.ts
+++ b/packages/git-api/src/git-api.ts
@@ -41,6 +41,15 @@ export interface GitStatus {
    * `inRepo: false`.
    */
   missing?: boolean;
+  /**
+   * The commit `HEAD` currently resolves to (`git status`'s `# branch.oid`
+   * line — `null` for a fresh repo with no commits yet). A free byproduct of
+   * the same porcelain-v2 status parse, not an extra `rev-parse` call. Lets a
+   * consumer notice a new commit landing (or a checkout/pull/rebase moving
+   * `HEAD`) by diffing this against the previous value, instead of re-running
+   * `log`/`commitCount` on every status refresh — see the commits view.
+   */
+  headSha?: string | null;
 }
 
 /** One commit, as listed by {@link GitAPI.log}. */
@@ -49,6 +58,15 @@ export interface GitLogEntry {
   shortHash: string;
   author: string;
   relativeDate: string;
+  /**
+   * Author date in strict ISO 8601 (`git log`'s `%aI`), e.g.
+   * `2026-08-26T09:15:00-04:00`. Absolute counterpart to
+   * {@link GitLogEntry.relativeDate} — for a tooltip showing the real
+   * date/time, since a relative string like "3 minutes ago" is only accurate
+   * as of when it was fetched and goes stale sitting in a list that isn't
+   * re-fetched every second.
+   */
+  authorDate: string;
   subject: string;
   /**
    * Number of files this commit touched — a merge commit's count is relative


### PR DESCRIPTION
## Summary

The Git panel's "View Commits" list never noticed new commits landing — a
pull, a commit from another terminal, or an agent — until you closed and
reopened it. This adds:

1. A manual **Refresh** button in the commits toolbar.
2. Automatic refresh: the list now updates itself whenever the branch's
   `HEAD` moves (new commit, pull, rebase, checkout), with no extra polling.
3. Commit row dates now show a tooltip with the exact date/time on hover,
   since the relative "3 minutes ago" text is only accurate as of when the
   list was last fetched and goes stale sitting on screen between refreshes.

## Details

### Auto-refresh mechanism

`GitStatus` gains a `headSha` field, parsed for free off the `# branch.oid`
line already present in `git status --porcelain=v2 -b` output — no extra
process spawn. `CommitListView`'s fetch effects now depend on
`status.headSha`, so a commit refetches the list without any new file
watcher: the existing repo-wide watch session (ADR 0037) already re-runs
`status()` on any change under the repo (confirmed `.git` isn't excluded from
that watch), which now surfaces as a `headSha` change that the commits view
reacts to.

A `refreshKey` prop on `CommitListView` is the manual escape hatch — the new
"Refresh" button in `CommitsTakeover` bumps it to force a refetch regardless
of whether `headSha` changed (e.g. retrying after a transient error).

### Absolute-date tooltip

`GitLogEntry` gains `authorDate` (ISO 8601, via `git log`'s `%aI`), threaded
through `log()`, `unmergedCommits()`, and `commitDetail()`. A new pure
`formatAuthorDate()` helper in `commit-list-model.ts` formats it via
`Intl.DateTimeFormat` for the `Tooltip` wrapping each row's relative-date
label, in both `CommitListView` and `CommitDetailView`.

### Test plan

- Unit tests added/updated: `parse-status.test.ts` (headSha parsing,
  including the `(initial)` no-commits-yet case), `git-service.test.ts`
  (missing/not-a-repo status shapes), `commit-list-model.test.ts`
  (`formatAuthorDate` contract + fallback on unparseable input).
- `pnpm --filter silo exec tsc --noEmit`, `pnpm test`, `pnpm lint` all green.
- Manually verified live in a running dev instance via the automation
  bridge: committed a file from a terminal outside the app and confirmed the
  commits list + count updated within ~3s with no click; clicked the new
  Refresh button and confirmed no error.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WeSthSHdbGFCXpNimfEPUC