### PR TITLE
fix(release): keep breaking commits on 0.x until we choose v1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "include-component-in-tag": true,
   "tag-separator": "-",
   "separate-pull-requests": true,
+  "bump-minor-pre-major": true,
   "packages": {
     "packages/sdk": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Enable `bump-minor-pre-major` in release-please so `feat!` / BREAKING CHANGE while still on 0.x bumps **minor** (e.g. sdk `0.40.2` → `0.41.0`), not major to `1.0.0`
- Follow-up: close the mistaken sdk/silo 1.0.0 release PRs and regenerate them

## Why
#442 was titled `feat(sdk)!` for an additive `@internal`→`@public` promotion. Release Please correctly (per Conventional Commits) proposed 1.0.0; we are not ready for v1.

## Test plan
- [ ] Merge this
- [ ] Close #441 / #443, delete their branches, re-run `release-please`
- [ ] New release PRs target sdk `0.41.0` and silo `0.57.0` (not `1.0.0`)


Made with [Cursor](https://cursor.com)