### PR TITLE
feat(agents): add OpenCode's in-app brand icon

### DIFF
--- a/docs/adding-a-coding-agent.md
+++ b/docs/adding-a-coding-agent.md
@@ -236,6 +236,14 @@ The catalog can't reach these; grep for an existing agent's name to find them al
   `docsUrl`.
 - `apps/docs/index.md` and `apps/website/src/homepage-copy.ts` — the "works
   with" line and the trust band (`AgentIconId` + an icon).
+- `packages/extensions-silo/src/agents/agent-icons.ts` — the **in-app** brand
+  mark, a separate icon from the marketing site's, shown in the Agents panel
+  and on CenterDock terminal tabs (`AgentIconGlyph.tsx`). Add an
+  `AGENT_ICONS[id]` entry (title, light/dark hex, single `0 0 24 24` SVG
+  path) even when the catalog entry is detection-only (Tier 1/2, no resume) —
+  the icon isn't gated on resume support. Easy to miss because nothing fails
+  loudly without it: `agentIconFor` just returns `undefined` and the row
+  renders with no icon.
 - `docs/domain-language.md` — if the agent introduces a new concept (a new
   resume kind, a new install strategy), the glossary changes with it.
 - An ADR or RFC only if you added a **mechanism** (a new resume kind, a new
@@ -250,6 +258,7 @@ The catalog can't reach these; grep for an existing agent's name to find them al
 - [ ] Unit tests: catalog integrity, detector goldens, resume command
 - [ ] `agent-sessions.md` section + matching `docsUrl` anchor
 - [ ] Website / docs "works with" lists and icon
+- [ ] In-app icon: `agent-icons.ts` entry (separate from the website's)
 - [ ] `pnpm lint`, `pnpm test`, `pnpm --filter silo exec tsc --noEmit` green
 - [ ] Verified in the real app: agent shows in Settings → Agents, tab dot
       tracks a turn, resume command copies and works after a restart

--- a/packages/extensions-silo/src/agents/AgentIconGlyph.tsx
+++ b/packages/extensions-silo/src/agents/AgentIconGlyph.tsx
@@ -12,6 +12,10 @@ import { agentIconFor } from "./agent-icons";
  * sets on an ancestor (the Agents panel points it at `--silo-color-text-hi`;
  * the CenterDock tab is sized/positioned entirely by host chrome, which also
  * supplies its own icon color via `currentColor` inheritance).
+ *
+ * Marks whose source design is duotone (OpenCode's frame-plus-panel) layer a
+ * second, 40%-opacity `accentPath` on top of the primary `path` rather than
+ * flattening both into one flat-color fill, which loses the panel entirely.
  */
 export function AgentIconGlyph({
   agentId,
@@ -39,6 +43,14 @@ export function AgentIconGlyph({
       aria-hidden="true"
     >
       <path d={icon.path} fill="currentColor" fillRule={icon.fillRule} />
+      {icon.accentPath && (
+        <path
+          d={icon.accentPath}
+          fill="currentColor"
+          fillRule={icon.accentFillRule}
+          opacity={0.4}
+        />
+      )}
     </svg>
   );
 }

--- a/packages/extensions-silo/src/agents/agent-icons.test.ts
+++ b/packages/extensions-silo/src/agents/agent-icons.test.ts
@@ -13,10 +13,11 @@ describe("agentIconFor", () => {
     expect(agentIconFor("codex")).toMatchObject({ title: "Codex" });
     expect(agentIconFor("grok")).toMatchObject({ title: "Grok" });
     expect(agentIconFor("pi")).toMatchObject({ title: "pi" });
+    expect(agentIconFor("opencode")).toMatchObject({ title: "OpenCode" });
   });
 
   it("flips genuinely-black marks to white for dark themes, but not colors with real contrast on both", () => {
-    for (const id of ["cursor", "copilot", "grok", "pi"]) {
+    for (const id of ["cursor", "copilot", "grok", "pi", "opencode"]) {
       const icon = agentIconFor(id);
       expect(icon?.hexLight).toBe("000000");
       expect(icon?.hexDark).toBe("FFFFFF");
@@ -30,6 +31,7 @@ describe("agentIconFor", () => {
   it("marks the icons whose path assumes evenodd fill, and only those", () => {
     expect(agentIconFor("codex")?.fillRule).toBe("evenodd");
     expect(agentIconFor("grok")?.fillRule).toBe("evenodd");
+    expect(agentIconFor("opencode")?.fillRule).toBe("evenodd");
     expect(agentIconFor("claude")?.fillRule).toBeUndefined();
     expect(agentIconFor("cursor")?.fillRule).toBeUndefined();
     expect(agentIconFor("copilot")?.fillRule).toBeUndefined();
@@ -39,5 +41,12 @@ describe("agentIconFor", () => {
   it("returns undefined for an unknown or missing id", () => {
     expect(agentIconFor("not-a-real-agent")).toBeUndefined();
     expect(agentIconFor(undefined)).toBeUndefined();
+  });
+
+  it("gives opencode a duotone accentPath, and only opencode", () => {
+    expect(agentIconFor("opencode")?.accentPath).toBeTruthy();
+    for (const id of ["claude", "cursor", "copilot", "codex", "grok", "pi"]) {
+      expect(agentIconFor(id)?.accentPath).toBeUndefined();
+    }
   });
 });

--- a/packages/extensions-silo/src/agents/agent-icons.ts
+++ b/packages/extensions-silo/src/agents/agent-icons.ts
@@ -13,6 +13,13 @@
  * - pi: no icon pack carries a mark for it. Reuses the geometric π glyph
  *   already drawn for it on the marketing site (`apps/website/src/App.tsx`,
  *   xerro-edit) — three bars/legs plus a curled tail, combined into one path.
+ * - opencode: no icon pack carries a mark for it either. Reuses OpenCode's
+ *   official portrait-frame mark, the same one drawn for the marketing site
+ *   (`apps/website/src/App.tsx`'s `OpencodeIcon`, sourced from paseo.sh) —
+ *   uniformly rescaled from that component's `96 64 288 384` viewBox into
+ *   this file's `0 0 24 24` convention. Its two source layers (an opaque
+ *   border-plus-window frame, and a translucent inner panel) map directly
+ *   onto {@link AgentIcon.path}/{@link AgentIcon.accentPath}.
  */
 
 export interface AgentIcon {
@@ -39,6 +46,14 @@ export interface AgentIcon {
    * default (`nonzero`). Getting this wrong renders solid over what should be
    * a cut-out hole in the glyph. */
   fillRule?: "evenodd";
+  /** A second SVG path (same viewBox) layered on top of {@link path} at 40%
+   * opacity, for a source mark that is genuinely duotone rather than flat —
+   * OpenCode's mark is a border plus a lighter inner panel. Omit for a flat
+   * single-tone mark; flattening a duotone source into one solid fill loses
+   * the panel and reads as a plain notched shape rather than a frame. */
+  accentPath?: string;
+  /** `fill-rule` for {@link accentPath}, independent of {@link fillRule}. */
+  accentFillRule?: "evenodd";
 }
 
 const AGENT_ICONS: Record<string, AgentIcon> = {
@@ -79,6 +94,14 @@ const AGENT_ICONS: Record<string, AgentIcon> = {
     hexLight: "000000",
     hexDark: "FFFFFF",
     path: "M4.5,5.4 H19.5 A1.3,1.3 0 0 1 20.8,6.7 A1.3,1.3 0 0 1 19.5,8 H4.5 A1.3,1.3 0 0 1 3.2,6.7 A1.3,1.3 0 0 1 4.5,5.4 Z M7.9,8 A1.3,1.3 0 0 1 9.2,9.3 V18.1 A1.3,1.3 0 0 1 7.9,19.4 A1.3,1.3 0 0 1 6.6,18.1 V9.3 A1.3,1.3 0 0 1 7.9,8 Z M16.1,8 A1.3,1.3 0 0 1 17.4,9.3 V15.9 A1.3,1.3 0 0 1 16.1,17.2 A1.3,1.3 0 0 1 14.8,15.9 V9.3 A1.3,1.3 0 0 1 16.1,8 Z M14.8 15.6h2.6a2.6 2.6 0 0 0 2.6 2.6v2.6a5.2 5.2 0 0 1-5.2-5.2z",
+  },
+  opencode: {
+    title: "OpenCode",
+    hexLight: "000000",
+    hexDark: "FFFFFF",
+    fillRule: "evenodd",
+    path: "M20.8 23H3.2V1H20.8V23ZM16.4 5.4H7.6V18.6H16.4V5.4Z",
+    accentPath: "M16.4 9.8V18.6H7.6V9.8H16.4Z",
   },
 };
 


### PR DESCRIPTION
## Summary

OpenCode got added as a supported agent (detection + the marketing site's icon), but the icon shown in Silo's own Agents panel and terminal tabs was missed — it lives in a separate file from the website's. This adds it, and updates the "adding a coding agent" doc so the in-app icon isn't skipped again next time.

## Details

- `packages/extensions-silo/src/agents/agent-icons.ts`: added an `opencode` entry to `AGENT_ICONS`, reusing OpenCode's official portrait-frame mark already drawn for the marketing site (`apps/website/src/App.tsx`'s `OpencodeIcon`), rescaled into this file's `0 0 24 24` convention.
- `packages/extensions-silo/src/agents/AgentIconGlyph.tsx`: added an optional `accentPath` layer (rendered at 40% opacity) to `AgentIcon`/`AgentIconGlyph`, since OpenCode's mark is genuinely duotone (a border-plus-window frame with a lighter inner panel) — flattening it into one solid fill lost the panel and read as a plain notched block rather than a frame. Verified against the website's source render via ImageMagick before landing on this shape.
- `agent-icons.test.ts`: covers the new `opencode` entry (title, black/white flip, evenodd fill rule) and that `accentPath` is set only for `opencode`.
- `docs/adding-a-coding-agent.md`: Step 8 and the checklist now call out `agent-icons.ts` explicitly as a separate, easy-to-miss surface from the website's icon — it isn't gated on resume support, and a missing entry fails silently (no icon shown, no error).

### Test plan

- [x] `pnpm --filter @silo-code/extensions-silo test` — 544/544 passing
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] Rendered the old (flattened) and new (duotone) icon against the website's source SVG with ImageMagick to confirm visual parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWzX3LAGj6CEcyXNfzzFJZ