### PR TITLE
feat(sdk)!: SettingRow enabled/dependent for gated sub-settings

### DIFF
--- a/apps/docs/.vitepress/theme/silo-demos.css
+++ b/apps/docs/.vitepress/theme/silo-demos.css
@@ -1159,16 +1159,16 @@ html.dark .silo-demo {
   color: var(--silo-color-text-lo);
 }
 .silo-demo .silo-setting-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: 20px;
   padding: 10px 0;
 }
 .silo-demo .silo-setting-row + .silo-setting-row {
   border-top: 1px solid var(--silo-color-border-strong);
 }
 .silo-demo .silo-setting-row .text {
+  align-self: center;
   min-width: 0;
 }
 .silo-demo .silo-setting-row .row-label {
@@ -1182,7 +1182,18 @@ html.dark .silo-demo {
   max-width: 420px;
 }
 .silo-demo .silo-setting-row .control {
+  align-self: center;
   flex-shrink: 0;
+}
+.silo-demo .silo-setting-row .dependent {
+  grid-column: 1;
+  grid-row: 2;
+  margin: 8px 0 0;
+  padding: 0 0 8px 16px;
+  border-left: 1px solid
+    color-mix(in srgb, var(--silo-color-text-hi) 30%, var(--silo-color-bg));
+  font-size: var(--silo-font-size-sm);
+  color: var(--silo-color-text-lo);
 }
 .silo-demo .status-ok {
   display: inline-flex;

--- a/apps/docs/api/types/functions/SettingRow.md
+++ b/apps/docs/api/types/functions/SettingRow.md
@@ -4,7 +4,7 @@
 function SettingRow(__namedParameters): Element;
 ```
 
-Defined in: [packages/sdk/src/SettingRow.tsx:28](https://github.com/silo-code/silo/blob/main/packages/sdk/src/SettingRow.tsx#L28)
+Defined in: [packages/sdk/src/SettingRow.tsx:58](https://github.com/silo-code/silo/blob/main/packages/sdk/src/SettingRow.tsx#L58)
 
 The label + hint + control row every settings surface uses: title and dim
 description on the left, the control pinned right. Rows in a group are
@@ -24,6 +24,26 @@ stylesheet import is needed in the extension.
 #### hint?
 
 `string`
+
+#### enabled?
+
+`boolean`
+
+Gates `dependent` — a plain boolean, unrelated to whatever control
+`children` renders. Omit (or leave `true`) to leave `dependent` always
+enabled.
+
+#### dependent?
+
+`ReactNode`
+
+Extra content rendered below the label+hint, in the same left column but
+its own row — sub-settings that only make sense while this row's own
+setting is on. Kept out of `children`'s vertical centering (it sits
+below, not inside, the label+hint block `children` centers against).
+Rendered inside a native `<fieldset>`: when `enabled` is `false`, every
+focusable descendant is disabled automatically and the whole block dims —
+no need to thread `disabled` into each child by hand.
 
 #### children?
 
@@ -49,3 +69,33 @@ The control — `Switch`, `Select`, `Input`, etc.
   />
 </SettingRow>
 ```
+
+A row can also nest sub-settings that only make sense while its own
+setting is on, via `enabled`/`dependent`:
+
+```tsx
+<SettingRow
+  label="Collapse older agents"
+  hint="Agents drop off into a collapsed section once older than the cutoff."
+  enabled={staleDoneEnabled}
+  dependent={
+    <CheckboxRow
+      label="Auto-expand on hover"
+      checked={autoExpand}
+      onChange={setAutoExpand}
+    />
+  }
+>
+  <Switch
+    checked={staleDoneEnabled}
+    onChange={setStaleDoneEnabled}
+    aria-label="Collapse older agents"
+  />
+</SettingRow>
+```
+
+`dependent` renders inside a native `<fieldset>`, so when `enabled` is
+`false` every focusable descendant is disabled automatically and the whole
+block dims — no need to thread `disabled` into each child by hand. `enabled`
+is a plain boolean unrelated to whatever `children` renders (a `Switch`, a
+`Select`, or nothing at all) — nothing requires the row to have a toggle.

--- a/apps/docs/design/components/structure.md
+++ b/apps/docs/design/components/structure.md
@@ -66,16 +66,59 @@ The label + hint + control row every settings surface uses: title and dim
 description on the left, the control pinned right. Rows in a group are
 separated by hairline dividers.
 
-| Prop     | Type        | Notes                                                                               |
-| -------- | ----------- | ----------------------------------------------------------------------------------- |
-| `label`  | `string`    | base / `text-hi`                                                                    |
-| `hint`   | `string?`   | sm / `text-lo`, wraps under the label                                               |
-| children | `ReactNode` | the control — `Switch`, `Select`, `Input`, a number field, or a small status recipe |
+| Prop        | Type         | Notes                                                                               |
+| ----------- | ------------ | ----------------------------------------------------------------------------------- |
+| `label`     | `string`     | base / `text-hi`                                                                    |
+| `hint`      | `string?`    | sm / `text-lo`, wraps under the label                                               |
+| `enabled`   | `boolean?`   | gates `dependent`; a plain boolean unrelated to whatever `children` is              |
+| `dependent` | `ReactNode?` | sub-settings below the hint, gated by `enabled` — see below                         |
+| children    | `ReactNode`  | the control — `Switch`, `Select`, `Input`, a number field, or a small status recipe |
 
 ::: tip Inline status is a recipe, not a component
 The "✓ Authenticated" pattern is an icon + `--silo-color-ok` text dropped into
 a SettingRow's control slot — deliberately not its own component.
 :::
+
+### Dependent sub-settings
+
+A row can nest a sub-setting that only makes sense while its own control is
+on — a cutoff field, a secondary checkbox. The row's control stays centered
+against just the label+hint above it, not the taller combined block.
+
+<div class="silo-demo silo-demo-block">
+  <div class="silo-section" style="max-width:520px;">
+    <div class="silo-section-header"><span class="silo-section-label">Agent views</span></div>
+    <div>
+      <div class="silo-setting-row" style="padding-top:0;">
+        <div class="text">
+          <div class="row-label">Collapse older agents</div>
+          <div class="row-hint">Agents drop off into a collapsed section once they are older than the cutoff period.</div>
+        </div>
+        <div class="control"><button class="silo-switch-track" data-checked="true" aria-label="Collapse older agents"></button></div>
+        <div class="dependent">Cutoff period&nbsp; <input class="silo-number" value="4" readonly style="width:3em;">&nbsp; hours</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+```tsx
+<SettingRow
+  label="Collapse older agents"
+  hint="Agents drop off into a collapsed section once they are older than the cutoff period."
+  enabled={staleDoneEnabled}
+  dependent={
+    <>
+      Cutoff period <Input type="number" value={hours} onChange={...} /> hours
+    </>
+  }
+>
+  <Switch checked={staleDoneEnabled} onChange={setStaleDoneEnabled} aria-label="Collapse older agents" />
+</SettingRow>
+```
+
+`dependent` renders inside a native `<fieldset>` — when `enabled` is `false`
+every focusable descendant is disabled automatically and the whole block
+dims, with no `disabled` prop to thread into each child by hand.
 
 ## ModalActions
 

--- a/docs/modal-design.md
+++ b/docs/modal-design.md
@@ -28,20 +28,21 @@ primary action).
 
 ## Need X → use component Y
 
-| Need                                 | Component                                                                                        |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| Action buttons                       | `Button` (`variant`: default/primary/danger)                                                     |
-| Icon-only action                     | `IconButton` + `Tooltip` (label alone isn't enough for sighted users)                            |
-| Button that opens a menu             | `MenuButton` (labelled + chevron) — see below                                                    |
-| Text field                           | `Input`, `Textarea`                                                                              |
-| Filter-as-you-type over a list       | `SearchInput` + `List` (compose them — no combined `FilterList`)                                 |
-| Click-to-edit a value in place       | `InlineEdit`                                                                                     |
-| On/off, pick-one-of-few              | `Switch`, `Select`, `CheckboxRow`, `RadioGroup`                                                  |
-| Switch between views                 | `Tabs`, `SegmentedTabs`                                                                          |
-| Rows of selectable things            | `List` / `ListRow`, `AddRow`                                                                     |
-| Status/identity pill                 | `Badge` (`tone`: `ok`/`warn`/`err`/`accent`/`neutral`; `size`: `md` default / `sm` for counters) |
-| "Nothing here" / explanatory copy    | `EmptyState`, `Callout`                                                                          |
-| Group settings, footer, scroll areas | `Section`, `SettingRow`, `ModalActions`, `.silo-scroll`                                          |
+| Need                                   | Component                                                                                        |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Action buttons                         | `Button` (`variant`: default/primary/danger)                                                     |
+| Icon-only action                       | `IconButton` + `Tooltip` (label alone isn't enough for sighted users)                            |
+| Button that opens a menu               | `MenuButton` (labelled + chevron) — see below                                                    |
+| Text field                             | `Input`, `Textarea`                                                                              |
+| Filter-as-you-type over a list         | `SearchInput` + `List` (compose them — no combined `FilterList`)                                 |
+| Click-to-edit a value in place         | `InlineEdit`                                                                                     |
+| On/off, pick-one-of-few                | `Switch`, `Select`, `CheckboxRow`, `RadioGroup`                                                  |
+| Switch between views                   | `Tabs`, `SegmentedTabs`                                                                          |
+| Rows of selectable things              | `List` / `ListRow`, `AddRow`                                                                     |
+| Status/identity pill                   | `Badge` (`tone`: `ok`/`warn`/`err`/`accent`/`neutral`; `size`: `md` default / `sm` for counters) |
+| "Nothing here" / explanatory copy      | `EmptyState`, `Callout`                                                                          |
+| Group settings, footer, scroll areas   | `Section`, `SettingRow`, `ModalActions`, `.silo-scroll`                                          |
+| Sub-settings gated on a sibling toggle | `SettingRow`'s `enabled`/`dependent` props — never a hand-rolled nested row                      |
 
 All exported from `@silo-code/sdk`. Full prop reference:
 [Design System → Components](https://getsilo.dev/design/#the-component-inventory).
@@ -89,6 +90,10 @@ applies automatically — your extension never bundles this CSS.
 - **Don't build a settings rail, tab strip, or page title inside a settings
   page or property tab.** That chrome is host-owned; your component is the
   body content only.
+- **Don't hand-roll a nested "only while a sibling toggle is on" row** (a raw
+  `.silo-setting-row` div with a manually-indented sub-control, manually
+  threading `disabled` into each child). Use `SettingRow`'s `enabled`/
+  `dependent` props — the fieldset auto-disables and dims for you.
 
 ## Stability gate
 

--- a/docs/proposals/0016-modal-design-system.md
+++ b/docs/proposals/0016-modal-design-system.md
@@ -93,8 +93,39 @@ Props sketches; `React.ComponentProps<...>` pass-through where natural.
 | `EmptyState`               | `icon?; tone?: "ok"\|"neutral"; title; description?; action?`                                      | Big circled icon + title + dim description; **no shadow/card of its own** — it lives in the modal body                                                                                                                                                                                                                                                                                             |
 | `Callout`                  | children                                                                                           | Quiet set-off box for explanatory copy: hairline `border-strong` border only — no fill, no tone. Not for status/alerts (Badge/EmptyState territory)                                                                                                                                                                                                                                                |
 | `Section`                  | `label; accessory?` + children                                                                     | Uppercase letter-spaced label at chrome−1                                                                                                                                                                                                                                                                                                                                                          |
-| `SettingRow`               | `label; hint?` + children (control)                                                                | Title (base/`text-hi`) + hint (sm/`text-lo`) left, control right, `border-strong` row dividers                                                                                                                                                                                                                                                                                                     |
+| `SettingRow`               | `label; hint?; enabled?; dependent?` + children (control)                                          | Title (base/`text-hi`) + hint (sm/`text-lo`) left, control right, `border-strong` row dividers. `enabled`/`dependent` (added post-launch, see below) nest gated sub-settings under the hint                                                                                                                                                                                                        |
 | `ModalActions`             | `start?` + children                                                                                | Right-aligned actions; optional left `start` slot (meta text or secondary action) replaces bespoke space-between footers. Promoted from host `Modal.tsx` into the SDK                                                                                                                                                                                                                              |
+
+**`SettingRow` dependent sub-settings (added 2026-08-27, additive within this
+RFC's own "new props" contract — no new component, no new RFC)** — settings
+pages had accumulated three different hand-rolled shapes for "a control that
+only makes sense while a sibling toggle is on" (Collapse older agents' cutoff
+input, Share side panel layout's checkbox, each with its own one-off CSS for
+what should have been one pattern). `SettingRow` gained two props: `enabled?:
+boolean` and `dependent?: ReactNode`. `dependent` renders below the hint, in
+the label/hint column, inside a native `<fieldset disabled={enabled ===
+false}>` — the browser auto-disables every focusable descendant with no
+per-child wiring, and `fieldset:disabled { opacity: .5 }` dims the whole block
+in one rule. `enabled` is a plain boolean unrelated to whatever `children`
+renders (a `Switch`, a `Select`, or nothing) — nothing requires the row to
+have a toggle at all. The row's own layout is CSS grid, not flex: `dependent`
+sits in its own grid row so it never affects how the control centers against
+label+hint above it — a tall dependent block doesn't drag the control down
+with it. The guide line is a `color-mix(in srgb, text-hi 30%, bg)` derivation
+(this RFC's existing "derivation formula, not a new token" rule) rather than
+`border`/`border-strong`: the plain `border` token is literally identical to
+`bg` in at least one theme (invisible), and `border-strong` still read too
+faint in review; deriving off `text-hi` guarantees real, correctly-signed
+contrast (darker in light themes, lighter in dark ones) in every theme by
+construction. 16px inset from the line to the content; 8px of bottom padding
+so the line runs past the last child rather than stopping flush with it.
+Ships in `packages/extension-host/src/layout/components.css` as
+`.silo-setting-row-dependent`, no extension-side CSS required. First proven
+internally (`@internal`, unstable, bundled-extensions-only) across four real
+call sites — Collapse older agents, Play a sound, Share side panel layout, and
+Enable/Threshold width under Laptop Mode (the last of these also fixed a
+latent bug: Threshold width was never actually disabled when Laptop Mode was
+off) — before this promotion to `@public`.
 
 **Scrollbars** — a `.silo-scroll` class (not a React component) for scrollable
 regions inside modals: 8px, transparent track, pill thumb

--- a/packages/extension-host/src/layout/components.css
+++ b/packages/extension-host/src/layout/components.css
@@ -937,17 +937,23 @@
    `dependent` prop — see its TSDoc). A native <fieldset> so `disabled`
    auto-propagates to every focusable descendant with no per-child wiring;
    reset to a plain block first since fieldsets carry their own UA border/
-   padding/min-width. `-border` (rather than the row divider's `-border-strong`)
-   was tried first for a subtler guide line, but verified invisible in at
-   least one theme where it's identical to `-bg` — `-border-strong` is the one
-   token guaranteed to read against the surface it sits on. */
+   padding/min-width. `-border` was tried first for a subtler guide line, but
+   verified invisible in at least one theme where it's identical to `-bg`;
+   `-border-strong` was tried next but still read as too faint. The line is a
+   `color-mix` derivation off `-text-hi` instead (RFC 0016's pattern for new
+   kit colors — badge tints, tab hover, etc. — rather than a new raw token):
+   guaranteed real contrast against `-bg` in every theme, and automatically
+   darker in light themes / lighter in dark ones since text-hi always
+   contrasts against bg by construction. Bottom padding lets the line run past
+   the last child instead of stopping flush with it. */
 .silo-setting-row-dependent {
   display: block;
   min-width: 0;
   margin: 8px 0 0;
-  padding: 0 0 0 12px;
+  padding: 0 0 8px 16px;
   border: 0;
-  border-left: 1px solid var(--silo-color-border-strong);
+  border-left: 1px solid
+    color-mix(in srgb, var(--silo-color-text-hi) 40%, var(--silo-color-bg));
 }
 .silo-setting-row-dependent:disabled {
   opacity: 0.5;

--- a/packages/extension-host/src/layout/components.css
+++ b/packages/extension-host/src/layout/components.css
@@ -901,11 +901,18 @@
   color: var(--silo-color-text-lo);
 }
 
+/* Grid, not flex: a row with `dependent` content needs the control
+   vertically centered against just the label+hint cell, not the taller
+   combined height once `dependent` is showing below it. Flex's single
+   cross-axis centers against the whole item including `dependent`; splitting
+   label+hint and `dependent` into their own grid rows (control spans only
+   the first) fixes that without any extra wrapper element. A row with no
+   `dependent` (most of them) still lays out identically — the implicit
+   second row is simply empty. */
 .silo-setting-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: 20px;
   padding: 10px 0;
 }
 
@@ -914,6 +921,9 @@
 }
 
 .silo-setting-row-text {
+  grid-column: 1;
+  grid-row: 1;
+  align-self: center;
   min-width: 0;
 }
 
@@ -930,11 +940,16 @@
 }
 
 .silo-setting-row-control {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
   flex-shrink: 0;
 }
 
-/* Dependent sub-settings nested under a row's hint (SettingRow's internal
-   `dependent` prop — see its TSDoc). A native <fieldset> so `disabled`
+/* Dependent sub-settings, below a row's label+hint (SettingRow's internal
+   `dependent` prop — see its TSDoc) — its own grid row, first column only,
+   so it never affects how `.silo-setting-row-control` centers against
+   `.silo-setting-row-text` above it. A native <fieldset> so `disabled`
    auto-propagates to every focusable descendant with no per-child wiring;
    reset to a plain block first since fieldsets carry their own UA border/
    padding/min-width. `-border` was tried first for a subtler guide line, but
@@ -948,6 +963,8 @@
    the last child instead of stopping flush with it. */
 .silo-setting-row-dependent {
   display: block;
+  grid-column: 1;
+  grid-row: 2;
   min-width: 0;
   margin: 8px 0 0;
   padding: 0 0 8px 16px;

--- a/packages/extension-host/src/layout/components.css
+++ b/packages/extension-host/src/layout/components.css
@@ -933,6 +933,26 @@
   flex-shrink: 0;
 }
 
+/* Dependent sub-settings nested under a row's hint (SettingRow's internal
+   `dependent` prop — see its TSDoc). A native <fieldset> so `disabled`
+   auto-propagates to every focusable descendant with no per-child wiring;
+   reset to a plain block first since fieldsets carry their own UA border/
+   padding/min-width. `-border` (rather than the row divider's `-border-strong`)
+   was tried first for a subtler guide line, but verified invisible in at
+   least one theme where it's identical to `-bg` — `-border-strong` is the one
+   token guaranteed to read against the surface it sits on. */
+.silo-setting-row-dependent {
+  display: block;
+  min-width: 0;
+  margin: 8px 0 0;
+  padding: 0 0 0 12px;
+  border: 0;
+  border-left: 1px solid var(--silo-color-border-strong);
+}
+.silo-setting-row-dependent:disabled {
+  opacity: 0.5;
+}
+
 /* ── ModalActions — start slot ───────────────────────────────────────────
  * The .silo-modal-actions container itself already exists in theme.css
  * (flex-end row). This adds the optional left slot for meta text or a

--- a/packages/extension-host/src/layout/components.css
+++ b/packages/extension-host/src/layout/components.css
@@ -953,7 +953,7 @@
   padding: 0 0 8px 16px;
   border: 0;
   border-left: 1px solid
-    color-mix(in srgb, var(--silo-color-text-hi) 40%, var(--silo-color-bg));
+    color-mix(in srgb, var(--silo-color-text-hi) 30%, var(--silo-color-bg));
 }
 .silo-setting-row-dependent:disabled {
   opacity: 0.5;

--- a/packages/extensions-core/src/agents-settings/index.tsx
+++ b/packages/extensions-core/src/agents-settings/index.tsx
@@ -1,17 +1,20 @@
 /**
  * Agents settings page — the single Application-rail entry (`id: "agents"`).
  *
- * **Options** tab composes host display prefs with `silo.agents`' published
- * {@link AgentsExtensionAPI.OptionsPanel} via `ctx.getExtension` — the same
- * bundled-only pattern as `silo.git-explorer` → `silo.git` (no general SDK for
- * extending built-in settings pages).
+ * **Behavior**, **Navigator**, and **Display** tabs compose host prefs with
+ * `silo.agents`' published {@link AgentsExtensionAPI} panels via
+ * `ctx.getExtension` — the same bundled-only pattern as `silo.git-explorer` →
+ * `silo.git` (no general SDK for extending built-in settings pages). The
+ * **Navigator** tab is present only while `silo.agents` is active, since all of
+ * its content comes from that extension; **Display** also carries a host-owned
+ * tab-title setting, so it stays.
  *
  * **Hooks** tab lives in {@link AgentsHooksPanel} so agent-catalog modularization
  * can evolve hook/extra-settings UI independently.
  */
 import { useState, type ComponentType } from "react";
 import { useSnapshot } from "valtio";
-import type { Extension, ExtensionContext } from "@silo-code/sdk";
+import type { Extension, ExtensionContext, TabItem } from "@silo-code/sdk";
 import { Section, Tabs, TabPanel, SettingRow, Switch } from "@silo-code/sdk";
 import { store, setTerminalSetting } from "@silo-code/extension-host/internal";
 import { AgentsHooksPanel } from "./AgentsHooksPanel";
@@ -19,23 +22,37 @@ import "./AgentsSettingsPage.css";
 
 /** Mirror of `silo.agents`' {@link AgentsExtensionAPI} — core cannot import silo. */
 interface SiloAgentsSettingsAPI {
-  OptionsPanel: ComponentType;
+  BehaviorPanel: ComponentType;
+  NavigatorPanel: ComponentType;
+  DisplayPanel: ComponentType;
 }
 
-type AgentsSettingsTab = "options" | "hooks";
+type AgentsSettingsTab = "behavior" | "navigator" | "display" | "hooks";
 
-function AgentsOptionsTab({ ctx }: { ctx: ExtensionContext }) {
+/** The live `silo.agents` API, or `null` when that extension isn't active. */
+function siloAgentsApi(ctx: ExtensionContext): SiloAgentsSettingsAPI | null {
+  const ext = ctx.getExtension<SiloAgentsSettingsAPI>("silo.agents");
+  return ext?.active ? (ext.api ?? null) : null;
+}
+
+function AgentsBehaviorTab({ ctx }: { ctx: ExtensionContext }) {
+  const api = siloAgentsApi(ctx);
+  return api?.BehaviorPanel != null ? <api.BehaviorPanel /> : null;
+}
+
+function AgentsNavigatorTab({ ctx }: { ctx: ExtensionContext }) {
+  const api = siloAgentsApi(ctx);
+  return api?.NavigatorPanel != null ? <api.NavigatorPanel /> : null;
+}
+
+function AgentsDisplayTab({ ctx }: { ctx: ExtensionContext }) {
   const hideGlyphs = useSnapshot(store).terminalSettings.hideAgentStatusGlyphs;
-  const siloAgents = ctx.getExtension<SiloAgentsSettingsAPI>("silo.agents");
-  const OptionsPanel =
-    siloAgents?.active && siloAgents.api?.OptionsPanel
-      ? siloAgents.api.OptionsPanel
-      : null;
+  const api = siloAgentsApi(ctx);
 
   return (
     <>
-      {OptionsPanel != null && <OptionsPanel />}
-      <Section label="Display">
+      {api?.DisplayPanel != null && <api.DisplayPanel />}
+      <Section label="Terminal tabs">
         <SettingRow
           label="Hide status glyphs in tab titles"
           hint="Strips agent status markers (Claude's ◐/✳, Codex's spinner, Cursor's “ - Working…”) from terminal tab titles."
@@ -54,7 +71,21 @@ function AgentsOptionsTab({ ctx }: { ctx: ExtensionContext }) {
 }
 
 function AgentsSettingsPage({ ctx }: { ctx: ExtensionContext }) {
-  const [tab, setTab] = useState<AgentsSettingsTab>("options");
+  const [tab, setTab] = useState<AgentsSettingsTab>("behavior");
+
+  // The Navigator tab's content is entirely `silo.agents`' — drop the tab
+  // when that extension isn't active rather than show an empty panel.
+  const hasNavigator =
+    ctx.getExtension<SiloAgentsSettingsAPI>("silo.agents")?.active === true;
+  const activeTab: AgentsSettingsTab =
+    tab === "navigator" && !hasNavigator ? "behavior" : tab;
+
+  const tabs: TabItem<AgentsSettingsTab>[] = [
+    { id: "behavior", label: "Behavior" },
+    ...(hasNavigator ? [{ id: "navigator" as const, label: "Navigator" }] : []),
+    { id: "display", label: "Display" },
+    { id: "hooks", label: "Hooks" },
+  ];
 
   return (
     <div className="es-page agents-settings-page">
@@ -63,18 +94,15 @@ function AgentsSettingsPage({ ctx }: { ctx: ExtensionContext }) {
       </div>
 
       <div className="agents-settings-tabs">
-        <Tabs
-          tabs={[
-            { id: "options", label: "Options" },
-            { id: "hooks", label: "Hooks" },
-          ]}
-          active={tab}
-          onSelect={setTab}
-        />
+        <Tabs tabs={tabs} active={activeTab} onSelect={setTab} />
         <TabPanel>
           <div className="silo-scroll agents-settings-scroll">
-            {tab === "options" ? (
-              <AgentsOptionsTab ctx={ctx} />
+            {activeTab === "behavior" ? (
+              <AgentsBehaviorTab ctx={ctx} />
+            ) : activeTab === "navigator" ? (
+              <AgentsNavigatorTab ctx={ctx} />
+            ) : activeTab === "display" ? (
+              <AgentsDisplayTab ctx={ctx} />
             ) : (
               <AgentsHooksPanel ctx={ctx} />
             )}

--- a/packages/extensions-core/src/agents-settings/index.tsx
+++ b/packages/extensions-core/src/agents-settings/index.tsx
@@ -29,9 +29,14 @@ interface SiloAgentsSettingsAPI {
 
 type AgentsSettingsTab = "behavior" | "navigator" | "display" | "hooks";
 
+/** The live `silo.agents` extension entry, for its `active` flag and API. */
+function getSiloAgents(ctx: ExtensionContext) {
+  return ctx.getExtension<SiloAgentsSettingsAPI>("silo.agents");
+}
+
 /** The live `silo.agents` API, or `null` when that extension isn't active. */
 function siloAgentsApi(ctx: ExtensionContext): SiloAgentsSettingsAPI | null {
-  const ext = ctx.getExtension<SiloAgentsSettingsAPI>("silo.agents");
+  const ext = getSiloAgents(ctx);
   return ext?.active ? (ext.api ?? null) : null;
 }
 
@@ -75,8 +80,7 @@ function AgentsSettingsPage({ ctx }: { ctx: ExtensionContext }) {
 
   // The Navigator tab's content is entirely `silo.agents`' — drop the tab
   // when that extension isn't active rather than show an empty panel.
-  const hasNavigator =
-    ctx.getExtension<SiloAgentsSettingsAPI>("silo.agents")?.active === true;
+  const hasNavigator = getSiloAgents(ctx)?.active === true;
   const activeTab: AgentsSettingsTab =
     tab === "navigator" && !hasNavigator ? "behavior" : tab;
 

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -633,7 +633,10 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
               >
                 Update
               </Button>
-            ) : (
+            ) : ext.builtin ? // Built-ins can't be uninstalled and the "Built-in" badge
+            // already says they're present — an "Installed" pill on top
+            // is just noise.
+            null : (
               <span className="ext-card-installed">Installed</span>
             )
           }

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -576,6 +576,12 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
       // Folder/URL/npm origin, noted compactly; the full path lives in the
       // detail callout (registry installs need no note).
       const localSource = localInstallSource(ext);
+      // Built-ins can't be uninstalled and the "Built-in" badge already says
+      // they're present — an "Installed" pill on top is just noise. (Pulled
+      // out of the `action` prop below and given its own boolean rather than
+      // a `null` ternary branch: Prettier doesn't format a comment attached
+      // to a bare `null` branch stably — each re-format further garbles it.)
+      const showInstalledPill = !upd && !ext.builtin;
       return (
         <ExtensionCard
           key={ext.id}
@@ -633,11 +639,10 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
               >
                 Update
               </Button>
-            ) : ext.builtin ? // Built-ins can't be uninstalled and the "Built-in" badge
-            // already says they're present — an "Installed" pill on top
-            // is just noise.
-            null : (
-              <span className="ext-card-installed">Installed</span>
+            ) : (
+              showInstalledPill && (
+                <span className="ext-card-installed">Installed</span>
+              )
             )
           }
           menu={

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.css
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.css
@@ -1,0 +1,13 @@
+/* Threshold width, nested as Enable Laptop Mode's SettingRow `dependent`
+   content. Label/hint reuse the kit's own `.silo-setting-row-label`/`-hint`
+   classes directly (same pattern as AgentsHooksPanel's AgentSettingsRow) —
+   only the input+capture-button row needs layout of its own. */
+.ls-threshold-label {
+  margin-top: 8px;
+}
+.ls-threshold-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
@@ -23,6 +23,7 @@ import {
   setSharedColumnWidthsEnabled,
 } from "@silo-code/extension-host/internal";
 import { confirmEnableGlobalPanelLayout } from "./GlobalPanelLayoutConfirm";
+import "./LayoutSettingsPage.css";
 
 // A module of the core.layout extension — small-screen mode's on/off switch
 // and width threshold, plus Global Side Panel Layout's two settings. The
@@ -85,71 +86,65 @@ export function makeLayoutSettingsPage(ctx: ExtensionContext) {
                 aria-label="Share side panel widths across workspaces"
               />
             </SettingRow>
-            {/* Hand-rolled instead of <SettingRow> (whose `hint` is a plain
-                string) so the sub-setting checkbox can sit inside the same
-                row's text column, directly under the hint, rather than as
-                its own separate row below. */}
-            <div className="silo-setting-row">
-              <div className="silo-setting-row-text">
-                <div className="silo-setting-row-label">
-                  Share side panel layout across workspaces
-                </div>
-                <div className="silo-setting-row-hint">
-                  Enable this setting to use the same side panel layout
-                  (position, visibility, collapse) across workspaces.
-                </div>
-                <div style={{ marginTop: "8px", marginBottom: "12px" }}>
-                  <CheckboxRow
-                    label="Also maintain active tab(s)"
-                    checked={snap.globalActiveTabEnabled}
-                    onChange={setGlobalActiveTabEnabled}
-                    disabled={!snap.globalPanelLayoutEnabled}
-                  />
-                </div>
-              </div>
-              <div className="silo-setting-row-control">
-                <Switch
-                  checked={snap.globalPanelLayoutEnabled}
-                  onChange={(next) => void toggleGlobalPanelLayout(next)}
-                  aria-label="Share side panel layout across workspaces"
+            <SettingRow
+              label="Share side panel layout across workspaces"
+              hint="Enable this setting to use the same side panel layout (position, visibility, collapse) across workspaces."
+              enabled={snap.globalPanelLayoutEnabled}
+              dependent={
+                <CheckboxRow
+                  label="Also maintain active tab(s)"
+                  checked={snap.globalActiveTabEnabled}
+                  onChange={setGlobalActiveTabEnabled}
                 />
-              </div>
-            </div>
+              }
+            >
+              <Switch
+                checked={snap.globalPanelLayoutEnabled}
+                onChange={(next) => void toggleGlobalPanelLayout(next)}
+                aria-label="Share side panel layout across workspaces"
+              />
+            </SettingRow>
           </Section>
           <Section label="Laptop Mode">
             <SettingRow
               label="Enable Laptop Mode"
               hint="Enable this setting to automatically hide the side panels when using Silo on a laptop (determined by threshold below)."
+              enabled={snap.smallScreenModeEnabled}
+              dependent={
+                <>
+                  <div className="silo-setting-row-label ls-threshold-label">
+                    Threshold width
+                  </div>
+                  <div className="silo-setting-row-hint">
+                    Below this window width (in pixels), side panels auto-hide.
+                  </div>
+                  <div className="ls-threshold-control">
+                    <Input
+                      type="number"
+                      min={MIN_SMALL_SCREEN_THRESHOLD_PX}
+                      value={thresholdInput}
+                      onChange={(e) => setThresholdInput(e.target.value)}
+                      onBlur={(e) => commitThreshold(e.target.value)}
+                    />
+                    <Tooltip content="Capture current width">
+                      <IconButton
+                        aria-label="Capture current width"
+                        onClick={() =>
+                          setSmallScreenThresholdPx(window.innerWidth)
+                        }
+                      >
+                        <Crosshair size={16} weight="bold" />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
+                </>
+              }
             >
               <Switch
                 checked={snap.smallScreenModeEnabled}
                 onChange={setSmallScreenModeEnabled}
                 aria-label="Enable Laptop Mode"
               />
-            </SettingRow>
-            <SettingRow
-              label="Threshold width"
-              hint="Below this window width (in pixels), side panels auto-hide."
-            >
-              <div
-                style={{ display: "flex", alignItems: "center", gap: "6px" }}
-              >
-                <Input
-                  type="number"
-                  min={MIN_SMALL_SCREEN_THRESHOLD_PX}
-                  value={thresholdInput}
-                  onChange={(e) => setThresholdInput(e.target.value)}
-                  onBlur={(e) => commitThreshold(e.target.value)}
-                />
-                <Tooltip content="Capture current width">
-                  <IconButton
-                    aria-label="Capture current width"
-                    onClick={() => setSmallScreenThresholdPx(window.innerWidth)}
-                  >
-                    <Crosshair size={16} weight="bold" />
-                  </IconButton>
-                </Tooltip>
-              </div>
             </SettingRow>
           </Section>
         </div>

--- a/packages/extensions-silo/src/agents/agents-api.ts
+++ b/packages/extensions-silo/src/agents/agents-api.ts
@@ -2,5 +2,10 @@ import type { ComponentType } from "react";
 
 /** Published by `silo.agents` for `core.agents-settings` (bundled-only composition). */
 export interface AgentsExtensionAPI {
-  OptionsPanel: ComponentType;
+  /** Embedded in the settings page's **Behavior** tab. */
+  BehaviorPanel: ComponentType;
+  /** Embedded in the settings page's **Navigator** tab. */
+  NavigatorPanel: ComponentType;
+  /** Embedded in the settings page's **Display** tab. */
+  DisplayPanel: ComponentType;
 }

--- a/packages/extensions-silo/src/agents/agents-panel.tsx
+++ b/packages/extensions-silo/src/agents/agents-panel.tsx
@@ -54,9 +54,10 @@ export interface PanelSection {
   rows: AgentRow[];
   subtitle: (row: AgentRow) => string;
   /** Whether the render below collapses this heading's rows by default,
-   * revealing them only while the section is hovered — only the "N+ hours
-   * old" heading does, since it's the one that piles up with rows you're
-   * least likely to still care about. */
+   * revealing them on hover or on click of the heading (see
+   * `staleHoverExpandEnabled`) — only the "N+ hours old" heading does, since
+   * it's the one that piles up with rows you're least likely to still care
+   * about. */
   collapsible?: boolean;
 }
 
@@ -350,8 +351,13 @@ export function AgentsPanel({
   // `groupBy` is a setting rather than a prop now: the two groupings were two
   // registered Navigator views until SDK 0.34, and are one view with a
   // "View by" header control since.
-  const { iconMode, groupBy, staleDoneEnabled, staleDoneHours } =
-    useServiceState(settingsService);
+  const {
+    iconMode,
+    groupBy,
+    staleDoneEnabled,
+    staleDoneHours,
+    staleHoverExpandEnabled,
+  } = useServiceState(settingsService);
 
   // "color" mode picks a brand hex that has to have contrast against the
   // host's actual active background, not just against Silo's dark theme —
@@ -515,11 +521,13 @@ export function AgentsPanel({
     dragCleanupRef.current = cleanup;
   }
 
-  // The "N+ hours old" section starts collapsed and reveals its rows only
-  // while the mouse is over it — attached to the section's own container
-  // (not the heading), so a click on a row inside it (which doesn't move the
-  // mouse) never collapses it mid-click; only actually leaving the section
-  // does.
+  // The "N+ hours old" section starts collapsed. With `staleHoverExpandEnabled`
+  // on, it reveals its rows while the mouse is over it — attached to the
+  // section's own container (not the heading), so a click on a row inside it
+  // (which doesn't move the mouse) never collapses it mid-click; only
+  // actually leaving the section does. With it off (the default), hover does
+  // nothing and the heading is a click-to-toggle disclosure instead — a
+  // stray hover while scrolling past the section can't pop it open.
   //
   // Collapse is debounced rather than instant: WebKit (and Chromium) re-hit-test
   // and fire mouseleave/mouseenter transitions on scroll, not just on real
@@ -531,6 +539,7 @@ export function AgentsPanel({
   // through the section's own rows) cancels the pending collapse; only a leave
   // that sticks around actually collapses it.
   const [staleHovered, setStaleHovered] = useState(false);
+  const [staleManuallyExpanded, setStaleManuallyExpanded] = useState(false);
   const staleCollapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -554,6 +563,9 @@ export function AgentsPanel({
       staleCollapseTimeoutRef.current = null;
       setStaleHovered(false);
     }, 300);
+  }
+  function handleStaleHeadingClick() {
+    setStaleManuallyExpanded((expanded) => !expanded);
   }
 
   const agentsSnapshot = ctx.agents.getState({ allWorkspaces: true });
@@ -660,13 +672,23 @@ export function AgentsPanel({
           const isStaleSection = section.key === STALE_DONE_SECTION_KEY;
           const isDraggableSection = section.key === "age";
           const expanded =
-            !isStaleSection || staleHovered || staleStartsExpanded;
+            !isStaleSection ||
+            staleStartsExpanded ||
+            (staleHoverExpandEnabled ? staleHovered : staleManuallyExpanded);
           return (
             <div
               key={section.key}
               className="ap-section"
-              onMouseEnter={isStaleSection ? handleStaleMouseEnter : undefined}
-              onMouseLeave={isStaleSection ? handleStaleMouseLeave : undefined}
+              onMouseEnter={
+                isStaleSection && staleHoverExpandEnabled
+                  ? handleStaleMouseEnter
+                  : undefined
+              }
+              onMouseLeave={
+                isStaleSection && staleHoverExpandEnabled
+                  ? handleStaleMouseLeave
+                  : undefined
+              }
             >
               {/* Every heading carries its row count. The status grouping's
                   three headings are fixed and so are often empty — a `0` says
@@ -675,7 +697,18 @@ export function AgentsPanel({
                   heading row entirely — "Agents" would only restate the
                   view's own title. */}
               {section.header !== "" && (
-                <div className="ap-section-title">
+                <div
+                  className={
+                    isStaleSection && !staleHoverExpandEnabled
+                      ? "ap-section-title ap-section-title-clickable"
+                      : "ap-section-title"
+                  }
+                  onClick={
+                    isStaleSection && !staleHoverExpandEnabled
+                      ? handleStaleHeadingClick
+                      : undefined
+                  }
+                >
                   {isStaleSection && (
                     <CaretRight
                       size="0.7em"

--- a/packages/extensions-silo/src/agents/agents-panel.tsx
+++ b/packages/extensions-silo/src/agents/agents-panel.tsx
@@ -538,8 +538,11 @@ export function AgentsPanel({
   // that's immediately followed by a re-enter (the common case while scrolling
   // through the section's own rows) cancels the pending collapse; only a leave
   // that sticks around actually collapses it.
-  const [staleHovered, setStaleHovered] = useState(false);
-  const [staleManuallyExpanded, setStaleManuallyExpanded] = useState(false);
+  // One flag serves both interaction modes (rather than a separate flag per
+  // mode) so toggling `staleHoverExpandEnabled` while the panel is mounted
+  // can't desync the two — the section's current open/closed state simply
+  // carries over to whichever mode is now active.
+  const [staleExpanded, setStaleExpanded] = useState(false);
   const staleCollapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -556,16 +559,16 @@ export function AgentsPanel({
       clearTimeout(staleCollapseTimeoutRef.current);
       staleCollapseTimeoutRef.current = null;
     }
-    setStaleHovered(true);
+    setStaleExpanded(true);
   }
   function handleStaleMouseLeave() {
     staleCollapseTimeoutRef.current = setTimeout(() => {
       staleCollapseTimeoutRef.current = null;
-      setStaleHovered(false);
+      setStaleExpanded(false);
     }, 300);
   }
   function handleStaleHeadingClick() {
-    setStaleManuallyExpanded((expanded) => !expanded);
+    setStaleExpanded((expanded) => !expanded);
   }
 
   const agentsSnapshot = ctx.agents.getState({ allWorkspaces: true });
@@ -672,22 +675,22 @@ export function AgentsPanel({
           const isStaleSection = section.key === STALE_DONE_SECTION_KEY;
           const isDraggableSection = section.key === "age";
           const expanded =
-            !isStaleSection ||
-            staleStartsExpanded ||
-            (staleHoverExpandEnabled ? staleHovered : staleManuallyExpanded);
+            !isStaleSection || staleStartsExpanded || staleExpanded;
+          // The stale section's disclosure trigger is either mode, never
+          // both: hover-mode wires the mouse handlers, click-mode makes the
+          // heading itself the toggle.
+          const isStaleHoverTrigger = isStaleSection && staleHoverExpandEnabled;
+          const isStaleClickTrigger =
+            isStaleSection && !staleHoverExpandEnabled;
           return (
             <div
               key={section.key}
               className="ap-section"
               onMouseEnter={
-                isStaleSection && staleHoverExpandEnabled
-                  ? handleStaleMouseEnter
-                  : undefined
+                isStaleHoverTrigger ? handleStaleMouseEnter : undefined
               }
               onMouseLeave={
-                isStaleSection && staleHoverExpandEnabled
-                  ? handleStaleMouseLeave
-                  : undefined
+                isStaleHoverTrigger ? handleStaleMouseLeave : undefined
               }
             >
               {/* Every heading carries its row count. The status grouping's
@@ -699,14 +702,12 @@ export function AgentsPanel({
               {section.header !== "" && (
                 <div
                   className={
-                    isStaleSection && !staleHoverExpandEnabled
+                    isStaleClickTrigger
                       ? "ap-section-title ap-section-title-clickable"
                       : "ap-section-title"
                   }
                   onClick={
-                    isStaleSection && !staleHoverExpandEnabled
-                      ? handleStaleHeadingClick
-                      : undefined
+                    isStaleClickTrigger ? handleStaleHeadingClick : undefined
                   }
                 >
                   {isStaleSection && (

--- a/packages/extensions-silo/src/agents/index.tsx
+++ b/packages/extensions-silo/src/agents/index.tsx
@@ -17,7 +17,9 @@ import { maybePlayTransitionSound } from "./sound";
 import {
   initSettings,
   clearSettingsListeners,
-  AgentsOptionsPanel,
+  AgentsBehaviorPanel,
+  AgentsNavigatorPanel,
+  AgentsDisplayPanel,
   settingsService,
 } from "./settings";
 import { AgentsPanel } from "./agents-panel";
@@ -112,6 +114,9 @@ function activate(ctx: ExtensionContext): AgentsExtensionAPI {
       provide(workspaceId): WorkspaceStatusRow[] {
         const ws = ctx.workspaces.get(workspaceId);
         if (!ws) return [];
+        // Opt-out: keep the Navigator's workspace rows quiet. The Agents view
+        // and tab badges still read `agents` directly and are unaffected.
+        if (!settingsService.getState().showWorkspaceStatusRows) return [];
         const rows: WorkspaceStatusRow[] = [];
         const behavior = settingsService.getState().focusBehavior;
         const hideFocusedRow = behavior === "hide";
@@ -206,7 +211,8 @@ function activate(ctx: ExtensionContext): AgentsExtensionAPI {
   let lastGroupBy = settingsService.getState().groupBy;
   ctx.subscriptions.push(
     settingsService.subscribe((s) => {
-      // Toggling "hide focused row" changes which rows render.
+      // Toggling "hide focused row" or "show agent status on workspace rows"
+      // changes which rows render.
       ctx.workspaces.invalidateStatus();
       // Toggling iconMode changes what silo.agents.tab-icon returns.
       ctx.terminals.invalidateTabAdornments();
@@ -305,7 +311,11 @@ function activate(ctx: ExtensionContext): AgentsExtensionAPI {
 
   injectStyles();
 
-  return { OptionsPanel: AgentsOptionsPanel };
+  return {
+    BehaviorPanel: AgentsBehaviorPanel,
+    NavigatorPanel: AgentsNavigatorPanel,
+    DisplayPanel: AgentsDisplayPanel,
+  };
 }
 
 function deactivate() {

--- a/packages/extensions-silo/src/agents/settings-store.ts
+++ b/packages/extensions-silo/src/agents/settings-store.ts
@@ -66,6 +66,11 @@ export interface AgentMonitorSettings {
    * Done heading into its own "N+ hours old" one. Whole hours, minimum 1.
    * Only takes effect while {@link staleDoneEnabled} is on. */
   staleDoneHours: number;
+  /** Whether hovering the "N+ hours old" section reveals its rows. Off
+   * (default): the section only opens on click, so a stray hover while
+   * scrolling past it never pops it open. On: the pre-existing hover-reveal
+   * behavior. Only takes effect while {@link staleDoneEnabled} is on. */
+  staleHoverExpandEnabled: boolean;
 }
 
 // Keys renamed on each shape change ("hideStatusWhenFocused" → "clearOnFocus"
@@ -79,6 +84,7 @@ const STORAGE_KEY_GROUP_BY = "agentsGroupBy";
 const STORAGE_KEY_SHOW_WS_STATUS_ROWS = "agentsShowWorkspaceStatusRows";
 const STORAGE_KEY_STALE_DONE_ENABLED = "agentsStaleDoneEnabled";
 const STORAGE_KEY_STALE_DONE_HOURS = "agentsStaleDoneHours";
+const STORAGE_KEY_STALE_HOVER_EXPAND_ENABLED = "agentsStaleHoverExpandEnabled";
 
 const DEFAULT_BEHAVIOR: FocusBehavior = "clear";
 const DEFAULT_SOUND_ENABLED = true;
@@ -89,6 +95,7 @@ export const DEFAULT_SHOW_WS_STATUS_ROWS = true;
 export const DEFAULT_STALE_DONE_ENABLED = true;
 export const DEFAULT_STALE_DONE_HOURS = 4;
 export const MIN_STALE_DONE_HOURS = 1;
+export const DEFAULT_STALE_HOVER_EXPAND_ENABLED = false;
 
 const VALID_BEHAVIORS: readonly FocusBehavior[] = ["clear", "hide", "none"];
 const VALID_ICON_MODES: readonly IconMode[] = ["none", "color", "monotone"];
@@ -152,6 +159,10 @@ function coerceStaleDoneHours(v: unknown): number {
     : DEFAULT_STALE_DONE_HOURS;
 }
 
+function coerceStaleHoverExpandEnabled(v: unknown): boolean {
+  return typeof v === "boolean" ? v : DEFAULT_STALE_HOVER_EXPAND_ENABLED;
+}
+
 let settings: AgentMonitorSettings = {
   focusBehavior: DEFAULT_BEHAVIOR,
   soundEnabled: DEFAULT_SOUND_ENABLED,
@@ -161,6 +172,7 @@ let settings: AgentMonitorSettings = {
   showWorkspaceStatusRows: DEFAULT_SHOW_WS_STATUS_ROWS,
   staleDoneEnabled: DEFAULT_STALE_DONE_ENABLED,
   staleDoneHours: DEFAULT_STALE_DONE_HOURS,
+  staleHoverExpandEnabled: DEFAULT_STALE_HOVER_EXPAND_ENABLED,
 };
 let backingStorage: ExtensionStorage | null = null;
 const listeners = new Set<(s: AgentMonitorSettings) => void>();
@@ -189,6 +201,10 @@ export const settingsService: ReactiveService<AgentMonitorSettings> & {
       settings.staleDoneEnabled,
     );
     backingStorage?.set(STORAGE_KEY_STALE_DONE_HOURS, settings.staleDoneHours);
+    backingStorage?.set(
+      STORAGE_KEY_STALE_HOVER_EXPAND_ENABLED,
+      settings.staleHoverExpandEnabled,
+    );
     for (const l of listeners) l(settings);
   },
 };
@@ -237,6 +253,12 @@ export function initSettings(storage: ExtensionStorage): {
         settings.staleDoneHours,
       ),
     );
+    const staleHoverExpandEnabled = coerceStaleHoverExpandEnabled(
+      storage.get<boolean>(
+        STORAGE_KEY_STALE_HOVER_EXPAND_ENABLED,
+        settings.staleHoverExpandEnabled,
+      ),
+    );
     if (
       focusBehavior !== settings.focusBehavior ||
       soundEnabled !== settings.soundEnabled ||
@@ -245,7 +267,8 @@ export function initSettings(storage: ExtensionStorage): {
       groupBy !== settings.groupBy ||
       showWorkspaceStatusRows !== settings.showWorkspaceStatusRows ||
       staleDoneEnabled !== settings.staleDoneEnabled ||
-      staleDoneHours !== settings.staleDoneHours
+      staleDoneHours !== settings.staleDoneHours ||
+      staleHoverExpandEnabled !== settings.staleHoverExpandEnabled
     ) {
       settings = {
         ...settings,
@@ -257,6 +280,7 @@ export function initSettings(storage: ExtensionStorage): {
         showWorkspaceStatusRows,
         staleDoneEnabled,
         staleDoneHours,
+        staleHoverExpandEnabled,
       };
       for (const l of listeners) l(settings);
     }

--- a/packages/extensions-silo/src/agents/settings-store.ts
+++ b/packages/extensions-silo/src/agents/settings-store.ts
@@ -55,6 +55,10 @@ export interface AgentMonitorSettings {
   iconMode: IconMode;
   /** Which axis the Agents view groups its rows by. */
   groupBy: GroupMode;
+  /** Whether `silo.agents` contributes per-terminal agent status rows to the
+   * Navigator's workspace rows. Off = the workspace rows stay quiet even while
+   * agents are working; the Agents view and tab badges are unaffected. */
+  showWorkspaceStatusRows: boolean;
   /** Whether the Agents panel segments long-done agents out of the Done
    * heading into a collapsible "N+ hours old" one at all. */
   staleDoneEnabled: boolean;
@@ -72,6 +76,7 @@ const STORAGE_KEY_SOUND_ENABLED = "soundEnabled";
 const STORAGE_KEY_SOUND_ID = "soundId";
 const STORAGE_KEY_ICON_MODE = "agentsIconMode";
 const STORAGE_KEY_GROUP_BY = "agentsGroupBy";
+const STORAGE_KEY_SHOW_WS_STATUS_ROWS = "agentsShowWorkspaceStatusRows";
 const STORAGE_KEY_STALE_DONE_ENABLED = "agentsStaleDoneEnabled";
 const STORAGE_KEY_STALE_DONE_HOURS = "agentsStaleDoneHours";
 
@@ -80,6 +85,7 @@ const DEFAULT_SOUND_ENABLED = true;
 const DEFAULT_SOUND_ID: SoundName = "chime";
 const DEFAULT_ICON_MODE: IconMode = "color";
 const DEFAULT_GROUP_BY: GroupMode = "age";
+export const DEFAULT_SHOW_WS_STATUS_ROWS = true;
 export const DEFAULT_STALE_DONE_ENABLED = true;
 export const DEFAULT_STALE_DONE_HOURS = 4;
 export const MIN_STALE_DONE_HOURS = 1;
@@ -126,6 +132,10 @@ function coerceGroupBy(v: unknown): GroupMode {
     : DEFAULT_GROUP_BY;
 }
 
+function coerceShowWorkspaceStatusRows(v: unknown): boolean {
+  return typeof v === "boolean" ? v : DEFAULT_SHOW_WS_STATUS_ROWS;
+}
+
 function coerceStaleDoneEnabled(v: unknown): boolean {
   return typeof v === "boolean" ? v : DEFAULT_STALE_DONE_ENABLED;
 }
@@ -148,6 +158,7 @@ let settings: AgentMonitorSettings = {
   soundId: DEFAULT_SOUND_ID,
   iconMode: DEFAULT_ICON_MODE,
   groupBy: DEFAULT_GROUP_BY,
+  showWorkspaceStatusRows: DEFAULT_SHOW_WS_STATUS_ROWS,
   staleDoneEnabled: DEFAULT_STALE_DONE_ENABLED,
   staleDoneHours: DEFAULT_STALE_DONE_HOURS,
 };
@@ -169,6 +180,10 @@ export const settingsService: ReactiveService<AgentMonitorSettings> & {
     backingStorage?.set(STORAGE_KEY_SOUND_ID, settings.soundId);
     backingStorage?.set(STORAGE_KEY_ICON_MODE, settings.iconMode);
     backingStorage?.set(STORAGE_KEY_GROUP_BY, settings.groupBy);
+    backingStorage?.set(
+      STORAGE_KEY_SHOW_WS_STATUS_ROWS,
+      settings.showWorkspaceStatusRows,
+    );
     backingStorage?.set(
       STORAGE_KEY_STALE_DONE_ENABLED,
       settings.staleDoneEnabled,
@@ -204,6 +219,12 @@ export function initSettings(storage: ExtensionStorage): {
     const groupBy = coerceGroupBy(
       storage.get<string>(STORAGE_KEY_GROUP_BY, settings.groupBy),
     );
+    const showWorkspaceStatusRows = coerceShowWorkspaceStatusRows(
+      storage.get<boolean>(
+        STORAGE_KEY_SHOW_WS_STATUS_ROWS,
+        settings.showWorkspaceStatusRows,
+      ),
+    );
     const staleDoneEnabled = coerceStaleDoneEnabled(
       storage.get<boolean>(
         STORAGE_KEY_STALE_DONE_ENABLED,
@@ -222,6 +243,7 @@ export function initSettings(storage: ExtensionStorage): {
       soundId !== settings.soundId ||
       iconMode !== settings.iconMode ||
       groupBy !== settings.groupBy ||
+      showWorkspaceStatusRows !== settings.showWorkspaceStatusRows ||
       staleDoneEnabled !== settings.staleDoneEnabled ||
       staleDoneHours !== settings.staleDoneHours
     ) {
@@ -232,6 +254,7 @@ export function initSettings(storage: ExtensionStorage): {
         soundId,
         iconMode,
         groupBy,
+        showWorkspaceStatusRows,
         staleDoneEnabled,
         staleDoneHours,
       };

--- a/packages/extensions-silo/src/agents/settings.test.ts
+++ b/packages/extensions-silo/src/agents/settings.test.ts
@@ -5,6 +5,7 @@ import {
   initSettings,
   clearSettingsListeners,
   SOUND_IDS,
+  DEFAULT_SHOW_WS_STATUS_ROWS,
   DEFAULT_STALE_DONE_ENABLED,
   DEFAULT_STALE_DONE_HOURS,
   type FocusBehavior,
@@ -262,6 +263,63 @@ describe("agent-monitor groupBy setting", () => {
     const listener = settingsService.subscribe((s) => seen.push(s.groupBy));
     settingsService.set({ groupBy: "workspace" });
     expect(seen).toEqual(["workspace"]);
+    listener.dispose();
+    sub.dispose();
+  });
+});
+
+describe("agent-monitor showWorkspaceStatusRows setting", () => {
+  beforeEach(() => {
+    clearSettingsListeners();
+    initSettings(
+      fakeStorage({
+        agentsShowWorkspaceStatusRows: DEFAULT_SHOW_WS_STATUS_ROWS,
+      }),
+    ).dispose();
+  });
+
+  it(`defaults to ${DEFAULT_SHOW_WS_STATUS_ROWS} with empty storage`, () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().showWorkspaceStatusRows).toBe(
+      DEFAULT_SHOW_WS_STATUS_ROWS,
+    );
+    sub.dispose();
+  });
+
+  it("hydrates a persisted false value (restart case)", () => {
+    const storage = fakeStorage({ agentsShowWorkspaceStatusRows: false });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().showWorkspaceStatusRows).toBe(false);
+    sub.dispose();
+  });
+
+  it("coerces a non-boolean persisted value to the default", () => {
+    const storage = fakeStorage({ agentsShowWorkspaceStatusRows: "nope" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().showWorkspaceStatusRows).toBe(
+      DEFAULT_SHOW_WS_STATUS_ROWS,
+    );
+    sub.dispose();
+  });
+
+  it("persists a change through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ showWorkspaceStatusRows: false });
+    expect(storage.get<boolean>("agentsShowWorkspaceStatusRows")).toBe(false);
+    sub.dispose();
+  });
+
+  it("notifies subscribers so the workspace rows re-render", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    const seen: boolean[] = [];
+    const listener = settingsService.subscribe((s) =>
+      seen.push(s.showWorkspaceStatusRows),
+    );
+    settingsService.set({ showWorkspaceStatusRows: false });
+    expect(seen).toEqual([false]);
     listener.dispose();
     sub.dispose();
   });

--- a/packages/extensions-silo/src/agents/settings.test.ts
+++ b/packages/extensions-silo/src/agents/settings.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SHOW_WS_STATUS_ROWS,
   DEFAULT_STALE_DONE_ENABLED,
   DEFAULT_STALE_DONE_HOURS,
+  DEFAULT_STALE_HOVER_EXPAND_ENABLED,
   type FocusBehavior,
 } from "./settings-store";
 
@@ -430,6 +431,50 @@ describe("agent-monitor staleDoneHours setting", () => {
     const sub = initSettings(storage);
     settingsService.set({ staleDoneHours: 6 });
     expect(storage.get<number>("agentsStaleDoneHours")).toBe(6);
+    sub.dispose();
+  });
+});
+
+describe("agent-monitor staleHoverExpandEnabled setting", () => {
+  beforeEach(() => {
+    clearSettingsListeners();
+    initSettings(
+      fakeStorage({
+        agentsStaleHoverExpandEnabled: DEFAULT_STALE_HOVER_EXPAND_ENABLED,
+      }),
+    ).dispose();
+  });
+
+  it(`defaults to ${DEFAULT_STALE_HOVER_EXPAND_ENABLED} with empty storage`, () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleHoverExpandEnabled).toBe(
+      DEFAULT_STALE_HOVER_EXPAND_ENABLED,
+    );
+    sub.dispose();
+  });
+
+  it("hydrates a persisted true value", () => {
+    const storage = fakeStorage({ agentsStaleHoverExpandEnabled: true });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleHoverExpandEnabled).toBe(true);
+    sub.dispose();
+  });
+
+  it("coerces a non-boolean persisted value to the default", () => {
+    const storage = fakeStorage({ agentsStaleHoverExpandEnabled: "nope" });
+    const sub = initSettings(storage);
+    expect(settingsService.getState().staleHoverExpandEnabled).toBe(
+      DEFAULT_STALE_HOVER_EXPAND_ENABLED,
+    );
+    sub.dispose();
+  });
+
+  it("persists a change through settingsService.set", () => {
+    const storage = fakeStorage();
+    const sub = initSettings(storage);
+    settingsService.set({ staleHoverExpandEnabled: true });
+    expect(storage.get<boolean>("agentsStaleHoverExpandEnabled")).toBe(true);
     sub.dispose();
   });
 });

--- a/packages/extensions-silo/src/agents/settings.tsx
+++ b/packages/extensions-silo/src/agents/settings.tsx
@@ -30,6 +30,7 @@ export {
   settingsService,
   initSettings,
   clearSettingsListeners,
+  DEFAULT_SHOW_WS_STATUS_ROWS,
   DEFAULT_STALE_DONE_ENABLED,
   DEFAULT_STALE_DONE_HOURS,
   MIN_STALE_DONE_HOURS,
@@ -66,8 +67,12 @@ const ICON_MODE_OPTIONS: { value: IconMode; label: string }[] = [
   { value: "monotone", label: "Monotone" },
 ];
 
-/** Embeddable options block — composed into core.agents-settings via getExtension. */
-export function AgentsOptionsPanel() {
+/**
+ * Embeddable behavior block — composed into the `core.agents-settings`
+ * **Behavior** tab via `getExtension`. Covers what viewing a finished agent
+ * does to its status, and the stop-working sound.
+ */
+export function AgentsBehaviorPanel() {
   const s = useServiceState(settingsService);
   return (
     <div className="am-options-panel">
@@ -98,6 +103,136 @@ export function AgentsOptionsPanel() {
           </RadioGroup>
         </div>
       </div>
+      <Section label="Sound">
+        {/* Hand-rolled instead of <SettingRow> so the sound picker can sit
+            inside the same row's text column, directly under the hint, rather
+            than as its own row below. */}
+        <div className="silo-setting-row">
+          <div className="silo-setting-row-text">
+            <div className="silo-setting-row-label">
+              Play a sound when an agent stops working
+            </div>
+            <div className="silo-setting-row-hint">
+              Plays whenever an agent stops working, whether or not you're
+              watching its terminal.
+            </div>
+            <div className="am-sound-control am-sound-subrow">
+              <Select
+                value={s.soundId}
+                disabled={!s.soundEnabled}
+                onChange={(e) =>
+                  settingsService.set({ soundId: e.target.value as SoundName })
+                }
+                aria-label="Notification sound"
+              >
+                {SOUND_IDS.map((name) => (
+                  <option key={name} value={name}>
+                    {soundLabel(name)}
+                  </option>
+                ))}
+              </Select>
+              <IconButton
+                size="sm"
+                disabled={!s.soundEnabled}
+                onClick={() => previewSound(s.soundId)}
+                aria-label={`Preview ${soundLabel(s.soundId)} sound`}
+              >
+                ▶
+              </IconButton>
+            </div>
+          </div>
+          <div className="silo-setting-row-control">
+            <Switch
+              checked={s.soundEnabled}
+              onChange={(soundEnabled) => settingsService.set({ soundEnabled })}
+              aria-label="Play a sound when an agent stops working"
+            />
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+/**
+ * Embeddable Navigator-preferences block — composed into the
+ * `core.agents-settings` **Navigator** tab via `getExtension`. Covers how
+ * agents surface in the Navigator: the per-workspace status rows and the
+ * Agents view's handling of long-finished runs.
+ */
+export function AgentsNavigatorPanel() {
+  const s = useServiceState(settingsService);
+  return (
+    <div className="am-options-panel">
+      <Section label="Workspace rows">
+        <SettingRow
+          label="Show agent status on workspace rows"
+          hint="Adds a per-terminal status row (working / waiting / done) under each workspace in the Navigator."
+        >
+          <Switch
+            checked={s.showWorkspaceStatusRows}
+            onChange={(showWorkspaceStatusRows) =>
+              settingsService.set({ showWorkspaceStatusRows })
+            }
+            aria-label="Show agent status on workspace rows"
+          />
+        </SettingRow>
+      </Section>
+      <Section label="Agent views">
+        {/* Hand-rolled instead of <SettingRow> (whose `hint` is a plain string)
+            so the cutoff-period control can sit inside the same row's text
+            column, directly under the hint, rather than as its own row below. */}
+        <div className="silo-setting-row">
+          <div className="silo-setting-row-text">
+            <div className="silo-setting-row-label">Collapse older agents</div>
+            <div className="silo-setting-row-hint">
+              Agents drop off into a collapsed section once they are older than
+              the cutoff period.
+            </div>
+            <div className="am-hours-control am-hours-subrow">
+              <span className="am-hours-label">Cutoff period</span>
+              <Input
+                className="am-hours-input"
+                type="number"
+                min={MIN_STALE_DONE_HOURS}
+                step={1}
+                value={s.staleDoneHours}
+                disabled={!s.staleDoneEnabled}
+                onChange={(e) => {
+                  const hours = Math.trunc(Number(e.target.value));
+                  if (!Number.isFinite(hours) || hours < MIN_STALE_DONE_HOURS)
+                    return;
+                  settingsService.set({ staleDoneHours: hours });
+                }}
+                aria-label="Cutoff period in hours"
+              />
+              <span className="am-hours-unit">hours</span>
+            </div>
+          </div>
+          <div className="silo-setting-row-control">
+            <Switch
+              checked={s.staleDoneEnabled}
+              onChange={(staleDoneEnabled) =>
+                settingsService.set({ staleDoneEnabled })
+              }
+              aria-label="Collapse older agents"
+            />
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+/**
+ * Embeddable display block — composed into the `core.agents-settings`
+ * **Display** tab via `getExtension`. Covers the agent brand icons shown in
+ * the agent views.
+ */
+export function AgentsDisplayPanel() {
+  const s = useServiceState(settingsService);
+  return (
+    <div className="am-options-panel">
       <Section label="Agent icons">
         <SettingRow label="Show agent app icons in the agent views">
           <Select
@@ -115,81 +250,6 @@ export function AgentsOptionsPanel() {
           </Select>
         </SettingRow>
       </Section>
-      <Section label="Agent views">
-        <SettingRow
-          label="Set old finished agents aside"
-          hint="Keeps Done focused on recent finishes — older ones collapse into their own section that expands on hover."
-        >
-          <Switch
-            checked={s.staleDoneEnabled}
-            onChange={(staleDoneEnabled) =>
-              settingsService.set({ staleDoneEnabled })
-            }
-            aria-label="Set old finished agents aside"
-          />
-        </SettingRow>
-        {s.staleDoneEnabled && (
-          <SettingRow label="Consider an agent old after">
-            <div className="am-hours-control">
-              <Input
-                className="am-hours-input"
-                type="number"
-                min={MIN_STALE_DONE_HOURS}
-                step={1}
-                value={s.staleDoneHours}
-                onChange={(e) => {
-                  const hours = Math.trunc(Number(e.target.value));
-                  if (!Number.isFinite(hours) || hours < MIN_STALE_DONE_HOURS)
-                    return;
-                  settingsService.set({ staleDoneHours: hours });
-                }}
-                aria-label="Consider an agent old after this many hours"
-              />
-              <span className="am-hours-unit">hours</span>
-            </div>
-          </SettingRow>
-        )}
-      </Section>
-      <Section label="Sound">
-        <span className="am-hint">
-          Play a sound whenever an agent stops working, whether or not you're
-          watching its terminal.
-        </span>
-        <SettingRow label="Play a sound when an agent stops working">
-          <Switch
-            checked={s.soundEnabled}
-            onChange={(soundEnabled) => settingsService.set({ soundEnabled })}
-            aria-label="Play a sound when an agent stops working"
-          />
-        </SettingRow>
-        <SettingRow label="Notification sound">
-          <div className="am-sound-control">
-            <Select
-              value={s.soundId}
-              onChange={(e) =>
-                settingsService.set({ soundId: e.target.value as SoundName })
-              }
-              aria-label="Notification sound"
-            >
-              {SOUND_IDS.map((name) => (
-                <option key={name} value={name}>
-                  {soundLabel(name)}
-                </option>
-              ))}
-            </Select>
-            <IconButton
-              size="sm"
-              onClick={() => previewSound(s.soundId)}
-              aria-label={`Preview ${soundLabel(s.soundId)} sound`}
-            >
-              ▶
-            </IconButton>
-          </div>
-        </SettingRow>
-      </Section>
     </div>
   );
 }
-
-/** @deprecated Use {@link AgentsOptionsPanel}. */
-export const AgentMonitorSettingsPage = AgentsOptionsPanel;

--- a/packages/extensions-silo/src/agents/settings.tsx
+++ b/packages/extensions-silo/src/agents/settings.tsx
@@ -106,22 +106,14 @@ export function AgentsBehaviorPanel() {
         </div>
       </div>
       <Section label="Sound">
-        {/* Hand-rolled instead of <SettingRow> so the sound picker can sit
-            inside the same row's text column, directly under the hint, rather
-            than as its own row below. */}
-        <div className="silo-setting-row">
-          <div className="silo-setting-row-text">
-            <div className="silo-setting-row-label">
-              Play a sound when an agent stops working
-            </div>
-            <div className="silo-setting-row-hint">
-              Plays whenever an agent stops working, whether or not you're
-              watching its terminal.
-            </div>
-            <div className="am-sound-control am-sound-subrow">
+        <SettingRow
+          label="Play a sound when an agent stops working"
+          hint="Plays whenever an agent stops working, whether or not you're watching its terminal."
+          enabled={s.soundEnabled}
+          dependent={
+            <div className="am-sound-control">
               <Select
                 value={s.soundId}
-                disabled={!s.soundEnabled}
                 onChange={(e) =>
                   settingsService.set({ soundId: e.target.value as SoundName })
                 }
@@ -135,22 +127,20 @@ export function AgentsBehaviorPanel() {
               </Select>
               <IconButton
                 size="sm"
-                disabled={!s.soundEnabled}
                 onClick={() => previewSound(s.soundId)}
                 aria-label={`Preview ${soundLabel(s.soundId)} sound`}
               >
                 ▶
               </IconButton>
             </div>
-          </div>
-          <div className="silo-setting-row-control">
-            <Switch
-              checked={s.soundEnabled}
-              onChange={(soundEnabled) => settingsService.set({ soundEnabled })}
-              aria-label="Play a sound when an agent stops working"
-            />
-          </div>
-        </div>
+          }
+        >
+          <Switch
+            checked={s.soundEnabled}
+            onChange={(soundEnabled) => settingsService.set({ soundEnabled })}
+            aria-label="Play a sound when an agent stops working"
+          />
+        </SettingRow>
       </Section>
     </div>
   );
@@ -181,56 +171,50 @@ export function AgentsNavigatorPanel() {
         </SettingRow>
       </Section>
       <Section label="Agent views">
-        {/* Hand-rolled instead of <SettingRow> (whose `hint` is a plain string)
-            so the cutoff-period control can sit inside the same row's text
-            column, directly under the hint, rather than as its own row below. */}
-        <div className="silo-setting-row">
-          <div className="silo-setting-row-text">
-            <div className="silo-setting-row-label">Collapse older agents</div>
-            <div className="silo-setting-row-hint">
-              Agents drop off into a collapsed section once they are older than
-              the cutoff period.
-            </div>
-            <div className="am-hours-control am-hours-subrow">
-              <span className="am-hours-label">Cutoff period</span>
-              <Input
-                className="am-hours-input"
-                type="number"
-                min={MIN_STALE_DONE_HOURS}
-                step={1}
-                value={s.staleDoneHours}
-                disabled={!s.staleDoneEnabled}
-                onChange={(e) => {
-                  const hours = Math.trunc(Number(e.target.value));
-                  if (!Number.isFinite(hours) || hours < MIN_STALE_DONE_HOURS)
-                    return;
-                  settingsService.set({ staleDoneHours: hours });
-                }}
-                aria-label="Cutoff period in hours"
-              />
-              <span className="am-hours-unit">hours</span>
-            </div>
-            <div className="am-checkbox-subrow">
-              <CheckboxRow
-                label="Auto-expand on hover"
-                checked={s.staleHoverExpandEnabled}
-                disabled={!s.staleDoneEnabled}
-                onChange={(staleHoverExpandEnabled) =>
-                  settingsService.set({ staleHoverExpandEnabled })
-                }
-              />
-            </div>
-          </div>
-          <div className="silo-setting-row-control">
-            <Switch
-              checked={s.staleDoneEnabled}
-              onChange={(staleDoneEnabled) =>
-                settingsService.set({ staleDoneEnabled })
-              }
-              aria-label="Collapse older agents"
-            />
-          </div>
-        </div>
+        <SettingRow
+          label="Collapse older agents"
+          hint="Agents drop off into a collapsed section once they are older than the cutoff period."
+          enabled={s.staleDoneEnabled}
+          dependent={
+            <>
+              <div className="am-hours-control">
+                <span className="am-hours-label">Cutoff period</span>
+                <Input
+                  className="am-hours-input"
+                  type="number"
+                  min={MIN_STALE_DONE_HOURS}
+                  step={1}
+                  value={s.staleDoneHours}
+                  onChange={(e) => {
+                    const hours = Math.trunc(Number(e.target.value));
+                    if (!Number.isFinite(hours) || hours < MIN_STALE_DONE_HOURS)
+                      return;
+                    settingsService.set({ staleDoneHours: hours });
+                  }}
+                  aria-label="Cutoff period in hours"
+                />
+                <span className="am-hours-unit">hours</span>
+              </div>
+              <div className="am-checkbox-subrow">
+                <CheckboxRow
+                  label="Auto-expand on hover"
+                  checked={s.staleHoverExpandEnabled}
+                  onChange={(staleHoverExpandEnabled) =>
+                    settingsService.set({ staleHoverExpandEnabled })
+                  }
+                />
+              </div>
+            </>
+          }
+        >
+          <Switch
+            checked={s.staleDoneEnabled}
+            onChange={(staleDoneEnabled) =>
+              settingsService.set({ staleDoneEnabled })
+            }
+            aria-label="Collapse older agents"
+          />
+        </SettingRow>
       </Section>
     </div>
   );

--- a/packages/extensions-silo/src/agents/settings.tsx
+++ b/packages/extensions-silo/src/agents/settings.tsx
@@ -7,6 +7,7 @@
 
 import {
   useServiceState,
+  CheckboxRow,
   IconButton,
   Input,
   RadioCard,
@@ -33,6 +34,7 @@ export {
   DEFAULT_SHOW_WS_STATUS_ROWS,
   DEFAULT_STALE_DONE_ENABLED,
   DEFAULT_STALE_DONE_HOURS,
+  DEFAULT_STALE_HOVER_EXPAND_ENABLED,
   MIN_STALE_DONE_HOURS,
   type AgentMonitorSettings,
   type FocusBehavior,
@@ -207,6 +209,16 @@ export function AgentsNavigatorPanel() {
                 aria-label="Cutoff period in hours"
               />
               <span className="am-hours-unit">hours</span>
+            </div>
+            <div className="am-checkbox-subrow">
+              <CheckboxRow
+                label="Auto-expand on hover"
+                checked={s.staleHoverExpandEnabled}
+                disabled={!s.staleDoneEnabled}
+                onChange={(staleHoverExpandEnabled) =>
+                  settingsService.set({ staleHoverExpandEnabled })
+                }
+              />
             </div>
           </div>
           <div className="silo-setting-row-control">

--- a/packages/extensions-silo/src/agents/styles.css
+++ b/packages/extensions-silo/src/agents/styles.css
@@ -117,6 +117,12 @@
 .am-hours-label {
   color: var(--silo-color-text-lo);
 }
+/* Auto-expand checkbox nested under the "Collapse older agents" hint, below
+   the cutoff-period control — sits in the parent row's text column, not a
+   row of its own. */
+.am-checkbox-subrow {
+  margin-top: 8px;
+}
 
 /* Agent views in the Navigator — all classes prefixed ap-; tokens
    only. Root inherits the column font size from `.side-pane`, so no absolute
@@ -152,6 +158,9 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--silo-color-text-lo);
+}
+.ap-section-title-clickable {
+  cursor: pointer;
 }
 .ap-section-caret {
   flex-shrink: 0;

--- a/packages/extensions-silo/src/agents/styles.css
+++ b/packages/extensions-silo/src/agents/styles.css
@@ -92,6 +92,11 @@
   align-items: center;
   gap: 8px;
 }
+/* Sound picker nested under the "Play a sound…" hint — sits in the parent
+   row's text column, not a row of its own. */
+.am-sound-subrow {
+  margin-top: 8px;
+}
 
 .am-hours-control {
   display: flex;
@@ -102,6 +107,14 @@
   width: 4em;
 }
 .am-hours-unit {
+  color: var(--silo-color-text-lo);
+}
+/* Cutoff-period control nested under the "Collapse older agents" hint —
+   sits in the parent row's text column, not a row of its own. */
+.am-hours-subrow {
+  margin-top: 8px;
+}
+.am-hours-label {
   color: var(--silo-color-text-lo);
 }
 

--- a/packages/extensions-silo/src/agents/styles.css
+++ b/packages/extensions-silo/src/agents/styles.css
@@ -92,11 +92,6 @@
   align-items: center;
   gap: 8px;
 }
-/* Sound picker nested under the "Play a sound…" hint — sits in the parent
-   row's text column, not a row of its own. */
-.am-sound-subrow {
-  margin-top: 8px;
-}
 
 .am-hours-control {
   display: flex;
@@ -109,17 +104,13 @@
 .am-hours-unit {
   color: var(--silo-color-text-lo);
 }
-/* Cutoff-period control nested under the "Collapse older agents" hint —
-   sits in the parent row's text column, not a row of its own. */
-.am-hours-subrow {
-  margin-top: 8px;
-}
 .am-hours-label {
   color: var(--silo-color-text-lo);
 }
-/* Auto-expand checkbox nested under the "Collapse older agents" hint, below
-   the cutoff-period control — sits in the parent row's text column, not a
-   row of its own. */
+/* Auto-expand checkbox, below the cutoff-period control — both sit inside
+   SettingRow's `dependent` block (see its TSDoc), which already handles the
+   indent/rule/spacing off the hint; this only separates the two from each
+   other. */
 .am-checkbox-subrow {
   margin-top: 8px;
 }

--- a/packages/sdk/src/SettingRow.tsx
+++ b/packages/sdk/src/SettingRow.tsx
@@ -45,11 +45,13 @@ export function SettingRow({
   /**
    * @internal Unstable. For bundled first-party extensions proving the UX;
    * not a documented public API. Third parties must not rely on it until a
-   * graduation RFC. Extra content rendered under the hint, in the same text
-   * column — sub-settings that only make sense while this row's own setting
-   * is on. Rendered inside a native `<fieldset>`: when `enabled` is `false`,
-   * every focusable descendant is disabled automatically and the whole block
-   * dims — no need to thread `disabled` into each child by hand.
+   * graduation RFC. Extra content rendered below the label+hint, in the same
+   * left column but its own row — sub-settings that only make sense while
+   * this row's own setting is on. Kept out of `children`'s vertical centering
+   * (it sits below, not inside, the label+hint block `children` centers
+   * against). Rendered inside a native `<fieldset>`: when `enabled` is
+   * `false`, every focusable descendant is disabled automatically and the
+   * whole block dims — no need to thread `disabled` into each child by hand.
    */
   dependent?: ReactNode;
   /** The control — `Switch`, `Select`, `Input`, etc. */
@@ -60,16 +62,16 @@ export function SettingRow({
       <div className="silo-setting-row-text">
         <div className="silo-setting-row-label">{label}</div>
         {hint != null && <div className="silo-setting-row-hint">{hint}</div>}
-        {dependent != null && (
-          <fieldset
-            className="silo-setting-row-dependent"
-            disabled={enabled === false}
-          >
-            {dependent}
-          </fieldset>
-        )}
       </div>
       <div className="silo-setting-row-control">{children}</div>
+      {dependent != null && (
+        <fieldset
+          className="silo-setting-row-dependent"
+          disabled={enabled === false}
+        >
+          {dependent}
+        </fieldset>
+      )}
     </div>
   );
 }

--- a/packages/sdk/src/SettingRow.tsx
+++ b/packages/sdk/src/SettingRow.tsx
@@ -22,6 +22,36 @@ import type { ReactNode } from "react";
  * </SettingRow>
  * ```
  *
+ * A row can also nest sub-settings that only make sense while its own
+ * setting is on, via `enabled`/`dependent`:
+ *
+ * ```tsx
+ * <SettingRow
+ *   label="Collapse older agents"
+ *   hint="Agents drop off into a collapsed section once older than the cutoff."
+ *   enabled={staleDoneEnabled}
+ *   dependent={
+ *     <CheckboxRow
+ *       label="Auto-expand on hover"
+ *       checked={autoExpand}
+ *       onChange={setAutoExpand}
+ *     />
+ *   }
+ * >
+ *   <Switch
+ *     checked={staleDoneEnabled}
+ *     onChange={setStaleDoneEnabled}
+ *     aria-label="Collapse older agents"
+ *   />
+ * </SettingRow>
+ * ```
+ *
+ * `dependent` renders inside a native `<fieldset>`, so when `enabled` is
+ * `false` every focusable descendant is disabled automatically and the whole
+ * block dims — no need to thread `disabled` into each child by hand. `enabled`
+ * is a plain boolean unrelated to whatever `children` renders (a `Switch`, a
+ * `Select`, or nothing at all) — nothing requires the row to have a toggle.
+ *
  * @category Consumer Services
  * @public
  */
@@ -35,23 +65,19 @@ export function SettingRow({
   label: string;
   hint?: string;
   /**
-   * @internal Unstable. For bundled first-party extensions proving the UX;
-   * not a documented public API. Third parties must not rely on it until a
-   * graduation RFC. Gates {@link dependent} — a plain boolean, unrelated to
-   * whatever control `children` renders (a `Switch`, a `Select`, or nothing
-   * at all). Omit (or leave `true`) to leave `dependent` always enabled.
+   * Gates `dependent` — a plain boolean, unrelated to whatever control
+   * `children` renders. Omit (or leave `true`) to leave `dependent` always
+   * enabled.
    */
   enabled?: boolean;
   /**
-   * @internal Unstable. For bundled first-party extensions proving the UX;
-   * not a documented public API. Third parties must not rely on it until a
-   * graduation RFC. Extra content rendered below the label+hint, in the same
-   * left column but its own row — sub-settings that only make sense while
-   * this row's own setting is on. Kept out of `children`'s vertical centering
-   * (it sits below, not inside, the label+hint block `children` centers
-   * against). Rendered inside a native `<fieldset>`: when `enabled` is
-   * `false`, every focusable descendant is disabled automatically and the
-   * whole block dims — no need to thread `disabled` into each child by hand.
+   * Extra content rendered below the label+hint, in the same left column but
+   * its own row — sub-settings that only make sense while this row's own
+   * setting is on. Kept out of `children`'s vertical centering (it sits
+   * below, not inside, the label+hint block `children` centers against).
+   * Rendered inside a native `<fieldset>`: when `enabled` is `false`, every
+   * focusable descendant is disabled automatically and the whole block dims —
+   * no need to thread `disabled` into each child by hand.
    */
   dependent?: ReactNode;
   /** The control — `Switch`, `Select`, `Input`, etc. */

--- a/packages/sdk/src/SettingRow.tsx
+++ b/packages/sdk/src/SettingRow.tsx
@@ -90,7 +90,7 @@ export function SettingRow({
         {hint != null && <div className="silo-setting-row-hint">{hint}</div>}
       </div>
       <div className="silo-setting-row-control">{children}</div>
-      {dependent != null && (
+      {Boolean(dependent) && (
         <fieldset
           className="silo-setting-row-dependent"
           disabled={enabled === false}

--- a/packages/sdk/src/SettingRow.tsx
+++ b/packages/sdk/src/SettingRow.tsx
@@ -28,10 +28,30 @@ import type { ReactNode } from "react";
 export function SettingRow({
   label,
   hint,
+  enabled,
+  dependent,
   children,
 }: {
   label: string;
   hint?: string;
+  /**
+   * @internal Unstable. For bundled first-party extensions proving the UX;
+   * not a documented public API. Third parties must not rely on it until a
+   * graduation RFC. Gates {@link dependent} — a plain boolean, unrelated to
+   * whatever control `children` renders (a `Switch`, a `Select`, or nothing
+   * at all). Omit (or leave `true`) to leave `dependent` always enabled.
+   */
+  enabled?: boolean;
+  /**
+   * @internal Unstable. For bundled first-party extensions proving the UX;
+   * not a documented public API. Third parties must not rely on it until a
+   * graduation RFC. Extra content rendered under the hint, in the same text
+   * column — sub-settings that only make sense while this row's own setting
+   * is on. Rendered inside a native `<fieldset>`: when `enabled` is `false`,
+   * every focusable descendant is disabled automatically and the whole block
+   * dims — no need to thread `disabled` into each child by hand.
+   */
+  dependent?: ReactNode;
   /** The control — `Switch`, `Select`, `Input`, etc. */
   children?: ReactNode;
 }) {
@@ -40,6 +60,14 @@ export function SettingRow({
       <div className="silo-setting-row-text">
         <div className="silo-setting-row-label">{label}</div>
         {hint != null && <div className="silo-setting-row-hint">{hint}</div>}
+        {dependent != null && (
+          <fieldset
+            className="silo-setting-row-dependent"
+            disabled={enabled === false}
+          >
+            {dependent}
+          </fieldset>
+        )}
       </div>
       <div className="silo-setting-row-control">{children}</div>
     </div>


### PR DESCRIPTION
## Summary

Adds an "Auto-expand on hover" option to Agents settings' "Collapse older agents" section — off by default, so hovering the collapsed "N+ hours old" list of agents never pops it open by accident; click the heading to expand it instead.

While building that, standardized how Settings screens show a sub-option that only makes sense while a parent toggle is on. Three other screens hand-rolled this pattern with their own one-off CSS (Play a sound, Share side panel layout, and Laptop Mode's Threshold width) — they're now on the same shared control, which also fixes a real bug: Threshold width could previously be edited even when Laptop Mode was off.

The shared control (`SettingRow`'s new `enabled`/`dependent` props) is a public addition to the `@silo-code/sdk` design kit, so any extension author gets the same "sub-settings gated on a toggle" building block going forward instead of reinventing it.

## Details

### What & why

- `SettingRow` (packages/sdk) gains `enabled?: boolean` and `dependent?: ReactNode`. `dependent` renders below the label/hint inside a native `<fieldset disabled={enabled === false}>` — every focusable descendant is disabled automatically and the block dims via one CSS rule, with no `disabled` prop to thread into each child by hand. `enabled` is a plain boolean unrelated to whatever `children` renders (a `Switch`, a `Select`, or nothing).
- `SettingRow`'s row layout moved from flex to CSS grid so `dependent` sits in its own grid row — the row's own control stays vertically centered against just the label+hint, unaffected by however tall `dependent` is.
- Shipped in two phases: first as `@internal`/unstable (proven across four real call sites), then promoted to `@public` once the shape held up with no changes needed. RFC 0016 (`docs/proposals/0016-modal-design-system.md`) is amended in place — still `accepted`, not `implemented` — to record the new props, matching the RFC's own "additive-only" contract for the kit.
- Migrated onto the new props: Collapse older agents, Play a sound, Share side panel layout, and (newly nested, not previously grouped at all) Threshold width under Enable Laptop Mode.
- Docs: `docs/modal-design.md`'s "Need X → use Y" table and Forbidden list, and the Design System's `SettingRow` reference page (`apps/docs/design/components/structure.md`), both updated with a live demo. `pnpm docs:api` regenerated and confirmed the new props show in the public reference.
- `/code-review medium --fix` pass applied on top: fixed a real bug where `SettingRow`'s `dependent != null` check let the common `dependent={cond && <X/>}` pattern render an empty dimmed box when `cond` was `false` (now `Boolean(dependent)`), and merged two never-reconciled expansion-state booleans in the Agents panel into one.
- Also fixed along the way: `ExtensionsPage`'s "Installed" pill logic used a `null` ternary branch with a leading comment that Prettier reformats non-idempotently (each pass further garbled the comment) — replaced with a named boolean.

### How to test

- Settings → Agents → Navigator tab → Collapse older agents: toggle "Auto-expand on hover" on/off and confirm hover-vs-click behavior on the "N+ hours old" section.
- Settings → Agents → Behavior tab → Play a sound, and Settings → Layout → both rows: toggle the parent switch off and confirm the dependent content dims and its controls are inert.
- Settings → Layout → Enable Laptop Mode off: confirm Threshold width's input and capture-width button are now actually disabled (previously they weren't).
- Unit tests: `pnpm --filter @silo-code/sdk test`, `pnpm --filter @silo-code/extensions-silo test`, `pnpm --filter @silo-code/extensions-core test`.

### Checklist

- [x] PR title is a valid Conventional Commit
- [x] `pnpm lint`, `pnpm format:check`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm test` pass
- [x] No new architecture-boundary violations (built-ins touch the app only via `ctx`)
- [x] Docs/`ctx` reference updated — `SettingRow`'s new props are documented and regenerated into the public API reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
