### PR TITLE
feat(navigator): view arrangement — reorder, disable, and a stacked mode

### DIFF
--- a/docs/decisions/0038-navigator-view-list.md
+++ b/docs/decisions/0038-navigator-view-list.md
@@ -5,6 +5,11 @@ date: 2026-08-13
 
 # 0038. The Navigator lists its views instead of hiding them in a menu
 
+> **The "Stacked collapsible sections" alternative below is superseded by ADR
+> [0044](./0044-navigator-stacked-arrangement.md)** — it shipped as an opt-in
+> arrangement (RFC [0030](../proposals/0030-navigator-view-arrangement.md)). The
+> View List described here remains the default.
+
 ## Context
 
 RFC [0023](../proposals/0023-workspace-panel-views.md) turned the Navigator into a
@@ -105,6 +110,10 @@ rejection of that shape.
   80px tall," which is an SDK contract change every existing view has to absorb.
   Worth revisiting if watching agents and workspaces simultaneously turns out to
   be the real need behind the frequent switching.
+  **Superseded by ADR [0044](./0044-navigator-stacked-arrangement.md):** RFC
+  0030 found the contract objection didn't hold (a section is a smaller
+  rectangle, not a different contract; `active` is a hint), and it shipped as an
+  opt-in arrangement with one-at-a-time still the default.
 - **An icon rail** down the panel's edge. Scales to many views for almost no
   space. Rejected for now: it forces `NavigatorView.icon` from optional to
   required, breaking third-party views that don't set one.

--- a/docs/decisions/0044-navigator-stacked-arrangement.md
+++ b/docs/decisions/0044-navigator-stacked-arrangement.md
@@ -1,0 +1,84 @@
+---
+status: accepted
+date: 2026-08-27
+---
+
+# 0044. The Navigator can stack its views instead of showing one at a time
+
+## Context
+
+ADR [0038](./0038-navigator-view-list.md) made the Navigator show its views one
+at a time behind an always-visible **View List**, and recorded "stacked
+collapsible sections" as an **explicitly deferred** alternative — "Genuinely
+more capable … and tested well as a mockup", deferred only because it looked
+like it "changes what a `NavigatorView` _is_, from 'owns the panel body' to
+'owns a section that may be 80px tall,' which is an SDK contract change every
+existing view has to absorb."
+
+RFC [0030](../proposals/0030-navigator-view-arrangement.md) revisited that and
+found the contract worry doesn't hold: a `NavigatorView` still renders one
+component that owns a rectangle — a section is just a smaller rectangle, and
+every non-trivial view already scrolls its own overflow because it can't assume
+panel height today either. `active` is documented as a throttle _hint_, not a
+guarantee, so "always `true` in stacked mode" stays within contract. Per-section
+headers reuse the existing `"navigator"` toolbar surface unchanged. So stacked
+mode ships entirely in `core.navigator`'s renderer with no public SDK change.
+
+RFC 0030 also added user control over the view set (reorder + enable/disable),
+which stacked mode consumes directly — it renders the enabled views in the
+user's order.
+
+## Decision
+
+The Navigator has a **view arrangement** preference (Settings → Layout →
+Navigator, global, persisted by `core.navigator`): **one at a time** (ADR 0038's
+View List + Active View, the default) or **stacked** (no View List; every
+enabled view is a collapsible section in the user's order, each with its own
+View Header). In stacked mode there is no Active View, every view's component
+gets `active` regardless of collapse state, and keyboard region-entry lands in
+the first expanded section.
+
+This **supersedes ADR 0038's "Stacked collapsible sections — deferred"**
+alternative. ADR 0038's one-at-a-time design remains the default arrangement and
+is otherwise unchanged.
+
+## Consequences
+
+- Watching two views at once (agents + workspaces) no longer means constant
+  switching — the motivating need ADR 0038 named when it deferred this.
+- **`active` no longer throttles in stacked mode.** A collapsed section's view
+  keeps running. Accepted because views are lightweight `ctx`-state projections;
+  if a genuinely expensive view appears, collapsed → `active: false` is a
+  forward-compatible change.
+- **Per-section max-height (~60vh) with inner scroll.** One long view can't bury
+  the sections under it; the panel still scrolls as one within the host
+  tab-pane, preserving the single-scroller invariant every view assumes.
+- Stacked mode with a single enabled view renders plain (no disclosure) — same
+  reasoning as ADR 0038's "one view → no View List".
+- No `@silo-code/sdk` change, no version bump. Third-party views work in stacked
+  mode with no action from their authors.
+- Draggable section splitters were **deferred** (see below), so section sizing
+  is not user-adjustable yet.
+
+## Alternatives considered
+
+- **Draggable section splitters** (true VS Code Explorer weighted panes).
+  Deferred, not rejected: more capable but fights the single-scroller model and
+  carries materially more state and code. Content-height + a per-section cap
+  covers the common case; splitters can follow if the cap proves too blunt.
+- **Collapsed section → `active: false`.** Deferred: preserves the throttle hint
+  but forces a definition of "active" spanning focus, expansion, and visibility,
+  and re-wakes a view on every expand. Forward-compatible to add later.
+- **Keeping stacked mode deferred** (ADR 0038's position). Rejected now that the
+  SDK-contract objection is shown not to hold — see RFC 0030.
+
+## References
+
+- RFC [0030](../proposals/0030-navigator-view-arrangement.md) — the full design
+  (reorder / disable + stacked mode) this ADR records.
+- ADR [0038](./0038-navigator-view-list.md) — the View List; its deferred
+  "stacked collapsible sections" alternative that this supersedes.
+- RFC [0023](../proposals/0023-workspace-panel-views.md) — the Navigator and
+  `ctx.registerNavigatorView`.
+- `packages/extensions-core/src/navigator/` — the panel, its pure view model,
+  and the `navigatorPrefs` store.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -78,3 +78,4 @@ A small, obvious choice needs neither.
 | [0041](./0041-pi-hook-as-installed-extension.md)        | Pi's session hook ships as an installed TypeScript extension | 2026-08-22 | accepted |
 | [0042](./0042-agent-catalog-modularization.md)          | Agent catalog modularization and declarative runtime policy  | 2026-08-22 | accepted |
 | [0043](./0043-opencode-tiered-support.md)               | OpenCode: zero-install activity now, resume deferred         | 2026-08-26 | accepted |
+| [0044](./0044-navigator-stacked-arrangement.md)         | The Navigator can stack its views instead of one at a time   | 2026-08-27 | accepted |

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -33,22 +33,39 @@ _Avoid_: Side Panel (when the intent is navigation), tab, mode (prefer View),
 editor view (the CenterDock `viewType` sense)
 
 **Active View**:
-The one View currently rendered in the Navigator. A persisted, global user
-choice — unrelated to the focus/activation sense "active" carries for
-workspaces, docks, and panels.
+The one View currently rendered in the Navigator's **one-at-a-time**
+arrangement. A persisted, global user choice — unrelated to the
+focus/activation sense "active" carries for workspaces, docks, and panels. The
+Stacked arrangement has no Active View.
 _Avoid_: Open view, current view, selected view, visible view
 
 **View List**:
-The rows at the top of the Navigator, one per registered View — how you reach a
-View, and what tells you which Views exist. Hidden when only one is registered.
+The rows at the top of the Navigator in the **one-at-a-time** arrangement, one
+per enabled View — how you reach a View, and what tells you which Views exist.
+Hidden when only one View is enabled, and absent entirely in the Stacked
+arrangement.
 _Avoid_: View selector, view menu, view switcher, view picker (none of these are
 a dropdown any more), tab bar
 
 **View Header**:
 The bar between the View List and the panel body. Names the Active View and
-hosts its toolbar actions.
+hosts its toolbar actions. In the Stacked arrangement there is one per section,
+each carrying its own view's title, disclosure toggle, and actions.
 _Avoid_: Navigator header (ambiguous with the View List above it), panel header,
 title bar
+
+**View arrangement**:
+How the Navigator lays out its enabled Views — a persisted, global user choice
+(Settings → Layout → Navigator). Either **one at a time** (the View List plus a
+single Active View — the default) or **Stacked**.
+_Avoid_: View mode, layout mode, Navigator mode
+
+**Stacked view**:
+The Navigator arrangement with no View List — every enabled View is a
+collapsible section, in the user's chosen order, each with its own View Header.
+No Active View: every section's body is live whether expanded or collapsed.
+_Avoid_: Split view, multi view, sections view; "stacked panel" (it's one
+panel, not several)
 
 **Open Workspace menu**:
 The shared "saved workspaces / New workspace…" menu offered from the Navigator's

--- a/docs/proposals/0030-navigator-view-arrangement.md
+++ b/docs/proposals/0030-navigator-view-arrangement.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: implemented
 created: 2026-08-27
 ---
 
@@ -269,4 +269,17 @@ gains **View arrangement** and **Stacked view** in the Navigator section.
 
 ## Decision
 
-_Filled in when this RFC leaves `draft`._
+**Implemented as proposed.** The Layout settings page gained a General /
+Navigator tab strip; the Navigator tab (composed from `core.navigator` via
+`getExtension`, hidden when that extension is off) reorders and enables/disables
+views and picks the arrangement. `core.navigator` owns a `navigatorPrefs` store
+on its `ctx.storage.global` and the pure `resolveViewList` resolver; the panel
+renders the enabled set in user order, one at a time or stacked.
+
+Two details settled during implementation, both matching the design here:
+`active` is passed as always-`true` in stacked mode (collapse is purely visual),
+and stacked sections cap at `60vh` with their own inner scroll.
+
+The crystallized decision — and the supersession of ADR 0038's deferred
+"stacked collapsible sections" alternative — is recorded in ADR
+[0044](../decisions/0044-navigator-stacked-arrangement.md).

--- a/docs/proposals/0030-navigator-view-arrangement.md
+++ b/docs/proposals/0030-navigator-view-arrangement.md
@@ -173,6 +173,15 @@ The View List is not rendered. Each enabled view, in `viewOrder`, is a
   the same contributions that sit in the single View Header today, now scoped
   next to their view. Marked `data-focus-chrome` so keyboard region-entry skips
   past headers into a body.
+- **Otherwise-unscoped chrome collapses to one section.** RFC 0023 left
+  `core.workspaces`' Add-workspace **+** unscoped so it shows on every view's
+  header. In one-at-a-time mode that's still one header, so nothing changes.
+  In stacked mode it would repeat down the panel — so `core.navigator` exposes
+  `stackedChromeHostViewId()` (the Workspaces section, or the top section if
+  Workspaces is hidden/disabled), and `core.workspaces` `when`-scopes its **+**
+  to that in stacked mode only. A view's _own_ scoped items (e.g. the Agents
+  view's "View by") are unaffected — they were already `when`-bound to their
+  view.
 - **Sizing.** Each expanded section is content-height; the panel scrolls as one
   (preserving the "host tab-pane is the sole scroller" invariant every view
   assumes). A section body taller than a cap (proposed: ~60% of panel height)
@@ -276,9 +285,12 @@ views and picks the arrangement. `core.navigator` owns a `navigatorPrefs` store
 on its `ctx.storage.global` and the pure `resolveViewList` resolver; the panel
 renders the enabled set in user order, one at a time or stacked.
 
-Two details settled during implementation, both matching the design here:
-`active` is passed as always-`true` in stacked mode (collapse is purely visual),
-and stacked sections cap at `60vh` with their own inner scroll.
+Details settled during implementation, all matching the design here: `active`
+is passed as always-`true` in stacked mode (collapse is purely visual); stacked
+sections cap at `60vh` with their own inner scroll; and `core.workspaces`'
+Add-workspace **+** stays unscoped in one-at-a-time mode but `when`-scopes to
+the single section named by `core.navigator`'s `stackedChromeHostViewId()` in
+stacked mode.
 
 The crystallized decision — and the supersession of ADR 0038's deferred
 "stacked collapsible sections" alternative — is recorded in ADR

--- a/docs/proposals/0030-navigator-view-arrangement.md
+++ b/docs/proposals/0030-navigator-view-arrangement.md
@@ -1,0 +1,272 @@
+---
+status: draft
+created: 2026-08-27
+---
+
+# 0030. Navigator view arrangement — reorder, disable, and a stacked mode
+
+## Summary
+
+Give the user control over the Navigator's views. A new **Navigator** tab on the
+Layout settings page holds two sections:
+
+1. **Views** — reorder the registered views and toggle each one on or off. The
+   order replaces `NavigatorView.order` as the source of truth for the View
+   List; a disabled view is filtered out of the Navigator entirely.
+2. **View arrangement** — choose between **One at a time** (today's View List +
+   single Active View) and **Stacked**, where the View List disappears and every
+   enabled view renders as a collapsible section, in the order from section 1.
+
+Stacked mode is the "stacked collapsible sections" alternative that ADR
+[0038](../decisions/0038-navigator-view-list.md) recorded as _deferred, not
+rejected_. No change to the public `NavigatorView` interface and no SDK version
+bump: the whole feature lives in `core.navigator`'s renderer, a preferences
+store on its `ctx.storage.global`, and a settings panel it publishes for
+`core.layout` to compose.
+
+## Motivation
+
+### The view list has no user controls
+
+ADR 0038 made every registered view a permanent ~30px row at the top of the
+Navigator, and noted the cost directly: "a user who installs several
+view-contributing extensions pays for a list they may rarely touch." Today there
+is no way to pay less. You cannot hide the Agents view when you are not running
+agents, you cannot hide Workspaces if you navigate entirely from a file tree,
+and you cannot put the view you actually use first — `NavigatorView.order` is set
+by the extension author, and the built-in views both register at `0`.
+
+### Switching is still switching
+
+ADR 0038 cut view-switching from "open a menu, scan it, click" to one click at a
+fixed position, but it is still an exclusive choice: with the Agents view open
+you cannot see the workspace list, and vice versa. ADR 0038's own _Alternatives_
+section calls this out — "Genuinely more capable — you stop switching and watch
+two views at once — and tested well as a mockup" — and defers stacked mode only
+because, at the time, it looked like an SDK contract change every existing view
+would have to absorb. This RFC argues it is not one (see _A view needs no new
+contract_ below), which removes the reason for the deferral.
+
+### These two are one feature
+
+Stacked mode renders views "in the order of the previous section" and skips the
+disabled ones — it consumes the reorder/disable model directly. Designing them
+apart would mean designing the ordering contract twice.
+
+## Design
+
+### Where it lives
+
+- **`core.navigator`** owns everything real: a `navigatorPrefs` reactive store
+  backed by its own `ctx.storage.global` (the same bag that already holds the
+  `activeView` key), the resolution logic that turns saved order + disabled set
+  into the list the panel renders, and a published `NavigatorSettingsPanel`
+  component.
+- **`core.layout`** adds the **Navigator** tab to its settings page and mounts
+  `ctx.getExtension("core.navigator")?.api?.NavigatorSettingsPanel`. It holds no
+  Navigator knowledge — the same bundled-only composition pattern as
+  `silo.agents` → `core.agents-settings`. The Layout page grows a `Tabs` strip:
+  the existing content becomes a **General** tab, **Navigator** is second, and
+  the Navigator tab is hidden when `core.navigator` is not active.
+
+`ctx.storage` is per-extension-namespaced, which is why the state cannot simply
+live wherever the settings component is rendered; `getExtension` composition
+keeps the owner and the editor in different extensions without a shared mutable
+module or a promotion to host state (host state is for host-internal mechanics —
+Global Side Panel Layout, small-screen mode — and Navigator view preferences are
+the panel extension's own concern, not the host's).
+
+### Preferences shape
+
+```ts
+interface NavigatorPrefs {
+  /**
+   * View ids in user order. A registered id not present here sorts after all
+   * listed ids, by NavigatorView.order then title. An id here that is not
+   * currently registered is retained untouched, so a view returns to its slot
+   * when its extension is re-enabled.
+   */
+  viewOrder: string[];
+  /** View ids the user has turned off. Retained across (un)registration, same
+   *  as viewOrder entries. */
+  disabledViews: string[];
+  /** How the panel body is arranged. */
+  arrangement: "one-at-a-time" | "stacked";
+  /** Per-view collapsed state in stacked mode, keyed by view id. Absent = expanded. */
+  stackedCollapsed: string[];
+}
+```
+
+All four keys are **global**, matching `activeView` and every other Navigator
+preference (per-workspace lenses are the confusion RFC 0023 removed). Stored as
+plain arrays of ids so an unknown id is inert rather than an error.
+
+### Resolving the view list
+
+One pure function, `resolveViewList(registered, prefs)`, is the single source of
+truth for both modes:
+
+1. Start from `registered` (what `navigatorViewRegistry.list()` returns).
+2. Sort: ids in `prefs.viewOrder` first, in that order; then the rest by
+   `NavigatorView.order ?? 0`, then `title`.
+3. Partition into `enabled` / `disabled` by `prefs.disabledViews`.
+4. Guarantee **at least one enabled view**: if `disabledViews` would empty the
+   list, the first view by the sort above is forced enabled (the settings UI
+   also blocks the toggle that would get there, but the resolver is
+   defensive — storage can arrive from another window).
+
+`resolveActiveView` (RFC 0023's existing fallback) then runs against `enabled`
+only. A saved `activeView` that is now disabled falls back to the first enabled
+view **without rewriting storage**, so re-enabling it restores the choice —
+identical to today's unregistered-view behavior.
+
+### Section 1 — Views
+
+A list of every **registered** view (views from disabled/unloaded extensions
+are not registered, so they do not appear — you can only arrange what exists).
+Each row:
+
+- the view's `icon` (reserved column if any view has one, per the panel's own
+  rule) and `title`;
+- **up / down** buttons to move it (disabled at the ends). Not drag: the list is
+  2–5 rows in a settings pane, there is no SDK reorder primitive, and up/down is
+  keyboard-accessible for free. Drag is a later refinement if the list grows.
+- an **enable toggle**. The last remaining enabled toggle is disabled with a
+  tooltip ("At least one view must stay on").
+
+Editing a row writes `viewOrder` / `disabledViews` through the `navigatorPrefs`
+store; `core.navigator` subscribes and re-renders. There is **no separate
+"default view" picker** — when no `activeView` is saved (or it resolved away),
+the Navigator opens on the first enabled view, so moving a view to the top makes
+it the effective default.
+
+### Section 2 — View arrangement
+
+A `RadioGroup` (or `SegmentedTabs`) with two options:
+
+- **One at a time** — unchanged from today: the View List renders every enabled
+  view as a row, the View Header names the Active View, one body is shown. ADR
+  0038's "only one view → no View List" rule still applies, counting enabled
+  views.
+- **Stacked** — described next.
+
+### Stacked mode
+
+The View List is not rendered. Each enabled view, in `viewOrder`, is a
+**collapsible section**:
+
+```
+┌─────────────────────────────┐
+│ ▾ Workspaces          [+]   │  ← per-section View Header (data-focus-chrome)
+│   …workspaces view body…    │
+├─────────────────────────────┤
+│ ▾ Agents        [Recent ▾]  │
+│   …agents view body…        │
+├─────────────────────────────┤
+│ ▸ Changes                   │  ← collapsed: header only
+└─────────────────────────────┘
+```
+
+- **Per-section View Header.** Each section carries its own header: a disclosure
+  triangle, the view `title`, and that view's `"navigator"`-surface toolbar
+  contributions (`ContributedToolbar surface="navigator" target={{ viewId }}`) —
+  the same contributions that sit in the single View Header today, now scoped
+  next to their view. Marked `data-focus-chrome` so keyboard region-entry skips
+  past headers into a body.
+- **Sizing.** Each expanded section is content-height; the panel scrolls as one
+  (preserving the "host tab-pane is the sole scroller" invariant every view
+  assumes). A section body taller than a cap (proposed: ~60% of panel height)
+  gets its own inner scroll so one long view cannot bury the sections below it.
+- **Collapse state** is persisted per view id in `stackedCollapsed`. Default:
+  every section expanded.
+- **`active` does not apply in stacked mode.** Every rendered view's component
+  gets `active: true`, regardless of collapse state. Collapsing a section is
+  purely visual — the view keeps running. This is a deliberate trade: the
+  `active`-based throttling a view does in one-at-a-time mode is off in stacked
+  mode, in exchange for not having to define "is a collapsed section active"
+  and not making views re-derive state every time they are expanded. Views are
+  lightweight projections of `ctx` state; the cost is acceptable. (If a future
+  view proves expensive enough that this bites, revisit — collapsed → `active:
+false` is a compatible change.)
+- **No Active View.** The `activeView` storage key is read only in
+  one-at-a-time mode. In stacked mode, keyboard region-entry
+  (`focusActivePaneContent`) lands in the **first expanded section's** body.
+  Switching arrangement back to one-at-a-time restores the saved `activeView`.
+- **One enabled view.** Rendered plain — the view's header and body, no
+  disclosure control — mirroring ADR 0038's one-view rule for the View List. A
+  section you cannot usefully collapse is pure chrome.
+
+### A view needs no new contract
+
+ADR 0038 deferred stacked mode because it seemed to change what a `NavigatorView`
+_is_: "from 'owns the panel body' to 'owns a section that may be 80px tall,'
+which is an SDK contract change every existing view has to absorb." It does not,
+for this design:
+
+- A `NavigatorView` still renders one component that owns a rectangle. In stacked
+  mode that rectangle is a section rather than the whole body — a smaller box,
+  not a different contract. A view that scrolls its own overflow (which every
+  non-trivial view already does, because it cannot assume panel height today
+  either) works unchanged.
+- `active` is documented as "the view may throttle work while off screen" — a
+  hint, not a guarantee. Always-`true` in stacked mode is within that contract;
+  a correct view still functions, it just does not get the throttle opportunity.
+- Per-section headers reuse the existing `"navigator"` toolbar surface with the
+  same `{ viewId }` target. A view's `when`-scoped contributions land in its own
+  section header with no change.
+
+So the public interface, the `@silo-code/sdk` barrel, and the SDK version are
+untouched. If implementation turns up a genuine need for new `NavigatorView`
+surface, that is a checkpoint to stop and bring it back here — it is not
+expected.
+
+### Sequencing
+
+One branch, `feat/navigator-view-arrangement`, three commits:
+
+1. **This RFC** (`draft`).
+2. **Section 1** — `navigatorPrefs` store, `resolveViewList`, the Navigator
+   settings tab with reorder + disable, `core.navigator` consuming the resolved
+   list in one-at-a-time mode. Shippable on its own; improves the existing mode.
+3. **Stacked mode** — the arrangement radio and the stacked renderer.
+
+On landing: RFC flips to `implemented`; a new ADR (0044) records the crystallized
+decision and supersedes ADR 0038's "Stacked collapsible sections — deferred"
+bullet; ADR 0038 and RFC 0023 get a superseding note; `docs/domain-language.md`
+gains **View arrangement** and **Stacked view** in the Navigator section.
+
+## Alternatives considered
+
+- **A dedicated "Navigator" settings page** rather than a tab on Layout.
+  Cleaner ownership (`core.navigator` registers its own page), but the Navigator
+  is a side panel and the Layout page is where side-panel preferences already
+  live (widths, Global Side Panel Layout, small-screen auto-hide). One more
+  top-level rail entry for three controls lost to that.
+- **Promote the prefs to host `store`**, like every other Layout-page setting.
+  Consistent with the page, but those settings edit host-internal mechanics; a
+  view's order and on/off state are `core.navigator`'s domain, not the host's.
+  `getExtension` composition keeps the boundary without host state.
+- **Drag-to-reorder** in section 1. Nicer at many rows, but there is no SDK
+  primitive (the Agents panel hand-rolled a pointer-drag), it is not
+  keyboard-accessible without extra work, and the list is short. Up/down now,
+  drag later if warranted.
+- **Collapsed section → `active: false`.** Would preserve the throttle hint, but
+  forces a definition of "active" that spans focus, expansion, and visibility,
+  and makes every expand re-wake a view. Deferred as a compatible future change
+  if a heavy view needs it.
+- **Draggable section splitters in stacked mode** (true VS Code Explorer). More
+  capable, but fights the single-scroller model and is materially more code and
+  state. Content-height + a per-section cap covers the common case; splitters
+  can follow.
+- **Per-workspace arrangement / view set.** Rejected for the reason RFC 0023
+  rejected a per-workspace active view: the Navigator moving out from under you
+  on workspace switch is exactly the disorientation the container exists to
+  remove.
+- **Disabling a view by disposing its registration** (signalling the extension).
+  Rejected: an extension should not have to handle "my view was hidden," and
+  re-enabling must be instant. A Navigator-side filter is cheaper and fully
+  reversible.
+
+## Decision
+
+_Filled in when this RFC leaves `draft`._

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -72,4 +72,4 @@ never deleted** — "we considered X and rejected it" stops the debate recurring
 | [0027](./0027-side-dock-layout-tree.md)                       | SideDock layout tree — free-form splits inside a side dock        | 2026-08-21 | implemented |
 | [0028](./0028-terminal-identity-environment.md)               | Terminal identity in the environment                              | 2026-08-23 | implemented |
 | [0029](./0029-sdk-sheet-homedir-confirm-dont-show.md)         | Public SDK: `showSheet`, `homeDir`, `confirmWithDontShowAgain`    | 2026-08-25 | implemented |
-| [0030](./0030-navigator-view-arrangement.md)                  | Navigator view arrangement — reorder, disable, and a stacked mode | 2026-08-27 | draft       |
+| [0030](./0030-navigator-view-arrangement.md)                  | Navigator view arrangement — reorder, disable, and a stacked mode | 2026-08-27 | implemented |

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -72,3 +72,4 @@ never deleted** — "we considered X and rejected it" stops the debate recurring
 | [0027](./0027-side-dock-layout-tree.md)                       | SideDock layout tree — free-form splits inside a side dock        | 2026-08-21 | implemented |
 | [0028](./0028-terminal-identity-environment.md)               | Terminal identity in the environment                              | 2026-08-23 | implemented |
 | [0029](./0029-sdk-sheet-homedir-confirm-dont-show.md)         | Public SDK: `showSheet`, `homeDir`, `confirmWithDontShowAgain`    | 2026-08-25 | implemented |
+| [0030](./0030-navigator-view-arrangement.md)                  | Navigator view arrangement — reorder, disable, and a stacked mode | 2026-08-27 | draft       |

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.css
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.css
@@ -1,0 +1,32 @@
+/* Layout settings gained a tab strip (General / Navigator) — same page-level
+   pattern as Agents settings (Tabs attached to a TabPanel below the title,
+   not header-inline SegmentedTabs). Row/section primitives are the SDK's. */
+
+.layout-settings-page {
+  gap: 12px;
+}
+
+.layout-settings-tabs {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout-settings-tabs > .silo-tab-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout-settings-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+  /* TabPanel already pads 14px; extra inset below the tab strip. */
+  padding-top: 20px;
+}

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ComponentType } from "react";
 import { useSnapshot } from "valtio";
 import { Crosshair } from "@phosphor-icons/react";
-import type { ExtensionContext } from "@silo-code/sdk";
+import type { ExtensionContext, TabItem } from "@silo-code/sdk";
 import {
   CheckboxRow,
   IconButton,
@@ -9,6 +9,8 @@ import {
   Section,
   SettingRow,
   Switch,
+  TabPanel,
+  Tabs,
   Tooltip,
 } from "@silo-code/sdk";
 import {
@@ -23,6 +25,14 @@ import {
   setSharedColumnWidthsEnabled,
 } from "@silo-code/extension-host/internal";
 import { confirmEnableGlobalPanelLayout } from "./GlobalPanelLayoutConfirm";
+import "./LayoutSettingsPage.css";
+
+/** Mirror of `core.navigator`'s {@link NavigatorExtensionAPI}. */
+interface NavigatorSettingsAPI {
+  SettingsPanel: ComponentType;
+}
+
+type LayoutTab = "general" | "navigator";
 
 // A module of the core.layout extension — small-screen mode's on/off switch
 // and width threshold, plus Global Side Panel Layout's two settings. The
@@ -36,6 +46,7 @@ import { confirmEnableGlobalPanelLayout } from "./GlobalPanelLayoutConfirm";
 export function makeLayoutSettingsPage(ctx: ExtensionContext) {
   return function LayoutSettingsPage() {
     const snap = useSnapshot(store);
+    const [tab, setTab] = useState<LayoutTab>("general");
     const [thresholdInput, setThresholdInput] = useState(
       String(snap.smallScreenThresholdPx),
     );
@@ -68,92 +79,122 @@ export function makeLayoutSettingsPage(ctx: ExtensionContext) {
       enableGlobalPanelLayout(choice);
     }
 
-    return (
-      <div className="es-page">
-        <div className="es-header">
-          <h2>Layout</h2>
-        </div>
-        <div className="es-scroll silo-scroll">
-          <Section label="Side Panel Layout">
-            <SettingRow
-              label="Share side panel widths across workspaces"
-              hint="Turn this off to give each workspace its own side panel widths — useful when one workspace splits a side panel into columns and needs it much wider than the rest."
-            >
-              <Switch
-                checked={snap.sharedColumnWidthsEnabled}
-                onChange={setSharedColumnWidthsEnabled}
-                aria-label="Share side panel widths across workspaces"
-              />
-            </SettingRow>
-            {/* Hand-rolled instead of <SettingRow> (whose `hint` is a plain
+    // The Navigator tab's content is entirely `core.navigator`'s — drop the
+    // tab when that extension isn't active rather than show an empty panel.
+    const hasNavigator =
+      ctx.getExtension<NavigatorSettingsAPI>("core.navigator")?.active === true;
+    const activeTab: LayoutTab =
+      tab === "navigator" && !hasNavigator ? "general" : tab;
+    const tabs: TabItem<LayoutTab>[] = [
+      { id: "general", label: "General" },
+      ...(hasNavigator
+        ? [{ id: "navigator" as const, label: "Navigator" }]
+        : []),
+    ];
+
+    const general = (
+      <>
+        <Section label="Side Panel Layout">
+          <SettingRow
+            label="Share side panel widths across workspaces"
+            hint="Turn this off to give each workspace its own side panel widths — useful when one workspace splits a side panel into columns and needs it much wider than the rest."
+          >
+            <Switch
+              checked={snap.sharedColumnWidthsEnabled}
+              onChange={setSharedColumnWidthsEnabled}
+              aria-label="Share side panel widths across workspaces"
+            />
+          </SettingRow>
+          {/* Hand-rolled instead of <SettingRow> (whose `hint` is a plain
                 string) so the sub-setting checkbox can sit inside the same
                 row's text column, directly under the hint, rather than as
                 its own separate row below. */}
-            <div className="silo-setting-row">
-              <div className="silo-setting-row-text">
-                <div className="silo-setting-row-label">
-                  Share side panel layout across workspaces
-                </div>
-                <div className="silo-setting-row-hint">
-                  Enable this setting to use the same side panel layout
-                  (position, visibility, collapse) across workspaces.
-                </div>
-                <div style={{ marginTop: "8px", marginBottom: "12px" }}>
-                  <CheckboxRow
-                    label="Also maintain active tab(s)"
-                    checked={snap.globalActiveTabEnabled}
-                    onChange={setGlobalActiveTabEnabled}
-                    disabled={!snap.globalPanelLayoutEnabled}
-                  />
-                </div>
+          <div className="silo-setting-row">
+            <div className="silo-setting-row-text">
+              <div className="silo-setting-row-label">
+                Share side panel layout across workspaces
               </div>
-              <div className="silo-setting-row-control">
-                <Switch
-                  checked={snap.globalPanelLayoutEnabled}
-                  onChange={(next) => void toggleGlobalPanelLayout(next)}
-                  aria-label="Share side panel layout across workspaces"
+              <div className="silo-setting-row-hint">
+                Enable this setting to use the same side panel layout (position,
+                visibility, collapse) across workspaces.
+              </div>
+              <div style={{ marginTop: "8px", marginBottom: "12px" }}>
+                <CheckboxRow
+                  label="Also maintain active tab(s)"
+                  checked={snap.globalActiveTabEnabled}
+                  onChange={setGlobalActiveTabEnabled}
+                  disabled={!snap.globalPanelLayoutEnabled}
                 />
               </div>
             </div>
-          </Section>
-          <Section label="Laptop Mode">
-            <SettingRow
-              label="Enable Laptop Mode"
-              hint="Enable this setting to automatically hide the side panels when using Silo on a laptop (determined by threshold below)."
-            >
+            <div className="silo-setting-row-control">
               <Switch
-                checked={snap.smallScreenModeEnabled}
-                onChange={setSmallScreenModeEnabled}
-                aria-label="Enable Laptop Mode"
+                checked={snap.globalPanelLayoutEnabled}
+                onChange={(next) => void toggleGlobalPanelLayout(next)}
+                aria-label="Share side panel layout across workspaces"
               />
-            </SettingRow>
-            <SettingRow
-              label="Threshold width"
-              hint="Below this window width (in pixels), side panels auto-hide."
-            >
-              <div
-                style={{ display: "flex", alignItems: "center", gap: "6px" }}
-              >
-                <Input
-                  type="number"
-                  min={MIN_SMALL_SCREEN_THRESHOLD_PX}
-                  value={thresholdInput}
-                  onChange={(e) => setThresholdInput(e.target.value)}
-                  onBlur={(e) => commitThreshold(e.target.value)}
-                />
-                <Tooltip content="Capture current width">
-                  <IconButton
-                    aria-label="Capture current width"
-                    onClick={() => setSmallScreenThresholdPx(window.innerWidth)}
-                  >
-                    <Crosshair size={16} weight="bold" />
-                  </IconButton>
-                </Tooltip>
-              </div>
-            </SettingRow>
-          </Section>
+            </div>
+          </div>
+        </Section>
+        <Section label="Laptop Mode">
+          <SettingRow
+            label="Enable Laptop Mode"
+            hint="Enable this setting to automatically hide the side panels when using Silo on a laptop (determined by threshold below)."
+          >
+            <Switch
+              checked={snap.smallScreenModeEnabled}
+              onChange={setSmallScreenModeEnabled}
+              aria-label="Enable Laptop Mode"
+            />
+          </SettingRow>
+          <SettingRow
+            label="Threshold width"
+            hint="Below this window width (in pixels), side panels auto-hide."
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              <Input
+                type="number"
+                min={MIN_SMALL_SCREEN_THRESHOLD_PX}
+                value={thresholdInput}
+                onChange={(e) => setThresholdInput(e.target.value)}
+                onBlur={(e) => commitThreshold(e.target.value)}
+              />
+              <Tooltip content="Capture current width">
+                <IconButton
+                  aria-label="Capture current width"
+                  onClick={() => setSmallScreenThresholdPx(window.innerWidth)}
+                >
+                  <Crosshair size={16} weight="bold" />
+                </IconButton>
+              </Tooltip>
+            </div>
+          </SettingRow>
+        </Section>
+      </>
+    );
+
+    return (
+      <div className="es-page layout-settings-page">
+        <div className="es-header">
+          <h2>Layout</h2>
+        </div>
+
+        <div className="layout-settings-tabs">
+          <Tabs tabs={tabs} active={activeTab} onSelect={setTab} />
+          <TabPanel>
+            <div className="silo-scroll layout-settings-scroll">
+              {activeTab === "navigator" ? <NavigatorTab ctx={ctx} /> : general}
+            </div>
+          </TabPanel>
         </div>
       </div>
     );
   };
+}
+
+function NavigatorTab({ ctx }: { ctx: ExtensionContext }) {
+  const nav = ctx.getExtension<NavigatorSettingsAPI>("core.navigator");
+  const Panel =
+    nav?.active && nav.api?.SettingsPanel ? nav.api.SettingsPanel : null;
+  return Panel != null ? <Panel /> : null;
 }

--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -163,3 +163,65 @@
 .nav-view[data-active="false"] {
   display: none;
 }
+
+/* ── Stacked arrangement (RFC 0030) ─────────────────────────────────────────
+   No view list; every enabled view is a collapsible section. The panel still
+   only sets a min-height — the host tab-pane stays the sole scroller — and
+   each open section caps its own height so one long view can't bury the rest. */
+.nav-panel--stacked {
+  padding-top: 0;
+}
+
+.nav-stack-section {
+  display: flex;
+  flex-direction: column;
+  flex: none;
+}
+
+/* Reuses .nav-view-header's bar treatment; draw the seam between sections
+   ourselves (data-view-list="false" suppresses the default top border). */
+.nav-stack-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.nav-stack-section + .nav-stack-section .nav-stack-header {
+  border-top: 1px solid var(--silo-color-border-strong);
+}
+
+/* The click target for expand/collapse — caret + title, filling the row so
+   the contributed toolbar is pushed to the right edge. `text-align: left`
+   undoes the UA button default that would otherwise centre the title text. */
+.nav-stack-disclosure {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nav-stack-caret {
+  flex: none;
+  color: var(--silo-color-text-lo);
+  transition: transform 0.12s ease;
+}
+
+.nav-stack-disclosure[aria-expanded="true"] .nav-stack-caret {
+  transform: rotate(90deg);
+}
+
+.nav-stack-body {
+  /* Content-height, capped — a taller view scrolls within its own section
+     rather than pushing the ones below it off screen. 60vh approximates
+     "most of the panel" without a container query. */
+  overflow-y: auto;
+  max-height: 60vh;
+}

--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -170,24 +170,31 @@
    each open section caps its own height so one long view can't bury the rest. */
 .nav-panel--stacked {
   padding-top: 0;
+  /* Trailing room after the last section, matching the inter-section gap. */
+  padding-bottom: 9px;
 }
 
+/* One uniform gap above every section — the same whitespace under the panel
+   title as between sections, regardless of what trailing padding each view
+   carries. No rule between sections: each header keeps its own bottom border
+   (from .nav-view-header) above its body. */
 .nav-stack-section {
   display: flex;
   flex-direction: column;
   flex: none;
+  margin-top: 9px;
 }
 
-/* Reuses .nav-view-header's bar treatment; draw the seam between sections
-   ourselves (data-view-list="false" suppresses the default top border). */
+/* Fixed header box so a section with header actions (Agents' "View by",
+   Workspaces' "+") is the same height as a text-only one — otherwise the
+   2em control makes those headers taller and the gaps read as uneven. */
 .nav-stack-header {
   position: sticky;
   top: 0;
   z-index: 1;
-}
-
-.nav-stack-section + .nav-stack-section .nav-stack-header {
-  border-top: 1px solid var(--silo-color-border-strong);
+  min-height: calc(2em + 8px);
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 /* The click target for expand/collapse — caret + title, filling the row so

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { ExtensionContext } from "@silo-code/sdk";
-import { useFocusGroup } from "@silo-code/sdk";
+import { useFocusGroup, useServiceState } from "@silo-code/sdk";
 import {
   ErrorBoundary,
   navigatorViewRegistry,
@@ -10,7 +10,9 @@ import {
   activeViewIndex,
   buildViewRows,
   resolveActiveView,
+  resolveViewList,
 } from "./navigator-views";
+import { navigatorPrefsService } from "./navigator-prefs";
 import "./NavigatorPanel.css";
 
 // Which view the Navigator is showing. Global scope, not workspace: the lens is
@@ -32,7 +34,15 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
       navigatorViewRegistry.subscribe(() => setViewTick((t) => t + 1)).dispose,
     [],
   );
-  const views = navigatorViewRegistry.list();
+  // The user's arrangement prefs (order + which views are on). `views` below is
+  // the enabled set in user order — everything downstream (list, active-view
+  // resolution, mounting) operates on that, so a disabled view is simply not
+  // part of the Navigator until it's turned back on.
+  const prefs = useServiceState(navigatorPrefsService);
+  const { enabled: views } = resolveViewList(
+    navigatorViewRegistry.list(),
+    prefs,
+  );
 
   // The user's chosen view, mirrored from global storage so hydration (and a
   // change made in another window) lands here.

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import type { ExtensionContext } from "@silo-code/sdk";
+import { CaretRight } from "@phosphor-icons/react";
+import type { ExtensionContext, NavigatorView } from "@silo-code/sdk";
 import { useFocusGroup, useServiceState } from "@silo-code/sdk";
 import {
   ErrorBoundary,
@@ -11,6 +12,7 @@ import {
   buildViewRows,
   resolveActiveView,
   resolveViewList,
+  toggleIdInList,
 } from "./navigator-views";
 import { navigatorPrefsService } from "./navigator-prefs";
 import "./NavigatorPanel.css";
@@ -26,6 +28,13 @@ const ACTIVE_VIEW_KEY = "activeView";
 const tabId = (viewId: string) => `nav-tab-${viewId}`;
 const tabPanelId = (viewId: string) => `nav-tabpanel-${viewId}`;
 
+/**
+ * The Navigator panel. A thin dispatcher: it resolves the user's enabled views
+ * (in their chosen order) and renders one of two arrangements — the View List +
+ * single Active View, or every view stacked in collapsible sections (RFC 0030).
+ * Stacked mode needs more than one enabled view to be worth its chrome; with
+ * one it falls through to the plain single-view render.
+ */
 export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
   // Re-render when views are registered or unregistered.
   const [, setViewTick] = useState(0);
@@ -34,16 +43,29 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
       navigatorViewRegistry.subscribe(() => setViewTick((t) => t + 1)).dispose,
     [],
   );
-  // The user's arrangement prefs (order + which views are on). `views` below is
-  // the enabled set in user order — everything downstream (list, active-view
-  // resolution, mounting) operates on that, so a disabled view is simply not
-  // part of the Navigator until it's turned back on.
   const prefs = useServiceState(navigatorPrefsService);
   const { enabled: views } = resolveViewList(
     navigatorViewRegistry.list(),
     prefs,
   );
 
+  return prefs.arrangement === "stacked" && views.length > 1 ? (
+    <StackedNavigator ctx={ctx} views={views} />
+  ) : (
+    <SwitcherNavigator ctx={ctx} views={views} />
+  );
+}
+
+/** The default arrangement: a list of every enabled view at the top, one of
+ * them shown below. Unchanged from ADR 0038 apart from operating on the
+ * enabled/ordered set rather than the raw registry. */
+function SwitcherNavigator({
+  ctx,
+  views,
+}: {
+  ctx: ExtensionContext;
+  views: NavigatorView[];
+}) {
   // The user's chosen view, mirrored from global storage so hydration (and a
   // change made in another window) lands here.
   const [savedViewId, setSavedViewId] = useState<string | undefined>(() =>
@@ -55,8 +77,8 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
     });
     return () => sub.dispose();
   }, [ctx]);
-  // Falls back when the saved view isn't registered (its extension is disabled
-  // or gone) without rewriting storage, so re-enabling brings the choice back.
+  // Falls back when the saved view isn't registered or is disabled, without
+  // rewriting storage, so re-enabling brings the choice back.
   const activeViewId = resolveActiveView(views, savedViewId);
 
   // Views mount on first activation and then stay mounted, hidden — the same
@@ -104,7 +126,7 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
 
   return (
     <div className="nav-panel">
-      {/* Every registered view, named and one click away — no menu (RFC 0023's
+      {/* Every enabled view, named and one click away — no menu (RFC 0023's
           selector was a dropdown; the list is the same choice made visible).
           Which one is open is said by the header below rather than by
           highlighting a row up here, so the list reads as a set of
@@ -203,6 +225,81 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
               <Comp active={isActive} />
             </ErrorBoundary>
           </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * The stacked arrangement (RFC 0030): no View List; every enabled view is a
+ * collapsible section in the user's order, each with its own header carrying
+ * that view's `"navigator"`-surface actions. There is no Active View — every
+ * mounted view gets `active` (collapse is purely visual, so a view keeps
+ * running), and keyboard region-entry lands in the first expanded body since
+ * the headers are `data-focus-chrome`.
+ */
+function StackedNavigator({
+  ctx,
+  views,
+}: {
+  ctx: ExtensionContext;
+  views: NavigatorView[];
+}) {
+  const prefs = useServiceState(navigatorPrefsService);
+  const collapsed = new Set(prefs.stackedCollapsed);
+
+  function toggle(viewId: string) {
+    navigatorPrefsService.set({
+      stackedCollapsed: toggleIdInList(prefs.stackedCollapsed, viewId),
+    });
+  }
+
+  return (
+    <div className="nav-panel nav-panel--stacked">
+      {views.map((view) => {
+        const isCollapsed = collapsed.has(view.id);
+        const Comp = view.component;
+        return (
+          <section
+            key={view.id}
+            className="nav-stack-section"
+            data-collapsed={isCollapsed ? "true" : "false"}
+          >
+            {/* `data-focus-chrome`: the disclosure + contributed toolbar are
+                controls, not content — region-entry skips past to the first
+                expanded body. Tab still reaches the disclosure normally. */}
+            <div
+              className="nav-view-header nav-stack-header"
+              data-focus-chrome
+              data-view-list="false"
+            >
+              <button
+                type="button"
+                className="nav-stack-disclosure"
+                aria-expanded={!isCollapsed}
+                onClick={() => toggle(view.id)}
+              >
+                <CaretRight
+                  className="nav-stack-caret"
+                  size={12}
+                  weight="bold"
+                  aria-hidden="true"
+                />
+                <span className="nav-view-header__title">{view.title}</span>
+              </button>
+              <ContributedToolbar
+                surface="navigator"
+                target={{ viewId: view.id }}
+                showMenu={ctx.ui.showMenu}
+              />
+            </div>
+            <div className="nav-stack-body" hidden={isCollapsed}>
+              <ErrorBoundary name={view.id}>
+                <Comp active />
+              </ErrorBoundary>
+            </div>
+          </section>
         );
       })}
     </div>

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -50,7 +50,11 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
   );
 
   return prefs.arrangement === "stacked" && views.length > 1 ? (
-    <StackedNavigator ctx={ctx} views={views} />
+    <StackedNavigator
+      ctx={ctx}
+      views={views}
+      collapsed={prefs.stackedCollapsed}
+    />
   ) : (
     <SwitcherNavigator ctx={ctx} views={views} />
   );
@@ -242,16 +246,17 @@ function SwitcherNavigator({
 function StackedNavigator({
   ctx,
   views,
+  collapsed: collapsedIds,
 }: {
   ctx: ExtensionContext;
   views: NavigatorView[];
+  collapsed: readonly string[];
 }) {
-  const prefs = useServiceState(navigatorPrefsService);
-  const collapsed = new Set(prefs.stackedCollapsed);
+  const collapsed = new Set(collapsedIds);
 
   function toggle(viewId: string) {
     navigatorPrefsService.set({
-      stackedCollapsed: toggleIdInList(prefs.stackedCollapsed, viewId),
+      stackedCollapsed: toggleIdInList(collapsedIds, viewId),
     });
   }
 

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
@@ -1,0 +1,66 @@
+/* The Navigator settings tab (RFC 0030). Chrome only — Section, Switch,
+   IconButton, Tooltip are the SDK's. Design tokens only. */
+
+.nav-settings-hint {
+  margin: 0 0 12px;
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
+  line-height: 1.5;
+}
+
+.nav-settings-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.nav-settings-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 6px;
+  border-radius: var(--silo-radius-sm);
+}
+
+.nav-settings-row:hover {
+  background: var(--silo-color-bg-hover);
+}
+
+/* A disabled view still lists, but reads as inactive. */
+.nav-settings-row[data-off="true"] .nav-settings-label,
+.nav-settings-row[data-off="true"] .nav-settings-icon {
+  color: var(--silo-color-text-lo);
+}
+
+.nav-settings-move {
+  display: inline-flex;
+  flex: none;
+  gap: 2px;
+}
+
+.nav-settings-icon {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  color: var(--silo-color-text-hi);
+}
+
+.nav-settings-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-hi);
+}
+
+.nav-settings-toggle-lock {
+  display: inline-flex;
+}

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
@@ -64,3 +64,9 @@
 .nav-settings-toggle-lock {
   display: inline-flex;
 }
+
+/* RadioCard spaces its own siblings; this just insets the group from the
+   Section label. */
+.nav-settings-arrangement {
+  margin-top: 6px;
+}

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { ArrowUp, ArrowDown } from "@phosphor-icons/react";
+import {
+  IconButton,
+  Section,
+  Switch,
+  Tooltip,
+  useServiceState,
+} from "@silo-code/sdk";
+import { navigatorViewRegistry } from "@silo-code/extension-host/internal";
+import { navigatorPrefsService } from "./navigator-prefs";
+import {
+  moveViewInOrder,
+  resolveViewList,
+  setViewDisabled,
+} from "./navigator-views";
+import "./NavigatorSettingsPanel.css";
+
+/**
+ * The **Navigator** settings tab's body — reorder the Navigator's views and
+ * turn ones off. Owned by `core.navigator` (it owns the `navigatorPrefs`
+ * store) and published for `core.layout` to compose into the Layout settings
+ * page (RFC 0030).
+ */
+export function NavigatorSettingsPanel() {
+  const prefs = useServiceState(navigatorPrefsService);
+
+  // Re-render when a view is registered / unregistered — same tick pattern as
+  // NavigatorPanel.
+  const [, setTick] = useState(0);
+  useEffect(
+    () => navigatorViewRegistry.subscribe(() => setTick((t) => t + 1)).dispose,
+    [],
+  );
+
+  const registered = navigatorViewRegistry.list();
+  const { ordered, enabled } = resolveViewList(registered, prefs);
+  const orderedIds = ordered.map((v) => v.id);
+  const enabledIds = new Set(enabled.map((v) => v.id));
+  const hasIcons = ordered.some((v) => v.icon);
+
+  function move(id: string, dir: -1 | 1) {
+    navigatorPrefsService.set({
+      viewOrder: moveViewInOrder(orderedIds, id, dir),
+    });
+  }
+  function toggle(id: string, on: boolean) {
+    navigatorPrefsService.set({
+      disabledViews: setViewDisabled(prefs.disabledViews, id, !on),
+    });
+  }
+
+  return (
+    <Section label="Views">
+      <p className="nav-settings-hint">
+        Reorder the Navigator&rsquo;s views, or turn off the ones you
+        don&rsquo;t use. The Navigator opens on the first enabled view.
+      </p>
+      <ul className="nav-settings-list">
+        {ordered.map((view, i) => {
+          const on = enabledIds.has(view.id);
+          const isLastEnabled = on && enabled.length === 1;
+          return (
+            <li
+              key={view.id}
+              className="nav-settings-row"
+              data-off={on ? undefined : "true"}
+            >
+              <span className="nav-settings-move">
+                <IconButton
+                  size="sm"
+                  aria-label={`Move ${view.title} up`}
+                  disabled={i === 0}
+                  onClick={() => move(view.id, -1)}
+                >
+                  <ArrowUp size={13} weight="bold" />
+                </IconButton>
+                <IconButton
+                  size="sm"
+                  aria-label={`Move ${view.title} down`}
+                  disabled={i === ordered.length - 1}
+                  onClick={() => move(view.id, 1)}
+                >
+                  <ArrowDown size={13} weight="bold" />
+                </IconButton>
+              </span>
+              {hasIcons && (
+                <span className="nav-settings-icon">{view.icon}</span>
+              )}
+              <span className="nav-settings-label">{view.title}</span>
+              {isLastEnabled ? (
+                <Tooltip content="At least one view must stay on">
+                  {/* Wrapper span so the tooltip has a hover target while the
+                      Switch itself is disabled. */}
+                  <span className="nav-settings-toggle-lock">
+                    <Switch
+                      checked
+                      disabled
+                      onChange={() => {}}
+                      aria-label={`Show ${view.title}`}
+                    />
+                  </span>
+                </Tooltip>
+              ) : (
+                <Switch
+                  checked={on}
+                  onChange={(next) => toggle(view.id, next)}
+                  aria-label={`Show ${view.title}`}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </Section>
+  );
+}

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
@@ -12,7 +12,7 @@ import {
 import { navigatorViewRegistry } from "@silo-code/extension-host/internal";
 import { navigatorPrefsService, type ViewArrangement } from "./navigator-prefs";
 import {
-  moveViewInOrder,
+  reorderSavedViews,
   resolveViewList,
   setViewDisabled,
 } from "./navigator-views";
@@ -43,7 +43,7 @@ export function NavigatorSettingsPanel() {
 
   function move(id: string, dir: -1 | 1) {
     navigatorPrefsService.set({
-      viewOrder: moveViewInOrder(orderedIds, id, dir),
+      viewOrder: reorderSavedViews(prefs.viewOrder, orderedIds, id, dir),
     });
   }
   function toggle(id: string, on: boolean) {

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
@@ -2,13 +2,15 @@ import { useEffect, useState } from "react";
 import { ArrowUp, ArrowDown } from "@phosphor-icons/react";
 import {
   IconButton,
+  RadioCard,
+  RadioGroup,
   Section,
   Switch,
   Tooltip,
   useServiceState,
 } from "@silo-code/sdk";
 import { navigatorViewRegistry } from "@silo-code/extension-host/internal";
-import { navigatorPrefsService } from "./navigator-prefs";
+import { navigatorPrefsService, type ViewArrangement } from "./navigator-prefs";
 import {
   moveViewInOrder,
   resolveViewList,
@@ -51,67 +53,93 @@ export function NavigatorSettingsPanel() {
   }
 
   return (
-    <Section label="Views">
-      <p className="nav-settings-hint">
-        Reorder the Navigator&rsquo;s views, or turn off the ones you
-        don&rsquo;t use. The Navigator opens on the first enabled view.
-      </p>
-      <ul className="nav-settings-list">
-        {ordered.map((view, i) => {
-          const on = enabledIds.has(view.id);
-          const isLastEnabled = on && enabled.length === 1;
-          return (
-            <li
-              key={view.id}
-              className="nav-settings-row"
-              data-off={on ? undefined : "true"}
-            >
-              <span className="nav-settings-move">
-                <IconButton
-                  size="sm"
-                  aria-label={`Move ${view.title} up`}
-                  disabled={i === 0}
-                  onClick={() => move(view.id, -1)}
-                >
-                  <ArrowUp size={13} weight="bold" />
-                </IconButton>
-                <IconButton
-                  size="sm"
-                  aria-label={`Move ${view.title} down`}
-                  disabled={i === ordered.length - 1}
-                  onClick={() => move(view.id, 1)}
-                >
-                  <ArrowDown size={13} weight="bold" />
-                </IconButton>
-              </span>
-              {hasIcons && (
-                <span className="nav-settings-icon">{view.icon}</span>
-              )}
-              <span className="nav-settings-label">{view.title}</span>
-              {isLastEnabled ? (
-                <Tooltip content="At least one view must stay on">
-                  {/* Wrapper span so the tooltip has a hover target while the
+    <>
+      <Section label="Views">
+        <p className="nav-settings-hint">
+          Reorder the Navigator&rsquo;s views, or turn off the ones you
+          don&rsquo;t use. The Navigator opens on the first enabled view.
+        </p>
+        <ul className="nav-settings-list">
+          {ordered.map((view, i) => {
+            const on = enabledIds.has(view.id);
+            const isLastEnabled = on && enabled.length === 1;
+            return (
+              <li
+                key={view.id}
+                className="nav-settings-row"
+                data-off={on ? undefined : "true"}
+              >
+                <span className="nav-settings-move">
+                  <IconButton
+                    size="sm"
+                    aria-label={`Move ${view.title} up`}
+                    disabled={i === 0}
+                    onClick={() => move(view.id, -1)}
+                  >
+                    <ArrowUp size={13} weight="bold" />
+                  </IconButton>
+                  <IconButton
+                    size="sm"
+                    aria-label={`Move ${view.title} down`}
+                    disabled={i === ordered.length - 1}
+                    onClick={() => move(view.id, 1)}
+                  >
+                    <ArrowDown size={13} weight="bold" />
+                  </IconButton>
+                </span>
+                {hasIcons && (
+                  <span className="nav-settings-icon">{view.icon}</span>
+                )}
+                <span className="nav-settings-label">{view.title}</span>
+                {isLastEnabled ? (
+                  <Tooltip content="At least one view must stay on">
+                    {/* Wrapper span so the tooltip has a hover target while the
                       Switch itself is disabled. */}
-                  <span className="nav-settings-toggle-lock">
-                    <Switch
-                      checked
-                      disabled
-                      onChange={() => {}}
-                      aria-label={`Show ${view.title}`}
-                    />
-                  </span>
-                </Tooltip>
-              ) : (
-                <Switch
-                  checked={on}
-                  onChange={(next) => toggle(view.id, next)}
-                  aria-label={`Show ${view.title}`}
-                />
-              )}
-            </li>
-          );
-        })}
-      </ul>
-    </Section>
+                    <span className="nav-settings-toggle-lock">
+                      <Switch
+                        checked
+                        disabled
+                        onChange={() => {}}
+                        aria-label={`Show ${view.title}`}
+                      />
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Switch
+                    checked={on}
+                    onChange={(next) => toggle(view.id, next)}
+                    aria-label={`Show ${view.title}`}
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </Section>
+
+      <Section label="View arrangement">
+        <div className="nav-settings-arrangement">
+          <RadioGroup
+            value={prefs.arrangement}
+            onChange={(v) =>
+              navigatorPrefsService.set({
+                arrangement: v as ViewArrangement,
+              })
+            }
+          >
+            <RadioCard
+              value="one-at-a-time"
+              title="One at a time"
+              description="A list of your views sits at the top of the Navigator; click one to show it."
+            />
+            <RadioCard
+              value="stacked"
+              title="Stacked"
+              description="No list — every enabled view is stacked in the order above, each collapsible."
+            />
+          </RadioGroup>
+        </div>
+      </Section>
+    </>
   );
 }

--- a/packages/extensions-core/src/navigator/index.tsx
+++ b/packages/extensions-core/src/navigator/index.tsx
@@ -1,5 +1,8 @@
 import type { Extension } from "@silo-code/sdk";
 import { NavigatorPanel } from "./NavigatorPanel";
+import { NavigatorSettingsPanel } from "./NavigatorSettingsPanel";
+import { initNavigatorPrefs } from "./navigator-prefs";
+import type { NavigatorExtensionAPI } from "./navigator-api";
 
 /**
  * `core.navigator` — the Navigator side panel: the one place you navigate the
@@ -15,10 +18,17 @@ import { NavigatorPanel } from "./NavigatorPanel";
  * workspace code, no agent code, and no knowledge of what any view shows —
  * which is the point: a new way to navigate is a new view, not a competing
  * side panel.
+ *
+ * It also owns the user's **view arrangement** preferences (order + which
+ * views are on) — a `navigatorPrefs` store on its `ctx.storage.global`, edited
+ * from a settings panel it publishes for `core.layout`'s Layout page to
+ * compose (RFC 0030).
  */
-export const extension: Extension = {
+export const extension: Extension<NavigatorExtensionAPI> = {
   id: "core.navigator",
-  activate(ctx) {
+  activate(ctx): NavigatorExtensionAPI {
+    ctx.subscriptions.push(initNavigatorPrefs(ctx.storage.global));
+
     ctx.registerSidePanel({
       id: "navigator",
       location: "left",
@@ -28,5 +38,7 @@ export const extension: Extension = {
       component: () => <NavigatorPanel ctx={ctx} />,
       order: 1,
     });
+
+    return { SettingsPanel: NavigatorSettingsPanel };
   },
 };

--- a/packages/extensions-core/src/navigator/index.tsx
+++ b/packages/extensions-core/src/navigator/index.tsx
@@ -1,7 +1,9 @@
 import type { Extension } from "@silo-code/sdk";
+import { navigatorViewRegistry } from "@silo-code/extension-host/internal";
 import { NavigatorPanel } from "./NavigatorPanel";
 import { NavigatorSettingsPanel } from "./NavigatorSettingsPanel";
-import { initNavigatorPrefs } from "./navigator-prefs";
+import { initNavigatorPrefs, navigatorPrefsService } from "./navigator-prefs";
+import { resolveViewList, stackedChromeHostId } from "./navigator-views";
 import type { NavigatorExtensionAPI } from "./navigator-api";
 
 /**
@@ -39,6 +41,20 @@ export const extension: Extension<NavigatorExtensionAPI> = {
       order: 1,
     });
 
-    return { SettingsPanel: NavigatorSettingsPanel };
+    return {
+      SettingsPanel: NavigatorSettingsPanel,
+      stackedChromeHostViewId() {
+        const prefs = navigatorPrefsService.getState();
+        const { enabled } = resolveViewList(
+          navigatorViewRegistry.list(),
+          prefs,
+        );
+        // Stacked needs >1 view to render as a stack (see NavigatorPanel);
+        // with one it falls through to the plain single-view render, where
+        // unscoped chrome belongs on that view like one-at-a-time.
+        if (prefs.arrangement !== "stacked" || enabled.length <= 1) return null;
+        return stackedChromeHostId(enabled) ?? null;
+      },
+    };
   },
 };

--- a/packages/extensions-core/src/navigator/navigator-api.ts
+++ b/packages/extensions-core/src/navigator/navigator-api.ts
@@ -1,0 +1,12 @@
+import type { ComponentType } from "react";
+
+/**
+ * Published by `core.navigator` for `core.layout` to compose into the Layout
+ * settings page's **Navigator** tab (bundled-only composition, the same pattern
+ * as `silo.agents` → `core.agents-settings`). `core.navigator` owns the
+ * `navigatorPrefs` store, so the editor for it has to come from here.
+ */
+export interface NavigatorExtensionAPI {
+  /** The **Navigator** settings tab's body — reorder / enable views. */
+  SettingsPanel: ComponentType;
+}

--- a/packages/extensions-core/src/navigator/navigator-api.ts
+++ b/packages/extensions-core/src/navigator/navigator-api.ts
@@ -9,4 +9,12 @@ import type { ComponentType } from "react";
 export interface NavigatorExtensionAPI {
   /** The **Navigator** settings tab's body — reorder / enable views. */
   SettingsPanel: ComponentType;
+  /**
+   * In the **stacked** arrangement, the id of the view whose section should
+   * carry otherwise-unscoped `"navigator"` toolbar chrome (the Add-workspace
+   * "+") — so it appears once, not on every section. `null` in the
+   * one-at-a-time arrangement, where such chrome shows on every view as
+   * before. `core.workspaces` reads this to scope its "+" in stacked mode.
+   */
+  stackedChromeHostViewId(): string | null;
 }

--- a/packages/extensions-core/src/navigator/navigator-prefs.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.test.ts
@@ -37,10 +37,9 @@ beforeEach(() => {
 describe("navigator prefs persistence", () => {
   it("defaults to empty order / disabled set", () => {
     const sub = initNavigatorPrefs(fakeStorage());
-    expect(navigatorPrefsService.getState()).toEqual({
-      viewOrder: [],
-      disabledViews: [],
-    });
+    const state = navigatorPrefsService.getState();
+    expect(state.viewOrder).toEqual([]);
+    expect(state.disabledViews).toEqual([]);
     sub.dispose();
   });
 
@@ -120,5 +119,54 @@ describe("navigator prefs persistence", () => {
     storage.set("navigatorViewOrder", ["a"]);
     storage.emit();
     expect(navigatorPrefsService.getState().viewOrder).toEqual([]);
+  });
+});
+
+describe("navigator arrangement pref", () => {
+  it("defaults to one-at-a-time", () => {
+    const sub = initNavigatorPrefs(fakeStorage());
+    expect(navigatorPrefsService.getState().arrangement).toBe("one-at-a-time");
+    expect(navigatorPrefsService.getState().stackedCollapsed).toEqual([]);
+    sub.dispose();
+  });
+
+  it("hydrates a persisted stacked arrangement + collapsed set", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({
+        navigatorArrangement: "stacked",
+        navigatorStackedCollapsed: ["silo.agents.by-status"],
+      }),
+    );
+    expect(navigatorPrefsService.getState().arrangement).toBe("stacked");
+    expect(navigatorPrefsService.getState().stackedCollapsed).toEqual([
+      "silo.agents.by-status",
+    ]);
+    sub.dispose();
+  });
+
+  it("coerces an unknown arrangement value to the default", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({ navigatorArrangement: "tiled" }),
+    );
+    expect(navigatorPrefsService.getState().arrangement).toBe("one-at-a-time");
+    sub.dispose();
+  });
+
+  it("persists an arrangement change through set()", () => {
+    const storage = fakeStorage();
+    const sub = initNavigatorPrefs(storage);
+    navigatorPrefsService.set({ arrangement: "stacked" });
+    expect(storage.get<string>("navigatorArrangement")).toBe("stacked");
+    sub.dispose();
+  });
+
+  it("picks up an arrangement that arrives after activation", () => {
+    const storage = fakeStorage();
+    const sub = initNavigatorPrefs(storage);
+    expect(navigatorPrefsService.getState().arrangement).toBe("one-at-a-time");
+    storage.set("navigatorArrangement", "stacked");
+    storage.emit();
+    expect(navigatorPrefsService.getState().arrangement).toBe("stacked");
+    sub.dispose();
   });
 });

--- a/packages/extensions-core/src/navigator/navigator-prefs.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { ExtensionStorage } from "@silo-code/sdk";
+import {
+  navigatorPrefsService,
+  initNavigatorPrefs,
+  clearNavigatorPrefsListeners,
+} from "./navigator-prefs";
+
+/** In-memory ExtensionStorage stand-in, mirroring the host's real contract. */
+function fakeStorage(
+  initial: Record<string, unknown> = {},
+): ExtensionStorage & { emit(): void } {
+  const data = new Map<string, unknown>(Object.entries(initial));
+  const listeners = new Set<() => void>();
+  return {
+    get: ((key: string, fallback?: unknown) =>
+      data.has(key) ? data.get(key) : fallback) as ExtensionStorage["get"],
+    set(key, value) {
+      if (value === undefined) data.delete(key);
+      else data.set(key, value);
+    },
+    keys: () => [...data.keys()],
+    subscribe(listener) {
+      listeners.add(listener);
+      return { dispose: () => listeners.delete(listener) };
+    },
+    emit() {
+      for (const l of listeners) l();
+    },
+  };
+}
+
+beforeEach(() => {
+  clearNavigatorPrefsListeners();
+});
+
+describe("navigator prefs persistence", () => {
+  it("defaults to empty order / disabled set", () => {
+    const sub = initNavigatorPrefs(fakeStorage());
+    expect(navigatorPrefsService.getState()).toEqual({
+      viewOrder: [],
+      disabledViews: [],
+    });
+    sub.dispose();
+  });
+
+  it("hydrates a persisted order and disabled set (restart case)", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({
+        navigatorViewOrder: ["silo.agents.by-status", "workspaces"],
+        navigatorDisabledViews: ["workspaces"],
+      }),
+    );
+    expect(navigatorPrefsService.getState().viewOrder).toEqual([
+      "silo.agents.by-status",
+      "workspaces",
+    ]);
+    expect(navigatorPrefsService.getState().disabledViews).toEqual([
+      "workspaces",
+    ]);
+    sub.dispose();
+  });
+
+  it("coerces a non-array persisted value to an empty list", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({
+        navigatorViewOrder: "workspaces",
+        navigatorDisabledViews: 3,
+      }),
+    );
+    expect(navigatorPrefsService.getState().viewOrder).toEqual([]);
+    expect(navigatorPrefsService.getState().disabledViews).toEqual([]);
+    sub.dispose();
+  });
+
+  it("coerces an array with non-string entries to an empty list", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({ navigatorViewOrder: ["ok", 42] }),
+    );
+    expect(navigatorPrefsService.getState().viewOrder).toEqual([]);
+    sub.dispose();
+  });
+
+  it("persists a change through set()", () => {
+    const storage = fakeStorage();
+    const sub = initNavigatorPrefs(storage);
+    navigatorPrefsService.set({ viewOrder: ["a", "b"] });
+    expect(storage.get<string[]>("navigatorViewOrder")).toEqual(["a", "b"]);
+    sub.dispose();
+  });
+
+  it("picks up a value that arrives after activation (async hydration)", () => {
+    const storage = fakeStorage();
+    const sub = initNavigatorPrefs(storage);
+    expect(navigatorPrefsService.getState().disabledViews).toEqual([]);
+    storage.set("navigatorDisabledViews", ["workspaces"]);
+    storage.emit();
+    expect(navigatorPrefsService.getState().disabledViews).toEqual([
+      "workspaces",
+    ]);
+    sub.dispose();
+  });
+
+  it("notifies subscribers on set() so the panel re-renders", () => {
+    const sub = initNavigatorPrefs(fakeStorage());
+    const seen: string[][] = [];
+    const l = navigatorPrefsService.subscribe((p) =>
+      seen.push([...p.viewOrder]),
+    );
+    navigatorPrefsService.set({ viewOrder: ["x"] });
+    expect(seen).toEqual([["x"]]);
+    l.dispose();
+    sub.dispose();
+  });
+
+  it("dispose stops reacting to further storage changes", () => {
+    const storage = fakeStorage();
+    const sub = initNavigatorPrefs(storage);
+    sub.dispose();
+    storage.set("navigatorViewOrder", ["a"]);
+    storage.emit();
+    expect(navigatorPrefsService.getState().viewOrder).toEqual([]);
+  });
+});

--- a/packages/extensions-core/src/navigator/navigator-prefs.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.ts
@@ -1,9 +1,9 @@
 /**
- * `core.navigator`'s own preferences: the user's view order and the set of
- * views they've turned off. Persisted in `core.navigator`'s
- * `ctx.storage.global` — the same bag that holds the `activeView` key — since
- * these are global "how the Navigator is arranged" choices, not per-workspace
- * lenses (RFC 0023 / RFC 0030).
+ * `core.navigator`'s own preferences: the user's view order, the set of views
+ * they've turned off, and whether the panel shows one view at a time or stacks
+ * them all. Persisted in `core.navigator`'s `ctx.storage.global` — the same bag
+ * that holds the `activeView` key — since these are global "how the Navigator
+ * is arranged" choices, not per-workspace lenses (RFC 0023 / RFC 0030).
  *
  * A tiny `ReactiveService` module singleton, mirroring the agent settings
  * store (`extensions-silo/src/agents/settings-store.ts`): the panel reads it
@@ -18,8 +18,12 @@
 
 import type { ExtensionStorage, ReactiveService } from "@silo-code/sdk";
 
-/** The persisted Navigator preferences. RFC 0030's `arrangement` /
- * `stackedCollapsed` keys land here when stacked mode ships. */
+/** How the Navigator arranges its enabled views (RFC 0030). */
+export type ViewArrangement = "one-at-a-time" | "stacked";
+
+export const DEFAULT_ARRANGEMENT: ViewArrangement = "one-at-a-time";
+
+/** The persisted Navigator preferences. */
 export interface NavigatorPrefs {
   /**
    * View ids in the user's chosen order. A registered id not listed here sorts
@@ -33,14 +37,29 @@ export interface NavigatorPrefs {
    * Retained across (un)registration, same as {@link viewOrder} entries.
    */
   disabledViews: readonly string[];
+  /**
+   * `"one-at-a-time"` (default): the View List + a single Active View.
+   * `"stacked"`: no View List; every enabled view is a collapsible section in
+   * {@link viewOrder}.
+   */
+  arrangement: ViewArrangement;
+  /**
+   * In stacked mode, the view ids whose section is collapsed. Absent = expanded.
+   * Retained across (un)registration, same as the lists above.
+   */
+  stackedCollapsed: readonly string[];
 }
 
 const STORAGE_KEY_VIEW_ORDER = "navigatorViewOrder";
 const STORAGE_KEY_DISABLED_VIEWS = "navigatorDisabledViews";
+const STORAGE_KEY_ARRANGEMENT = "navigatorArrangement";
+const STORAGE_KEY_STACKED_COLLAPSED = "navigatorStackedCollapsed";
 
 const DEFAULT_PREFS: NavigatorPrefs = {
   viewOrder: [],
   disabledViews: [],
+  arrangement: DEFAULT_ARRANGEMENT,
+  stackedCollapsed: [],
 };
 
 /** Coerce persisted JSON to a string array — anything else becomes `[]`. */
@@ -48,6 +67,10 @@ function coerceIdList(v: unknown): readonly string[] {
   return Array.isArray(v) && v.every((x) => typeof x === "string")
     ? (v as string[])
     : [];
+}
+
+function coerceArrangement(v: unknown): ViewArrangement {
+  return v === "stacked" || v === "one-at-a-time" ? v : DEFAULT_ARRANGEMENT;
 }
 
 function sameList(a: readonly string[], b: readonly string[]): boolean {
@@ -70,6 +93,10 @@ export const navigatorPrefsService: ReactiveService<NavigatorPrefs> & {
     prefs = { ...prefs, ...patch };
     backingStorage?.set(STORAGE_KEY_VIEW_ORDER, [...prefs.viewOrder]);
     backingStorage?.set(STORAGE_KEY_DISABLED_VIEWS, [...prefs.disabledViews]);
+    backingStorage?.set(STORAGE_KEY_ARRANGEMENT, prefs.arrangement);
+    backingStorage?.set(STORAGE_KEY_STACKED_COLLAPSED, [
+      ...prefs.stackedCollapsed,
+    ]);
     for (const l of listeners) l(prefs);
   },
 };
@@ -91,11 +118,28 @@ export function initNavigatorPrefs(storage: ExtensionStorage): {
     const disabledViews = coerceIdList(
       storage.get<unknown>(STORAGE_KEY_DISABLED_VIEWS, prefs.disabledViews),
     );
+    const arrangement = coerceArrangement(
+      storage.get<unknown>(STORAGE_KEY_ARRANGEMENT, prefs.arrangement),
+    );
+    const stackedCollapsed = coerceIdList(
+      storage.get<unknown>(
+        STORAGE_KEY_STACKED_COLLAPSED,
+        prefs.stackedCollapsed,
+      ),
+    );
     if (
       !sameList(viewOrder, prefs.viewOrder) ||
-      !sameList(disabledViews, prefs.disabledViews)
+      !sameList(disabledViews, prefs.disabledViews) ||
+      arrangement !== prefs.arrangement ||
+      !sameList(stackedCollapsed, prefs.stackedCollapsed)
     ) {
-      prefs = { ...prefs, viewOrder, disabledViews };
+      prefs = {
+        ...prefs,
+        viewOrder,
+        disabledViews,
+        arrangement,
+        stackedCollapsed,
+      };
       for (const l of listeners) l(prefs);
     }
   }

--- a/packages/extensions-core/src/navigator/navigator-prefs.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.ts
@@ -1,0 +1,112 @@
+/**
+ * `core.navigator`'s own preferences: the user's view order and the set of
+ * views they've turned off. Persisted in `core.navigator`'s
+ * `ctx.storage.global` — the same bag that holds the `activeView` key — since
+ * these are global "how the Navigator is arranged" choices, not per-workspace
+ * lenses (RFC 0023 / RFC 0030).
+ *
+ * A tiny `ReactiveService` module singleton, mirroring the agent settings
+ * store (`extensions-silo/src/agents/settings-store.ts`): the panel reads it
+ * with `useServiceState`, the settings tab writes it with `set()`, and both
+ * live in different extensions (`core.navigator` owns the store; `core.layout`
+ * renders the editor via `getExtension`), so keeping the state here — not in
+ * host state and not in a component — is what lets that composition work.
+ *
+ * Types-only `@silo-code/sdk` import so this module (and its unit test) never
+ * loads the SDK runtime.
+ */
+
+import type { ExtensionStorage, ReactiveService } from "@silo-code/sdk";
+
+/** The persisted Navigator preferences. RFC 0030's `arrangement` /
+ * `stackedCollapsed` keys land here when stacked mode ships. */
+export interface NavigatorPrefs {
+  /**
+   * View ids in the user's chosen order. A registered id not listed here sorts
+   * after every listed id (by `NavigatorView.order` then title). An id listed
+   * here that isn't currently registered is kept untouched, so a view returns
+   * to its slot when its extension is re-enabled.
+   */
+  viewOrder: readonly string[];
+  /**
+   * View ids the user has turned off — filtered out of the Navigator entirely.
+   * Retained across (un)registration, same as {@link viewOrder} entries.
+   */
+  disabledViews: readonly string[];
+}
+
+const STORAGE_KEY_VIEW_ORDER = "navigatorViewOrder";
+const STORAGE_KEY_DISABLED_VIEWS = "navigatorDisabledViews";
+
+const DEFAULT_PREFS: NavigatorPrefs = {
+  viewOrder: [],
+  disabledViews: [],
+};
+
+/** Coerce persisted JSON to a string array — anything else becomes `[]`. */
+function coerceIdList(v: unknown): readonly string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string")
+    ? (v as string[])
+    : [];
+}
+
+function sameList(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}
+
+let prefs: NavigatorPrefs = DEFAULT_PREFS;
+let backingStorage: ExtensionStorage | null = null;
+const listeners = new Set<(p: NavigatorPrefs) => void>();
+
+export const navigatorPrefsService: ReactiveService<NavigatorPrefs> & {
+  set(patch: Partial<NavigatorPrefs>): void;
+} = {
+  getState: () => prefs,
+  subscribe(listener) {
+    listeners.add(listener);
+    return { dispose: () => listeners.delete(listener) };
+  },
+  set(patch) {
+    prefs = { ...prefs, ...patch };
+    backingStorage?.set(STORAGE_KEY_VIEW_ORDER, [...prefs.viewOrder]);
+    backingStorage?.set(STORAGE_KEY_DISABLED_VIEWS, [...prefs.disabledViews]);
+    for (const l of listeners) l(prefs);
+  },
+};
+
+/**
+ * Bind persisted storage to the service — call once from `core.navigator`'s
+ * `activate()`. Reads immediately and re-reads on every storage change, since
+ * `ctx.storage` hydrates asynchronously and a value saved last session (or in
+ * another window) may not be present the instant `activate` runs.
+ */
+export function initNavigatorPrefs(storage: ExtensionStorage): {
+  dispose(): void;
+} {
+  backingStorage = storage;
+  function read() {
+    const viewOrder = coerceIdList(
+      storage.get<unknown>(STORAGE_KEY_VIEW_ORDER, prefs.viewOrder),
+    );
+    const disabledViews = coerceIdList(
+      storage.get<unknown>(STORAGE_KEY_DISABLED_VIEWS, prefs.disabledViews),
+    );
+    if (
+      !sameList(viewOrder, prefs.viewOrder) ||
+      !sameList(disabledViews, prefs.disabledViews)
+    ) {
+      prefs = { ...prefs, viewOrder, disabledViews };
+      for (const l of listeners) l(prefs);
+    }
+  }
+  read();
+  const sub = storage.subscribe(read);
+  return { dispose: () => sub.dispose() };
+}
+
+/** Test seam — drop all subscribers and reset to compiled defaults. */
+export function clearNavigatorPrefsListeners(): void {
+  listeners.clear();
+  prefs = DEFAULT_PREFS;
+  backingStorage = null;
+}

--- a/packages/extensions-core/src/navigator/navigator-prefs.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.ts
@@ -145,7 +145,13 @@ export function initNavigatorPrefs(storage: ExtensionStorage): {
   }
   read();
   const sub = storage.subscribe(read);
-  return { dispose: () => sub.dispose() };
+  return {
+    dispose: () => {
+      sub.dispose();
+      // Stop `set()` writing to storage the extension no longer owns.
+      if (backingStorage === storage) backingStorage = null;
+    },
+  };
 }
 
 /** Test seam — drop all subscribers and reset to compiled defaults. */

--- a/packages/extensions-core/src/navigator/navigator-views.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.test.ts
@@ -5,6 +5,7 @@ import {
   activeViewIndex,
   buildViewRows,
   moveViewInOrder,
+  reorderSavedViews,
   resolveActiveView,
   resolveViewList,
   setViewDisabled,
@@ -203,6 +204,56 @@ describe("setViewDisabled", () => {
   it("is idempotent", () => {
     expect(setViewDisabled(["a"], "a", true)).toEqual(["a"]);
     expect(setViewDisabled(["a"], "b", false)).toEqual(["a"]);
+  });
+});
+
+describe("reorderSavedViews", () => {
+  it("moves a registered view and rewrites the saved order", () => {
+    // Nothing saved yet; three registered views displayed a,b,c.
+    expect(reorderSavedViews([], ["a", "b", "c"], "c", -1)).toEqual([
+      "a",
+      "c",
+      "b",
+    ]);
+  });
+
+  it("keeps a saved id for a currently-unregistered view in its slot", () => {
+    // Saved order a,b,C,d where C's extension is disabled (not displayed).
+    // User nudges b down past d.
+    const saved = ["a", "b", "C", "d"];
+    const displayed = ["a", "b", "d"];
+    expect(reorderSavedViews(saved, displayed, "b", 1)).toEqual([
+      "a",
+      "d",
+      "C",
+      "b",
+    ]);
+  });
+
+  it("leaves an unregistered leading id untouched", () => {
+    const saved = ["GONE", "a", "b"];
+    const displayed = ["a", "b"];
+    expect(reorderSavedViews(saved, displayed, "b", -1)).toEqual([
+      "GONE",
+      "b",
+      "a",
+    ]);
+  });
+
+  it("appends registered ids that were never saved", () => {
+    // a is saved; b, c are registered but not yet in viewOrder.
+    expect(reorderSavedViews(["a"], ["a", "b", "c"], "c", -1)).toEqual([
+      "a",
+      "c",
+      "b",
+    ]);
+  });
+
+  it("is a no-op at an edge (still returns a fresh array)", () => {
+    const saved = ["a", "b"];
+    const out = reorderSavedViews(saved, ["a", "b"], "a", -1);
+    expect(out).toEqual(["a", "b"]);
+    expect(out).not.toBe(saved);
   });
 });
 

--- a/packages/extensions-core/src/navigator/navigator-views.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.test.ts
@@ -9,6 +9,7 @@ import {
   resolveActiveView,
   resolveViewList,
   setViewDisabled,
+  stackedChromeHostId,
   toggleIdInList,
 } from "./navigator-views";
 
@@ -254,6 +255,25 @@ describe("reorderSavedViews", () => {
     const out = reorderSavedViews(saved, ["a", "b"], "a", -1);
     expect(out).toEqual(["a", "b"]);
     expect(out).not.toBe(saved);
+  });
+});
+
+describe("stackedChromeHostId", () => {
+  it("is the Workspaces view when it's enabled", () => {
+    const enabled = [
+      view("ext.status", "Agents"),
+      view(DEFAULT_VIEW_ID, "Workspaces"),
+    ];
+    expect(stackedChromeHostId(enabled)).toBe(DEFAULT_VIEW_ID);
+  });
+
+  it("falls back to the top view when Workspaces is hidden", () => {
+    const enabled = [view("ext.status", "Agents"), view("ext.tasks", "Tasks")];
+    expect(stackedChromeHostId(enabled)).toBe("ext.status");
+  });
+
+  it("is undefined when nothing is enabled", () => {
+    expect(stackedChromeHostId([])).toBeUndefined();
   });
 });
 

--- a/packages/extensions-core/src/navigator/navigator-views.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.test.ts
@@ -8,6 +8,7 @@ import {
   resolveActiveView,
   resolveViewList,
   setViewDisabled,
+  toggleIdInList,
 } from "./navigator-views";
 
 function view(
@@ -202,5 +203,21 @@ describe("setViewDisabled", () => {
   it("is idempotent", () => {
     expect(setViewDisabled(["a"], "a", true)).toEqual(["a"]);
     expect(setViewDisabled(["a"], "b", false)).toEqual(["a"]);
+  });
+});
+
+describe("toggleIdInList", () => {
+  it("adds an absent id", () => {
+    expect(toggleIdInList(["a"], "b")).toEqual(["a", "b"]);
+  });
+
+  it("removes a present id", () => {
+    expect(toggleIdInList(["a", "b"], "a")).toEqual(["b"]);
+  });
+
+  it("never mutates the input", () => {
+    const input = ["a"];
+    toggleIdInList(input, "b");
+    expect(input).toEqual(["a"]);
   });
 });

--- a/packages/extensions-core/src/navigator/navigator-views.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.test.ts
@@ -4,15 +4,19 @@ import {
   DEFAULT_VIEW_ID,
   activeViewIndex,
   buildViewRows,
+  moveViewInOrder,
   resolveActiveView,
+  resolveViewList,
+  setViewDisabled,
 } from "./navigator-views";
 
 function view(
   id: string,
   title = id,
   icon?: NavigatorView["icon"],
+  order?: number,
 ): NavigatorView {
-  return { id, title, icon, component: () => null };
+  return { id, title, icon, order, component: () => null };
 }
 
 const views = [
@@ -99,5 +103,104 @@ describe("buildViewRows", () => {
     const [row] = buildViewRows([withIcon], undefined);
     expect(row.title).toBe("Acme");
     expect(row.icon).toBe("🔧");
+  });
+});
+
+describe("resolveViewList", () => {
+  const noPrefs = { viewOrder: [], disabledViews: [] };
+  const reg = [
+    view("b", "Beta", undefined, 2),
+    view("a", "Alpha", undefined, 1),
+    view("c", "Gamma", undefined, 1),
+  ];
+
+  it("sorts unlisted views by order then title with no prefs", () => {
+    const { ordered } = resolveViewList(reg, noPrefs);
+    // a(1) and c(1) tie on order → title: Alpha before Gamma; then b(2).
+    expect(ordered.map((v) => v.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("puts viewOrder ids first, in that order, rest appended by sort", () => {
+    const { ordered } = resolveViewList(reg, {
+      viewOrder: ["b", "c"],
+      disabledViews: [],
+    });
+    expect(ordered.map((v) => v.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("skips a viewOrder id that isn't registered", () => {
+    const { ordered } = resolveViewList(reg, {
+      viewOrder: ["gone", "b"],
+      disabledViews: [],
+    });
+    expect(ordered.map((v) => v.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("partitions enabled / disabled by disabledViews", () => {
+    const { enabled, disabled } = resolveViewList(reg, {
+      viewOrder: [],
+      disabledViews: ["a"],
+    });
+    expect(enabled.map((v) => v.id)).toEqual(["c", "b"]);
+    expect(disabled.map((v) => v.id)).toEqual(["a"]);
+  });
+
+  it("forces the first view on when disabledViews would empty the list", () => {
+    const { enabled } = resolveViewList(reg, {
+      viewOrder: ["a", "b", "c"],
+      disabledViews: ["a", "b", "c"],
+    });
+    expect(enabled.map((v) => v.id)).toEqual(["a"]);
+  });
+
+  it("returns empty lists when nothing is registered", () => {
+    expect(resolveViewList([], noPrefs)).toEqual({
+      ordered: [],
+      enabled: [],
+      disabled: [],
+    });
+  });
+});
+
+describe("moveViewInOrder", () => {
+  it("moves an id up", () => {
+    expect(moveViewInOrder(["a", "b", "c"], "b", -1)).toEqual(["b", "a", "c"]);
+  });
+
+  it("moves an id down", () => {
+    expect(moveViewInOrder(["a", "b", "c"], "b", 1)).toEqual(["a", "c", "b"]);
+  });
+
+  it("is a no-op at the top edge", () => {
+    expect(moveViewInOrder(["a", "b"], "a", -1)).toEqual(["a", "b"]);
+  });
+
+  it("is a no-op at the bottom edge", () => {
+    expect(moveViewInOrder(["a", "b"], "b", 1)).toEqual(["a", "b"]);
+  });
+
+  it("is a no-op when the id isn't present", () => {
+    expect(moveViewInOrder(["a", "b"], "x", 1)).toEqual(["a", "b"]);
+  });
+
+  it("returns a fresh array (never mutates the input)", () => {
+    const input = ["a", "b"];
+    moveViewInOrder(input, "a", 1);
+    expect(input).toEqual(["a", "b"]);
+  });
+});
+
+describe("setViewDisabled", () => {
+  it("adds an id when disabling", () => {
+    expect(setViewDisabled(["a"], "b", true)).toEqual(["a", "b"]);
+  });
+
+  it("removes an id when enabling", () => {
+    expect(setViewDisabled(["a", "b"], "b", false)).toEqual(["a"]);
+  });
+
+  it("is idempotent", () => {
+    expect(setViewDisabled(["a"], "a", true)).toEqual(["a"]);
+    expect(setViewDisabled(["a"], "b", false)).toEqual(["a"]);
   });
 });

--- a/packages/extensions-core/src/navigator/navigator-views.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.ts
@@ -97,6 +97,35 @@ export function setViewDisabled(
     : disabledViews.filter((x) => x !== id);
 }
 
+/**
+ * Apply a one-slot move within the *displayed* (registered) order and weave
+ * the result back into the full saved `viewOrder`, so ids for views that
+ * aren't currently registered keep their slot — the navigator-prefs contract
+ * ("a view returns to its slot when its extension is re-enabled").
+ *
+ * `displayedIds` is the registered views in their current on-screen order
+ * (i.e. `resolveViewList(...).ordered` mapped to ids); its registered entries
+ * that came from `savedOrder` are in `savedOrder`'s order, so the positional
+ * weave below stays consistent.
+ */
+export function reorderSavedViews(
+  savedOrder: readonly string[],
+  displayedIds: readonly string[],
+  id: string,
+  dir: -1 | 1,
+): string[] {
+  const swapped = moveViewInOrder(displayedIds, id, dir);
+  const displayed = new Set(displayedIds);
+  const out: string[] = [];
+  let i = 0;
+  for (const vid of savedOrder) {
+    if (displayed.has(vid)) out.push(swapped[i++]);
+    else out.push(vid); // not registered right now — hold its position
+  }
+  for (; i < swapped.length; i++) out.push(swapped[i]); // newly-saved registered ids
+  return out;
+}
+
 /** Toggle `id`'s membership in a list — used for stacked-mode collapse state. */
 export function toggleIdInList(list: readonly string[], id: string): string[] {
   return list.includes(id) ? list.filter((x) => x !== id) : [...list, id];

--- a/packages/extensions-core/src/navigator/navigator-views.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.ts
@@ -158,6 +158,20 @@ export function resolveActiveView(
 }
 
 /**
+ * In the **stacked** arrangement, the one section that carries otherwise-
+ * unscoped `"navigator"` toolbar chrome — today just `core.workspaces`'
+ * Add-workspace "+". It sits on the Workspaces section, or on the top section
+ * if Workspaces is hidden. `undefined` only when nothing is enabled (which
+ * {@link resolveViewList} prevents). One-at-a-time mode doesn't call this —
+ * there, unscoped chrome shows on every view as before.
+ */
+export function stackedChromeHostId(
+  enabled: readonly NavigatorView[],
+): string | undefined {
+  return (enabled.find((v) => v.id === DEFAULT_VIEW_ID) ?? enabled[0])?.id;
+}
+
+/**
  * Where roving focus parks when it enters the view list — the active row, so
  * arrowing starts from what's on screen. `findIndex`'s `-1` (no active view,
  * e.g. nothing registered yet) is passed through rather than clamped here:

--- a/packages/extensions-core/src/navigator/navigator-views.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.ts
@@ -1,10 +1,101 @@
 import type { NavigatorView } from "@silo-code/sdk";
 
-// Pure model for the Navigator's view list (RFC 0023). The panel names every
-// registered view in a list at the top and renders one of them below; nothing
-// here is special-cased for the Workspaces view — it is registered through the
-// same public API as any other, and only named below as the fallback the panel
-// opens on.
+// Pure model for the Navigator's view list (RFC 0023 / RFC 0030). The panel
+// names every enabled view in a list at the top and renders one of them below;
+// nothing here is special-cased for the Workspaces view — it is registered
+// through the same public API as any other, and only named below as the
+// fallback the panel opens on.
+
+/** The subset of {@link import("./navigator-prefs").NavigatorPrefs} the
+ * resolver needs — kept structural so this module stays free of the prefs
+ * store. */
+export interface ViewArrangementPrefs {
+  viewOrder: readonly string[];
+  disabledViews: readonly string[];
+}
+
+/** Registered views split by the user's arrangement preferences. */
+export interface ResolvedViewList {
+  /** Every registered view in final sort order (enabled and disabled
+   * interleaved) — the row order for the settings list. */
+  ordered: NavigatorView[];
+  /** Enabled views only, in the same order — what the Navigator renders. */
+  enabled: NavigatorView[];
+  /** Disabled-but-registered views, in the same order. */
+  disabled: NavigatorView[];
+}
+
+/**
+ * Sort registered views by the user's order, then resolve which are enabled.
+ *
+ * Order: ids listed in `prefs.viewOrder` come first, in that order; every
+ * other registered view follows, by `NavigatorView.order ?? 0` then `title`.
+ * A `viewOrder` id that isn't registered is skipped (but the caller keeps it
+ * in storage, so it returns to its slot if its extension comes back).
+ *
+ * Enabled = not in `prefs.disabledViews`, with one guard: if that would leave
+ * nothing enabled, the first view in sort order is forced on. The settings UI
+ * also blocks the toggle that would get there, but storage can arrive from
+ * another window, so the resolver is the real backstop.
+ */
+export function resolveViewList(
+  registered: readonly NavigatorView[],
+  prefs: ViewArrangementPrefs,
+): ResolvedViewList {
+  const byId = new Map(registered.map((v) => [v.id, v]));
+  const listed = prefs.viewOrder
+    .map((id) => byId.get(id))
+    .filter((v): v is NavigatorView => v != null);
+  const listedIds = new Set(listed.map((v) => v.id));
+  const rest = registered
+    .filter((v) => !listedIds.has(v.id))
+    .sort(
+      (a, b) =>
+        (a.order ?? 0) - (b.order ?? 0) || a.title.localeCompare(b.title),
+    );
+  const ordered = [...listed, ...rest];
+
+  const disabledSet = new Set(prefs.disabledViews);
+  let enabled = ordered.filter((v) => !disabledSet.has(v.id));
+  if (enabled.length === 0 && ordered.length > 0) enabled = [ordered[0]];
+  const enabledIds = new Set(enabled.map((v) => v.id));
+  const disabled = ordered.filter((v) => !enabledIds.has(v.id));
+
+  return { ordered, enabled, disabled };
+}
+
+/**
+ * The full ordered id list with `id` moved one slot in `dir` (`-1` up, `1`
+ * down). A no-op at the ends or when `id` isn't present. This becomes the new
+ * `viewOrder` — which then lists every registered view explicitly, so the
+ * order is stable across restarts.
+ */
+export function moveViewInOrder(
+  orderedIds: readonly string[],
+  id: string,
+  dir: -1 | 1,
+): string[] {
+  const from = orderedIds.indexOf(id);
+  if (from === -1) return [...orderedIds];
+  const to = from + dir;
+  if (to < 0 || to >= orderedIds.length) return [...orderedIds];
+  const next = [...orderedIds];
+  [next[from], next[to]] = [next[to], next[from]];
+  return next;
+}
+
+/** Add or remove `id` from the disabled list (idempotent). */
+export function setViewDisabled(
+  disabledViews: readonly string[],
+  id: string,
+  disabled: boolean,
+): string[] {
+  const has = disabledViews.includes(id);
+  if (disabled === has) return [...disabledViews];
+  return disabled
+    ? [...disabledViews, id]
+    : disabledViews.filter((x) => x !== id);
+}
 
 /**
  * The view the Navigator opens with when the user hasn't chosen one — the

--- a/packages/extensions-core/src/navigator/navigator-views.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.ts
@@ -97,6 +97,11 @@ export function setViewDisabled(
     : disabledViews.filter((x) => x !== id);
 }
 
+/** Toggle `id`'s membership in a list — used for stacked-mode collapse state. */
+export function toggleIdInList(list: readonly string[], id: string): string[] {
+  return list.includes(id) ? list.filter((x) => x !== id) : [...list, id];
+}
+
 /**
  * The view the Navigator opens with when the user hasn't chosen one — the
  * workspace list, registered by `core.workspaces`. Only a *preference* for

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -25,9 +25,12 @@
   /* Small top padding is the "drop before the first entry" catch-all zone (a
      group's line sits at -7px, which the Navigator header above absorbs — it
      no longer risks clipping against the pane top, so this doesn't need the
-     12px it carried when the list was the whole panel). Bottom padding is the
-     always-present drop-at-the-end strip below the last entry. */
-  padding: 4px 0 24px;
+     12px it carried when the list was the whole panel). Bottom padding is a
+     small drop-at-the-end strip; in the one-at-a-time arrangement the bigger
+     catch area comes from `.workspaces-body`'s `min-height: 100%` fill, and in
+     the stacked arrangement the section is content-height, so this is kept
+     modest to match the uniform gap the Navigator puts between sections. */
+  padding: 4px 0 8px;
 }
 
 .ws-item {

--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -6,6 +6,7 @@ import {
   homeDir,
   confirmAndCloseWorkspace,
 } from "@silo-code/extension-host/internal";
+import type { NavigatorExtensionAPI } from "../navigator/navigator-api";
 import { WorkspacesView } from "./WorkspacesView";
 import { WorkspaceStatusItem } from "./WorkspaceStatusItem";
 import { registerWorkspaceCycle } from "./workspace-cycle";
@@ -66,15 +67,27 @@ export const extension: Extension = {
 
     // "Add workspace" in the Navigator header. A toolbar contribution rather
     // than panel chrome, which is what lets core.navigator stay ignorant of
-    // workspaces — and it is deliberately *unscoped* (no `when`), so opening
-    // or creating a workspace stays one click away from whichever view the
-    // user is in.
+    // workspaces.
+    //
+    // One-at-a-time arrangement: unscoped, on every view's header, so
+    // New-workspace stays one click away wherever you are (RFC 0023).
+    // Stacked arrangement: every view's header is on screen at once, so it
+    // would repeat down the panel — `core.navigator` names the single section
+    // that should carry it (the Workspaces section, or the top one if
+    // Workspaces is hidden) and this scopes to that.
     ctx.registerToolbarItem({
       id: "core.workspaces.add",
       surface: "navigator",
       icon: "Plus",
       label: "Add workspace",
       tooltip: "Add workspace",
+      when: (_keys, target) => {
+        const host =
+          ctx
+            .getExtension<NavigatorExtensionAPI>("core.navigator")
+            ?.api?.stackedChromeHostViewId() ?? null;
+        return host === null || target.viewId === host;
+      },
       menu: () => ctx.workspaces.getOpenWorkspaceMenuItems(),
     });
 


### PR DESCRIPTION
## Summary

The Navigator (the left panel you switch workspaces and agents from) now has settings. Under **Settings → Layout → Navigator** you can:

1. **Reorder its views** and **turn ones off** — hide the Agents view when you're not running agents, hide Workspaces if you navigate from a file tree, or put the view you actually use first. At least one view stays on.
2. **Choose how the views are laid out** — "One at a time" (today's behaviour: a list of views at the top, one shown below) or "Stacked", where the list disappears and every enabled view is shown at once as a collapsible section, in the order you set. Stacked lets you watch agents and the workspace list together instead of flipping between them.

Both settings are global and remembered across restarts. The "New workspace" **+** button behaves as before in one-at-a-time mode; in stacked mode it appears once, on the Workspaces section (or the top section if Workspaces is hidden), instead of repeating on every section.

Nothing changes for anyone who doesn't open the new settings — one-at-a-time is the default and works exactly as it did.

## Details

RFC `docs/proposals/0030-navigator-view-arrangement.md` carries the full design; ADR `docs/decisions/0044` records the stacked-mode decision and supersedes ADR 0038's deferred "stacked collapsible sections" alternative. No `@silo-code/sdk` change and no version bump — the whole feature is `core.navigator`'s renderer plus a preferences store.

### Structure

- **`core.navigator`** owns a `navigatorPrefs` reactive store on its own `ctx.storage.global` (`viewOrder`, `disabledViews`, `arrangement`, `stackedCollapsed` — all global, alongside the existing `activeView` key), the pure `resolveViewList` resolver, and a published `SettingsPanel` component. It also exposes `stackedChromeHostViewId()`.
- **`core.layout`** gains a General/Navigator tab strip on its settings page and mounts `core.navigator`'s panel via `getExtension` — the same bundled-only composition as `silo.agents` → `core.agents-settings`. The Navigator tab is hidden when `core.navigator` isn't active.
- **`NavigatorPanel`** splits into a thin dispatcher over `SwitcherNavigator` (unchanged one-at-a-time behaviour) and `StackedNavigator` (new).

### `resolveViewList`

Single source of truth for both arrangements: sorts registered views by saved order (unlisted views append by `NavigatorView.order` then title), partitions enabled/disabled, and forces the first view on if the disabled set would empty the list. `resolveActiveView` runs against the enabled set; a saved `activeView` that's now disabled falls back without rewriting storage. `reorderSavedViews` weaves a reorder back into the full saved list so a view whose extension is currently disabled keeps its slot.

### Stacked mode

- Each enabled view is a `<section>` with its own header (disclosure toggle + title + that view's `"navigator"`-surface toolbar contributions), marked `data-focus-chrome`.
- No Active View: every rendered view gets `active` regardless of collapse state (collapse is purely visual — a compatible `active={!isCollapsed}` refinement is deferred in the ADR). Keyboard region-entry lands in the first expanded section.
- Sections cap at `60vh` with their own inner scroll; uniform `9px` gap above every section; fixed-height headers so action-bearing and text-only headers match. Single enabled view renders plain (no disclosure).
- The `activeView` storage key is read only in one-at-a-time mode; switching back restores it.
- `core.workspaces` `when`-scopes its `+` to `stackedChromeHostViewId()` in stacked mode only (unscoped, on every view, in one-at-a-time — unchanged from RFC 0023).

### Docs

RFC 0030 (`implemented`), ADR 0044 (`accepted`), notes added to ADR 0038 and its index; `docs/domain-language.md` gains **View arrangement** and **Stacked view** and updates **Active View** / **View List**.

### Tests

`navigator-prefs.test.ts` (store: defaults, hydration, coercion, async, dispose, subscriber notification for all four keys) and `navigator-views.test.ts` (`resolveViewList`, `moveViewInOrder`, `reorderSavedViews`, `setViewDisabled`, `toggleIdInList`, `stackedChromeHostId`). `pnpm lint`, `pnpm --filter silo exec tsc --noEmit`, and the extensions-core / extensions-silo / extension-host suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
