### PR TITLE
feat(theme-presets): add White theme and polish the picker

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -94,8 +94,8 @@ const STORAGE_KEY = "silo-demo-theme";
 
 const THEMES = [
   { id: "light", name: "Light", accent: "#0078d4" },
+  { id: "white", name: "White", accent: "#0078d4" },
   { id: "dark", name: "Dark", accent: "#a0a0a0" },
-  { id: "gruvbox-dark", name: "Gruvbox Dark", accent: "#83a598" },
   { id: "high-contrast-dark", name: "High Contrast Dark", accent: "#a0a0a0" },
   {
     id: "high-contrast-light",
@@ -105,6 +105,7 @@ const THEMES = [
   { id: "solarized-dark", name: "Solarized Dark", accent: "#cb4b16" },
   { id: "solarized-light", name: "Solarized Light", accent: "#d25f26" },
   { id: "tokyo-night", name: "Tokyo Night", accent: "#7aa2f7" },
+  { id: "gruvbox-dark", name: "Gruvbox Dark", accent: "#83a598" },
 ];
 
 function currentDemoTheme() {

--- a/apps/docs/.vitepress/theme/silo-demos.css
+++ b/apps/docs/.vitepress/theme/silo-demos.css
@@ -4,8 +4,8 @@
    Renders the design-system components inline in the docs pages, styled with
    the same token values the app ships. Light is the default (unprefixed)
    block; every other bundled preset — Dark, Gruvbox Dark, High Contrast
-   Dark/Light, Solarized Dark/Light, Tokyo Night — is a `[data-silo-demo-theme
-   ="<id>"]` override block below, mirroring
+   Dark/Light, Solarized Dark/Light, Tokyo Night, White — is a
+   `[data-silo-demo-theme="<id>"]` override block below, mirroring
    packages/extension-host/src/layout/presets.ts +
    packages/extensions-silo/src/theme-presets/index.ts. Everything is scoped
    under `.silo-demo` so nothing leaks into VitePress chrome.
@@ -278,6 +278,23 @@ html[data-silo-demo-theme="tokyo-night"] .silo-demo {
   --silo-button-bg: var(--silo-color-button-bg);
   --silo-button-hover-bg: color-mix(in srgb, var(--silo-button-bg) 85%, #000);
   --silo-button-active-bg: color-mix(in srgb, var(--silo-button-bg) 75%, #000);
+}
+
+html[data-silo-demo-theme="white"] .silo-demo {
+  /* tokens — White (true-white chrome, darker text than Light) */
+  --silo-color-bg: #ffffff;
+  --silo-color-bg-hover: #f3f3f3;
+  --silo-color-bg-active: #ebebeb;
+  --silo-color-button-bg: #f0f0f0;
+  --silo-color-button-text: #333333;
+  --silo-color-text-hi: #333333;
+  --silo-color-text: #555555;
+  --silo-color-text-lo: #888888;
+  --silo-color-input-bg: #f5f5f5;
+  --silo-color-input-text: #1f1f1f;
+  --silo-color-input-border: #f5f5f5;
+  --silo-color-border: #ececec;
+  --silo-color-border-strong: #d0d0d0;
 }
 
 .silo-demo.silo-demo-block {

--- a/packages/extension-host/src/layout/SideColumn.css
+++ b/packages/extension-host/src/layout/SideColumn.css
@@ -27,7 +27,11 @@
   font-weight: 600;
   background: transparent;
   border-bottom: 2px solid var(--silo-tab-border-active);
-  margin-bottom: -1px;
+  /* Keep the 2px underline inside the header. A negative margin used to pull
+     1px into the panel body so it could cover a hairline that no longer
+     exists — opaque panel tops (e.g. Navigator's sticky `.nav-views`) then
+     painted over that pixel and the active mark looked 1px thinner than
+     tabs whose body starts with a non-covering toolbar. */
 }
 
 /* Keyboard focus indicator: when this side dock holds focus, the active tab's

--- a/packages/extensions-core/src/themes/ThemeStatusItem.tsx
+++ b/packages/extensions-core/src/themes/ThemeStatusItem.tsx
@@ -68,7 +68,7 @@ export function ThemeStatusItem({
   const activeName = activePreset?.name ?? activeCustom?.name ?? activeId;
 
   function openPicker() {
-    const items: MenuEntry[] = [{ type: "header", label: "Built-in" }];
+    const items: MenuEntry[] = [];
     for (const preset of presets) {
       items.push({
         label: preset.name,

--- a/packages/extensions-silo/src/theme-presets/index.ts
+++ b/packages/extensions-silo/src/theme-presets/index.ts
@@ -5,48 +5,58 @@ import type { Extension, ThemePreset } from "@silo-code/sdk";
 // is a regular contribution — the same path a third-party extension would use.
 // These move out of core so the picker's bundled themes are independently
 // removable and so theming is a real contribution point, not a core list.
-// Listed alphabetically by name; keep new entries in that order.
+//
+// Order: White first (sits under Light in the picker — CORE_PRESETS are Dark,
+// Light, then this list); Gruvbox Dark last (under Tokyo Night). Everything
+// between is alphabetical by name.
 const PRESETS: ThemePreset[] = [
   {
-    id: "gruvbox-dark",
-    name: "Gruvbox Dark",
-    base: "dark",
-    colorScheme: "dark",
+    id: "white",
+    name: "White",
+    base: "light",
+    colorScheme: "light",
+    // Light's chrome is a mid gray (#e5e5e5) with white content panes. White
+    // flips the chrome to true white and uses soft gray only where a surface
+    // needs to recess (inputs, tab tray, status bar, hover) so seams still
+    // read without the gray frame. Text is darker than Light so labels and
+    // content clear the white page without going full High Contrast Light.
     vars: {
-      "--silo-color-bg": "#1d2021",
-      "--silo-color-bg-hover": "#3c3836",
-      "--silo-color-bg-active": "#665c5466",
-      "--silo-color-button-bg": "#504945",
-      "--silo-color-button-text": "#a89984",
-      "--silo-color-text-hi": "#a89984",
-      "--silo-color-text": "#928374",
-      "--silo-color-text-lo": "#5f564d",
-      "--silo-color-input-bg": "#282828",
-      "--silo-color-input-border": "#453f3b",
-      "--silo-color-input-text": "#ebdbb2",
-      "--silo-color-border": "transparent",
-      "--silo-color-border-strong": "#7c6f64",
-      "--silo-color-accent": "#83a598",
-      "--silo-color-accent-2": "#d3869b",
-      "--silo-content-text": "#ebdbb2",
-      "--silo-content-editor-text-dim": "#d5c4a1",
-      "--silo-content-editor-text-faint": "#a89984",
-      "--silo-color-ok": "#b8bb26",
-      "--silo-color-warn": "#fabd2f",
-      "--silo-color-err": "#fb4934",
-      "--silo-content-tab-tray-bg": "#1d2021",
-      "--silo-content-tab-tray-text": "#a89984",
-      "--silo-content-tab-text-inactive": "#7c6f64",
-      "--silo-content-tab-text": "#a89984",
-      "--silo-content-tab-text-active": "#ebdbb2",
-      "--silo-statusbar-bg": "#1a1c1d",
-      "--silo-statusbar-text": "#a89984",
-      // Notify (toast) — a warm brown card from the theme's own family, lighter
-      // than the app bg so it lifts, darker than the buttons (#504945) so they
-      // read; cream text to match.
-      "--silo-notify-bg": "#3a3634",
-      "--silo-notify-text": "#d5c4a1",
-      "--silo-notify-text-hi": "#ebdbb2",
+      "--silo-color-bg": "#ffffff",
+      "--silo-color-bg-hover": "#f3f3f3",
+      // Soft gray instead of Light's blue (#cce4ff) — selection should read
+      // without a tinted block on the white page.
+      "--silo-color-bg-active": "#ebebeb",
+      "--silo-color-button-bg": "#f0f0f0",
+      "--silo-color-button-text": "#333333",
+      "--silo-color-text-hi": "#333333",
+      "--silo-color-text": "#555555",
+      "--silo-color-text-lo": "#888888",
+      "--silo-color-input-bg": "#f5f5f5",
+      // Same as the fill — Light hides the ring by matching the panel; here the
+      // recessed fill already draws the field, so a visible edge is just noise.
+      "--silo-color-input-border": "#f5f5f5",
+      "--silo-color-input-text": "#1f1f1f",
+      "--silo-color-border": "#ececec",
+      "--silo-color-border-strong": "#d0d0d0",
+      "--silo-color-toolbar-text": "#1f1f1f",
+      "--silo-color-toolbar-text-disabled": "#6b6b6b",
+      "--silo-color-toolbar-input-bg": "#f5f5f5",
+      "--silo-color-content-text": "#1f1f1f",
+      "--silo-content-text": "#1f1f1f",
+      "--silo-content-editor-text-dim": "#4a4a4a",
+      "--silo-content-editor-text-faint": "#757575",
+      "--silo-content-tab-tray-bg": "#f5f5f5",
+      "--silo-content-tab-tray-text": "#555555",
+      "--silo-content-tab-text-inactive": "#6b6b6b",
+      "--silo-content-tab-text": "#333333",
+      "--silo-content-tab-text-active": "#1a1a1a",
+      "--silo-statusbar-bg": "#f0f0f0",
+      "--silo-statusbar-text": "#333333",
+      "--silo-tab-text-active": "#1a1a1a",
+      "--silo-tab-text": "#333333",
+      "--silo-tab-bg-hover": "#f3f3f3",
+      "--silo-notify-text": "#333333",
+      "--silo-notify-text-hi": "#1a1a1a",
     },
   },
   {
@@ -243,6 +253,48 @@ const PRESETS: ThemePreset[] = [
       "--silo-tab-text": "#787c99",
       "--silo-tab-bg-hover": "#1f2335",
       "--silo-tab-border-active": "#3d4461",
+    },
+  },
+  {
+    id: "gruvbox-dark",
+    name: "Gruvbox Dark",
+    base: "dark",
+    colorScheme: "dark",
+    vars: {
+      "--silo-color-bg": "#1d2021",
+      "--silo-color-bg-hover": "#3c3836",
+      "--silo-color-bg-active": "#665c5466",
+      "--silo-color-button-bg": "#504945",
+      "--silo-color-button-text": "#a89984",
+      "--silo-color-text-hi": "#a89984",
+      "--silo-color-text": "#928374",
+      "--silo-color-text-lo": "#5f564d",
+      "--silo-color-input-bg": "#282828",
+      "--silo-color-input-border": "#453f3b",
+      "--silo-color-input-text": "#ebdbb2",
+      "--silo-color-border": "transparent",
+      "--silo-color-border-strong": "#7c6f64",
+      "--silo-color-accent": "#83a598",
+      "--silo-color-accent-2": "#d3869b",
+      "--silo-content-text": "#ebdbb2",
+      "--silo-content-editor-text-dim": "#d5c4a1",
+      "--silo-content-editor-text-faint": "#a89984",
+      "--silo-color-ok": "#b8bb26",
+      "--silo-color-warn": "#fabd2f",
+      "--silo-color-err": "#fb4934",
+      "--silo-content-tab-tray-bg": "#1d2021",
+      "--silo-content-tab-tray-text": "#a89984",
+      "--silo-content-tab-text-inactive": "#7c6f64",
+      "--silo-content-tab-text": "#a89984",
+      "--silo-content-tab-text-active": "#ebdbb2",
+      "--silo-statusbar-bg": "#1a1c1d",
+      "--silo-statusbar-text": "#a89984",
+      // Notify (toast) — a warm brown card from the theme's own family, lighter
+      // than the app bg so it lifts, darker than the buttons (#504945) so they
+      // read; cream text to match.
+      "--silo-notify-bg": "#3a3634",
+      "--silo-notify-text": "#d5c4a1",
+      "--silo-notify-text-hi": "#ebdbb2",
     },
   },
 ];

--- a/packages/extensions-silo/src/theme-presets/theme-presets.test.ts
+++ b/packages/extensions-silo/src/theme-presets/theme-presets.test.ts
@@ -29,13 +29,18 @@ describe("theme-presets extension", () => {
         "high-contrast-dark",
         "high-contrast-light",
         "solarized-dark",
+        "white",
       ]),
     );
   });
 
-  it("registers presets in alphabetical order by name", () => {
+  it("registers White first, Gruvbox last, and the middle alphabetically", () => {
     const names = activateAndCollect().map((p) => p.name);
-    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+    expect(names[0]).toBe("White");
+    expect(names.at(-1)).toBe("Gruvbox Dark");
+    expect(names.slice(1, -1)).toEqual(
+      [...names.slice(1, -1)].sort((a, b) => a.localeCompare(b)),
+    );
   });
 
   it("keeps High Contrast Dark on the dark base with brighter text and selection fills", () => {
@@ -80,6 +85,24 @@ describe("theme-presets extension", () => {
     expect(solarizedDark!.base).toBe("dark");
     expect(solarizedDark!.colorScheme).toBe("dark");
     expect(solarizedDark!.vars["--silo-color-bg"]).toBe("#002b36");
+  });
+
+  it("keeps White on the light base with a true-white chrome and darker text", () => {
+    const white = activateAndCollect().find((p) => p.id === "white");
+    expect(white).toBeDefined();
+    expect(white!.base).toBe("light");
+    expect(white!.colorScheme).toBe("light");
+    expect(white!.vars["--silo-color-bg"]).toBe("#ffffff");
+    expect(white!.vars["--silo-color-bg-hover"]).toBe("#f3f3f3");
+    expect(white!.vars["--silo-color-bg-active"]).toBe("#ebebeb");
+    expect(white!.vars["--silo-color-input-bg"]).toBe("#f5f5f5");
+    expect(white!.vars["--silo-content-tab-tray-bg"]).toBe("#f5f5f5");
+    expect(white!.vars["--silo-statusbar-bg"]).toBe("#f0f0f0");
+    expect(white!.vars["--silo-color-text-hi"]).toBe("#333333");
+    expect(white!.vars["--silo-color-text"]).toBe("#555555");
+    expect(white!.vars["--silo-color-content-text"]).toBe("#1f1f1f");
+    // Accent stays on Light's blue — White only recolors surfaces + type.
+    expect(white!.vars["--silo-color-accent"]).toBeUndefined();
   });
 
   it("gives Gruvbox Dark its own warm notify (toast) palette", () => {


### PR DESCRIPTION
## Summary
- Add a **White** theme preset: true-white chrome, darker type than Light, soft gray selection, input border matched to fill
- Picker order: Dark → Light → White → … → Tokyo Night → Gruvbox Dark; drop the Built-in header
- Fix side-panel active-tab underline looking 1px thinner when an opaque panel top (e.g. Navigator) covered the old `-1px` overlap

## Test plan
- [ ] Open theme picker: White sits under Light; Gruvbox under Tokyo Night; no Built-in header
- [ ] Select White: panels are white, text is darker than Light, active workspace row is gray (not blue), filter inputs have no visible ring
- [ ] Compare Navigator vs right-panel active tab underlines — same 2px thickness
- [ ] Docs demo theme picker includes White and matches app token resolution (`pnpm --filter docs exec vitest run .vitepress/theme/silo-demos.sync.test.ts`)


Made with [Cursor](https://cursor.com)