### PR TITLE
feat(settings): host-own settings page titles

### DIFF
--- a/apps/docs/api/registration/register-settings-page.md
+++ b/apps/docs/api/registration/register-settings-page.md
@@ -1,6 +1,8 @@
 # ctx.registerSettingsPage
 
-Add a page to the Settings dialog, listed in the left rail with optional `group` / `order`.
+Add a page to the Settings dialog. The host draws the left rail entry and the
+pane title from `SettingsPage.title` — your component is the body only (no
+`<h2>`).
 
 ```ts
 ctx.registerSettingsPage(page: SettingsPage): Disposable
@@ -12,7 +14,7 @@ ctx.registerSettingsPage(page: SettingsPage): Disposable
 ctx.registerSettingsPage({
   id: "acme",
   title: "Acme",
-  component: AcmeSettings, // a React component
+  component: AcmeSettings, // body only — no page title
 });
 ```
 

--- a/apps/docs/api/types/interfaces/Extension.md
+++ b/apps/docs/api/types/interfaces/Extension.md
@@ -1,6 +1,6 @@
 # Interface: Extension\<API\>
 
-Defined in: [packages/sdk/src/types.ts:978](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L978)
+Defined in: [packages/sdk/src/types.ts:981](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L981)
 
 The shape of a Silo extension: a stable id plus an
 [activate](#activate) function the host calls once, passing
@@ -25,7 +25,7 @@ extensions that publish nothing.
 id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:984](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L984)
+Defined in: [packages/sdk/src/types.ts:987](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L987)
 
 Unique extension id, conventionally namespaced: `core.*` for Silo's core
 feature set, `silo.*` for its optional bundled features, `<vendor>.*` for
@@ -39,7 +39,7 @@ third parties (e.g. `"core.editor"`, `"silo.git"`, `"acme.foo"`).
 optional manifest?: ExtensionManifest;
 ```
 
-Defined in: [packages/sdk/src/types.ts:991](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L991)
+Defined in: [packages/sdk/src/types.ts:994](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L994)
 
 Optional display metadata for the **Extensions** settings page. Built-in
 extensions declare it here so they can be listed (and disabled) with a name
@@ -54,7 +54,7 @@ package manifest instead. See [ExtensionManifest](ExtensionManifest.md).
 activate(ctx): void | API;
 ```
 
-Defined in: [packages/sdk/src/types.ts:998](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L998)
+Defined in: [packages/sdk/src/types.ts:1001](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L1001)
 
 Called once by the host; register contributions against `ctx` here.
 **Optionally return an API object** to publish it for other extensions to
@@ -79,7 +79,7 @@ extension publishes no API.
 optional deactivate(): void;
 ```
 
-Defined in: [packages/sdk/src/types.ts:1000](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L1000)
+Defined in: [packages/sdk/src/types.ts:1003](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L1003)
 
 Optional cleanup hook (reserved for dynamic load/unload).
 

--- a/apps/docs/api/types/interfaces/ExtensionContext.md
+++ b/apps/docs/api/types/interfaces/ExtensionContext.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionContext
 
-Defined in: [packages/sdk/src/types.ts:685](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L685)
+Defined in: [packages/sdk/src/types.ts:688](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L688)
 
 The object handed to [Extension.activate](Extension.md#activate). It is the *only* sanctioned
 way an extension touches the running app: register contributions, invoke
@@ -16,7 +16,7 @@ commands, and read/drive state through the typed consumer services. Every
 readonly extensionId: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:687](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L687)
+Defined in: [packages/sdk/src/types.ts:690](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L690)
 
 The activating extension's id (its [Extension.id](Extension.md#id)).
 
@@ -28,7 +28,7 @@ The activating extension's id (its [Extension.id](Extension.md#id)).
 readonly subscriptions: Disposable[];
 ```
 
-Defined in: [packages/sdk/src/types.ts:689](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L689)
+Defined in: [packages/sdk/src/types.ts:692](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L692)
 
 Disposables tracked for this extension; the host disposes them on teardown.
 
@@ -40,7 +40,7 @@ Disposables tracked for this extension; the host disposes them on teardown.
 readonly storage: ExtensionStorageScopes;
 ```
 
-Defined in: [packages/sdk/src/types.ts:705](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L705)
+Defined in: [packages/sdk/src/types.ts:708](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L708)
 
 Persisted, per-extension key/value storage, in two scopes
 ([ExtensionStorageScopes](ExtensionStorageScopes.md)): `global` (shared across all workspaces —
@@ -64,7 +64,7 @@ scope keyed by panel id, for panel-local UI state.)
 readonly workspaces: WorkspaceService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:787](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L787)
+Defined in: [packages/sdk/src/types.ts:790](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L790)
 
 Consumer API for driving workspace state — create, rename, reorder,
 activate, soft close/reopen, and hard delete. Subscribe to a frozen
@@ -78,7 +78,7 @@ state for read access without depending on Valtio.
 readonly editors: EditorService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:793](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L793)
+Defined in: [packages/sdk/src/types.ts:796](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L796)
 
 The editor & document domain — open files into editor tabs, drive the
 active editor (save / close), and register editor save handlers. Opening
@@ -92,7 +92,7 @@ editors lives here, not on [ExtensionContext.workspaces](#workspaces).
 readonly layout: LayoutService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:799](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L799)
+Defined in: [packages/sdk/src/types.ts:802](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L802)
 
 Consumer API for app layout — side-panel collapse state. Read via
 getState/useServiceState/subscribe; drive via toggleSidePanel /
@@ -106,7 +106,7 @@ setSidePanelCollapsed.
 readonly process: ProcessService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:805](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L805)
+Defined in: [packages/sdk/src/types.ts:808](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L808)
 
 Persistent process / PTY sessions that **survive app restarts** — the core
 primitive under the terminal (and future task runners, REPLs). Spawn or
@@ -120,7 +120,7 @@ re-attach a session and drive it via the returned `ProcessSession`.
 readonly processes: ProcessesService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:813](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L813)
+Defined in: [packages/sdk/src/types.ts:816](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L816)
 
 Workspace process observability — a live view of what is running in each
 terminal, with optional CPU/memory stats and a surgical kill that leaves the
@@ -136,7 +136,7 @@ See [ProcessesService](ProcessesService.md) for the full API.
 readonly agents: AgentsService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:823](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L823)
+Defined in: [packages/sdk/src/types.ts:826](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L826)
 
 Host-computed coding-agent activity and resume-identity observability —
 a live, read-only view of what each terminal's agent is doing
@@ -154,7 +154,7 @@ registration API. **@beta** — the shape may still change. See
 readonly terminals: TerminalService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:831](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L831)
+Defined in: [packages/sdk/src/types.ts:834](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L834)
 
 Consumer API for the terminal domain — open a terminal tab in a workspace
 (`create`) or reap a workspace's terminals (`closeWorkspace`). The terminal
@@ -170,7 +170,7 @@ from the workspace's records, and PTY sessions live on
 readonly files: FileService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:837](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L837)
+Defined in: [packages/sdk/src/types.ts:840](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L840)
 
 Host-mediated filesystem access — read / write / list / watch, all routed
 through the host rather than raw Tauri. The single privileged chokepoint
@@ -184,7 +184,7 @@ for the filesystem; watcher lifecycle is host-owned (see [FileService](FileServi
 readonly search: SearchService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:844](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L844)
+Defined in: [packages/sdk/src/types.ts:847](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L847)
 
 Cross-file content search over the workspace — the core primitive under the
 Search panel (and future quick-open / find-references). Runs a native search
@@ -199,7 +199,7 @@ with matches grouped by file. See [SearchService](SearchService.md).
 readonly theme: ThemeService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:851](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L851)
+Defined in: [packages/sdk/src/types.ts:854](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L854)
 
 Consumer API for the theme domain — read the merged preset set + active
 theme, switch themes, and manage custom themes. Read via getState /
@@ -214,7 +214,7 @@ subscribe; contribute a new preset via
 readonly dnd: DndService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:858](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L858)
+Defined in: [packages/sdk/src/types.ts:861](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L861)
 
 Drag-and-drop — be a drag source ([DndService.beginDrag](DndService.md#begindrag)) and a drop
 target ([DndService.registerDropTarget](DndService.md#registerdroptarget)), with typed payloads
@@ -229,7 +229,7 @@ drag affordance and the modifier-mode resolution.
 readonly ui: UiService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:865](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L865)
+Defined in: [packages/sdk/src/types.ts:868](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L868)
 
 User-interaction — the only sanctioned way to talk to the user (the host
 renders the chrome). Native file/folder pickers ([UiService.pickFolder](UiService.md#pickfolder),
@@ -244,7 +244,7 @@ notifications ([UiService.notify](UiService.md#notify)). Mirrors VS Code's `wind
 readonly net: NetworkService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:873](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L873)
+Defined in: [packages/sdk/src/types.ts:876](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L876)
 
 Server-side HTTP client — makes requests from the Rust backend, bypassing
 the browser's CORS policy. Use when browser `fetch` is insufficient:
@@ -260,7 +260,7 @@ loading a URL. See [NetworkService](NetworkService.md) for the full API.
 readonly webview: WebviewService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:880](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L880)
+Defined in: [packages/sdk/src/types.ts:883](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L883)
 
 Real DOM access, navigation control, and native pixel capture inside an
 `<iframe>` you own — including cross-origin content the browser's
@@ -275,7 +275,7 @@ same-origin policy would otherwise fully sandbox. Requires the
 readonly system: SystemService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:888](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L888)
+Defined in: [packages/sdk/src/types.ts:891](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L891)
 
 Static host-platform metadata — the OS, CPU architecture, and running Silo
 version. Values are baked into the binary at build time and never change
@@ -291,7 +291,7 @@ See [SystemService](SystemService.md) for the full API.
 readonly log: LogService;
 ```
 
-Defined in: [packages/sdk/src/types.ts:901](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L901)
+Defined in: [packages/sdk/src/types.ts:904](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L904)
 
 Write-only structured logger scoped to this extension. Entries appear in
 the **Output** panel under the extension's display name. A channel is
@@ -312,7 +312,7 @@ ctx.log.show(); // open the Output panel, select this extension's channel
 registerEditor(editor): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:707](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L707)
+Defined in: [packages/sdk/src/types.ts:710](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L710)
 
 Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 
@@ -334,7 +334,7 @@ Register an [Editor](Editor.md) (a presenter for a file type's editor tab).
 registerFileType(type): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:709](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L709)
+Defined in: [packages/sdk/src/types.ts:712](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L712)
 
 Register a [FileType](FileType.md) (declarative file metadata).
 
@@ -356,7 +356,7 @@ Register a [FileType](FileType.md) (declarative file metadata).
 registerCommand(cmd): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:711](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L711)
+Defined in: [packages/sdk/src/types.ts:714](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L714)
 
 Register a [Command](Command.md) (a named, invokable action).
 
@@ -378,7 +378,7 @@ Register a [Command](Command.md) (a named, invokable action).
 registerMenuItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:713](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L713)
+Defined in: [packages/sdk/src/types.ts:716](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L716)
 
 Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a menu).
 
@@ -400,7 +400,7 @@ Register a [MenuItemContribution](MenuItemContribution.md) (place a command in a
 registerContextMenuItem<S>(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:719](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L719)
+Defined in: [packages/sdk/src/types.ts:722](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L722)
 
 Register a [ContextMenuContribution](ContextMenuContribution.md) (add a command to a built-in
 surface's right-click context menu). The invoked command receives the
@@ -430,7 +430,7 @@ surface's [MenuContext](MenuContext.md) target as its first argument.
 registerToolbarItem<S>(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:730](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L730)
+Defined in: [packages/sdk/src/types.ts:733](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L733)
 
 Register a [ToolbarItemContribution](../type-aliases/ToolbarItemContribution.md) (icon-only, text-only,
 icon+text, or dropdown) in the trailing cluster of an editor or terminal
@@ -463,7 +463,7 @@ surface's breadcrumbs setting is on. See
 invalidateToolbarItems(): void;
 ```
 
-Defined in: [packages/sdk/src/types.ts:738](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L738)
+Defined in: [packages/sdk/src/types.ts:741](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L741)
 
 Signal that toolbar-item `when` / `checked` data changed. Causes every
 toolbar surface — editor, terminal, and the Navigator header — to re-query
@@ -481,7 +481,7 @@ contributions and re-render.
 registerKeybinding(binding): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:740](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L740)
+Defined in: [packages/sdk/src/types.ts:743](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L743)
 
 Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 
@@ -503,7 +503,7 @@ Register a [Keybinding](Keybinding.md) (bind a shortcut to a command).
 registerSidePanel(panel): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:742](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L742)
+Defined in: [packages/sdk/src/types.ts:745](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L745)
 
 Register a [SidePanel](SidePanel.md) (a left/right column panel).
 
@@ -525,7 +525,7 @@ Register a [SidePanel](SidePanel.md) (a left/right column panel).
 registerNavigatorView(view): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:748](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L748)
+Defined in: [packages/sdk/src/types.ts:751](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L751)
 
 Register a [NavigatorView](NavigatorView.md) — a projection the user can switch the
 Navigator panel to. Prefer this over a second side panel when your surface
@@ -549,7 +549,7 @@ is another way to navigate the app.
 registerDockPanelKind<T>(kind): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:754](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L754)
+Defined in: [packages/sdk/src/types.ts:757](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L757)
 
 Register a [DockPanelKind](DockPanelKind.md) (a center-dock tab kind). The params
 generic `T` is inferred from the component's [DockPanelProps](DockPanelProps.md)
@@ -579,7 +579,7 @@ annotation, so kinds with typed params register without casts.
 registerStatusItem(item): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:758](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L758)
+Defined in: [packages/sdk/src/types.ts:761](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L761)
 
 Register a [StatusItem](StatusItem.md) (a status-bar widget).
 
@@ -601,7 +601,7 @@ Register a [StatusItem](StatusItem.md) (a status-bar widget).
 registerSettingsPage(page): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:760](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L760)
+Defined in: [packages/sdk/src/types.ts:763](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L763)
 
 Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 
@@ -623,7 +623,7 @@ Register a [SettingsPage](SettingsPage.md) (a page in the Settings dialog).
 registerThemePreset(preset): Disposable;
 ```
 
-Defined in: [packages/sdk/src/types.ts:766](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L766)
+Defined in: [packages/sdk/src/types.ts:769](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L769)
 
 Register a [ThemePreset](ThemePreset.md) (a selectable theme in the picker).
 
@@ -650,7 +650,7 @@ Use [ctx.theme.registerPreset()](ThemeService.md#registerpreset) instead.
 executeCommand<T>(id, ...args): Promise<T>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:781](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L781)
+Defined in: [packages/sdk/src/types.ts:784](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L784)
 
 Invoke a registered command by id — including commands contributed by
 other extensions. The minimal "operate" primitive; pairs with the typed
@@ -693,7 +693,7 @@ Expected return type of the command (defaults to `unknown`).
 getExtension<API>(id): ExtensionHandle<API> | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:915](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L915)
+Defined in: [packages/sdk/src/types.ts:918](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L918)
 
 Resolve a handle to another extension in order to consume the API it
 published (the value its [Extension.activate](Extension.md#activate) returned). This is how

--- a/apps/docs/api/types/interfaces/ExtensionHandle.md
+++ b/apps/docs/api/types/interfaces/ExtensionHandle.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionHandle\<API\>
 
-Defined in: [packages/sdk/src/types.ts:926](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L926)
+Defined in: [packages/sdk/src/types.ts:929](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L929)
 
 A handle to another extension, obtained via
 [ExtensionContext.getExtension](ExtensionContext.md#getextension). Lets one extension consume another's
@@ -20,7 +20,7 @@ published API while tolerating its absence.
 readonly id: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:928](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L928)
+Defined in: [packages/sdk/src/types.ts:931](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L931)
 
 The resolved extension's id.
 
@@ -32,7 +32,7 @@ The resolved extension's id.
 readonly active: boolean;
 ```
 
-Defined in: [packages/sdk/src/types.ts:930](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L930)
+Defined in: [packages/sdk/src/types.ts:933](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L933)
 
 True once that extension has activated.
 
@@ -44,7 +44,7 @@ True once that extension has activated.
 readonly api: API | undefined;
 ```
 
-Defined in: [packages/sdk/src/types.ts:933](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L933)
+Defined in: [packages/sdk/src/types.ts:936](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L936)
 
 Its published API (what its `activate` returned), or `undefined` if it
 hasn't activated or published nothing.

--- a/apps/docs/api/types/interfaces/ExtensionManifest.md
+++ b/apps/docs/api/types/interfaces/ExtensionManifest.md
@@ -1,6 +1,6 @@
 # Interface: ExtensionManifest
 
-Defined in: [packages/sdk/src/types.ts:949](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L949)
+Defined in: [packages/sdk/src/types.ts:952](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L952)
 
 Display metadata for an extension, surfaced in the **Extensions** settings
 page (name, one-line description, version, and [\* \| publisher](#publisher) brand). For built-in extensions this is declared in-code on the
@@ -18,7 +18,7 @@ namespace for the publisher) when one is absent.
 readonly optional name?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:951](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L951)
+Defined in: [packages/sdk/src/types.ts:954](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L954)
 
 Human-friendly name shown in the Extensions list (falls back to the id).
 
@@ -30,7 +30,7 @@ Human-friendly name shown in the Extensions list (falls back to the id).
 readonly optional description?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:953](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L953)
+Defined in: [packages/sdk/src/types.ts:956](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L956)
 
 One-line description shown beneath the name.
 
@@ -42,7 +42,7 @@ One-line description shown beneath the name.
 readonly optional version?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:955](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L955)
+Defined in: [packages/sdk/src/types.ts:958](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L958)
 
 Version string shown next to the name.
 
@@ -54,7 +54,7 @@ Version string shown next to the name.
 readonly optional publisher?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:962](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L962)
+Defined in: [packages/sdk/src/types.ts:965](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L965)
 
 The publisher/brand shown beside the name (e.g. `"Silo"`). Built-in
 extensions are always branded `"Silo"` by the host regardless of this field;

--- a/apps/docs/api/types/interfaces/SettingsPage.md
+++ b/apps/docs/api/types/interfaces/SettingsPage.md
@@ -24,9 +24,10 @@ Unique id for this settings page.
 title: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:654](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L654)
+Defined in: [packages/sdk/src/types.ts:657](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L657)
 
-Label shown in the Settings left rail.
+Label shown in the Settings left rail **and** as the host-owned page
+title in the pane. Do not render your own `<h2>` — the host draws this.
 
 ***
 
@@ -36,7 +37,7 @@ Label shown in the Settings left rail.
 optional group?: string;
 ```
 
-Defined in: [packages/sdk/src/types.ts:661](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L661)
+Defined in: [packages/sdk/src/types.ts:664](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L664)
 
 Optional grouping key for the left rail (groups sorted lexically, separated
 by a divider). Honored only for `core.*` pages; a page contributed by any
@@ -51,7 +52,7 @@ ignored for those.
 optional order?: number;
 ```
 
-Defined in: [packages/sdk/src/types.ts:663](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L663)
+Defined in: [packages/sdk/src/types.ts:666](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L666)
 
 Sort order within the group. Lower sorts first. Defaults to 0.
 
@@ -63,7 +64,7 @@ Sort order within the group. Lower sorts first. Defaults to 0.
 component: ComponentType;
 ```
 
-Defined in: [packages/sdk/src/types.ts:665](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L665)
+Defined in: [packages/sdk/src/types.ts:668](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L668)
 
 Renders the right-hand pane when this page is selected.
 
@@ -76,7 +77,7 @@ optional badge?: ComponentType<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/types.ts:672](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L672)
+Defined in: [packages/sdk/src/types.ts:675](https://github.com/silo-code/silo/blob/main/packages/sdk/src/types.ts#L675)
 
 Optional small indicator rendered after the title in the left rail (e.g.
 an update-available count). Rendered as its own component — separate from

--- a/apps/docs/guide/building-modals.md
+++ b/apps/docs/guide/building-modals.md
@@ -222,7 +222,7 @@ ctx.registerSettingsPage({
 });
 ```
 
-That renders as:
+The host draws the pane title from `title` — don't render your own `<h2>`. That renders as:
 
 <div class="silo-demo silo-demo-block">
   <div class="sd-frame">

--- a/examples/extensions/clock-extension/src/index.tsx
+++ b/examples/extensions/clock-extension/src/index.tsx
@@ -14,11 +14,11 @@ const STYLE_ID = "silo-clock-styles";
 const STYLES = `
 .clock-status { font-variant-numeric: tabular-nums; }
 
-/* Settings page — mirrors the host's Editor / Keyboard Shortcuts pages so a
-   third-party page reads as one family. */
+/* Settings page — body only; the host draws the page title from
+   SettingsPage.title. Consume only --silo-* design tokens (plus the
+   settings sheet's --settings-* contract) so the extension themes correctly
+   and scales with uiFontSize. */
 .clock-page { display: flex; flex-direction: column; height: 100%; gap: 12px; }
-.clock-header { display: flex; align-items: center; min-height: var(--settings-header-height); }
-.clock-header h2 { margin: 0; font-size: 1.1em; color: var(--silo-color-text-hi); }
 .clock-list { display: flex; flex-direction: column; margin-left: calc(var(--settings-pane-pad) * -1); }
 .clock-row {
   display: flex;
@@ -154,9 +154,6 @@ function ClockSettingsPage() {
   const s = useServiceState(settingsService);
   return (
     <div className="clock-page">
-      <div className="clock-header">
-        <h2>Clock</h2>
-      </div>
       <div className="clock-list">
         <ToggleRow
           label="24-hour clock"

--- a/packages/extension-host/src/components/SettingsPage.css
+++ b/packages/extension-host/src/components/SettingsPage.css
@@ -1,6 +1,8 @@
 /* Settings **page** chrome — the shell each settings page renders inside
-   (`.es-page` / `.es-header` / `.es-scroll`), shared by Editor, Terminal,
-   Keybindings, Agents, Extensions, and every contributed page.
+   (`.es-page` / `.es-scroll`), shared by Editor, Terminal, Keybindings,
+   Agents, Extensions, and every contributed page. The page *title* is
+   host-owned (`.settings-sheet-page-title` in SettingsSheet.css) — pages
+   must not draw their own `<h2>`.
 
    Lives here rather than beside the surface that hosts those pages: it outlived
    the Settings *modal* it was originally written in, and would have had to move
@@ -14,20 +16,6 @@
   flex-direction: column;
   height: 100%;
   gap: 20px;
-}
-
-.es-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: var(--settings-header-height);
-}
-
-.es-header h2 {
-  margin: 0;
-  font-size: 1.1em;
-  color: var(--silo-color-text-hi);
 }
 
 /* SearchInput (SDK) spans the page width on Editor / Terminal. */

--- a/packages/extension-host/src/components/SettingsSheet.css
+++ b/packages/extension-host/src/components/SettingsSheet.css
@@ -15,7 +15,10 @@
      inside it would size against undefined values. */
   --settings-font: calc(var(--silo-font-size-base) + 1px);
   font-size: var(--settings-font);
-  --settings-header-height: calc(var(--settings-font) + 14px);
+  /* Sized to fit IconButton `sm` (2em) / SegmentedTabs without growing the
+     row — the page header is a fixed height so contributing actions never
+     bumps body content down. */
+  --settings-header-height: calc(var(--settings-font) * 2);
   --settings-pane-pad: 24px;
 }
 
@@ -33,12 +36,9 @@
   flex: 0 0 272px;
   display: flex;
   flex-direction: column;
-  /* The pane's own 24px top padding plus a 2px optical nudge. Matching boxes
-     (see `.settings-sheet-title`) line the two titles up geometrically, but the
-     rail title is set larger than the page title, so its cap height still reads
-     high against it — and a full 4px overshot the other way. The nudge is on
-     the rail's padding rather than the title alone so the sections below move
-     with it. */
+  /* Same top inset as the pane — both titles sit in identical
+     `--settings-header-height` boxes, so matching padding keeps their
+     optical centres lined up as `--settings-font` scales. */
   padding: 26px 12px 24px;
   border-right: 1px solid var(--silo-color-border);
   /* Pages own their own scrolling; the rail scrolls only when the settings
@@ -47,28 +47,70 @@
 
   /* The rail reads a step larger than page content — it's navigation, held at
      arm's length, not prose. Everything in it (items, heading, icons) sizes off
-     this one value in em/calc, so the rail scales as a unit. */
+     this one value in em/calc, so the rail scales as a unit. Also the shared
+     chrome-title size (Settings + page title) is keyed off this. */
   --settings-rail-font: calc(var(--settings-font) + 1px);
   font-size: var(--settings-rail-font);
 }
 
-/* "Settings" has to line up with the page title beside it, and a page title
-   isn't simply text at the top of the pane: it sits in `.es-header`, a flex row
-   of `--settings-header-height` that centres it (the row is sized for a header
-   carrying an action button, so a bare title floats in the middle of it). This
-   adopts the same box and the same centring, which keeps the two aligned as the
-   UI font scales instead of only at one size — a hand-tuned offset would drift
-   the moment `--settings-font` changed. The two titles differ in size, so it's
-   their optical centres that match, not their baselines. */
-.settings-sheet-title {
+/* Shared chrome title — "Settings" in the rail and the host-owned page title
+   in the pane. Same size/weight so they line up; the *row* height lives on
+   `.settings-sheet-title` / `.settings-sheet-page-header` (fixed, so header
+   actions never bump body content). */
+.settings-sheet-title,
+.settings-sheet-page-title {
   display: flex;
   align-items: center;
-  min-height: var(--settings-header-height);
-  font-size: 1.15em;
+  margin: 0;
+  /* Absolute to `--settings-font`, not `em` of the parent — the rail's base
+     is a step larger than the pane's, and both titles must resolve to the
+     same px (17.25 at the default scale). */
+  font-size: calc(1.15 * (var(--settings-font) + 1px));
   font-weight: 600;
   color: var(--silo-color-text-hi);
+}
+
+.settings-sheet-title {
+  height: var(--settings-header-height);
   padding: 0 10px;
   margin-bottom: 20px;
+}
+
+/* Page title row — title left, optional actions right. Fixed height so a
+   page with tools and a page without share the same content start Y. */
+.settings-sheet-page-header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: var(--settings-header-height);
+}
+
+.settings-sheet-page-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  /* Fill the row and centre the glyphs in it — same vertical centre as the
+     actions, instead of centering a taller line-box that sits the text high
+     and makes the tools read bottom-aligned. */
+  height: 100%;
+  line-height: 1;
+}
+
+.settings-sheet-page-header-actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  height: 100%;
+}
+
+/* Tooltip wraps its trigger in an inline <span>; without this the span's
+   line-box baseline gap makes the control sit off-centre in the row. */
+.settings-sheet-page-header-actions > .silo-tooltip-host {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
 }
 
 .settings-sheet-section + .settings-sheet-section {
@@ -148,11 +190,23 @@
 .settings-sheet-pane {
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
   /* Pages own their scroll regions via `.silo-scroll`; keep the pane from
      growing a second scrollbar in the close button's gutter. */
   overflow: hidden;
-  padding: 24px 48px 24px var(--settings-pane-pad);
+  /* 26px top matches the rail so host page title and "Settings" share a top
+     inset (both centre in `--settings-header-height`). */
+  padding: 26px 48px 24px var(--settings-pane-pad);
   color: var(--silo-color-text);
+}
+
+.settings-sheet-page-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .settings-sheet-empty {

--- a/packages/extension-host/src/components/SettingsSheet.tsx
+++ b/packages/extension-host/src/components/SettingsSheet.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 import { useSnapshot } from "valtio";
 import type { SettingsPage } from "@silo-code/sdk";
 import { Sheet } from "../extension-host/Sheet";
@@ -9,6 +16,11 @@ import {
   resolveActivePage,
 } from "../extension-host/settings-rail";
 import {
+  eatDuplicateSettingsTitle,
+  paneTitleFor,
+} from "../extension-host/settings-page-title";
+import { SettingsHeaderActionsProvider } from "../extension-host/settings-header-actions";
+import {
   settingsSheet as ui,
   closeSettings,
 } from "../extension-host/settings-sheet";
@@ -17,10 +29,16 @@ import "./SettingsPage.css";
 import "./SettingsSheet.css";
 
 // Settings — a centered app sheet (extension-host/Sheet.tsx) holding the
-// registered settings pages in a two-section icon rail. Replaced the Settings
-// modal it grew out of; the page registry and the page components themselves
-// are unchanged, so only the container and the rail differ from what was here
-// before.
+// registered settings pages in a two-section icon rail. The host owns the
+// page title (from SettingsPage.title); page components are body-only.
+//
+// Pages that need tools beside the title (SegmentedTabs, overflow ⋮, …)
+// portal them into the header-actions slot via SettingsHeaderActions — the
+// header is a fixed height, so contributing actions never bumps body content.
+//
+// During the migration window, SettingsPageBody also hides a page-drawn
+// heading that duplicates the host title (eatDuplicateSettingsTitle) so
+// third-party extensions that still render their own <h2> don't double up.
 //
 // The sheet primitive underneath is still experimental and host-internal.
 // Settings is its first real consumer — which is the point of using it here
@@ -43,14 +61,42 @@ function RailIcon({ page }: { page: SettingsPage }) {
   );
 }
 
+/**
+ * Mounts the active page and eats a leading duplicate title if the page still
+ * draws one. `pageId` re-runs the scan when the rail selection changes.
+ */
+function SettingsPageBody({
+  title,
+  pageId,
+  children,
+}: {
+  title: string;
+  pageId: string;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const root = ref.current;
+    if (!root) return;
+    eatDuplicateSettingsTitle(root, title);
+  }, [title, pageId, children]);
+  return (
+    <div ref={ref} className="settings-sheet-page-body">
+      {children}
+    </div>
+  );
+}
+
 export function SettingsSheet() {
   const snap = useSnapshot(ui);
   const sections = railSections(useSettingsPages());
+  const [actionsSlot, setActionsSlot] = useState<HTMLElement | null>(null);
 
   if (!snap.open) return null;
 
   const active = resolveActivePage(sections, snap.pageId);
   const ActiveComponent = active?.component;
+  const pageTitle = paneTitleFor(active);
 
   return (
     <Sheet
@@ -91,8 +137,19 @@ export function SettingsSheet() {
           ))}
         </nav>
         <section className="settings-sheet-pane">
-          {ActiveComponent ? (
-            <ActiveComponent />
+          {pageTitle != null && active ? (
+            <SettingsHeaderActionsProvider slot={actionsSlot}>
+              <div className="settings-sheet-page-header">
+                <h2 className="settings-sheet-page-title">{pageTitle}</h2>
+                <div
+                  ref={setActionsSlot}
+                  className="settings-sheet-page-header-actions"
+                />
+              </div>
+              <SettingsPageBody title={pageTitle} pageId={active.id}>
+                {ActiveComponent ? <ActiveComponent /> : null}
+              </SettingsPageBody>
+            </SettingsHeaderActionsProvider>
           ) : (
             <div className="settings-sheet-empty">
               No settings pages registered.

--- a/packages/extension-host/src/extension-host/sdk-internal.ts
+++ b/packages/extension-host/src/extension-host/sdk-internal.ts
@@ -57,6 +57,13 @@ export type { ModalProps } from "./Modal";
 export { Sheet } from "./Sheet";
 export type { SheetProps } from "./Sheet";
 
+// Settings page header-actions slot — core pages portal tools (SegmentedTabs,
+// overflow ⋮, …) into the host-owned title row so body content Y stays fixed.
+export {
+  SettingsHeaderActions,
+  SettingsHeaderActionsProvider,
+} from "./settings-header-actions";
+
 // The generic `(ui, storage, opts)` implementation behind the now-public
 // `ctx.ui.confirmWithDontShowAgain` (RFC 0029) — its option types
 // (`ConfirmDontShowAgainMode`/`Options`) are public SDK exports now. Still

--- a/packages/extension-host/src/extension-host/settings-header-actions.tsx
+++ b/packages/extension-host/src/extension-host/settings-header-actions.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Slot in the Settings sheet's host-owned page header where a page can mount
+ * tools (SegmentedTabs, IconButton, …) without taking a row in the body —
+ * so content Y stays fixed whether the page contributes actions or not.
+ *
+ * Core-only for now (`@silo-code/extension-host/internal`); promote to the
+ * public SDK if/when third-party settings pages need the same slot.
+ */
+
+const SettingsHeaderActionsContext = createContext<HTMLElement | null>(null);
+
+export function SettingsHeaderActionsProvider({
+  slot,
+  children,
+}: {
+  slot: HTMLElement | null;
+  children: ReactNode;
+}) {
+  return (
+    <SettingsHeaderActionsContext.Provider value={slot}>
+      {children}
+    </SettingsHeaderActionsContext.Provider>
+  );
+}
+
+/**
+ * Portal children into the active settings page's header-actions slot.
+ * Renders nothing when used outside Settings (no provider / slot not ready).
+ */
+export function SettingsHeaderActions({ children }: { children: ReactNode }) {
+  const slot = useContext(SettingsHeaderActionsContext);
+  if (!slot) return null;
+  return createPortal(children, slot);
+}

--- a/packages/extension-host/src/extension-host/settings-page-title.test.ts
+++ b/packages/extension-host/src/extension-host/settings-page-title.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { SettingsPage } from "@silo-code/sdk";
+import { eatDuplicateSettingsTitle, paneTitleFor } from "./settings-page-title";
+
+function page(over: Partial<SettingsPage> & { title: string }): SettingsPage {
+  return {
+    id: over.id ?? "x",
+    component: () => null,
+    ...over,
+  };
+}
+
+describe("paneTitleFor", () => {
+  it("returns the registered title for the active page", () => {
+    expect(paneTitleFor(page({ title: "System Monitor" }))).toBe(
+      "System Monitor",
+    );
+  });
+
+  it("returns null when no page is active", () => {
+    expect(paneTitleFor(undefined)).toBeNull();
+    expect(paneTitleFor(null)).toBeNull();
+  });
+});
+
+describe("eatDuplicateSettingsTitle", () => {
+  function mount(html: string): HTMLElement {
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    document.body.appendChild(root);
+    return root;
+  }
+
+  it("hides a leading h2 whose text matches the host title", () => {
+    const root = mount(
+      `<div class="sms-settings-page"><h2 class="sms-settings-title">System Monitor</h2><div class="body">x</div></div>`,
+    );
+    const eaten = eatDuplicateSettingsTitle(root, "System Monitor");
+    expect(eaten?.hidden).toBe(true);
+    expect(eaten?.textContent).toBe("System Monitor");
+  });
+
+  it("hides an h2 nested in a header wrapper at the top of the page", () => {
+    const root = mount(
+      `<div class="es-page"><div class="es-header"><h2>Editor</h2></div><input /></div>`,
+    );
+    expect(eatDuplicateSettingsTitle(root, "Editor")?.hidden).toBe(true);
+  });
+
+  it("is a no-op when the page already omitted its title", () => {
+    const root = mount(
+      `<div class="es-page"><input placeholder="Search" /><div class="silo-section">rows</div></div>`,
+    );
+    expect(eatDuplicateSettingsTitle(root, "Editor")).toBeNull();
+  });
+
+  it("does not hide a matching h2 that sits below other content", () => {
+    const root = mount(
+      `<div class="page"><button type="button">Browse</button><h2>Extensions</h2></div>`,
+    );
+    expect(eatDuplicateSettingsTitle(root, "Extensions")).toBeNull();
+    expect(root.querySelector("h2")?.hidden).toBe(false);
+  });
+
+  it("does not hide a leading h2 with different text", () => {
+    const root = mount(`<div><h2>Authentication</h2></div>`);
+    expect(eatDuplicateSettingsTitle(root, "GitHub Actions")).toBeNull();
+    expect(root.querySelector("h2")?.hidden).toBe(false);
+  });
+});

--- a/packages/extension-host/src/extension-host/settings-page-title.ts
+++ b/packages/extension-host/src/extension-host/settings-page-title.ts
@@ -1,0 +1,68 @@
+import type { SettingsPage } from "@silo-code/sdk";
+
+/**
+ * Host-owned pane heading for the active settings page.
+ *
+ * `SettingsPage.title` is the single source — drawn by SettingsSheet, never by
+ * the page component. Returns `null` when no page is active (empty pane).
+ */
+export function paneTitleFor(
+  page: SettingsPage | null | undefined,
+): string | null {
+  return page?.title ?? null;
+}
+
+/**
+ * Hide a page-drawn duplicate of the host title during the migration window.
+ *
+ * Extension settings pages used to render their own `<h2>{title}</h2>`. The
+ * host now draws that title; until authors remove theirs, the first `h1`/`h2`
+ * whose text matches `title` and that sits at the top of the page (no other
+ * visible content before it) is hidden. Once the page stops drawing a title,
+ * this is a no-op.
+ *
+ * Returns the element that was hidden, or `null` if nothing matched.
+ */
+export function eatDuplicateSettingsTitle(
+  root: ParentNode,
+  title: string,
+): HTMLElement | null {
+  const heading = root.querySelector("h1, h2");
+  if (!(heading instanceof HTMLElement)) return null;
+  if (heading.textContent?.trim() !== title) return null;
+
+  for (const el of root.querySelectorAll("*")) {
+    if (el === heading) {
+      heading.hidden = true;
+      return heading;
+    }
+    // Wrappers that only exist to hold the heading don't count as content.
+    if (el.contains(heading)) continue;
+    if (hasOwnVisiblePresence(el)) return null;
+  }
+  return null;
+}
+
+/** True when `el` itself (not via a descendant) shows something to the user. */
+function hasOwnVisiblePresence(el: Element): boolean {
+  if (
+    el.tagName === "SCRIPT" ||
+    el.tagName === "STYLE" ||
+    el.tagName === "LINK"
+  ) {
+    return false;
+  }
+  if (
+    el.matches(
+      "input, textarea, select, button, img, svg, [role='tablist'], [role='tabs']",
+    )
+  ) {
+    return true;
+  }
+  for (const node of el.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/extensions-core/src/about/AboutPage.css
+++ b/packages/extensions-core/src/about/AboutPage.css
@@ -1,27 +1,50 @@
 .about-page {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  gap: 8px;
-  text-align: center;
+  align-items: flex-start;
+  gap: 16px;
+  margin-top: 40px;
 }
 
 .about-icon {
-  width: 96px;
-  height: 96px;
-  border-radius: 22px;
-  margin-bottom: 4px;
+  width: 64px;
+  height: 64px;
+  border-radius: 14px;
+  flex: none;
 }
 
-.about-tagline {
-  max-width: 30ch;
+.about-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 42ch;
+}
+
+.about-headline,
+.about-intro {
+  margin: 0;
+}
+
+.about-headline {
+  font-size: 1.15em;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--silo-color-text-hi);
+}
+
+.about-intro {
+  line-height: 1.45;
   color: var(--silo-color-text);
 }
 
-.about-version {
+.about-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   margin-top: 4px;
+}
+
+.about-version {
   font-size: calc(var(--settings-font) - 1px);
   color: var(--silo-color-text-lo);
   font-family: var(--silo-font-mono, monospace);

--- a/packages/extensions-core/src/about/index.tsx
+++ b/packages/extensions-core/src/about/index.tsx
@@ -3,6 +3,11 @@ import type { Extension, SystemInfo, SystemService } from "@silo-code/sdk";
 import siloIcon from "./silo-icon.png";
 import "./AboutPage.css";
 
+/** Keep in sync with `apps/website/src/homepage-copy.ts` (HEADLINE + INTRO_COPY). */
+const HEADLINE = "One window — every project, every agent";
+const INTRO =
+  "Terminals, agents, and layout stay intact — switch between them instantly. 100% open source, free forever.";
+
 function AboutPage({ system }: { system: SystemService }) {
   const [info, setInfo] = useState<SystemInfo | null>(null);
 
@@ -15,17 +20,24 @@ function AboutPage({ system }: { system: SystemService }) {
 
   return (
     <div className="about-page">
-      <img className="about-icon" src={siloIcon} alt="Silo" />
-      <div className="about-tagline">
-        Run every workspace at once. Switch instantly, lose nothing.
+      <img
+        className="about-icon"
+        src={siloIcon}
+        alt=""
+        width={64}
+        height={64}
+      />
+      <div className="about-copy">
+        <p className="about-headline">{HEADLINE}</p>
+        <p className="about-intro">{INTRO}</p>
       </div>
       {info && (
-        <>
+        <div className="about-meta">
           <div className="about-version">Version {info.siloVersion}</div>
           <div className="about-platform">
             {info.os} · {info.arch}
           </div>
-        </>
+        </div>
       )}
     </div>
   );

--- a/packages/extensions-core/src/agents-settings/AgentsSettingsPage.css
+++ b/packages/extensions-core/src/agents-settings/AgentsSettingsPage.css
@@ -1,8 +1,8 @@
-/* Agents settings uses the shared settings page chrome (`.es-page` /
- * `.es-header` from SettingsPage.css) and SDK primitives (Section, Callout,
- * Badge, Button). Tab content scrolls via `.silo-scroll` inside TabPanel,
- * matching system-monitor settings spacing. Keep this file for the unboxed WIP
- * banner and the per-row docs link under the SettingRow hint. */
+/* Agents settings uses the shared settings page chrome (`.es-page` from
+ * SettingsPage.css; the page title is host-owned) and SDK primitives (Section,
+ * Callout, Badge, Button). Tab content scrolls via `.silo-scroll` inside
+ * TabPanel, matching system-monitor settings spacing. Keep this file for the
+ * unboxed WIP banner and the per-row docs link under the SettingRow hint. */
 
 .agents-settings-banner {
   margin: 0;

--- a/packages/extensions-core/src/agents-settings/index.tsx
+++ b/packages/extensions-core/src/agents-settings/index.tsx
@@ -93,10 +93,6 @@ function AgentsSettingsPage({ ctx }: { ctx: ExtensionContext }) {
 
   return (
     <div className="es-page agents-settings-page">
-      <div className="es-header">
-        <h2>Agents</h2>
-      </div>
-
       <div className="agents-settings-tabs">
         <Tabs tabs={tabs} active={activeTab} onSelect={setTab} />
         <TabPanel>

--- a/packages/extensions-core/src/editor/EditorSettingsPage.tsx
+++ b/packages/extensions-core/src/editor/EditorSettingsPage.tsx
@@ -210,9 +210,6 @@ export function EditorSettingsPage() {
 
   return (
     <div className="es-page">
-      <div className="es-header">
-        <h2>Editor</h2>
-      </div>
       <SearchInput
         value={query}
         onValueChange={setQuery}

--- a/packages/extensions-core/src/extensions/ExtensionsPage.css
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.css
@@ -1,28 +1,10 @@
-/* Mirrors the Editor / Keyboard Shortcuts pages so contributed settings pages
-   read as one family: same page gap, header height, title size, and flat
-   border-bottom rows. */
+/* Settings page shell — title is host-owned (SettingsSheet renders
+   `SettingsPage.title`); header tools portal into the title row via
+   SettingsHeaderActions. This is only the body. */
 .ext-page {
   display: flex;
   flex-direction: column;
   height: 100%;
-  gap: 12px;
-}
-
-.ext-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: var(--settings-header-height);
-}
-.ext-header h2 {
-  margin: 0;
-  font-size: 1.1em;
-  color: var(--silo-color-text-hi);
-}
-.ext-header-actions {
-  display: flex;
-  align-items: center;
   gap: 12px;
 }
 

--- a/packages/extensions-core/src/extensions/ExtensionsPage.tsx
+++ b/packages/extensions-core/src/extensions/ExtensionsPage.tsx
@@ -16,6 +16,7 @@ import {
 import {
   getExtensionManager,
   fetchRegistryIndex,
+  SettingsHeaderActions,
   type InstalledExtension,
   type ManifestPreview,
   type RegistryExtension,
@@ -336,218 +337,216 @@ export function makeExtensionsPage(ctx: ExtensionContext) {
     const listTab = view.kind;
 
     return (
-      <div className="ext-page">
-        <div className="ext-header">
-          <h2>Extensions</h2>
-          <div className="ext-header-actions">
-            <SegmentedTabs
-              tabs={[
-                { id: "browse", label: "Browse" },
-                {
-                  id: "installed",
-                  label:
-                    updates.length > 0
-                      ? `Installed (${updates.length})`
-                      : "Installed",
-                },
-              ]}
-              active={listTab}
-              onSelect={(id) => setView({ kind: id })}
-            />
-            <Tooltip content="More install options">
-              {/* `sm` (2em) rather than the default 2.5em: `.es-header` declares
-                  `min-height: var(--settings-header-height)`, and a full-size
-                  icon button is taller than that — it stretched the row, which
-                  pushed the centred page title down out of line with the
-                  Settings rail beside it. The segmented tabs already sit under
-                  that height. */}
-              <IconButton
-                size="sm"
-                aria-label="More install options"
-                onClick={(e) => openPageMenu(e.currentTarget)}
-              >
-                <DotsThreeVertical size={16} weight="bold" />
-              </IconButton>
-            </Tooltip>
-          </div>
-        </div>
-
-        {view.kind === "browse" ? (
-          <>
-            <div className="ext-list-bar">
-              <SearchInput
-                value={browseQuery}
-                onValueChange={setBrowseQuery}
-                placeholder="Search the extension registry…"
-              />
-              {renderUpdateAll()}
-            </div>
-            {registry.status === "ready" && (
-              <div className="ext-cats">
-                <button
-                  className={`ext-cat${category === "" ? " ext-cat-active" : ""}`}
-                  onClick={() => setCategory("")}
-                >
-                  all
-                </button>
-                {registryCategories(registry.entries).map((c) => (
-                  <button
-                    key={c}
-                    className={`ext-cat${category === c ? " ext-cat-active" : ""}`}
-                    onClick={() => setCategory(category === c ? "" : c)}
-                  >
-                    {c}
-                  </button>
-                ))}
-              </div>
-            )}
-            {registry.status === "loading" ? (
-              <EmptyState title="Loading the extension registry…" />
-            ) : registry.status === "error" ? (
-              <EmptyState
-                title="Couldn't reach the extension registry"
-                description={registry.message}
-                action={
-                  <Button onClick={() => void loadRegistry()}>Retry</Button>
-                }
-              />
-            ) : catalog.length === 0 ? (
-              <EmptyState title="No extensions match." />
-            ) : (
-              <div className="ext-grid silo-scroll">
-                {catalog.map((entry) => {
-                  const state = browseInstallState(entry, extensions, updates);
-                  const installedExt = extensions.find(
-                    (e) => e.id === entry.id,
-                  );
-                  // A folder/URL/npm install of this id: note the origin in
-                  // place of the registry download count (it's not this build).
-                  const localSource = localInstallSource(installedExt);
-                  const upd = updates.find((u) => u.id === entry.id);
-                  return (
-                    <ExtensionCard
-                      key={entry.id}
-                      name={entry.name}
-                      icon={extensionIconFor(entry.id)}
-                      publisher={publisherOf(entry.id)}
-                      verified={entry.latest?.provenance === "attested"}
-                      description={entry.description}
-                      onOpenDetails={() =>
-                        setView({
-                          kind: "detail",
-                          id: entry.id,
-                          from: "browse",
-                        })
-                      }
-                      badges={
-                        <>
-                          {entry.latest && (
-                            <span className="ext-version">
-                              v{entry.latest.version}
-                            </span>
-                          )}
-                          {state === "update-available" && (
-                            <Badge tone="warn">Update</Badge>
-                          )}
-                          {localSource ? (
-                            <Badge tone="outline">
-                              {sourceBadgeLabel(localSource.kind)}
-                            </Badge>
-                          ) : (
-                            <span className="ext-card-meta">
-                              <span className="ext-card-downloads">
-                                {entry.totalDownloads}
-                              </span>{" "}
-                              downloads
-                            </span>
-                          )}
-                        </>
-                      }
-                      action={
-                        upd && installedExt ? (
-                          <Button
-                            size="sm"
-                            variant="primary"
-                            disabled={busy === entry.id}
-                            onClick={() => update(installedExt)}
-                          >
-                            Update
-                          </Button>
-                        ) : state === "installed" ? (
-                          // Not a button: there's nothing to do to an already
-                          // installed extension from here. Styled like the
-                          // Install it replaces so the grid keeps one rhythm.
-                          <span className="ext-card-installed">Installed</span>
-                        ) : state === "not-installed" &&
-                          isInstallable(entry) ? (
-                          <Button
-                            size="sm"
-                            disabled={busy === entry.id}
-                            onClick={() => installFromRegistry(entry.id)}
-                          >
-                            Install
-                          </Button>
-                        ) : null
-                      }
-                      menu={
-                        installedExt ? (
-                          <MenuButton
-                            size="sm"
-                            label="More"
-                            aria-label="Extension actions"
-                            disabled={busy === entry.id}
-                            onClick={(e) =>
-                              openRowMenu(installedExt, e.currentTarget)
-                            }
-                          />
-                        ) : null
-                      }
-                    />
-                  );
-                })}
-              </div>
-            )}
-          </>
-        ) : (
-          <>
-            <div className="ext-list-bar">
-              {extensions.length > 0 && (
+      <>
+        <SettingsHeaderActions>
+          <SegmentedTabs
+            tabs={[
+              { id: "browse", label: "Browse" },
+              {
+                id: "installed",
+                label:
+                  updates.length > 0
+                    ? `Installed (${updates.length})`
+                    : "Installed",
+              },
+            ]}
+            active={listTab}
+            onSelect={(id) => setView({ kind: id })}
+          />
+          <Tooltip content="More install options">
+            <IconButton
+              size="sm"
+              aria-label="More install options"
+              onClick={(e) => openPageMenu(e.currentTarget)}
+            >
+              <DotsThreeVertical size={16} weight="bold" />
+            </IconButton>
+          </Tooltip>
+        </SettingsHeaderActions>
+        <div className="ext-page">
+          {view.kind === "browse" ? (
+            <>
+              <div className="ext-list-bar">
                 <SearchInput
-                  value={query}
-                  onValueChange={setQuery}
-                  placeholder="Search installed extensions…"
+                  value={browseQuery}
+                  onValueChange={setBrowseQuery}
+                  placeholder="Search the extension registry…"
                 />
-              )}
-              {renderUpdateAll()}
-            </div>
-
-            {extensions.length === 0 ? (
-              <EmptyState
-                title="No extensions installed yet"
-                description="Find one in Browse."
-              />
-            ) : visible.length === 0 ? (
-              <EmptyState title={`No extensions match “${query}”.`} />
-            ) : (
-              <div className="ext-groups silo-scroll">
-                {groups.installed.length > 0 && (
-                  <div className="ext-grid">
-                    {groups.installed.map(renderInstalledCard)}
-                  </div>
-                )}
-                {groups.builtin.length > 0 && (
-                  <>
-                    <h3 className="ext-group-head">Built-in Extensions</h3>
-                    <div className="ext-grid">
-                      {groups.builtin.map(renderInstalledCard)}
-                    </div>
-                  </>
-                )}
+                {renderUpdateAll()}
               </div>
-            )}
-          </>
-        )}
-      </div>
+              {registry.status === "ready" && (
+                <div className="ext-cats">
+                  <button
+                    className={`ext-cat${category === "" ? " ext-cat-active" : ""}`}
+                    onClick={() => setCategory("")}
+                  >
+                    all
+                  </button>
+                  {registryCategories(registry.entries).map((c) => (
+                    <button
+                      key={c}
+                      className={`ext-cat${category === c ? " ext-cat-active" : ""}`}
+                      onClick={() => setCategory(category === c ? "" : c)}
+                    >
+                      {c}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {registry.status === "loading" ? (
+                <EmptyState title="Loading the extension registry…" />
+              ) : registry.status === "error" ? (
+                <EmptyState
+                  title="Couldn't reach the extension registry"
+                  description={registry.message}
+                  action={
+                    <Button onClick={() => void loadRegistry()}>Retry</Button>
+                  }
+                />
+              ) : catalog.length === 0 ? (
+                <EmptyState title="No extensions match." />
+              ) : (
+                <div className="ext-grid silo-scroll">
+                  {catalog.map((entry) => {
+                    const state = browseInstallState(
+                      entry,
+                      extensions,
+                      updates,
+                    );
+                    const installedExt = extensions.find(
+                      (e) => e.id === entry.id,
+                    );
+                    // A folder/URL/npm install of this id: note the origin in
+                    // place of the registry download count (it's not this build).
+                    const localSource = localInstallSource(installedExt);
+                    const upd = updates.find((u) => u.id === entry.id);
+                    return (
+                      <ExtensionCard
+                        key={entry.id}
+                        name={entry.name}
+                        icon={extensionIconFor(entry.id)}
+                        publisher={publisherOf(entry.id)}
+                        verified={entry.latest?.provenance === "attested"}
+                        description={entry.description}
+                        onOpenDetails={() =>
+                          setView({
+                            kind: "detail",
+                            id: entry.id,
+                            from: "browse",
+                          })
+                        }
+                        badges={
+                          <>
+                            {entry.latest && (
+                              <span className="ext-version">
+                                v{entry.latest.version}
+                              </span>
+                            )}
+                            {state === "update-available" && (
+                              <Badge tone="warn">Update</Badge>
+                            )}
+                            {localSource ? (
+                              <Badge tone="outline">
+                                {sourceBadgeLabel(localSource.kind)}
+                              </Badge>
+                            ) : (
+                              <span className="ext-card-meta">
+                                <span className="ext-card-downloads">
+                                  {entry.totalDownloads}
+                                </span>{" "}
+                                downloads
+                              </span>
+                            )}
+                          </>
+                        }
+                        action={
+                          upd && installedExt ? (
+                            <Button
+                              size="sm"
+                              variant="primary"
+                              disabled={busy === entry.id}
+                              onClick={() => update(installedExt)}
+                            >
+                              Update
+                            </Button>
+                          ) : state === "installed" ? (
+                            // Not a button: there's nothing to do to an already
+                            // installed extension from here. Styled like the
+                            // Install it replaces so the grid keeps one rhythm.
+                            <span className="ext-card-installed">
+                              Installed
+                            </span>
+                          ) : state === "not-installed" &&
+                            isInstallable(entry) ? (
+                            <Button
+                              size="sm"
+                              disabled={busy === entry.id}
+                              onClick={() => installFromRegistry(entry.id)}
+                            >
+                              Install
+                            </Button>
+                          ) : null
+                        }
+                        menu={
+                          installedExt ? (
+                            <MenuButton
+                              size="sm"
+                              label="More"
+                              aria-label="Extension actions"
+                              disabled={busy === entry.id}
+                              onClick={(e) =>
+                                openRowMenu(installedExt, e.currentTarget)
+                              }
+                            />
+                          ) : null
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="ext-list-bar">
+                {extensions.length > 0 && (
+                  <SearchInput
+                    value={query}
+                    onValueChange={setQuery}
+                    placeholder="Search installed extensions…"
+                  />
+                )}
+                {renderUpdateAll()}
+              </div>
+
+              {extensions.length === 0 ? (
+                <EmptyState
+                  title="No extensions installed yet"
+                  description="Find one in Browse."
+                />
+              ) : visible.length === 0 ? (
+                <EmptyState title={`No extensions match “${query}”.`} />
+              ) : (
+                <div className="ext-groups silo-scroll">
+                  {groups.installed.length > 0 && (
+                    <div className="ext-grid">
+                      {groups.installed.map(renderInstalledCard)}
+                    </div>
+                  )}
+                  {groups.builtin.length > 0 && (
+                    <>
+                      <h3 className="ext-group-head">Built-in Extensions</h3>
+                      <div className="ext-grid">
+                        {groups.builtin.map(renderInstalledCard)}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </>
     );
 
     /**

--- a/packages/extensions-core/src/keybindings/KeybindingsPage.css
+++ b/packages/extensions-core/src/keybindings/KeybindingsPage.css
@@ -1,8 +1,7 @@
-/* Page chrome (header, search width, scroll/group gap) is the shared
-   `.es-page`/`.es-header`/`.es-scroll` from SettingsPage.css — this page
-   used to carry its own duplicate copy (`.kb-page`/`.kb-header`/`.kb-list`),
-   which is why its spacing drifted out of sync with every other settings
-   page. Only what's genuinely bespoke to a keybinding row lives here. */
+/* Page chrome (search, scroll/group gap) is mostly the shared
+   `.es-page`/`.es-scroll` from SettingsPage.css — the page title and any
+   header tools are host-owned. Only what's genuinely bespoke to a
+   keybinding row lives here. */
 
 .kb-row {
   display: flex;

--- a/packages/extensions-core/src/keybindings/index.tsx
+++ b/packages/extensions-core/src/keybindings/index.tsx
@@ -17,6 +17,7 @@ import {
   overrideKey,
   isRemoved,
   setKeybindingCaptureActive,
+  SettingsHeaderActions,
 } from "@silo-code/extension-host/internal";
 import {
   bindingsAfterRemove,
@@ -253,127 +254,131 @@ function makePage(ctx: ExtensionContext) {
     const sortedGroups = groupCommands(rows, menuFor);
 
     return (
-      <div className="es-page">
-        <div className="es-header">
-          <h2>Keyboard Shortcuts</h2>
+      <>
+        <SettingsHeaderActions>
           <Tooltip content="More options">
             <IconButton
+              size="sm"
               aria-label="More options"
               onClick={(e) => openPageMenu(e.currentTarget)}
             >
               <DotsThreeVertical size={16} weight="bold" />
             </IconButton>
           </Tooltip>
-        </div>
-        <SearchInput
-          value={query}
-          onValueChange={setQuery}
-          placeholder="Search commands or keys…"
-          autoFocus
-        />
-        <div className="es-scroll silo-scroll">
-          {sortedGroups.map(([group, cmds]) => (
-            <Section key={group} label={group}>
-              {cmds.map((c) => {
-                const eff = effectiveKey(c.id);
-                const state = rowState({
-                  unbound: isRemoved(c.id),
-                  overrideKey: overrideKey(c.id),
-                  defaultKey: defaultKey(c.id),
-                  effectiveKey: eff,
-                });
-                const isCapturing =
-                  capture.kind === "capturing" && capture.commandId === c.id;
-                const isConfirming =
-                  capture.kind === "confirming" && capture.commandId === c.id;
-                const reassignLabel =
-                  isConfirming && capture.kind === "confirming"
-                    ? (commandRegistry.get(capture.reassignFrom[0])?.label ??
-                      capture.reassignFrom[0])
-                    : "";
-                const reassignExtra =
-                  isConfirming &&
-                  capture.kind === "confirming" &&
-                  capture.reassignFrom.length > 1
-                    ? ` +${capture.reassignFrom.length - 1}`
-                    : "";
+        </SettingsHeaderActions>
+        <div className="es-page">
+          <SearchInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder="Search commands or keys…"
+            autoFocus
+          />
+          <div className="es-scroll silo-scroll">
+            {sortedGroups.map(([group, cmds]) => (
+              <Section key={group} label={group}>
+                {cmds.map((c) => {
+                  const eff = effectiveKey(c.id);
+                  const state = rowState({
+                    unbound: isRemoved(c.id),
+                    overrideKey: overrideKey(c.id),
+                    defaultKey: defaultKey(c.id),
+                    effectiveKey: eff,
+                  });
+                  const isCapturing =
+                    capture.kind === "capturing" && capture.commandId === c.id;
+                  const isConfirming =
+                    capture.kind === "confirming" && capture.commandId === c.id;
+                  const reassignLabel =
+                    isConfirming && capture.kind === "confirming"
+                      ? (commandRegistry.get(capture.reassignFrom[0])?.label ??
+                        capture.reassignFrom[0])
+                      : "";
+                  const reassignExtra =
+                    isConfirming &&
+                    capture.kind === "confirming" &&
+                    capture.reassignFrom.length > 1
+                      ? ` +${capture.reassignFrom.length - 1}`
+                      : "";
 
-                let keyContent: ReactNode;
-                let keyClass = "kb-key-btn";
-                if (isConfirming) {
-                  keyClass += " kb-key-btn-confirm";
-                  keyContent = (
-                    <span className="kb-capture-hint">
-                      Used by {reassignLabel}
-                      {reassignExtra}. Enter to reassign, Esc to cancel.
-                    </span>
-                  );
-                } else if (isCapturing) {
-                  keyClass += " kb-key-btn-capture";
-                  keyContent = (
-                    <span className="kb-capture-hint">
-                      Press desired key combination…
-                    </span>
-                  );
-                } else if (eff) {
-                  keyClass +=
-                    state === "override" ? " kb-key-btn-override" : "";
-                  keyContent = <kbd className="kb-key">{displayKey(eff)}</kbd>;
-                } else if (state === "unbound") {
-                  keyClass += " kb-key-btn-unbound";
-                  keyContent = (
-                    <span className="kb-unbound" title="Unbound">
-                      —
-                    </span>
-                  );
-                } else {
-                  keyClass += " kb-key-btn-empty";
-                  keyContent = <span className="kb-unbound">—</span>;
-                }
+                  let keyContent: ReactNode;
+                  let keyClass = "kb-key-btn";
+                  if (isConfirming) {
+                    keyClass += " kb-key-btn-confirm";
+                    keyContent = (
+                      <span className="kb-capture-hint">
+                        Used by {reassignLabel}
+                        {reassignExtra}. Enter to reassign, Esc to cancel.
+                      </span>
+                    );
+                  } else if (isCapturing) {
+                    keyClass += " kb-key-btn-capture";
+                    keyContent = (
+                      <span className="kb-capture-hint">
+                        Press desired key combination…
+                      </span>
+                    );
+                  } else if (eff) {
+                    keyClass +=
+                      state === "override" ? " kb-key-btn-override" : "";
+                    keyContent = (
+                      <kbd className="kb-key">{displayKey(eff)}</kbd>
+                    );
+                  } else if (state === "unbound") {
+                    keyClass += " kb-key-btn-unbound";
+                    keyContent = (
+                      <span className="kb-unbound" title="Unbound">
+                        —
+                      </span>
+                    );
+                  } else {
+                    keyClass += " kb-key-btn-empty";
+                    keyContent = <span className="kb-unbound">—</span>;
+                  }
 
-                return (
-                  <div
-                    key={c.id}
-                    className="kb-row"
-                    onContextMenu={(e) => openRowMenu(c.id, e)}
-                  >
-                    <div className="kb-cmd">
-                      <span className="kb-label">{c.label}</span>
-                      <span className="kb-id">{c.id}</span>
-                    </div>
-                    <button
-                      type="button"
-                      className={keyClass}
-                      aria-label={
-                        isCapturing || isConfirming
-                          ? `Capture keybinding for ${c.label}`
-                          : `Change keybinding for ${c.label}`
-                      }
-                      onClick={() =>
-                        setCapture({ kind: "capturing", commandId: c.id })
-                      }
-                      ref={(el) => {
-                        if (
-                          el &&
-                          (isCapturing || isConfirming) &&
-                          document.activeElement !== el
-                        ) {
-                          el.focus();
-                        }
-                      }}
+                  return (
+                    <div
+                      key={c.id}
+                      className="kb-row"
+                      onContextMenu={(e) => openRowMenu(c.id, e)}
                     >
-                      {keyContent}
-                    </button>
-                  </div>
-                );
-              })}
-            </Section>
-          ))}
-          {rows.length === 0 && (
-            <div className="kb-empty">No commands match “{query}”.</div>
-          )}
+                      <div className="kb-cmd">
+                        <span className="kb-label">{c.label}</span>
+                        <span className="kb-id">{c.id}</span>
+                      </div>
+                      <button
+                        type="button"
+                        className={keyClass}
+                        aria-label={
+                          isCapturing || isConfirming
+                            ? `Capture keybinding for ${c.label}`
+                            : `Change keybinding for ${c.label}`
+                        }
+                        onClick={() =>
+                          setCapture({ kind: "capturing", commandId: c.id })
+                        }
+                        ref={(el) => {
+                          if (
+                            el &&
+                            (isCapturing || isConfirming) &&
+                            document.activeElement !== el
+                          ) {
+                            el.focus();
+                          }
+                        }}
+                      >
+                        {keyContent}
+                      </button>
+                    </div>
+                  );
+                })}
+              </Section>
+            ))}
+            {rows.length === 0 && (
+              <div className="kb-empty">No commands match “{query}”.</div>
+            )}
+          </div>
         </div>
-      </div>
+      </>
     );
   };
 }

--- a/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
+++ b/packages/extensions-core/src/layout/LayoutSettingsPage.tsx
@@ -171,10 +171,6 @@ export function makeLayoutSettingsPage(ctx: ExtensionContext) {
 
     return (
       <div className="es-page layout-settings-page">
-        <div className="es-header">
-          <h2>Layout</h2>
-        </div>
-
         <div className="layout-settings-tabs">
           <Tabs tabs={tabs} active={activeTab} onSelect={setTab} />
           <TabPanel>

--- a/packages/extensions-core/src/terminal/TerminalSettingsPage.tsx
+++ b/packages/extensions-core/src/terminal/TerminalSettingsPage.tsx
@@ -380,9 +380,6 @@ export function TerminalSettingsPage() {
 
   return (
     <div className="es-page">
-      <div className="es-header">
-        <h2>Terminal</h2>
-      </div>
       <SearchInput
         value={query}
         onValueChange={setQuery}

--- a/packages/extensions-silo/src/agents/styles.css
+++ b/packages/extensions-silo/src/agents/styles.css
@@ -26,37 +26,8 @@
   border-radius: 1px;
 }
 
-/* Settings page — mirrors the host's Editor / Keyboard Shortcuts pages so a
-   third-party page reads as one family. */
-.am-page {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  gap: 12px;
-}
-.am-header {
-  display: flex;
-  align-items: center;
-  min-height: var(--settings-header-height);
-  flex-shrink: 0;
-}
-.am-header h2 {
-  margin: 0;
-  font-size: 1.1em;
-  color: var(--silo-color-text-hi);
-}
-/* Scrolls independently of the header once the sections (focus behavior,
-   agent icons, sound) run taller than the settings pane. Scroll behavior and
-   scrollbar appearance come from the host's `.silo-scroll` class (applied in
-   settings.tsx) — no overflow/scrollbar rules needed here. */
-.am-body {
-  flex: 1 1 auto;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-/* Embedded in core.agents-settings Options tab — parent owns scroll chrome. */
+/* Agents settings panels embed into core.agents-settings tabs — the page
+   title is host-owned. Parent owns scroll chrome. */
 .am-options-panel {
   display: flex;
   flex-direction: column;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -650,7 +650,10 @@ export interface StatusItem {
 export interface SettingsPage {
   /** Unique id for this settings page. */
   id: string;
-  /** Label shown in the Settings left rail. */
+  /**
+   * Label shown in the Settings left rail **and** as the host-owned page
+   * title in the pane. Do not render your own `<h2>` — the host draws this.
+   */
   title: string;
   /**
    * Optional grouping key for the left rail (groups sorted lexically, separated


### PR DESCRIPTION
## Summary
- Host draws `SettingsPage.title` in the Settings sheet chrome (matched to the rail “Settings” title) so pages no longer paint their own `<h2>`
- Migration: hide a leftover leading page-drawn title that duplicates the host title until extensions update
- Header tools (Extensions tabs/⋮, Keybindings ⋮) portal into a fixed-height actions slot so body content Y stays stable
- About page: top-left layout + website proposition copy

## Test plan
- [ ] Open Settings → Editor / Terminal / Layout / Agents: title aligns with “Settings”, no double title
- [ ] Extensions: Browse/Installed + ⋮ sit top-right in the title row; search/content start Y matches other pages
- [ ] Keyboard Shortcuts: ⋮ in title row; search full-width below
- [ ] Install/open an extension settings page that still draws its own `<h2>` (e.g. System Monitor before its update): only one title visible
- [ ] About Silo: top-left icon + “One window — every project, every agent” + intro; version/platform below


Made with [Cursor](https://cursor.com)