### PR TITLE
docs(proposals): add lightweight change-planning convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ Orientation docs (read when relevant):
 
 - `docs/decisions/` — ADRs: the architecture decisions of record (the durable "why").
 - `docs/proposals/` — RFCs: forward-looking designs not yet decided.
+- `docs/change-planning-convention.md` — how a substantial change is planned:
+  proposal → (temporary) planning package → implementation → verification →
+  collapse back to one durable proposal. See "Planning a substantial change" below.
 - `docs/domain-language.md` — the domain glossary: ubiquitous language for the
   product, including UI component naming (Panels & Docking, Navigator, …).
   Kept current via the workflow in `.agents/skills/silo-domain-modeling/SKILL.md`.
@@ -71,6 +74,36 @@ and proposals (`docs/proposals/`). Design a new primitive by adding it to the
 roadmap as `planned` (with its sketched surface) _first_, then implement it and
 flip it to `stable`. Expanding `ExtensionContext` (`ctx`) is the main ongoing
 work — and the moment to run through that workflow.
+
+## Planning a substantial change
+
+A change with real product/architectural/API/persistence impact, cross-cutting
+reach, significant complexity, or ambiguity needing explicit decisions gets a
+proposal. Small, low-risk changes (typo/CSS/dep-bump/localized fix) don't —
+implement those directly. Full workflow:
+[change-planning convention](docs/change-planning-convention.md).
+
+- **Proposal** — one `docs/proposals/NNNN-name.md`
+  ([template](docs/proposals/template.md)): problem, motivation, proposed
+  change, rough scope.
+- **Planning package** — once `accepted` and implementation is starting, expand
+  that file into `docs/proposals/NNNN-name/` with `proposal.md`,
+  `requirements.md`, `design.md`, `tasks.md`
+  ([skeletons](docs/proposals/planning-template/)). These three planning files
+  are **temporary**. Implement against them, keep `tasks.md` current, follow
+  existing ADRs, fix the design when the code contradicts it, ship tests in the
+  same change.
+- **Verify** against every requirement and acceptance criterion
+  (`pnpm test` / `tsc --noEmit` / `pnpm lint`), then **collapse**: delete
+  `requirements.md` / `design.md` / `tasks.md` and rewrite the directory back to
+  one curated `docs/proposals/NNNN-name.md`, `status: implemented`. Curate the
+  durable intent and outcome — don't concatenate.
+
+The durable record is the collapsed proposal plus any **ADR**
+(`docs/decisions/`) for a lasting architectural decision; the code and tests are
+the truth of _how it works now_. The implementation may live in another repo
+(e.g. an extension in `silo-code/silo-extensions`) — the proposal stays here and
+names it.
 
 ## Domain language — keep the glossary in sync AS YOU BUILD
 

--- a/docs/change-planning-convention.md
+++ b/docs/change-planning-convention.md
@@ -1,0 +1,235 @@
+# Change-planning convention
+
+A lightweight way to plan and execute a **substantial** change — with a human,
+a coding agent, or both — without a framework, CLI, dependency, or metadata
+system. It is ordinary Markdown in `docs/proposals/`, and it is an extension of
+the existing [proposal / RFC lifecycle](./proposals/README.md), not a separate
+system. The decision to adopt it is
+[ADR 0045](./decisions/0045-ephemeral-change-planning.md).
+
+## Why it exists
+
+Substantial work benefits from writing down _what_ must be true, _how_ it will
+be built, and _which steps_ get there — before and during implementation. But
+those planning notes stop being useful once the code exists: the code and its
+tests become the truth of _what the system does_, and the durable _why_ belongs
+in a decision record. So planning here is **ephemeral**: it expands a proposal
+while the work is active and collapses back to a single curated document when
+the work is done.
+
+## The lifecycle
+
+```
+idea
+  │
+  ▼
+docs/proposals/NNNN-name.md          Stage 1 — Proposal (single file)
+  │   accepted, and real implementation work is about to start
+  ▼
+docs/proposals/NNNN-name/            Stage 2 — Planning package (temporary)
+  ├── proposal.md
+  ├── requirements.md
+  ├── design.md
+  └── tasks.md
+  │   implement ──► verify
+  ▼
+docs/proposals/NNNN-name.md          Stage 5 — Collapse
+    status: implemented                (curated, not concatenated)
+```
+
+Numbering is the same sequence as every other proposal — sequential,
+permanent, never reused (`NNNN-kebab-title`). A planning package keeps the
+proposal's number; only its _shape_ changes.
+
+## When to use it
+
+Use the workflow when a change has meaningful:
+
+- product behavior
+- architectural or cross-cutting impact
+- public API / SDK-surface change
+- persistence or data-model change
+- significant implementation complexity
+- ambiguity that needs explicit decisions
+
+Implement directly — no proposal, no planning package — for typo fixes,
+localized bug fixes, obvious CSS/UI adjustments, dependency bumps, small
+refactors, and other low-risk changes. This repo already gates the truly small
+surface additions at "just a `planned` roadmap entry" (see
+[`proposals/README.md`](./proposals/README.md)); that still holds. The goal is
+better engineering context, not documentation ceremony — an agent should decide
+based on the change, not create planning files because the convention exists.
+
+## Stage 1 — Proposal
+
+A new idea is a single file, `docs/proposals/NNNN-name.md`, using
+[`proposals/template.md`](./proposals/template.md). It is lightweight: problem,
+motivation, proposed change, rough scope, `status: draft`. It does **not** need
+requirements, design, or a task breakdown yet — its job is to capture and
+discuss the idea.
+
+## Stage 2 — Planning package
+
+Once the proposal is `accepted` and implementation work is about to begin,
+expand the single file into a directory of the same name with four files
+(skeletons in [`proposals/planning-template/`](./proposals/planning-template/)):
+
+### `proposal.md`
+
+The human-facing overview — problem, motivation, proposed solution, scope,
+alternatives where useful, status. What someone reads to understand the change
+without reading the diff. Carries the frontmatter.
+
+### `requirements.md`
+
+The behavioral specification: what the result must do, explicit and testable
+where practical, each with acceptance criteria.
+
+```md
+## R1 — Task creation
+
+The system must let a user create a task.
+
+### Acceptance criteria
+
+- [ ] A task can be created from the UI.
+- [ ] The task receives a unique identifier.
+- [ ] The task persists across an application restart.
+```
+
+### `design.md`
+
+The technical design for satisfying the requirements — only what's useful for
+implementation: architecture, components, data flow, APIs/interfaces,
+persistence, error handling, testing strategy, technical constraints, and the
+existing ADRs the design must respect. It describes intent; it does not
+duplicate the source.
+
+### `tasks.md`
+
+The implementation plan as Markdown checkboxes — concrete, independently
+understandable, ordered where dependencies matter, each small enough for an
+agent to execute and verify. Working state: keep it current as work proceeds.
+
+```md
+- [ ] Add the task model
+- [ ] Add persistence
+- [ ] Add the create/list API
+- [ ] Add tests
+```
+
+## Stage 3 — Implementation
+
+Implement against the approved requirements, design, and tasks. While doing so:
+
+1. Follow the existing ADRs (`docs/decisions/`).
+2. Don't expand scope without writing down why (in `proposal.md` or `tasks.md`).
+3. Check tasks off as they land.
+4. Add or update tests in the same change (see `AGENTS.md` → Testing).
+5. When implementation contradicts the design, fix the design — don't follow a
+   plan you've discovered is wrong.
+6. If implementation forces a significant, durable architectural decision,
+   write or update an ADR (`docs/decisions/`) in the same change.
+
+## Stage 4 — Verification
+
+Before calling the work complete:
+
+1. Check the implementation against **every** requirement and acceptance
+   criterion.
+2. Run the relevant tests (`pnpm test`, `pnpm --filter silo exec tsc --noEmit`,
+   `pnpm lint`).
+3. Note any requirement left intentionally unmet, and why.
+4. Confirm any durable decision is recorded as an ADR.
+
+"All tasks checked" is not the bar. "The result satisfies the agreed
+requirements" is.
+
+## Stage 5 — Collapse
+
+Delete the `requirements.md`, `design.md`, and `tasks.md` files. Rewrite the
+directory back into a single `docs/proposals/NNNN-name.md` with
+`status: implemented`. The numbered proposal file itself is never deleted — it
+stays as the permanent record, exactly like every other proposal.
+
+**Curate; don't concatenate.** The final proposal answers one question:
+
+> What did we build, why, and what should a future developer or agent know?
+
+It generally contains: title; `status: implemented`; problem; motivation; the
+final solution; the requirements that still matter; the design/architecture
+information worth keeping; important decisions; implementation references
+(repo / package / extension); related ADRs. It does **not** preserve every task
+or intermediate design thought — the code and tests are the truth of _how it
+works now_.
+
+```md
+---
+status: implemented
+created: 2026-08-30
+---
+
+# 0031. Tasks extension
+
+## Summary
+
+A `silo.tasks` extension for tracking implementation work alongside agent
+sessions. Implemented in `silo-code/silo-extensions` (`tasks/`).
+
+## Motivation
+
+...
+
+## Final design
+
+Tasks are owned by the extension and persisted via `ctx.storage` (workspace
+scope). The panel is a contributed Navigator view ...
+
+## Requirements that still matter
+
+- Tasks persist across restarts and across workspace switches.
+- A task's identifier is stable for its lifetime.
+
+## Related decisions
+
+- ADR 0004 — public `@silo-code/sdk` is types-first
+- ADR 0022 — on-disk storage layout
+```
+
+## The role of ADRs / decisions
+
+A proposal describes a change and then records its outcome. An **ADR**
+(`docs/decisions/`) records a durable architectural choice that stays relevant
+long after the change ships — "we chose `ctx.storage` over a bespoke file,
+because …". If the work produced such a choice, it belongs in an ADR, and the
+collapsed proposal links to it rather than restating it. See
+[`decisions/README.md`](./decisions/README.md) for the ADR-vs-proposal test.
+
+## Cross-repository work
+
+The proposal and its planning package live with the **product whose behavior
+and architecture change** — this repo — even when the implementation lands
+elsewhere. For a Silo extension built in `silo-code/silo-extensions`, the
+proposal stays here and names the implementation repo and package explicitly
+(e.g. "implemented in `silo-code/silo-extensions`, `tasks/`"). This keeps every
+repo in the ecosystem from growing its own disconnected planning history.
+
+## Relationship to the roadmap
+
+Unchanged: a new public primitive still starts as a `planned` entry on
+[`apps/docs/roadmap.md`](../apps/docs/roadmap.md) with its sketched surface, and
+flips to `stable` when it ships. The planning package is where the design work
+behind that flip happens; `design.md` and the roadmap sketch should agree.
+
+## Principles
+
+1. **Planning is ephemeral.** Requirements, design, and tasks are working
+   artifacts — they don't stay in the repo forever.
+2. **Decisions are durable.** Architectural reasoning goes in ADRs.
+3. **Implemented proposals are durable.** The collapsed proposal captures
+   intent, outcome, and context.
+4. **Code is the source of truth for implementation.** The proposal doesn't
+   duplicate it — read the proposal and ADRs for intent, then read the code and
+   tests for current behavior.
+5. **Framework-neutral.** Ordinary Markdown, directories, and the conventions
+   this repo already has. Nothing here names a tool or methodology.

--- a/docs/decisions/0045-ephemeral-change-planning.md
+++ b/docs/decisions/0045-ephemeral-change-planning.md
@@ -1,0 +1,84 @@
+---
+status: accepted
+date: 2026-08-30
+---
+
+# 0045. Substantial changes are planned in an ephemeral proposal expansion
+
+## Context
+
+Silo's contributors drive this repo with coding agents, and substantial work
+(a new extension, a `ctx` domain, a persistence change) benefits from writing
+down requirements, a design, and a task breakdown before and during
+implementation. The repo already has `docs/proposals/` (RFCs) for
+forward-looking design and `docs/decisions/` (ADRs) for settled architectural
+reasoning, but no convention for the working artifacts _between_ an accepted
+proposal and a shipped change — so agents either skip that planning or invent
+ad-hoc structures per task.
+
+The spec-driven-development frameworks that formalize this (Spec Kit, OpenSpec,
+Kiro, and similar) bring a CLI, dependencies, metadata files, and
+framework-specific directories. That trades away the property that this repo is
+readable as an ordinary codebase, and couples the planning history to one tool.
+
+At the same time, planning notes stop being useful once the code exists: the
+code and its tests are the truth of _what the system does_, and the durable
+_why_ belongs in an ADR. Keeping full requirements/design/task documents in the
+tree forever means every reader wades through stale intermediate thinking.
+
+## Decision
+
+A substantial change is planned by **temporarily expanding its proposal**. An
+`accepted` `docs/proposals/NNNN-name.md`, when implementation starts, becomes a
+directory `docs/proposals/NNNN-name/` holding `proposal.md`, `requirements.md`,
+`design.md`, and `tasks.md`. On completion the three planning files are deleted
+and the directory collapses back to a single curated `NNNN-name.md` with
+`status: implemented`. The numbered proposal file is never deleted; the
+`requirements.md` / `design.md` / `tasks.md` are ephemeral by design.
+
+The convention is ordinary Markdown and directories only — no CLI, dependency,
+metadata system, or framework-specific naming. It is documented in
+`docs/change-planning-convention.md`, with skeletons in
+`docs/proposals/planning-template/`, and summarized in `AGENTS.md`. Existing
+proposals are not migrated. Small, low-risk changes get no proposal at all.
+
+## Consequences
+
+- One planning workflow for humans and every coding agent, expressed in files
+  the repo already understands — a fresh clone reveals nothing about which
+  tool or methodology produced it.
+- The durable surface stays small: one curated proposal per change plus any
+  ADR, both linking to code rather than restating it.
+- Curating the collapsed proposal is manual work at the end of a change, and
+  the `requirements.md`/`design.md`/`tasks.md` are lost once deleted (they
+  remain in git history). This is intentional — the collapsed proposal and the
+  ADRs are meant to carry everything worth keeping.
+- The proposal can live in this repo while the implementation lands in another
+  (e.g. `silo-code/silo-extensions`); the proposal names the implementation
+  repo and package.
+- No enforcement. Whether a change is "substantial enough" is a judgment call,
+  and an over-eager planning package for a trivial change is its own kind of
+  noise.
+
+## Alternatives considered
+
+- **Adopt a spec-driven-development framework** (Spec Kit / OpenSpec / Kiro /
+  similar) — rejected: adds a CLI, dependencies, and framework-specific
+  directories, couples planning history to one tool, and makes the repo stop
+  reading as an ordinary codebase.
+- **Keep `requirements.md` / `design.md` / `tasks.md` in the tree permanently**
+  — rejected: they go stale the moment the code diverges, and every future
+  reader pays to skim intermediate thinking that the code, tests, and ADRs
+  already supersede.
+- **Do nothing beyond the existing RFC template** — rejected: leaves agents
+  without a shared structure for the planning phase of substantial work, which
+  is exactly where ambiguity and scope drift are most expensive.
+
+## References
+
+- `docs/change-planning-convention.md` — the full workflow and rationale.
+- `docs/proposals/planning-template/` — the four-file skeleton.
+- `docs/proposals/README.md`, `AGENTS.md` — updated to describe the expansion.
+- ADR [0039](./0039-self-contained-agent-docs.md),
+  [0040](./0040-skills-canonical-location-symlink.md) — prior process decisions
+  keeping contributor tooling tool-agnostic and framework-neutral.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -33,49 +33,50 @@ A small, obvious choice needs neither.
 
 ## Index
 
-| ADR                                                     | Title                                                        | Date       | Status   |
-| ------------------------------------------------------- | ------------------------------------------------------------ | ---------- | -------- |
-| [0001](./0001-in-process-extension-architecture.md)     | In-process, registry-based extension architecture            | 2026-05-23 | accepted |
-| [0002](./0002-imperative-registration-no-manifest.md)   | Imperative registration; no static manifest (v1)             | 2026-05-23 | accepted |
-| [0003](./0003-monorepo-pnpm.md)                         | Monorepo with pnpm workspaces                                | 2026-05-29 | accepted |
-| [0004](./0004-sdk-types-first.md)                       | Public `@silo-code/sdk` is types-first                       | 2026-05-29 | accepted |
-| [0005](./0005-ui-library-internal.md)                   | Component library (`@silo-code/ui`) stays internal           | 2026-05-29 | accepted |
-| [0006](./0006-open-platform-licensing.md)               | Open-platform MIT licensing                                  | 2026-05-30 | accepted |
-| [0007](./0007-core-primitive-vs-extension-test.md)      | Core-primitive vs extension-feature test                     | 2026-05-31 | accepted |
-| [0008](./0008-extension-decomposition-provider-view.md) | Extension decomposition; provider/view split                 | 2026-05-31 | accepted |
-| [0009](./0009-extension-communication-and-events.md)    | Extension communication: typed APIs + domain events          | 2026-05-31 | accepted |
-| [0010](./0010-persistent-process-sessions.md)           | Persistent process sessions as a core primitive              | 2026-05-31 | accepted |
-| [0011](./0011-editor-and-terminal-are-core.md)          | Editor and terminal are core surfaces                        | 2026-05-31 | accepted |
-| [0012](./0012-dev-automation-rpc.md)                    | Dev-only automation RPC                                      | 2026-06-01 | accepted |
-| [0013](./0013-trust-tiers-two-barrel-sdk.md)            | Extension trust tiers + two-barrel SDK                       | 2026-06-02 | accepted |
-| [0014](./0014-per-extension-enablement.md)              | Per-extension enablement config (Obsidian-style)             | 2026-06-02 | accepted |
-| [0015](./0015-phased-security-model.md)                 | Phased security model for privileged primitives              | 2026-06-02 | accepted |
-| [0016](./0016-ctx-dnd-primitive.md)                     | First-class drag-and-drop primitive (`ctx.dnd`)              | 2026-06-02 | accepted |
-| [0017](./0017-css-theming-contract.md)                  | CSS theming contract (`--silo-*` token tiers)                | 2026-06-02 | accepted |
-| [0018](./0018-host-owned-chrome.md)                     | Host-owned UI chrome: modals + unified menu                  | 2026-06-03 | accepted |
-| [0019](./0019-runtime-extension-loading.md)             | Runtime extension loading + manifest validation              | 2026-06-04 | accepted |
-| [0020](./0020-silo-extensions-bundled.md)               | Ship `silo.*` bundled, surfaced as disable-able              | 2026-06-04 | accepted |
-| [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model            | 2026-06-08 | accepted |
-| [0022](./0022-on-disk-storage-layout.md)                | On-disk storage layout: config / app-state / runtime         | 2026-06-10 | accepted |
-| [0023](./0023-workspace-groups-host-internal.md)        | Workspace panel groups are host-internal                     | 2026-06-30 | accepted |
-| [0024](./0024-release-channels.md)                      | Two release channels: stable and nightly                     | 2026-07-01 | accepted |
-| [0025](./0025-pending-remove-worktree.md)               | Pending remove worktree: close folder on start               | 2026-07-17 | accepted |
-| [0026](./0026-sdk-component-set.md)                     | A curated presentational component set joins the SDK         | 2026-07-18 | accepted |
-| [0027](./0027-terminal-link-policy.md)                  | Unified terminal link policy: modifier-click to open         | 2026-07-21 | accepted |
-| [0028](./0028-sealed-agent-detection.md)                | Sealed agent detection and honest resume                     | 2026-07-29 | accepted |
-| [0029](./0029-adornments-vs-registration.md)            | Adornments vs registration                                   | 2026-07-31 | accepted |
-| [0030](./0030-activity-chrome.md)                       | Activity as first-class chrome                               | 2026-07-31 | accepted |
-| [0031](./0031-update-check-analytics.md)                | Update-check analytics via a Cloudflare Worker proxy         | 2026-08-01 | accepted |
-| [0032](./0032-dock-active-panel-authority.md)           | One authority decides a dock's active panel                  | 2026-08-04 | accepted |
-| [0033](./0033-laptop-mode-independent-layout.md)        | Laptop Mode is a second independent layout                   | 2026-08-06 | accepted |
-| [0034](./0034-focus-and-activation-authority.md)        | Focus/activation: the live dock, and only the active panel   | 2026-08-07 | proposed |
-| [0035](./0035-global-side-panel-layout.md)              | Global Side Panel Layout is an opt-in shared arrangement     | 2026-08-08 | accepted |
-| [0036](./0036-unified-update-ui-and-changelog.md)       | Unified update UI, in-app changelog, and skip-version        | 2026-08-10 | accepted |
-| [0037](./0037-git-repo-watch-session.md)                | A published, live git-state session (`GitAPI.watchRepo`)     | 2026-08-12 | accepted |
-| [0038](./0038-navigator-view-list.md)                   | The Navigator lists its views instead of hiding them         | 2026-08-13 | accepted |
-| [0039](./0039-self-contained-agent-docs.md)             | Self-contained agent docs, no external skill dependency      | 2026-08-15 | accepted |
-| [0040](./0040-skills-canonical-location-symlink.md)     | Skills live in `.agents/skills/`, `.claude/skills/` symlinks | 2026-08-16 | accepted |
-| [0041](./0041-pi-hook-as-installed-extension.md)        | Pi's session hook ships as an installed TypeScript extension | 2026-08-22 | accepted |
-| [0042](./0042-agent-catalog-modularization.md)          | Agent catalog modularization and declarative runtime policy  | 2026-08-22 | accepted |
-| [0043](./0043-opencode-tiered-support.md)               | OpenCode: zero-install activity now, resume deferred         | 2026-08-26 | accepted |
-| [0044](./0044-navigator-stacked-arrangement.md)         | The Navigator can stack its views instead of one at a time   | 2026-08-27 | accepted |
+| ADR                                                     | Title                                                              | Date       | Status   |
+| ------------------------------------------------------- | ------------------------------------------------------------------ | ---------- | -------- |
+| [0001](./0001-in-process-extension-architecture.md)     | In-process, registry-based extension architecture                  | 2026-05-23 | accepted |
+| [0002](./0002-imperative-registration-no-manifest.md)   | Imperative registration; no static manifest (v1)                   | 2026-05-23 | accepted |
+| [0003](./0003-monorepo-pnpm.md)                         | Monorepo with pnpm workspaces                                      | 2026-05-29 | accepted |
+| [0004](./0004-sdk-types-first.md)                       | Public `@silo-code/sdk` is types-first                             | 2026-05-29 | accepted |
+| [0005](./0005-ui-library-internal.md)                   | Component library (`@silo-code/ui`) stays internal                 | 2026-05-29 | accepted |
+| [0006](./0006-open-platform-licensing.md)               | Open-platform MIT licensing                                        | 2026-05-30 | accepted |
+| [0007](./0007-core-primitive-vs-extension-test.md)      | Core-primitive vs extension-feature test                           | 2026-05-31 | accepted |
+| [0008](./0008-extension-decomposition-provider-view.md) | Extension decomposition; provider/view split                       | 2026-05-31 | accepted |
+| [0009](./0009-extension-communication-and-events.md)    | Extension communication: typed APIs + domain events                | 2026-05-31 | accepted |
+| [0010](./0010-persistent-process-sessions.md)           | Persistent process sessions as a core primitive                    | 2026-05-31 | accepted |
+| [0011](./0011-editor-and-terminal-are-core.md)          | Editor and terminal are core surfaces                              | 2026-05-31 | accepted |
+| [0012](./0012-dev-automation-rpc.md)                    | Dev-only automation RPC                                            | 2026-06-01 | accepted |
+| [0013](./0013-trust-tiers-two-barrel-sdk.md)            | Extension trust tiers + two-barrel SDK                             | 2026-06-02 | accepted |
+| [0014](./0014-per-extension-enablement.md)              | Per-extension enablement config (Obsidian-style)                   | 2026-06-02 | accepted |
+| [0015](./0015-phased-security-model.md)                 | Phased security model for privileged primitives                    | 2026-06-02 | accepted |
+| [0016](./0016-ctx-dnd-primitive.md)                     | First-class drag-and-drop primitive (`ctx.dnd`)                    | 2026-06-02 | accepted |
+| [0017](./0017-css-theming-contract.md)                  | CSS theming contract (`--silo-*` token tiers)                      | 2026-06-02 | accepted |
+| [0018](./0018-host-owned-chrome.md)                     | Host-owned UI chrome: modals + unified menu                        | 2026-06-03 | accepted |
+| [0019](./0019-runtime-extension-loading.md)             | Runtime extension loading + manifest validation                    | 2026-06-04 | accepted |
+| [0020](./0020-silo-extensions-bundled.md)               | Ship `silo.*` bundled, surfaced as disable-able                    | 2026-06-04 | accepted |
+| [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model                  | 2026-06-08 | accepted |
+| [0022](./0022-on-disk-storage-layout.md)                | On-disk storage layout: config / app-state / runtime               | 2026-06-10 | accepted |
+| [0023](./0023-workspace-groups-host-internal.md)        | Workspace panel groups are host-internal                           | 2026-06-30 | accepted |
+| [0024](./0024-release-channels.md)                      | Two release channels: stable and nightly                           | 2026-07-01 | accepted |
+| [0025](./0025-pending-remove-worktree.md)               | Pending remove worktree: close folder on start                     | 2026-07-17 | accepted |
+| [0026](./0026-sdk-component-set.md)                     | A curated presentational component set joins the SDK               | 2026-07-18 | accepted |
+| [0027](./0027-terminal-link-policy.md)                  | Unified terminal link policy: modifier-click to open               | 2026-07-21 | accepted |
+| [0028](./0028-sealed-agent-detection.md)                | Sealed agent detection and honest resume                           | 2026-07-29 | accepted |
+| [0029](./0029-adornments-vs-registration.md)            | Adornments vs registration                                         | 2026-07-31 | accepted |
+| [0030](./0030-activity-chrome.md)                       | Activity as first-class chrome                                     | 2026-07-31 | accepted |
+| [0031](./0031-update-check-analytics.md)                | Update-check analytics via a Cloudflare Worker proxy               | 2026-08-01 | accepted |
+| [0032](./0032-dock-active-panel-authority.md)           | One authority decides a dock's active panel                        | 2026-08-04 | accepted |
+| [0033](./0033-laptop-mode-independent-layout.md)        | Laptop Mode is a second independent layout                         | 2026-08-06 | accepted |
+| [0034](./0034-focus-and-activation-authority.md)        | Focus/activation: the live dock, and only the active panel         | 2026-08-07 | proposed |
+| [0035](./0035-global-side-panel-layout.md)              | Global Side Panel Layout is an opt-in shared arrangement           | 2026-08-08 | accepted |
+| [0036](./0036-unified-update-ui-and-changelog.md)       | Unified update UI, in-app changelog, and skip-version              | 2026-08-10 | accepted |
+| [0037](./0037-git-repo-watch-session.md)                | A published, live git-state session (`GitAPI.watchRepo`)           | 2026-08-12 | accepted |
+| [0038](./0038-navigator-view-list.md)                   | The Navigator lists its views instead of hiding them               | 2026-08-13 | accepted |
+| [0039](./0039-self-contained-agent-docs.md)             | Self-contained agent docs, no external skill dependency            | 2026-08-15 | accepted |
+| [0040](./0040-skills-canonical-location-symlink.md)     | Skills live in `.agents/skills/`, `.claude/skills/` symlinks       | 2026-08-16 | accepted |
+| [0041](./0041-pi-hook-as-installed-extension.md)        | Pi's session hook ships as an installed TypeScript extension       | 2026-08-22 | accepted |
+| [0042](./0042-agent-catalog-modularization.md)          | Agent catalog modularization and declarative runtime policy        | 2026-08-22 | accepted |
+| [0043](./0043-opencode-tiered-support.md)               | OpenCode: zero-install activity now, resume deferred               | 2026-08-26 | accepted |
+| [0044](./0044-navigator-stacked-arrangement.md)         | The Navigator can stack its views instead of one at a time         | 2026-08-27 | accepted |
+| [0045](./0045-ephemeral-change-planning.md)             | Substantial changes are planned in an ephemeral proposal expansion | 2026-08-30 | accepted |

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -30,9 +30,32 @@ roadmap badge flips `planned → stable`, optionally an ADR records the crystall
 decision, and the CHANGELOG/semver reflect it. **Rejected/superseded proposals are
 never deleted** — "we considered X and rejected it" stops the debate recurring.
 
+## Planning packages (for substantial implementation work)
+
+When a proposal is `accepted` and real implementation work is about to start, it
+may temporarily expand from a single file into a directory of the same name:
+
+```
+docs/proposals/NNNN-name/
+├── proposal.md       ← the overview + frontmatter
+├── requirements.md   ← behavioural spec + acceptance criteria
+├── design.md         ← technical design
+└── tasks.md          ← the implementation checklist
+```
+
+`requirements.md` / `design.md` / `tasks.md` are **ephemeral working
+artifacts**. When the work is implemented and verified they are deleted and the
+directory collapses back to a single curated `NNNN-name.md` with
+`status: implemented` — the numbered proposal file itself is never deleted.
+Skeletons: [`planning-template/`](./planning-template/). Full workflow (when to
+expand, how to collapse, cross-repo work): the
+[change-planning convention](../change-planning-convention.md). Small changes
+don't get a proposal at all — see below.
+
 ## Conventions
 
-- **Numbering** is sequential (`NNNN-kebab-title.md`), permanent, never reused.
+- **Numbering** is sequential (`NNNN-kebab-title.md`), permanent, never reused —
+  a planning package keeps its proposal's number.
 - **Self-contained.** Like ADRs, a proposal carries its own design; it links to
   other proposals/ADRs (stable) but only sparingly to the narrative docs, which
   will be overhauled. Once `implemented`, the proposal _is_ the record.

--- a/docs/proposals/planning-template/design.md
+++ b/docs/proposals/planning-template/design.md
@@ -1,0 +1,39 @@
+# Design — NNNN. <short title>
+
+How the requirements will be satisfied. Include only what's useful for
+implementation; don't restate the source. Working artifact — removed when the
+proposal collapses (durable pieces move into the collapsed proposal or an ADR).
+
+## Architecture
+
+<Where this lives — package(s), extension(s) — and how the pieces fit.>
+
+## Components
+
+<The new or changed units and their responsibilities.>
+
+## Data flow
+
+<How data moves through the change; sequence of the important path.>
+
+## APIs / interfaces
+
+<New or changed public surface. If it touches `@silo-code/sdk`, note the
+`docs-sync` workflow applies.>
+
+## Persistence
+
+<What is stored, where, in what shape, and how it migrates.>
+
+## Error handling
+
+<Failure modes and how each is handled or surfaced.>
+
+## Testing strategy
+
+<What gets unit-tested and how; any fixtures or helpers needed.>
+
+## Constraints and existing decisions
+
+<Technical constraints, and the ADRs (`docs/decisions/`) this design must
+respect. List them.>

--- a/docs/proposals/planning-template/proposal.md
+++ b/docs/proposals/planning-template/proposal.md
@@ -1,0 +1,32 @@
+---
+status: accepted # draft | accepted | implemented | rejected | superseded-by NNNN
+created: YYYY-MM-DD
+# supersedes: NNNN        (optional)
+# superseded-by: NNNN     (optional)
+---
+
+# NNNN. <short title of the change>
+
+## Summary
+
+One paragraph: what this changes, in plain terms a reviewer can grasp without
+the diff.
+
+## Motivation
+
+The problem and why it's worth a designed change now — what's painful or
+missing today, what becomes possible.
+
+## Proposed solution
+
+The shape of the change at a high level. Detail lives in `design.md`.
+
+## Scope
+
+What's in, what's explicitly out. If the implementation lands in another repo,
+name it here (repo + package/extension).
+
+## Alternatives considered
+
+Options weighed and why they lose or are deferred (deferred ≠ rejected — say
+which). Optional at this stage; fill in as they come up.

--- a/docs/proposals/planning-template/requirements.md
+++ b/docs/proposals/planning-template/requirements.md
@@ -1,0 +1,22 @@
+# Requirements — NNNN. <short title>
+
+The behavioral specification: what must be true when this is done. Keep
+requirements explicit and testable where practical, each with acceptance
+criteria. Working artifact — removed when the proposal collapses.
+
+## R1 — <requirement name>
+
+<One or two sentences stating what the system must do.>
+
+### Acceptance criteria
+
+- [ ] <observable, checkable outcome>
+- [ ] <observable, checkable outcome>
+
+## R2 — <requirement name>
+
+...
+
+## Out of scope
+
+- <thing a reader might expect that this deliberately does not do>

--- a/docs/proposals/planning-template/tasks.md
+++ b/docs/proposals/planning-template/tasks.md
@@ -1,0 +1,26 @@
+# Tasks — NNNN. <short title>
+
+The implementation plan. Each task is concrete, independently understandable,
+and small enough to execute and verify. Ordered where dependencies matter.
+Keep the checkboxes current as work proceeds. Working artifact — removed when
+the proposal collapses.
+
+## <group, e.g. Data model>
+
+- [ ] <task>
+- [ ] <task>
+
+## <group, e.g. API>
+
+- [ ] <task>
+
+## Tests
+
+- [ ] <task>
+
+## Verification
+
+- [ ] Every requirement in `requirements.md` is met or explicitly noted as not.
+- [ ] `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm lint` pass.
+- [ ] Durable decisions recorded as ADRs.
+- [ ] Proposal collapsed to a single curated `NNNN-name.md`.


### PR DESCRIPTION
## Summary

Silo already has RFCs (`docs/proposals/`) for forward-looking design and ADRs (`docs/decisions/`) for settled decisions, but no shared convention for the working notes between an accepted proposal and a shipped change. Agents either skip that planning or invent an ad-hoc structure each time.

This adds a lightweight convention for planning substantial changes: an accepted proposal temporarily expands into a small package of planning files (requirements, design, tasks), the work is implemented and verified against them, and then the package collapses back to a single curated proposal document. The planning files are deliberately throwaway; the durable record is the collapsed proposal plus any ADR.

It is an evolution of the existing proposal lifecycle, not a new system — ordinary Markdown and directories, no CLI, dependency, or framework. Existing proposals are not migrated, and small low-risk changes still get no proposal at all.

Docs-only change; nothing here affects the app or SDK.

## Details

### New

- **`docs/change-planning-convention.md`** — the developer-facing explanation: why the convention exists, the proposal → planning package → implementation → verification → collapse lifecycle, when to use it vs. implement directly, the four planning artifacts, how the package collapses (curate, don't concatenate), the role of ADRs, cross-repository work (proposal lives with the product whose behaviour changes; implementation may land in `silo-code/silo-extensions`), and how it relates to the roadmap `planned → stable` flow. Aligned to the repo's existing status vocabulary and numbering.
- **`docs/proposals/planning-template/`** — minimal, generic skeletons for `proposal.md`, `requirements.md`, `design.md`, `tasks.md`. Sits alongside the existing single-file `template.md`. No framework terminology.
- **`docs/decisions/0045-ephemeral-change-planning.md`** — ADR recording the adoption decision, matching the precedent of process ADRs 0039/0040. Documents the rejection of SDD frameworks (Spec Kit / OpenSpec / Kiro / similar) and of keeping planning files in the tree permanently.

### Changed

- **`docs/proposals/README.md`** — new "Planning packages" section describing the expand/collapse and linking the template + convention doc; numbering note updated to cover packages.
- **`docs/decisions/README.md`** — index row for ADR 0045 (Prettier realigned the table).
- **`AGENTS.md`** — concise "Planning a substantial change" section (detail stays in the convention doc) plus an orientation-docs entry.

### Preserved

Existing RFC/ADR numbering, `status` fields, the self-contained principle, the "nothing is deleted" rule (the numbered proposal file is never removed — only its ephemeral siblings), and the "small surface additions just get a roadmap entry" gate are all explicitly reconciled rather than replaced.

### Verification

- `pnpm lint`, Prettier, and `pnpm test` all run and pass via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)