### PR TITLE
fix(agents): stop auto-sorting Recent view by duration

### DIFF
--- a/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
@@ -203,7 +203,7 @@ describe("buildAgeSections (staleDoneEnabled: true)", () => {
     expect(sections.find((s) => s.header === "")?.collapsible).toBeUndefined();
   });
 
-  it("mixes ready, working and recent done rows into one list, ordered by since (most recent first), not by status", () => {
+  it("mixes ready, working and recent done rows into one list without auto-sorting by since", () => {
     const sections = buildAgeSections(
       [
         row({
@@ -231,7 +231,7 @@ describe("buildAgeSections (staleDoneEnabled: true)", () => {
     );
     expect(
       sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
-    ).toEqual(["newest", "middle", "oldest"]);
+    ).toEqual(["oldest", "newest", "middle"]);
   });
 
   it("splits only done rows older than the configured threshold into their own heading", () => {
@@ -270,7 +270,7 @@ describe("buildAgeSections (staleDoneEnabled: true)", () => {
     ).toEqual(["stale-done"]);
   });
 
-  it("puts undragged rows above dragged ones, and honors manualOrder's relative order for the dragged ones", () => {
+  it("prepends unknown rows above manualOrder and honors that relative order for the known ones", () => {
     const sections = buildAgeSections(
       [
         row({ terminalId: "a", since: hoursAgo(1) }),
@@ -279,15 +279,30 @@ describe("buildAgeSections (staleDoneEnabled: true)", () => {
       ],
       true,
       8,
-      ["c", "a"], // dragged, in this order — "b" was never touched
+      ["c", "a"], // known, in this order — "b" is new
     );
     expect(
       sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
     ).toEqual([
-      "b", // undragged, floats to the top
-      "c", // dragged, first in manualOrder
-      "a", // dragged, second in manualOrder
+      "b", // new, prepended
+      "c", // known, first in manualOrder
+      "a", // known, second in manualOrder
     ]);
+  });
+
+  it("keeps a known row put even when its since is more recent than neighbors", () => {
+    const sections = buildAgeSections(
+      [
+        row({ terminalId: "old-top", since: hoursAgo(9) }),
+        row({ terminalId: "fresh", since: hoursAgo(1) }),
+      ],
+      true,
+      8,
+      ["old-top", "fresh"],
+    );
+    expect(
+      sections.find((s) => s.header === "")?.rows.map((r) => r.terminalId),
+    ).toEqual(["old-top", "fresh"]);
   });
 
   it("ignores manualOrder ids with no matching row instead of erroring", () => {

--- a/packages/extensions-silo/src/agents/agents-panel-view.test.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-view.test.ts
@@ -8,6 +8,7 @@ import {
   isAtLeastHoursOld,
   moveItem,
   orderAgeRows,
+  reconcileAgeManualOrder,
   updateDoneSince,
   type AgentRow,
 } from "./agents-panel-view";
@@ -539,32 +540,65 @@ describe("moveItem", () => {
   });
 });
 
+describe("reconcileAgeManualOrder", () => {
+  it("prepends newcomers and keeps known relative order", () => {
+    expect(reconcileAgeManualOrder(["b", "a"], ["c", "a", "b"])).toEqual([
+      "c",
+      "b",
+      "a",
+    ]);
+  });
+
+  it("drops ids that left the visible set", () => {
+    expect(reconcileAgeManualOrder(["gone", "a", "b"], ["b", "a"])).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("seeds an empty order from the visible id list as-is", () => {
+    expect(reconcileAgeManualOrder([], ["a", "b", "c"])).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("preserves multiple newcomers in the order they appear", () => {
+    expect(reconcileAgeManualOrder(["z"], ["n1", "n2", "z"])).toEqual([
+      "n1",
+      "n2",
+      "z",
+    ]);
+  });
+});
+
 describe("orderAgeRows", () => {
-  it("with an empty manualOrder, sorts every row by since (most recent first)", () => {
+  it("with an empty manualOrder, keeps row encounter order (no since-sort)", () => {
     const rows = [
       row({ terminalId: "oldest", since: hoursAgo(3) }),
       row({ terminalId: "newest", since: hoursAgo(1) }),
       row({ terminalId: "middle", since: hoursAgo(2) }),
     ];
     expect(orderAgeRows(rows, []).map((r) => r.terminalId)).toEqual([
+      "oldest",
       "newest",
       "middle",
-      "oldest",
     ]);
   });
 
-  it("puts every undragged row above every dragged row", () => {
+  it("prepends every unknown id above the manualOrder sequence", () => {
     const rows = [
-      row({ terminalId: "dragged-1", since: hoursAgo(1) }),
-      row({ terminalId: "undragged", since: hoursAgo(9) }),
-      row({ terminalId: "dragged-2", since: hoursAgo(2) }),
+      row({ terminalId: "known-1", since: hoursAgo(1) }),
+      row({ terminalId: "new", since: hoursAgo(9) }),
+      row({ terminalId: "known-2", since: hoursAgo(2) }),
     ];
     expect(
-      orderAgeRows(rows, ["dragged-1", "dragged-2"]).map((r) => r.terminalId),
-    ).toEqual(["undragged", "dragged-1", "dragged-2"]);
+      orderAgeRows(rows, ["known-1", "known-2"]).map((r) => r.terminalId),
+    ).toEqual(["new", "known-1", "known-2"]);
   });
 
-  it("orders dragged rows by their position in manualOrder, not by since", () => {
+  it("orders known rows by their position in manualOrder, not by since", () => {
     const rows = [
       row({ terminalId: "a", since: hoursAgo(1) }),
       row({ terminalId: "b", since: hoursAgo(9) }),
@@ -573,6 +607,17 @@ describe("orderAgeRows", () => {
     expect(orderAgeRows(rows, ["b", "a"]).map((r) => r.terminalId)).toEqual([
       "b",
       "a",
+    ]);
+  });
+
+  it("does not reshuffle when a known row's since becomes more recent", () => {
+    const rows = [
+      row({ terminalId: "a", since: hoursAgo(9) }),
+      row({ terminalId: "b", since: hoursAgo(1) }),
+    ];
+    expect(orderAgeRows(rows, ["a", "b"]).map((r) => r.terminalId)).toEqual([
+      "a",
+      "b",
     ]);
   });
 

--- a/packages/extensions-silo/src/agents/agents-panel-view.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-view.ts
@@ -176,9 +176,8 @@ export function isAtLeastHoursOld(isoDate: string, hours: number): boolean {
  * Ordering is driven purely by the fixed ISO `since` string, never by an
  * elapsed duration computed against `Date.now()` — so a row's position never
  * shifts on its own as time passes between renders, only the elapsed label
- * next to it does. Exported so the "Recent" grouping (`buildAgeSections` in
- * `agents-panel.tsx`) can sort its flat, cross-section list with the same
- * jitter-free rule instead of drifting from this one.
+ * next to it does. Used by the status and workspace views; the "Recent" view
+ * does not auto-sort (see {@link orderAgeRows} / {@link reconcileAgeManualOrder}).
  */
 export function compareRows(x: AgentRow, y: AgentRow): number {
   if (x.since && y.since) return y.since.localeCompare(x.since);
@@ -270,33 +269,49 @@ export function moveItem<T>(
 }
 
 /**
- * Final row order for the "Recent" view's flat, non-stale section. A row the
- * user has never dragged sorts by {@link compareRows} (most recent first)
- * and floats above every dragged row — a freshly-started or freshly-finished
- * agent should read as "new" without the user having to go drag it there
- * themselves. A row present in `manualOrder` (the id sequence a previous drag
- * left behind, persisted by `./manual-order`) instead keeps that exact
- * relative order, below the undragged rows.
+ * Merge newly-visible terminal ids into the "Recent" view's persisted order.
+ * Ids in `visibleIds` that aren't yet in `manualOrder` are prepended (newest
+ * at the top, in the order they appear in `visibleIds`); known ids keep their
+ * relative order; ids that dropped out of the flat section are removed.
  *
- * Nothing here prunes `manualOrder` — an id that's dropped out of `rows`
- * entirely (terminal closed, or the row aged into the stale section) simply
- * has no matching row to place, so it's silently inert. `agents-panel.tsx`
- * is the one persisting a trimmed `manualOrder` back once that happens, so
- * storage doesn't accumulate ids forever.
+ * Pure — callers (the panel's reconcile effect) decide when to persist.
+ */
+export function reconcileAgeManualOrder(
+  manualOrder: readonly string[],
+  visibleIds: readonly string[],
+): string[] {
+  const known = new Set(manualOrder);
+  const visible = new Set(visibleIds);
+  const newcomers = visibleIds.filter((id) => !known.has(id));
+  const kept = manualOrder.filter((id) => visible.has(id));
+  return [...newcomers, ...kept];
+}
+
+/**
+ * Final row order for the "Recent" view's flat, non-stale section. Order is
+ * purely the persisted `manualOrder` (drag), with any id not yet in that list
+ * prepended at the top — never sorted by {@link compareRows} / duration. A
+ * state change (ready → working → done) must not reshuffle the list; only a
+ * drag or a newly-appeared agent does.
+ *
+ * `agents-panel.tsx` persists the same rule via {@link reconcileAgeManualOrder}
+ * so newcomers stick at the top across reloads and closed/stale ids don't
+ * accumulate in storage. An id in `manualOrder` with no matching row is
+ * silently skipped here (inert until that reconcile trims it).
  */
 export function orderAgeRows(
   rows: readonly AgentRow[],
   manualOrder: readonly string[],
 ): AgentRow[] {
-  const manualIndex = new Map(manualOrder.map((id, i) => [id, i]));
-  const undragged: AgentRow[] = [];
-  const dragged: AgentRow[] = [];
-  for (const row of rows) {
-    (manualIndex.has(row.terminalId) ? dragged : undragged).push(row);
-  }
-  undragged.sort(compareRows);
-  dragged.sort(
-    (a, b) => manualIndex.get(a.terminalId)! - manualIndex.get(b.terminalId)!,
+  const byId = new Map(rows.map((row) => [row.terminalId, row]));
+  const orderedIds = reconcileAgeManualOrder(
+    manualOrder,
+    rows.map((row) => row.terminalId),
   );
-  return [...undragged, ...dragged];
+  const ordered: AgentRow[] = [];
+  for (const id of orderedIds) {
+    const row = byId.get(id);
+    if (row) ordered.push(row);
+  }
+  return ordered;
 }

--- a/packages/extensions-silo/src/agents/agents-panel.tsx
+++ b/packages/extensions-silo/src/agents/agents-panel.tsx
@@ -16,6 +16,7 @@ import {
   isAtLeastHoursOld,
   moveItem,
   orderAgeRows,
+  reconcileAgeManualOrder,
   SECTION_ORDER,
   type AgentRow,
   type AgentSection,
@@ -137,23 +138,17 @@ export function buildWorkspaceSections(
 /**
  * The "Recent" view (internal `groupBy` value `"age"`): unlike status or
  * workspace grouping, every row sits in one flat, unheaded-by-status list —
- * no status or workspace bucketing above it. Rows the user hasn't
- * drag-reordered sort by {@link compareRows} (most recently changed first);
- * `manualOrder` (see `./manual-order`) carries whatever order a drag left
- * behind for the rest — see {@link orderAgeRows} for exactly how the two mix.
- * The one exception, drag or no drag, is the same "N+ hours old" split
- * `buildStatusSections` uses: a done row that's sat past `staleDoneHours`
- * still peels off into its own collapsible heading (tagged with the same
- * `STALE_DONE_SECTION_KEY`, so the panel's existing hover-to-reveal behavior
- * applies unchanged, and it stays un-reorderable — see `agents-panel.tsx`'s
- * render, which only wires drag handlers for `key === "age"`), since burying
- * genuinely stale rows among fresh ones defeats the point of this view.
- *
- * Because {@link compareRows} orders by the fixed `since` timestamp rather
- * than an elapsed duration recomputed on every render, an undragged row's
- * position never shifts on its own as time passes — only its displayed
- * elapsed label does — so a row stays put unless its actual state changes or
- * the user drags it.
+ * no status or workspace bucketing above it. Order is entirely manual:
+ * {@link orderAgeRows} / `manualOrder` (see `./manual-order`) — new agents
+ * prepend at the top, and positions only change on drag-and-drop. There is
+ * no automatic sort by duration/`since`. The one exception is the same
+ * "N+ hours old" split `buildStatusSections` uses: a done row that's sat
+ * past `staleDoneHours` still peels off into its own collapsible heading
+ * (tagged with the same `STALE_DONE_SECTION_KEY`, so the panel's existing
+ * hover-to-reveal behavior applies unchanged, and it stays un-reorderable —
+ * see `agents-panel.tsx`'s render, which only wires drag handlers for
+ * `key === "age"`), since burying genuinely stale rows among fresh ones
+ * defeats the point of this view.
  */
 export function buildAgeSections(
   rows: readonly AgentRow[],
@@ -500,10 +495,9 @@ export function AgentsPanel({
         // `insertAt` up by one once the dragged row is removed, so the
         // final index is one less than the original insertion point.
         const finalIndex = insertAt > from ? insertAt - 1 : insertAt;
-        // The whole visible order becomes the new manual order, not just the
-        // two swapped rows — so a row that was sorting purely by recency
-        // (not yet in `manualOrder`) gets carried into it too, exactly where
-        // it was sitting when the drag happened.
+        // Persist the whole visible order after the move — every flat-section
+        // id is already in `manualOrder` (reconcile prepends newcomers), so
+        // this is just rewriting positions from the drag.
         manualOrderService.set(
           moveItem(
             sectionRows.map((r) => r.terminalId),
@@ -590,19 +584,22 @@ export function AgentsPanel({
 
   const staleStartsExpanded = staleSectionStartsExpanded(sections);
 
-  // Trim `manualOrder` once a dragged row drops out of the flat section for
-  // good (terminal closed, or it aged into "N+ hours old") — otherwise
-  // storage would carry that id forever. `orderAgeRows` already treats a
-  // manual-order id with no matching row as inert, so this is pure
-  // housekeeping, not correctness: it only ever removes ids, never changes
-  // display order.
+  // Keep `manualOrder` in sync with the flat section: prepend any newly
+  // visible terminal ids (so they stay at the top across reloads) and drop
+  // ids that left for good (closed, or aged into "N+ hours old"). Display
+  // already applies the same rule via `orderAgeRows`; this only persists it.
   useEffect(() => {
     if (groupBy !== "age") return;
-    const flatIds = new Set(
-      sections.find((s) => s.key === "age")?.rows.map((r) => r.terminalId),
-    );
-    const trimmed = manualOrder.filter((id) => flatIds.has(id));
-    if (trimmed.length !== manualOrder.length) manualOrderService.set(trimmed);
+    const flatIds =
+      sections.find((s) => s.key === "age")?.rows.map((r) => r.terminalId) ??
+      [];
+    const next = reconcileAgeManualOrder(manualOrder, flatIds);
+    if (
+      next.length !== manualOrder.length ||
+      next.some((id, i) => id !== manualOrder[i])
+    ) {
+      manualOrderService.set(next);
+    }
   });
 
   function openRowMenu(row: AgentRow, at: { x: number; y: number }) {

--- a/packages/extensions-silo/src/agents/manual-order.ts
+++ b/packages/extensions-silo/src/agents/manual-order.ts
@@ -1,15 +1,16 @@
 /**
- * The persisted drag order for the "Recent" view's flat section — a plain
- * list of terminal ids in the order the user last left them via drag. Empty
- * by default, which reduces `orderAgeRows` to its unmodified
- * most-recent-first sort, so nobody who's never dragged a row sees any
- * change in behavior.
+ * The persisted row order for the "Recent" view's flat section — a plain
+ * list of terminal ids. Updated when the user drag-reorders, and when the
+ * panel reconciles newcomers (prepended at the top) or closed/stale rows
+ * (dropped). Empty until the first reconcile or drag; display applies the
+ * same rule via `orderAgeRows` / `reconcileAgeManualOrder` in
+ * `agents-panel-view.ts`.
  *
  * A `ReactiveService` like `./settings-store`, rather than folded into that
  * store directly: it's read the same way (`useServiceState` in
- * `agents-panel.tsx`) but changes for a different reason — a user drag, not a
- * settings-page edit — and keeping it separate means a settings change never
- * has to reason about drag state or vice versa.
+ * `agents-panel.tsx`) but changes for a different reason — a user drag or
+ * reconcile, not a settings-page edit — and keeping it separate means a
+ * settings change never has to reason about drag state or vice versa.
  */
 
 import type { ExtensionStorage, ReactiveService } from "@silo-code/sdk";


### PR DESCRIPTION
## Summary
- Agents Navigator **Recent** no longer auto-sorts by `since`/duration; order is manual-only (drag-and-drop).
- New agents are prepended at the top and persisted via `reconcileAgeManualOrder`; closed/stale ids are trimmed.
- Unit tests cover prepend, stable known-order, and no reshuffle when duration changes.

## Test plan
- [ ] Open Agents → Recent with several agents; drag to reorder and confirm order sticks across status changes (ready/working/done).
- [ ] Start a new agent and confirm it appears at the top without reshuffling existing rows.
- [ ] Confirm elapsed labels still update while positions stay put.
- [ ] Confirm “N+ hours old” still peels off stale done rows and is not drag-reorderable.


Made with [Cursor](https://cursor.com)