### PR TITLE
feat(terminal): drop redundant agent-name prefix from tab titles when the icon already shows it

### DIFF
--- a/packages/extension-host/src/extension-host/agent-catalog.test.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.test.ts
@@ -25,6 +25,7 @@ import {
   detectFromOsc,
   detectIdleAfterWorking,
   detectFromOutput,
+  stripAgentTitleIdentityPrefix,
 } from "./agent-catalog";
 
 describe("leaderBasename — Windows executable names (RFC: Windows agents)", () => {
@@ -88,6 +89,14 @@ describe("catalog integrity", () => {
           `^sh "\\$HOME/${TRACK_SCRIPT_REL}" ${a.id} # ${SILO_HOOK_MARKER}$`,
         ),
       );
+    }
+  });
+
+  it("titleIdentityPrefix, where present, is a non-empty literal", () => {
+    for (const a of AGENT_CATALOG) {
+      if (a.titleIdentityPrefix !== undefined) {
+        expect(a.titleIdentityPrefix.length).toBeGreaterThan(0);
+      }
     }
   });
 
@@ -517,6 +526,38 @@ describe("agentById", () => {
 
   it("returns undefined for an unknown id", () => {
     expect(agentById("nope")).toBeUndefined();
+  });
+});
+
+describe("stripAgentTitleIdentityPrefix", () => {
+  it("strips pi's and OpenCode's redundant identity prefix", () => {
+    expect(stripAgentTitleIdentityPrefix("pi", "π - notes - xerro-edit")).toBe(
+      "notes - xerro-edit",
+    );
+    expect(
+      stripAgentTitleIdentityPrefix("opencode", "OC | Silo Tasks Extension"),
+    ).toBe("Silo Tasks Extension");
+  });
+
+  it("leaves the title alone for an agent with no titleIdentityPrefix", () => {
+    expect(
+      stripAgentTitleIdentityPrefix("claude", "✳ Fix the flaky test"),
+    ).toBe("✳ Fix the flaky test");
+  });
+
+  it("leaves the title alone when it doesn't actually lead with the prefix", () => {
+    expect(stripAgentTitleIdentityPrefix("pi", "xerro-edit")).toBe(
+      "xerro-edit",
+    );
+  });
+
+  it("leaves the title alone for an unknown or missing agentId", () => {
+    expect(stripAgentTitleIdentityPrefix("not-a-real-agent", "π - notes")).toBe(
+      "π - notes",
+    );
+    expect(stripAgentTitleIdentityPrefix(undefined, "π - notes")).toBe(
+      "π - notes",
+    );
   });
 });
 

--- a/packages/extension-host/src/extension-host/agent-catalog.ts
+++ b/packages/extension-host/src/extension-host/agent-catalog.ts
@@ -299,6 +299,19 @@ export interface AgentDefinition {
    * yet read this agent's activity (it still appears via `ctx.processes`
    * leader/cwd facts, just with no `working`/`idle` state). */
   activityDetectors: OscDetector[];
+  /**
+   * A literal prefix this agent's own OSC 0 title carries that is purely
+   * self-identification (pi's `"π - "`, OpenCode's `"OC | "`) — redundant
+   * once the tab is already showing that agent's icon, since the icon says
+   * the same thing visually. `core.terminal` strips it via
+   * {@link stripAgentTitleIdentityPrefix}, and only when
+   * `ctx.terminals.getIcons` confirms an icon is actually rendered for that
+   * tab; left alone otherwise; the prefix is then the tab's only identity
+   * signal. Undefined for every agent whose title doesn't lead with its own
+   * name (most don't — Claude's spinner/idle marker is a status signal, not
+   * an identity one, and is handled separately by `stripAgentStatusMarkers`).
+   */
+  titleIdentityPrefix?: string;
   /** Raw-output fallback for status that isn't reliably exposed via OSC
    * (Cursor Agent's spinner, when `showStatusIndicators` is off — the
    * upstream default). Undefined for agents that don't need one. */
@@ -705,6 +718,9 @@ const opencode: AgentDefinition = {
   displayName: "OpenCode",
   // Native compiled binary — argv0 is `opencode` directly, no node-wrapping.
   leaderNames: ["opencode"],
+  // Its async session-naming rename (see `contract` below) leads with this —
+  // redundant once the tab shows OpenCode's icon.
+  titleIdentityPrefix: "OC | ",
   // No OSC-based signal exists at all (see contract) — activity comes only
   // from the raw-output bar-spinner fallback, same shape as Cursor Agent's.
   activityDetectors: [],
@@ -865,6 +881,24 @@ function includesPathMarker(haystack: string, marker: string): boolean {
 /** The catalog entry with this id (as written into hook events / persisted). */
 export function agentById(id: string): AgentDefinition | undefined {
   return AGENT_CATALOG.find((a) => a.id === id);
+}
+
+/**
+ * Strip `agentId`'s {@link AgentDefinition.titleIdentityPrefix} from `title`,
+ * if it has one and `title` leads with it. The caller — `core.terminal` — is
+ * responsible for only calling this once it has confirmed (via
+ * `ctx.terminals.getIcons`) that the tab is actually showing an icon for this
+ * terminal; this function itself has no opinion on that, since the catalog
+ * doesn't know about icons or tab chrome.
+ */
+export function stripAgentTitleIdentityPrefix(
+  agentId: string | undefined,
+  title: string,
+): string {
+  const prefix = agentId ? agentById(agentId)?.titleIdentityPrefix : undefined;
+  return prefix && title.startsWith(prefix)
+    ? title.slice(prefix.length)
+    : title;
 }
 
 /** Agents that expose an installable hook — the rows the Settings → Agents

--- a/packages/extension-host/src/extension-host/agent-osc-detectors.ts
+++ b/packages/extension-host/src/extension-host/agent-osc-detectors.ts
@@ -339,8 +339,10 @@ const COPILOT_PROGRESS_PREFIX = "4;";
 // Pi's TUI sets the title to "π - <session> - <cwd>". That carries no
 // working/idle state (unlike Claude's spinner prefix), but it is a reliable,
 // pi-specific identity signal for plain-shell terminals where argv0 is `node`
-// and leader-name matching alone would miss it.
-const PI_TITLE_PREFIX = "π - ";
+// and leader-name matching alone would miss it. Exported so `agent-catalog.ts`
+// can reuse the exact same literal as pi's `titleIdentityPrefix` — the prefix
+// that's redundant once the tab already shows pi's icon.
+export const PI_TITLE_PREFIX = "π - ";
 
 export function detectPiTitle(
   code: number,

--- a/packages/extension-host/src/extension-host/agents/pi.ts
+++ b/packages/extension-host/src/extension-host/agents/pi.ts
@@ -38,7 +38,11 @@
  * - Every failure is swallowed. Session tracking must never break a pi turn.
  */
 
-import { detectPiTitle, detectCopilotCLI } from "../agent-osc-detectors";
+import {
+  detectPiTitle,
+  detectCopilotCLI,
+  PI_TITLE_PREFIX,
+} from "../agent-osc-detectors";
 import type { AgentDefinition } from "../agent-catalog";
 
 export interface PiExtensionParams {
@@ -118,6 +122,9 @@ export function buildPiAgentDefinition(deps: PiAgentDeps): AgentDefinition {
     // a `#!/usr/bin/env node` shebang — so the foreground process reports as
     // node-wrapped, exactly like Claude and Copilot.
     leaderNames: ["pi"],
+    // Redundant once the tab shows pi's own icon — same literal detectPiTitle
+    // matches on, reused rather than duplicated.
+    titleIdentityPrefix: PI_TITLE_PREFIX,
     // Pi emits the same OSC 9;4 progress protocol Copilot does (`4;3` on turn
     // start, `4;0` on turn end), so it shares that detector rather than
     // getting a near-identical copy. Its OSC 0 title ("π - <session> - <cwd>")

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -399,12 +399,15 @@ export {
 // `core.agents-settings` page reads `hookInstallableAgents()` (and the hook
 // descriptor on each entry) to render the install toggles. Core-only —
 // detection/resume are sealed, so there is no public `registerAgent`.
+// `stripAgentTitleIdentityPrefix` is `core.terminal`'s presentation-side use:
+// dropping an agent's own redundant title prefix once its icon is shown.
 export {
   hookInstallableAgents,
   sessionFileAgents,
   buildTrackSessionScript,
   TRACK_SCRIPT_REL,
   AGENT_HOOKS_DIR_REL,
+  stripAgentTitleIdentityPrefix,
 } from "./agent-catalog";
 export type {
   AgentDefinition,

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -40,6 +40,7 @@ import {
   notifyTerminalSessionGone,
   notifyTerminalSessionRecreated,
   stripAgentStatusMarkers,
+  stripAgentTitleIdentityPrefix,
   spawnTerminalSession,
   readClipboardText,
   registerTerminalClear,
@@ -946,14 +947,25 @@ export function TerminalPanel(
 
     // The OSC title with agent status markers removed (see
     // `stripAgentStatusMarkers`), or verbatim when the user turned the setting
-    // off. Read per-call rather than stripped once at onTitleChange time so
-    // toggling the setting takes effect on the next read() tick instead of
-    // waiting for the agent to push another title. Returns "" when the title
-    // was nothing but a marker, which callers treat as "no title yet".
-    const displayOscTitle = () =>
-      store.terminalSettings.hideAgentStatusGlyphs
+    // off; then, if this tab is actually showing an agent icon right now (per
+    // `ctx.terminals.getIcons` — the same registry the tab itself renders
+    // from, so this can't drift from what's on screen), also drop that
+    // agent's own redundant identity prefix (pi's "π - ", OpenCode's "OC | ")
+    // via `stripAgentTitleIdentityPrefix` — the icon already says which agent
+    // this is. Read per-call rather than computed once at onTitleChange time
+    // so toggling the setting, or the icon setting, takes effect on the next
+    // read() tick instead of waiting for the agent to push another title.
+    // Returns "" when the title was nothing but a marker, which callers treat
+    // as "no title yet".
+    const displayOscTitle = () => {
+      const glyphsStripped = store.terminalSettings.hideAgentStatusGlyphs
         ? stripAgentStatusMarkers(oscTitle)
         : oscTitle;
+      const iconShown = ctx.terminals.getIcons(terminalId).length > 0;
+      if (!iconShown) return glyphsStripped;
+      const agentId = ctx.agents.getByTerminalId(terminalId)?.agentId;
+      return stripAgentTitleIdentityPrefix(agentId, glyphsStripped);
+    };
     // Foreground process, from the host (RFC 0010 N1). `fg` stays null until the
     // first update so we fall back to legacy behavior if the signal never
     // arrives. At a prompt, a program's stale OSC title is dropped (N1a); a


### PR DESCRIPTION
## Summary

pi and OpenCode tabs currently show both their brand icon *and* a redundant leading text prefix ("π - ", "OC | ") baked into the title they push — the icon already says which agent it is. This drops that prefix from the displayed tab title, but only while the icon is actually showing; if icon display is turned off (or the agent has no icon), the prefix stays since it's then the only visible identity signal.

## Details

- `packages/extension-host/src/extension-host/agent-catalog.ts`: added an optional `titleIdentityPrefix` field to `AgentDefinition`, and an exported `stripAgentTitleIdentityPrefix(agentId, title)` helper. Set on pi (`"π - "`, reusing the same constant `detectPiTitle` already matches on) and OpenCode (`"OC | "`, confirmed against its OSC title contract).
- `packages/extension-host/src/extension-host/agent-osc-detectors.ts`: exported `PI_TITLE_PREFIX` so the catalog can reuse the literal instead of duplicating it.
- `packages/extension-host/src/extension-host/sdk-internal.ts`: re-exports the new helper through the privileged internal barrel, alongside the existing `stripAgentStatusMarkers` (same presentation-side pattern).
- `packages/extensions-core/src/terminal/TerminalPanel.tsx`: `displayOscTitle()` now checks `ctx.terminals.getIcons(terminalId)` — the same registry the tab itself renders icons from, so this can't drift from what's actually on screen — and only then calls `stripAgentTitleIdentityPrefix` with the terminal's `agentId` (from `ctx.agents.getByTerminalId`).
- Tests: `agent-catalog.test.ts` covers `stripAgentTitleIdentityPrefix` (strips for pi/OpenCode, leaves other agents and non-matching titles alone) plus a catalog-integrity check that any `titleIdentityPrefix` is non-empty.

### Test plan

- [x] `pnpm --filter @silo-code/extension-host test` — 1386/1386 passing
- [x] `pnpm --filter @silo-code/extensions-core test` — 365/365 passing
- [x] `pnpm --filter silo exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWzX3LAGj6CEcyXNfzzFJZ