### PR TITLE
fix(terminal): stop sweep probes from false-exiting live sessions

### DIFF
--- a/apps/desktop/scripts/repro-terminal-false-exit.sh
+++ b/apps/desktop/scripts/repro-terminal-false-exit.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+# Repro / verify: false "Process exited" when the app's data client drops but
+# the session-host (and shell) stay alive.
+#
+# Default trigger (METHOD=evict): open a second Data client on the session
+# socket. Under MAX_DATA_CLIENTS=1 the daemon evicts the live UI client → app
+# reader EOF → overlay "Process exited (code 0)" while the host stays up.
+# Same end state as the prod OpenCode incident (instatic, 2026-08-28).
+#
+# METHOD=silent-hold: connect, read T_HELLO, send nothing for >FG_CLASSIFY_TIMEOUT
+# (100ms). Pre-fix: daemon defaulted the quiet socket to Data and evicted the UI
+# client (maintenance-sweep race). Post-fix: quiet peer is ignored; UI stays up.
+# Host log pre-fix: evicted prior client (cap) (+ often ring-replay drop).
+#
+# Optional trigger (METHOD=stall): SIGSTOP the *app* while the PTY floods
+# (`yes`), hoping host→app broadcast hits the 1s write deadline. Flakier on
+# macOS (large socket buffers); kept for exploring the write-timeout path.
+# (Inverse of repro-terminal-ui-freeze.sh, which SIGSTOPs the session-host.)
+#
+# Observed prod signature:
+#   terminal.log:  exit … reason=eof   (no matching kill)
+#   host log:      client detached  (and/or evicted prior client)
+#   UI:            "Process exited (code 0) / Session ended…"
+#   ps:            session-host + shell still alive
+#   workspace switch does NOT recover (panel stays mounted in exited state);
+#   app restart does (fresh attach).
+#
+# Dev note: forced eviction reliably reproduces eof + live host + dead UI
+# (terminal-host loses --active; switch does not heal). The prod "Session
+# ended" overlay text is not always painted in Dev — panel often goes blank
+# instead. Still counts as FALSE_EXIT for before/detect.
+#
+# Prerequisites:
+#   - Silo Dev running with automation (`pnpm dev`) listening on :7878
+#   - macOS
+#
+# Usage:
+#   ./apps/desktop/scripts/repro-terminal-false-exit.sh detect
+#   ./apps/desktop/scripts/repro-terminal-false-exit.sh visual
+#   ./apps/desktop/scripts/repro-terminal-false-exit.sh before   # expect FALSE_EXIT (unfixed)
+#   ./apps/desktop/scripts/repro-terminal-false-exit.sh after    # expect RECOVERED (fixed)
+#
+# Env:
+#   METHOD=evict|silent-hold|stall   default evict
+#   HOLD_SEC=3             stall only: how long app stays SIGSTOP'd
+#   SILENT_HOLD_SEC=0.25   silent-hold: quiet connect duration (must be >0.1s)
+#   SETTLE_SEC=1           wait after trigger before probing
+#   KEEP_WORKSPACE=1       skip deleteWorkspace so you can poke the overlay
+#   SILO_AUTOMATION_PORT=7878
+#
+# Exit codes:
+#   0  — mode matched expectation (or detect/visual finished)
+#   1  — expectation failed / setup error
+#   2  — automation bridge not reachable
+
+set -euo pipefail
+
+MODE="${1:-detect}"
+PORT="${SILO_AUTOMATION_PORT:-7878}"
+BASE="http://127.0.0.1:${PORT}"
+METHOD="${METHOD:-evict}"
+HOLD_SEC="${HOLD_SEC:-5}"
+SETTLE_SEC="${SETTLE_SEC:-2}"
+COUNTDOWN_SEC="${COUNTDOWN_SEC:-5}"
+VISUAL_HOLD_SEC="${VISUAL_HOLD_SEC:-15}"
+KEEP_WORKSPACE="${KEEP_WORKSPACE:-0}"
+WS_NAME="false-exit-repro-$$"
+PARK_NAME="false-exit-park-$$"
+BUSY_ID="automation.false-exit-repro"
+DEV_LOG="${HOME}/Library/Application Support/com.silo.desktop.dev/logs/terminal.log"
+EVICT_HOLD_SEC="${EVICT_HOLD_SEC:-2}"
+SILENT_HOLD_SEC="${SILENT_HOLD_SEC:-0.25}"
+
+silo() {
+  local timeout="${2:-30}"
+  curl -sS -m "$timeout" -X POST "$BASE/" \
+    -H 'X-Silo-Automation: 1' \
+    -H 'Content-Type: application/json' \
+    --data "$1"
+}
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+case "$MODE" in
+  before|after|detect|visual) ;;
+  -h|--help)
+    sed -n '2,50p' "$0" | sed 's/^# \?//'
+    exit 0
+    ;;
+  *)
+    die "usage: $0 detect|visual|before|after"
+    ;;
+esac
+
+case "$METHOD" in
+  evict|silent-hold|stall) ;;
+  *) die "METHOD must be evict|silent-hold|stall (got $METHOD)" ;;
+esac
+
+echo "== false Process-exited repro (mode=$MODE method=$METHOD) =="
+
+# --- bridge ---
+if ! ping_out=$(silo '{"op":"ping"}' 5 2>/dev/null); then
+  echo "Automation bridge not reachable at $BASE" >&2
+  echo "Start Silo Dev first: pnpm dev" >&2
+  exit 2
+fi
+[[ "$ping_out" == '{"ok":true,"result":"pong"}' ]] || die "unexpected ping: $ping_out"
+echo "bridge: ok"
+
+APP_PID=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1 || true)
+[[ -n "${APP_PID:-}" ]] || die "could not find app PID listening on $PORT"
+echo "app_pid: $APP_PID"
+ps -p "$APP_PID" -o command= | head -1
+
+LOG_MARK=$(python3 -c 'import time; print(int(time.time()*1000))')
+echo "log_mark_ms: $LOG_MARK"
+
+WS_DIR=""
+PARK_DIR=""
+WS_ID=""
+PARK_ID=""
+HOST_PID=""
+APP_STOPPED=0
+EVICT_PID=""
+
+cleanup() {
+  local code=$?
+  if [[ -n "${EVICT_PID:-}" ]] && kill -0 "$EVICT_PID" 2>/dev/null; then
+    kill "$EVICT_PID" 2>/dev/null || true
+    wait "$EVICT_PID" 2>/dev/null || true
+  fi
+  if [[ "$APP_STOPPED" -eq 1 ]] && kill -0 "$APP_PID" 2>/dev/null; then
+    kill -CONT "$APP_PID" 2>/dev/null || true
+    APP_STOPPED=0
+    echo "cleanup: SIGCONT app (was still stopped)"
+  fi
+  silo "{\"op\":\"clearBusyStatus\",\"args\":{\"id\":\"$BUSY_ID\"}}" 5 >/dev/null 2>&1 || true
+  if [[ "$KEEP_WORKSPACE" != "1" ]]; then
+    if [[ -n "${WS_ID:-}" ]]; then
+      echo "cleanup: deleting sandbox workspace ${WS_ID} (${WS_NAME})..."
+      del_out=$(silo "{\"op\":\"deleteWorkspace\",\"args\":{\"id\":\"$WS_ID\"}}" 15 2>&1) || del_out="DELETE_FAIL:$del_out"
+      echo "cleanup: deleteWorkspace -> $del_out"
+      WS_ID=""
+    fi
+    if [[ -n "${PARK_ID:-}" ]]; then
+      echo "cleanup: deleting park workspace ${PARK_ID}..."
+      silo "{\"op\":\"deleteWorkspace\",\"args\":{\"id\":\"$PARK_ID\"}}" 15 >/dev/null 2>&1 || true
+      PARK_ID=""
+    fi
+  else
+    echo "cleanup: KEEP_WORKSPACE=1 — left ${WS_NAME} (${WS_ID}) for inspection"
+  fi
+  rm -rf "${WS_DIR:-}" "${PARK_DIR:-}" 2>/dev/null || true
+  exit "$code"
+}
+trap cleanup EXIT
+
+WS_DIR=$(mktemp -d /tmp/silo-false-exit-repro.XXXXXX)
+PARK_DIR=$(mktemp -d /tmp/silo-false-exit-park.XXXXXX)
+
+OPEN=$(silo "{\"op\":\"openWorkspace\",\"args\":{\"folder\":\"$WS_DIR\",\"name\":\"$WS_NAME\"}}")
+WS_ID=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["result"]["id"])' "$OPEN")
+silo "{\"op\":\"activateWorkspace\",\"args\":{\"id\":\"$WS_ID\"}}" >/dev/null
+TERM=$(silo "{\"op\":\"openTerminal\",\"args\":{\"cwd\":\"$WS_DIR\",\"workspaceId\":\"$WS_ID\"}}")
+TERM_ID=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["result"]["terminalId"])' "$TERM")
+
+silo "{\"op\":\"sendText\",\"args\":{\"terminalId\":\"$TERM_ID\",\"text\":\"echo false-exit-repro-ready\",\"addNewline\":true}}" >/dev/null
+sleep 0.5
+
+LIST=$(silo "{\"op\":\"listTerminals\",\"args\":{\"workspaceId\":\"$WS_ID\"}}")
+SESSION_ID=$(python3 -c '
+import json,sys
+d=json.loads(sys.argv[1]); tid=sys.argv[2]
+print(next((t.get("sessionId") or "") for t in d["result"]["terminals"] if t["id"]==tid))
+' "$LIST" "$TERM_ID")
+[[ -n "$SESSION_ID" ]] || die "no sessionId after spawn; list=$LIST"
+HANDLE="silo-${SESSION_ID:0:8}"
+HOST_PID=$(pgrep -f "session-host ${HANDLE} " | head -1 || true)
+[[ -n "${HOST_PID:-}" ]] || die "no session-host process for $HANDLE"
+echo "terminal: $TERM_ID"
+echo "session:  $SESSION_ID"
+echo "handle:   $HANDLE"
+echo "host_pid: $HOST_PID"
+
+# Wait until the panel has finished attach and registered onExit — otherwise
+# we race automation's ensureSession spawn and only observe a stuck loading
+# panel, not the false-exit path.
+echo -n "waiting for terminal ready"
+for _ in $(seq 1 50); do
+  ready=$(silo '{"op":"eval","args":{"expr":"[...document.querySelectorAll(\".dock-host[data-active=\\\"true\\\"] .terminal-host\")].some(h=>h.classList.contains(\"terminal-host--active\"))"}}' 5 2>/dev/null || echo fail)
+  if [[ "$ready" == '{"ok":true,"result":true}' ]]; then
+    echo " — ready"
+    break
+  fi
+  echo -n "."
+  sleep 0.2
+done
+if [[ "$ready" != '{"ok":true,"result":true}' ]]; then
+  die "terminal never became ready (panel onExit not registered yet)"
+fi
+
+HOST_LOG=$(find "${TMPDIR:-/tmp}" /var/folders -path "*/silo-pty/dev/${HANDLE}.log" 2>/dev/null | head -1 || true)
+SOCK=$(find "${TMPDIR:-/tmp}" /var/folders -path "*/silo-pty/dev/${HANDLE}.sock" 2>/dev/null | head -1 || true)
+echo "host_log: ${HOST_LOG:-"(missing)"}"
+echo "sock:     ${SOCK:-"(missing)"}"
+[[ -n "$SOCK" && -S "$SOCK" ]] || die "session sock not found for $HANDLE"
+
+base_eval=$(silo '{"op":"eval","args":{"expr":"document.readyState"}}' 5)
+[[ "$base_eval" == '{"ok":true,"result":"complete"}' ]] || die "baseline eval failed: $base_eval"
+echo "baseline: ping+eval ok"
+
+PARK=$(silo "{\"op\":\"openWorkspace\",\"args\":{\"folder\":\"$PARK_DIR\",\"name\":\"$PARK_NAME\"}}")
+PARK_ID=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["result"]["id"])' "$PARK")
+silo "{\"op\":\"activateWorkspace\",\"args\":{\"id\":\"$WS_ID\"}}" >/dev/null
+
+if [[ "$MODE" == visual ]]; then
+  echo
+  echo "============================================================"
+  echo "  FOCUS SILO DEV — workspace: $WS_NAME"
+  echo "  Trigger ($METHOD) in ${COUNTDOWN_SEC}s."
+  echo "  Watch for: Process exited / Session ended overlay."
+  echo "============================================================"
+  echo
+  for ((i = COUNTDOWN_SEC; i >= 1; i--)); do
+    printf '\r  trigger in %2d … ' "$i"
+    sleep 1
+  done
+  printf '\r  inducing false exit now.        \n'
+fi
+
+silo "{\"op\":\"setBusyStatus\",\"args\":{\"id\":\"$BUSY_ID\",\"label\":\"False-exit repro ($METHOD)\",\"detail\":\"inducing data-client drop\",\"urgency\":\"high\"}}" >/dev/null
+
+induce_evict() {
+  # Connect as a second Data client: read T_HELLO, send T_RESIZE so we classify
+  # as Data (not FG). Daemon evicts the UI client (MAX_DATA_CLIENTS=1).
+  # Hold the socket open briefly so eviction sticks, then exit.
+  python3 - "$SOCK" "$EVICT_HOLD_SEC" <<'PY' &
+import socket, struct, sys, time
+sock_path, hold = sys.argv[1], float(sys.argv[2])
+T_RESIZE, T_HELLO = 1, 5
+
+def recv_exact(s, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = s.recv(n - len(buf))
+        if not chunk:
+            raise SystemExit(f"short read: got {buf!r}, want {n} bytes")
+        buf += chunk
+    return buf
+
+def read_frame(s):
+    hdr = recv_exact(s, 5)
+    tag, length = hdr[0], struct.unpack(">I", hdr[1:])[0]
+    payload = recv_exact(s, length) if length else b""
+    return tag, payload
+
+def write_frame(s, tag, payload=b""):
+    s.sendall(bytes([tag]) + struct.pack(">I", len(payload)) + payload)
+
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(sock_path)
+tag, payload = read_frame(s)
+if tag != T_HELLO:
+    raise SystemExit(f"expected T_HELLO=5, got {tag}")
+# Announce Data role immediately (resize), same as a real attach.
+cols, rows = 120, 40
+write_frame(s, T_RESIZE, struct.pack(">HH", cols, rows))
+print(f"evict_client: connected, HELLO ok proto={struct.unpack('>I', payload)[0]}, sent T_RESIZE; holding {hold}s", flush=True)
+time.sleep(hold)
+s.close()
+print("evict_client: closed", flush=True)
+PY
+  EVICT_PID=$!
+  echo "inducing: second Data client on $SOCK (pid $EVICT_PID)"
+  # Wait until eviction has had time to run + UI processes EOF.
+  wait "$EVICT_PID" || die "evict client failed"
+  EVICT_PID=""
+}
+
+induce_silent_hold() {
+  # Sweep-race stand-in: stay connected past FG_CLASSIFY_TIMEOUT (100ms) with
+  # no role frame. Classify defaults to Data → evicts the live UI client.
+  python3 - "$SOCK" "$SILENT_HOLD_SEC" <<'PY' &
+import socket, struct, sys, time
+sock_path, hold = sys.argv[1], float(sys.argv[2])
+T_HELLO = 5
+
+def recv_exact(s, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = s.recv(n - len(buf))
+        if not chunk:
+            raise SystemExit(f"short read: got {buf!r}, want {n} bytes")
+        buf += chunk
+    return buf
+
+def read_frame(s):
+    hdr = recv_exact(s, 5)
+    tag, length = hdr[0], struct.unpack(">I", hdr[1:])[0]
+    payload = recv_exact(s, length) if length else b""
+    return tag, payload
+
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(sock_path)
+tag, payload = read_frame(s)
+if tag != T_HELLO:
+    raise SystemExit(f"expected T_HELLO=5, got {tag}")
+print(
+    f"silent_hold: connected, HELLO ok proto={struct.unpack('>I', payload)[0]}; "
+    f"holding quiet {hold}s (no Data/FG frame)",
+    flush=True,
+)
+time.sleep(hold)
+s.close()
+print("silent_hold: closed", flush=True)
+PY
+  EVICT_PID=$!
+  echo "inducing: silent-hold on $SOCK (pid $EVICT_PID, ${SILENT_HOLD_SEC}s)"
+  wait "$EVICT_PID" || die "silent-hold client failed"
+  EVICT_PID=""
+}
+
+induce_stall() {
+  silo "{\"op\":\"sendText\",\"args\":{\"terminalId\":\"$TERM_ID\",\"text\":\"yes 'false-exit-flood'\",\"addNewline\":true}}" >/dev/null
+  sleep 0.4
+  echo "inducing: SIGSTOP app pid=$APP_PID for ${HOLD_SEC}s (host keeps writing)"
+  kill -STOP "$APP_PID"
+  APP_STOPPED=1
+  sleep "$HOLD_SEC"
+  kill -CONT "$APP_PID"
+  APP_STOPPED=0
+  echo "induced: SIGCONT app (state=$(ps -p "$APP_PID" -o state= | tr -d ' '))"
+}
+
+case "$METHOD" in
+  evict) induce_evict ;;
+  silent-hold) induce_silent_hold ;;
+  stall) induce_stall ;;
+esac
+
+sleep "$SETTLE_SEC"
+
+# --- probes ---
+HOST_ALIVE=0
+if kill -0 "$HOST_PID" 2>/dev/null; then
+  HOST_ALIVE=1
+  echo "host: still alive (pid $HOST_PID)"
+else
+  echo "host: DEAD (unexpected — this would be a real exit path)"
+fi
+
+OVERLAY=0
+UI_DEAD=0
+ui_probe=$(silo '{"op":"eval","args":{"expr":"(() => { const hosts=[...document.querySelectorAll(\".dock-host[data-active=\\\"true\\\"] .terminal-host\")].map(h=>h.className); const overlay=document.querySelector(\".terminal-overlay\"); return JSON.stringify({hosts, overlayText:overlay?overlay.innerText:null}); })()"}}' 10 || echo EVAL_FAIL)
+echo "ui_probe: $ui_probe"
+eval "$(python3 - "$ui_probe" <<'PY'
+import json, sys
+raw = sys.argv[1]
+overlay = 0
+ui_dead = 0
+try:
+    outer = json.loads(raw)
+    data = json.loads(outer.get("result") or "{}")
+    text = data.get("overlayText") or ""
+    if "Process exited" in text or "Session ended" in text:
+        overlay = 1
+    hosts = data.get("hosts") or []
+    # Dead = at least one host in the active dock, none ready.
+    if hosts and not any("terminal-host--active" in h for h in hosts):
+        ui_dead = 1
+except Exception as e:
+    print(f"echo 'ui_probe parse err: {e}'", file=sys.stderr)
+print(f"OVERLAY={overlay}")
+print(f"UI_DEAD={ui_dead}")
+PY
+)"
+if [[ "$OVERLAY" -eq 1 ]]; then
+  echo "overlay: Process exited / Session ended present"
+else
+  echo "overlay: NOT present (prod showed this; Dev may show blank dead UI instead)"
+fi
+if [[ "$UI_DEAD" -eq 1 ]]; then
+  echo "ui: active-dock terminal-host lacks --active (dead / not ready)"
+fi
+
+EOF_LOG=0
+if [[ -f "$DEV_LOG" ]]; then
+  if awk -v mark="$LOG_MARK" -v sid="$SESSION_ID" '
+    $1+0 >= mark+0 && $0 ~ ("exit session=" sid) && $0 ~ /reason=eof/ { found=1 }
+    END { exit found ? 0 : 1 }
+  ' "$DEV_LOG"; then
+    EOF_LOG=1
+    echo "terminal.log: exit … reason=eof for this session (after mark)"
+    awk -v mark="$LOG_MARK" -v sid="$SESSION_ID" '
+      $1+0 >= mark+0 && index($0, sid) { print }
+    ' "$DEV_LOG" | tail -15
+  else
+    echo "terminal.log: no reason=eof for this session after mark"
+  fi
+else
+  echo "terminal.log: missing at $DEV_LOG"
+fi
+
+if [[ -n "$HOST_LOG" && -f "$HOST_LOG" ]]; then
+  echo "host log (tail):"
+  tail -12 "$HOST_LOG"
+fi
+
+KILL_LOG=0
+if [[ -f "$DEV_LOG" ]] && awk -v mark="$LOG_MARK" -v sid="$SESSION_ID" '
+  $1+0 >= mark+0 && $0 ~ ("kill session=" sid) { found=1 }
+  END { exit found ? 0 : 1 }
+' "$DEV_LOG"; then
+  KILL_LOG=1
+  echo "terminal.log: WARN unexpected kill for this session"
+fi
+
+SWITCH_STUCK=0
+if [[ "$OVERLAY" -eq 1 || "$UI_DEAD" -eq 1 ]]; then
+  silo "{\"op\":\"activateWorkspace\",\"args\":{\"id\":\"$PARK_ID\"}}" >/dev/null
+  sleep 0.4
+  silo "{\"op\":\"activateWorkspace\",\"args\":{\"id\":\"$WS_ID\"}}" >/dev/null
+  sleep 0.4
+  switch_probe=$(silo '{"op":"eval","args":{"expr":"(() => { const hosts=[...document.querySelectorAll(\".dock-host[data-active=\\\"true\\\"] .terminal-host\")].map(h=>h.className); const overlay=document.querySelector(\".terminal-overlay\"); return JSON.stringify({hosts, overlayText:overlay?overlay.innerText:null}); })()"}}' 10 || echo EVAL_FAIL)
+  echo "after_workspace_switch: $switch_probe"
+  eval "$(python3 - "$switch_probe" <<'PY'
+import json, sys
+raw = sys.argv[1]
+stuck = 0
+try:
+    data = json.loads(json.loads(raw).get("result") or "{}")
+    text = data.get("overlayText") or ""
+    hosts = data.get("hosts") or []
+    if "Process exited" in text or "Session ended" in text:
+        stuck = 1
+    elif hosts and not any("terminal-host--active" in h for h in hosts):
+        stuck = 1
+except Exception:
+    pass
+print(f"SWITCH_STUCK={stuck}")
+PY
+)"
+  if [[ "$SWITCH_STUCK" -eq 1 ]]; then
+    echo "workspace switch: still dead (expected for this bug)"
+  else
+    echo "workspace switch: recovered to ready (unexpected)"
+  fi
+fi
+
+silo "{\"op\":\"setBusyStatus\",\"args\":{\"id\":\"$BUSY_ID\",\"label\":\"False-exit repro — done\",\"detail\":\"overlay=$OVERLAY host=$HOST_ALIVE eof=$EOF_LOG\",\"urgency\":\"normal\"}}" >/dev/null
+
+if [[ "$MODE" == visual ]]; then
+  echo
+  echo "Holding ${VISUAL_HOLD_SEC}s so you can inspect (Enter skips)…"
+  set +e
+  for ((left = VISUAL_HOLD_SEC; left >= 1; left--)); do
+    silo "{\"op\":\"setBusyStatus\",\"args\":{\"id\":\"$BUSY_ID\",\"label\":\"False-exit hold — ${left}s\",\"detail\":\"KEEP_WORKSPACE=$KEEP_WORKSPACE\",\"urgency\":\"normal\"}}" 3 >/dev/null 2>&1
+    read -r -t 1 _
+    if [[ $? -eq 0 ]]; then
+      echo "ended early by Enter"
+      break
+    fi
+  done
+  set -e
+fi
+
+echo
+# Prod painted the exited overlay; Dev after forced eviction often goes blank
+# (not ready, no overlay) instead. Both are false death: eof + live host + no
+# kill + UI not live, and workspace switch does not recover.
+#
+# After the fix: eof may still land in the log (data client dropped), but the
+# panel reattaches — active dock shows terminal-host--active again.
+if [[ "$HOST_ALIVE" -eq 1 && "$EOF_LOG" -eq 1 && "$KILL_LOG" -eq 0 && "$OVERLAY" -eq 0 && "$UI_DEAD" -eq 0 ]]; then
+  # Confirm ready explicitly from last probe
+  if echo "$ui_probe" | grep -q 'terminal-host--active'; then
+    VERDICT=RECOVERED
+    echo "VERDICT: RECOVERED — eof fired but UI reattached (host still live)"
+  else
+    VERDICT=EOF_ONLY
+    echo "VERDICT: EOF_ONLY — backend eof, UI neither dead nor clearly ready"
+  fi
+elif [[ "$HOST_ALIVE" -eq 1 && "$EOF_LOG" -eq 1 && "$KILL_LOG" -eq 0 && ( "$OVERLAY" -eq 1 || "$UI_DEAD" -eq 1 ) ]]; then
+  VERDICT=FALSE_EXIT
+  echo "VERDICT: FALSE_EXIT — live host + reason=eof (no kill) + UI dead"
+  if [[ "$OVERLAY" -eq 1 ]]; then
+    echo "         UI: exited overlay (matches prod screenshot)"
+  else
+    echo "         UI: blank / not-ready (Dev variant; no Session-ended overlay)"
+  fi
+  if [[ "$SWITCH_STUCK" -eq 1 ]]; then
+    echo "         workspace switch did not recover (matches prod)"
+  fi
+elif [[ "$HOST_ALIVE" -eq 1 && "$EOF_LOG" -eq 1 && "$KILL_LOG" -eq 0 ]]; then
+  VERDICT=EOF_ONLY
+  echo "VERDICT: EOF_ONLY — backend false-exit signature, but UI still looks ready"
+elif [[ "$HOST_ALIVE" -eq 0 ]]; then
+  VERDICT=REAL_EXIT
+  echo "VERDICT: REAL_EXIT — host died (not the bug under test)"
+else
+  VERDICT=NO_REPRO
+  echo "VERDICT: NO_REPRO — host alive, no false-exit signature"
+  if [[ "$METHOD" == stall ]]; then
+    echo "  tip: try METHOD=evict|silent-hold or HOLD_SEC=8"
+  elif [[ "$METHOD" == silent-hold ]]; then
+    echo "  (expected after the classify-timeout fix: quiet peer ignored, UI stays up)"
+  fi
+fi
+
+case "$MODE" in
+  detect|visual)
+    echo "mode=$MODE; done"
+    exit 0
+    ;;
+  before)
+    if [[ "$VERDICT" == FALSE_EXIT ]]; then
+      echo "PASS (before): false Process-exited reproduced"
+      exit 0
+    fi
+    echo "FAIL (before): expected FALSE_EXIT, got $VERDICT" >&2
+    exit 1
+    ;;
+  after)
+    # Remount fix → RECOVERED (eof still happens, UI heals). Daemon classify
+    # fix → NO_REPRO for silent-hold (quiet peer never evicts). Both are green.
+    if [[ "$VERDICT" == RECOVERED || "$VERDICT" == NO_REPRO ]]; then
+      echo "PASS (after): $VERDICT — no stuck Session-ended overlay"
+      exit 0
+    fi
+    echo "FAIL (after): expected RECOVERED|NO_REPRO, got $VERDICT" >&2
+    exit 1
+    ;;
+esac

--- a/crates/pty-host/src/daemon.rs
+++ b/crates/pty-host/src/daemon.rs
@@ -25,8 +25,10 @@ const RING_CAP: usize = 256 * 1024;
 const MAX_DATA_CLIENTS: usize = 1;
 /// Max simultaneous foreground-subscribe clients.
 const MAX_FG_CLIENTS: usize = 2;
-/// How long to wait after HELLO for `T_SUBSCRIBE_FG` before treating the
-/// connection as a data client (ring replay + broadcast).
+/// How long to wait after HELLO for an explicit role frame (`T_SUBSCRIBE_FG` or
+/// a Data frame). Past this we still do **not** assume Data — a quiet socket
+/// that later disconnects is a discovery probe / stalled peer, and registering
+/// it would evict the live UI client under `MAX_DATA_CLIENTS=1`.
 const FG_CLASSIFY_TIMEOUT: Duration = Duration::from_millis(100);
 /// Chunk size for ring replay and live broadcast frames (keeps each socket
 /// write within the write-timeout budget).
@@ -369,18 +371,38 @@ fn run_daemon(
         });
 
         // Classify in a side thread so the accept loop stays responsive.
-        // Data clients are registered after a short wait (or sooner if they
-        // send a non-subscribe frame); FG clients never join `clients`.
+        // Data clients register only after an explicit Data frame (or FG after
+        // `T_SUBSCRIBE_FG`); never on classify-timeout alone — that footgun is
+        // what made maintenance-sweep `is_live` probes (and any quiet socket
+        // held past FG_CLASSIFY_TIMEOUT) evict the live UI client.
         let clients_f = clients.clone();
         let ring_f = ring.clone();
         let write_half_f = write_half.clone();
         let gone_f = client_gone;
         std::thread::spawn(move || {
-            let role = role_rx
-                .recv_timeout(FG_CLASSIFY_TIMEOUT)
-                .unwrap_or(ClientRole::Data);
-            // Connect-and-drop probes disconnect before any role frame; do not
-            // register them as Data (that would evict the live UI client).
+            let role = match role_rx.recv_timeout(FG_CLASSIFY_TIMEOUT) {
+                Ok(role) => role,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    // Still connected but quiet. Wait for an explicit role
+                    // frame; if the peer disconnects first, treat as a probe.
+                    if gone_f.load(Ordering::SeqCst) {
+                        log("ignoring disconnect before classify");
+                        return;
+                    }
+                    match role_rx.recv() {
+                        Ok(role) => role,
+                        Err(_) => {
+                            log("ignoring disconnect before classify");
+                            return;
+                        }
+                    }
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    log("ignoring disconnect before classify");
+                    return;
+                }
+            };
+            // Peer may have dropped between the role announce and here.
             if gone_f.load(Ordering::SeqCst) {
                 log("ignoring disconnect before classify");
                 return;
@@ -910,6 +932,82 @@ mod tests {
                 }
             }
             assert!(saw_fg, "data client must still receive T_FG_REP after probes");
+        });
+    }
+
+    /// Quiet socket held past `FG_CLASSIFY_TIMEOUT` with no role frame — the
+    /// maintenance-sweep race stand-in (`METHOD=silent-hold`). Must not default
+    /// to Data and evict the live UI client.
+    #[test]
+    fn silent_hold_does_not_evict_data_client() {
+        crate::test_support::with_temp_dir("silent-hold", |_dir| {
+            let daemon = TestDaemon::spawn("t-silent-hold", vec!["sleep".into(), "600".into()]);
+            let mut data = connect_retry(&daemon.sock);
+            let (tag, _) = read_frame(&mut data).expect("hello");
+            assert_eq!(tag, T_HELLO);
+            write_frame(&mut data, T_RESIZE, &resize_payload(80, 24)).expect("resize");
+            std::thread::sleep(FG_CLASSIFY_TIMEOUT + Duration::from_millis(50));
+
+            let mut quiet = connect_retry(&daemon.sock);
+            let (tag, _) = read_frame(&mut quiet).expect("hello");
+            assert_eq!(tag, T_HELLO);
+            // Hold past classify timeout with no Data/FG frame, then drop —
+            // same shape as a starved `is_live` probe under load.
+            std::thread::sleep(FG_CLASSIFY_TIMEOUT + Duration::from_millis(150));
+            drop(quiet);
+            std::thread::sleep(FG_CLASSIFY_TIMEOUT + Duration::from_millis(50));
+
+            write_frame(&mut data, T_FG_REQ, &[]).expect("fg req after silent hold");
+            data.set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("read timeout");
+            let mut saw_fg = false;
+            for _ in 0..8 {
+                match read_frame(&mut data) {
+                    Ok((T_FG_REP, _)) => {
+                        saw_fg = true;
+                        break;
+                    }
+                    Ok(_) => continue,
+                    Err(e) => panic!("data client died after silent hold: {e}"),
+                }
+            }
+            assert!(
+                saw_fg,
+                "data client must survive a quiet socket held past classify timeout"
+            );
+        });
+    }
+
+    /// A slow Data announce (past `FG_CLASSIFY_TIMEOUT`) must still register and
+    /// receive ring/broadcast — we wait for an explicit frame rather than
+    /// giving up or mis-classifying probes.
+    #[test]
+    fn slow_data_announce_still_registers() {
+        crate::test_support::with_temp_dir("slow-data", |_dir| {
+            let daemon = TestDaemon::spawn("t-slow-data", vec!["sleep".into(), "600".into()]);
+            let mut stream = connect_retry(&daemon.sock);
+            let (tag, _) = read_frame(&mut stream).expect("hello");
+            assert_eq!(tag, T_HELLO);
+            std::thread::sleep(FG_CLASSIFY_TIMEOUT + Duration::from_millis(50));
+            write_frame(&mut stream, T_RESIZE, &resize_payload(80, 24)).expect("late resize");
+            std::thread::sleep(Duration::from_millis(50));
+
+            write_frame(&mut stream, T_FG_REQ, &[]).expect("fg req");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("read timeout");
+            let mut saw_fg = false;
+            for _ in 0..8 {
+                match read_frame(&mut stream) {
+                    Ok((T_FG_REP, _)) => {
+                        saw_fg = true;
+                        break;
+                    }
+                    Ok(_) => continue,
+                    Err(e) => panic!("slow Data client never registered: {e}"),
+                }
+            }
+            assert!(saw_fg, "late T_RESIZE must still classify as Data");
         });
     }
 

--- a/packages/extension-host/src/extension-host/terminal-attach-trace.ts
+++ b/packages/extension-host/src/extension-host/terminal-attach-trace.ts
@@ -25,7 +25,11 @@ export type TerminalAttachTraceEvent =
   | "ui_attach_fail"
   | "ui_attach_gone"
   | "ui_recreate"
-  | "ui_init_cancelled";
+  | "ui_init_cancelled"
+  /** Data-client EOF while session-host may still be alive — remount to reattach. */
+  | "ui_reconnect"
+  /** Reconnect budget exhausted; painting the permanent exited overlay. */
+  | "ui_reconnect_give_up";
 
 export type TraceFieldValue = string | number | boolean | null | undefined;
 

--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -60,7 +60,11 @@ import {
   type HoveredTerminalLink,
   type TerminalLinkRange,
 } from "./terminal-link-policy";
-import { findTerminalOwnerId } from "./terminal-lifecycle";
+import {
+  findTerminalOwnerId,
+  planExitStreamEnd,
+  planSessionGoneAfterAttach,
+} from "./terminal-lifecycle";
 import {
   beginTerminalRestoreAttach,
   endTerminalRestoreAttach,
@@ -192,6 +196,11 @@ export function TerminalPanel(
   // When auto-recreating after a 404, holds the stale sessionId so the next
   // init() run can replay its persisted buffer into the fresh session.
   const replayFromRef = useRef<string>("");
+  // After a data-stream EOF we remount to reattach (false Process-exited). These
+  // track the original exit code (for the overlay if the host is truly gone)
+  // and how many reconnects we've already spent without a sustained ready.
+  const pendingExitCodeRef = useRef<number | null>(null);
+  const exitReconnectCountRef = useRef(0);
   // Find overlay (Cmd+F). `seed` carries the terminal's current selection into
   // the search box at open time; bumping `nonce` re-focuses the box if Cmd+F is
   // pressed while it's already open.
@@ -806,7 +815,37 @@ export function TerminalPanel(
           return true;
         });
         const exitSub = session.onExit((exitCode) => {
-          setLifecycle({ kind: "exited", sessionId, exitCode });
+          // Stream EOF ≠ shell death: the session-host often drops the UI data
+          // client while the PTY keeps running. Remount/reattach first; only
+          // paint "Session ended" after the reconnect budget is spent or attach
+          // comes back SESSION_GONE (see planSessionGoneAfterAttach).
+          const plan = planExitStreamEnd({
+            exitCode,
+            reconnectCount: exitReconnectCountRef.current,
+          });
+          if (plan.action === "exited") {
+            logTerminalAttachTrace("ui_reconnect_give_up", {
+              terminalId,
+              workspaceId: activeWsId,
+              sessionId,
+              exitCode,
+              attempts: exitReconnectCountRef.current,
+            });
+            pendingExitCodeRef.current = null;
+            setLifecycle({ kind: "exited", sessionId, exitCode });
+            return;
+          }
+          exitReconnectCountRef.current = plan.attempt;
+          pendingExitCodeRef.current = exitCode;
+          logTerminalAttachTrace("ui_reconnect", {
+            terminalId,
+            workspaceId: activeWsId,
+            sessionId,
+            exitCode,
+            attempt: plan.attempt,
+          });
+          setLifecycle({ kind: "loading" });
+          setVersion((v) => v + 1);
         });
         const onData = term.onData((data) => session.write(data));
         let resizeTimer: number | null = null;
@@ -835,6 +874,9 @@ export function TerminalPanel(
           },
         );
 
+        // Sustained ready — clear reconnect bookkeeping from a prior false exit.
+        pendingExitCodeRef.current = null;
+        exitReconnectCountRef.current = 0;
         setLifecycle({ kind: "ready", sessionId });
 
         // Trigger resize to ensure Claude Code renders properly on both create and restore
@@ -851,6 +893,27 @@ export function TerminalPanel(
       } catch (err) {
         const e = err as Error & { status?: number };
         if (e.status === 404) {
+          const gonePlan = planSessionGoneAfterAttach({
+            pendingExitCode: pendingExitCodeRef.current,
+          });
+          if (gonePlan === "exited") {
+            // Reconnect after stream EOF found no live host — real session end.
+            const exitCode = pendingExitCodeRef.current ?? 0;
+            pendingExitCodeRef.current = null;
+            logTerminalAttachTrace("ui_attach_gone", {
+              terminalId,
+              workspaceId: activeWsId,
+              sessionId: tRec.sessionId,
+              message: e.message,
+              reason: "reconnect-host-gone",
+            });
+            setLifecycle({
+              kind: "exited",
+              sessionId: tRec.sessionId,
+              exitCode,
+            });
+            return;
+          }
           // PTY daemon died (e.g. reboot). Save the old sessionId so the next
           // init() run can replay its persisted buffer after spawning a fresh shell.
           logTerminalAttachTrace("ui_attach_gone", {

--- a/packages/extensions-core/src/terminal/terminal-lifecycle.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-lifecycle.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { findTerminalOwnerId } from "./terminal-lifecycle";
+import {
+  findTerminalOwnerId,
+  MAX_EXIT_RECONNECTS,
+  planExitStreamEnd,
+  planSessionGoneAfterAttach,
+} from "./terminal-lifecycle";
 
 describe("findTerminalOwnerId", () => {
   const workspaces = [
@@ -37,5 +42,42 @@ describe("findTerminalOwnerId", () => {
       findTerminalOwnerId([null, undefined, workspaces[0]], "term_b"),
     ).toBe("ws_a");
     expect(findTerminalOwnerId([null, undefined], "term_b")).toBeNull();
+  });
+});
+
+describe("planExitStreamEnd", () => {
+  it("reconnects while under the attempt cap (false Process-exited)", () => {
+    expect(planExitStreamEnd({ exitCode: 0, reconnectCount: 0 })).toEqual({
+      action: "reconnect",
+      attempt: 1,
+    });
+    expect(planExitStreamEnd({ exitCode: 0, reconnectCount: 2 })).toEqual({
+      action: "reconnect",
+      attempt: 3,
+    });
+  });
+
+  it("gives up at MAX_EXIT_RECONNECTS and surfaces exited", () => {
+    expect(
+      planExitStreamEnd({
+        exitCode: 0,
+        reconnectCount: MAX_EXIT_RECONNECTS,
+      }),
+    ).toEqual({ action: "exited", exitCode: 0 });
+    expect(
+      planExitStreamEnd({ exitCode: 1, reconnectCount: 5, maxReconnects: 3 }),
+    ).toEqual({ action: "exited", exitCode: 1 });
+  });
+});
+
+describe("planSessionGoneAfterAttach", () => {
+  it("shows exited when SESSION_GONE follows a reconnect attempt", () => {
+    expect(planSessionGoneAfterAttach({ pendingExitCode: 0 })).toBe("exited");
+  });
+
+  it("recreates when SESSION_GONE is a cold restore (no pending exit)", () => {
+    expect(planSessionGoneAfterAttach({ pendingExitCode: null })).toBe(
+      "recreate",
+    );
   });
 });

--- a/packages/extensions-core/src/terminal/terminal-lifecycle.ts
+++ b/packages/extensions-core/src/terminal/terminal-lifecycle.ts
@@ -18,3 +18,43 @@ export function findTerminalOwnerId(
   }
   return null;
 }
+
+/** Cap on automatic reattach attempts after a data-client EOF (false exit). */
+export const MAX_EXIT_RECONNECTS = 3;
+
+/**
+ * What {@link TerminalPanel} should do when the PTY data stream ends.
+ *
+ * A stream EOF is not always a dead shell: the session-host can drop the UI's
+ * data client (write timeout, MAX_DATA_CLIENTS eviction, …) while the shell
+ * keeps running. Prefer a bounded reattach over the permanent "Session ended"
+ * overlay; only give up after {@link MAX_EXIT_RECONNECTS} failures in a row.
+ */
+export type ExitStreamPlan =
+  | { action: "reconnect"; attempt: number }
+  | { action: "exited"; exitCode: number };
+
+export function planExitStreamEnd(opts: {
+  exitCode: number;
+  reconnectCount: number;
+  maxReconnects?: number;
+}): ExitStreamPlan {
+  const max = opts.maxReconnects ?? MAX_EXIT_RECONNECTS;
+  if (opts.reconnectCount < max) {
+    return { action: "reconnect", attempt: opts.reconnectCount + 1 };
+  }
+  return { action: "exited", exitCode: opts.exitCode };
+}
+
+/**
+ * After a reconnect-driven remount, a SESSION_GONE attach means the host
+ * really died — show the exited overlay with the original exit code. A
+ * SESSION_GONE on cold restore (no pending exit) keeps today's recreate path.
+ */
+export type SessionGonePlan = "exited" | "recreate";
+
+export function planSessionGoneAfterAttach(opts: {
+  pendingExitCode: number | null;
+}): SessionGonePlan {
+  return opts.pendingExitCode !== null ? "exited" : "recreate";
+}


### PR DESCRIPTION
## Summary
- Session-host classify no longer treats a quiet socket as Data after 100ms — that raced with the hourly maintenance `is_live` storm and evicted the live UI client under `MAX_DATA_CLIENTS=1` while the shell kept running (false “Process exited / Session ended”).
- Remount/reattach on stream EOF (bounded) as belt-and-suspenders for real multi-attach drops.
- Add `repro-terminal-false-exit.sh` (`METHOD=silent-hold|evict`) for before/after verification.

## Test plan
- [x] `cargo test` in `crates/pty-host`: `silent_hold_does_not_evict_data_client`, `discovery_probe_does_not_evict_data_client`, `slow_data_announce_still_registers`
- [x] Dev: `METHOD=silent-hold …/repro-terminal-false-exit.sh after` → `NO_REPRO`
- [x] Dev: `METHOD=evict …/repro-terminal-false-exit.sh after` → `RECOVERED` (`ui_reconnect` → `ui_attach_ok`)
- [ ] Smoke: leave many terminals idle past an hourly maintenance sweep; no mass Session-ended overlay


Made with [Cursor](https://cursor.com)