### PR TITLE
docs: account for multi-phase changes in the planning convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,11 @@ implement those directly. Full workflow:
 - **Verify** against every requirement and acceptance criterion
   (`pnpm test` / `tsc --noEmit` / `pnpm lint`), then **collapse**: delete
   `requirements.md` / `design.md` / `tasks.md` and rewrite the directory back to
-  one curated `docs/proposals/NNNN-name.md`, `status: implemented`. Curate the
-  durable intent and outcome — don't concatenate.
+  one curated `docs/proposals/NNNN-name.md`. Curate the durable intent and
+  outcome — don't concatenate. `status: implemented` once every phase the
+  proposal commits to has shipped; for a change planned in multiple phases,
+  collapse keeps `status: accepted` and re-expands for the next phase — see
+  "Multi-phase changes" in the convention doc.
 
 The durable record is the collapsed proposal plus any **ADR**
 (`docs/decisions/`) for a lasting architectural decision; the code and tests are

--- a/docs/change-planning-convention.md
+++ b/docs/change-planning-convention.md
@@ -37,6 +37,10 @@ docs/proposals/NNNN-name.md          Stage 5 — Collapse
     status: implemented                (curated, not concatenated)
 ```
 
+This is the single-pass shape. A change that ships as multiple sequenced
+phases loops Stages 2–5 once per phase instead of once total — see
+[Multi-phase changes](#multi-phase-changes) below.
+
 Numbering is the same sequence as every other proposal — sequential,
 permanent, never reused (`NNNN-kebab-title`). A planning package keeps the
 proposal's number; only its _shape_ changes.
@@ -175,12 +179,12 @@ status: implemented
 created: 2026-08-30
 ---
 
-# 0031. Tasks extension
+# 0099. Notes extension
 
 ## Summary
 
-A `silo.tasks` extension for tracking implementation work alongside agent
-sessions. Implemented in `silo-code/silo-extensions` (`tasks/`).
+A `silo.notes` extension for jotting scratch notes alongside agent sessions.
+Implemented in `silo-code/silo-extensions` (`notes/`).
 
 ## Motivation
 
@@ -188,19 +192,71 @@ sessions. Implemented in `silo-code/silo-extensions` (`tasks/`).
 
 ## Final design
 
-Tasks are owned by the extension and persisted via `ctx.storage` (workspace
+Notes are owned by the extension and persisted via `ctx.storage` (workspace
 scope). The panel is a contributed Navigator view ...
 
 ## Requirements that still matter
 
-- Tasks persist across restarts and across workspace switches.
-- A task's identifier is stable for its lifetime.
+- Notes persist across restarts and across workspace switches.
+- A note's identifier is stable for its lifetime.
 
 ## Related decisions
 
 - ADR 0004 — public `@silo-code/sdk` is types-first
 - ADR 0022 — on-disk storage layout
 ```
+
+## Multi-phase changes
+
+Some proposals define more than one phase up front — a build sequenced into
+shippable slices, each usable before the next begins, typically written as a
+phase table under **Proposed solution**. The five stages above still apply,
+but Stages 2–5 repeat **once per phase** instead of once for the whole
+proposal:
+
+```
+docs/proposals/NNNN-name.md          status: accepted, phase table in Proposed solution
+  │   phase 1 accepted for implementation
+  ▼
+docs/proposals/NNNN-name/            Stage 2 (phase 1) — scoped to phase 1 only
+  │   implement ──► verify (phase 1)
+  ▼
+docs/proposals/NNNN-name.md          Stage 5 (phase 1) — collapse
+    status: accepted                    (stays accepted; phases remain)
+  │   phase 2 accepted for implementation
+  ▼
+docs/proposals/NNNN-name/            Stage 2 (phase 2) — scoped to phase 2 only
+  │   ...repeat per phase...
+  ▼
+docs/proposals/NNNN-name.md          Stage 5 (final phase) — collapse
+    status: implemented                 (every planned phase has shipped)
+```
+
+Rules:
+
+- **Say the scope out loud.** The expanded `proposal.md` names which phase the
+  package covers — a short note is enough — so a reader mid-package isn't left
+  guessing whether `requirements.md` describes the whole proposal or one slice
+  of it.
+- **`status` tracks the whole proposal, not the phase just shipped.** A
+  proposal collapsed after phase 1 stays `accepted`; it only becomes
+  `implemented` once every phase the proposal commits to has shipped and
+  collapsed.
+- **The phase table survives every collapse.** Curate it like everything else
+  in Stage 5: mark what shipped, keep what's still planned, so the next
+  phase's package starts from an accurate picture instead of re-deriving one
+  from the diff or git history.
+- **A dropped or reshaped phase says so, in the collapsed proposal.** Update
+  the phase table and explain why rather than leaving a stale commitment a
+  future reader would otherwise trust.
+- **Re-expansion is Stage 2 again.** A fresh `requirements.md` / `design.md` /
+  `tasks.md`, scoped to the next phase and informed by whatever the prior
+  collapse curated — not a continuation of the files deleted last time.
+
+This needs no new proposal number and no new ADR — it is the same proposal,
+still governed by [ADR 0045](./decisions/0045-ephemeral-change-planning.md);
+only the planning package's scope and how many times Stage 5 runs differ from
+a single-pass change.
 
 ## The role of ADRs / decisions
 
@@ -239,3 +295,6 @@ behind that flip happens; `design.md` and the roadmap sketch should agree.
    tests for current behavior.
 5. **Framework-neutral.** Ordinary Markdown, directories, and the conventions
    this repo already has. Nothing here names a tool or methodology.
+6. **A phased change collapses per phase, not per proposal.** `status` reflects
+   the whole proposal — it stays `accepted` until every planned phase has
+   shipped, not the moment any one phase does.

--- a/docs/proposals/planning-template/design.md
+++ b/docs/proposals/planning-template/design.md
@@ -4,6 +4,9 @@ How the requirements will be satisfied. Include only what's useful for
 implementation; don't restate the source. Working artifact — removed when the
 proposal collapses (durable pieces move into the collapsed proposal or an ADR).
 
+For one phase of a multi-phase proposal, design only that phase — later
+phases' designs get their own `design.md` when their turn comes.
+
 ## Architecture
 
 <Where this lives — package(s), extension(s) — and how the pieces fit.>

--- a/docs/proposals/planning-template/proposal.md
+++ b/docs/proposals/planning-template/proposal.md
@@ -19,7 +19,10 @@ missing today, what becomes possible.
 
 ## Proposed solution
 
-The shape of the change at a high level. Detail lives in `design.md`.
+The shape of the change at a high level. Detail lives in `design.md`. If the
+change ships as multiple sequenced phases, name them here as a table (phase,
+rough scope) — see "Multi-phase changes" in `change-planning-convention.md`
+for how planning and collapse work per phase.
 
 ## Scope
 

--- a/docs/proposals/planning-template/requirements.md
+++ b/docs/proposals/planning-template/requirements.md
@@ -4,6 +4,10 @@ The behavioral specification: what must be true when this is done. Keep
 requirements explicit and testable where practical, each with acceptance
 criteria. Working artifact — removed when the proposal collapses.
 
+For one phase of a multi-phase proposal, scope this file to that phase only —
+say which phase in `proposal.md`, and list later phases' requirements under
+"Out of scope" below.
+
 ## R1 — <requirement name>
 
 <One or two sentences stating what the system must do.>

--- a/docs/proposals/planning-template/tasks.md
+++ b/docs/proposals/planning-template/tasks.md
@@ -23,7 +23,7 @@ the proposal collapses.
 - [ ] Every requirement in `requirements.md` is met or explicitly noted as not.
 - [ ] `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm lint` pass.
 - [ ] Durable decisions recorded as ADRs.
-- [ ] Proposal collapsed to a single curated `NNNN-name.md` — `status:
-  implemented` if this was the last planned phase, `status: accepted` with
-      the phase table updated if phases remain (see "Multi-phase changes" in
+- [ ] Proposal collapsed to a single curated `NNNN-name.md`. Status
+      `implemented` if this was the last planned phase; `accepted` with the
+      phase table updated if phases remain (see "Multi-phase changes" in
       `change-planning-convention.md`).

--- a/docs/proposals/planning-template/tasks.md
+++ b/docs/proposals/planning-template/tasks.md
@@ -23,4 +23,7 @@ the proposal collapses.
 - [ ] Every requirement in `requirements.md` is met or explicitly noted as not.
 - [ ] `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm lint` pass.
 - [ ] Durable decisions recorded as ADRs.
-- [ ] Proposal collapsed to a single curated `NNNN-name.md`.
+- [ ] Proposal collapsed to a single curated `NNNN-name.md` — `status:
+  implemented` if this was the last planned phase, `status: accepted` with
+      the phase table updated if phases remain (see "Multi-phase changes" in
+      `change-planning-convention.md`).


### PR DESCRIPTION
## Summary

Teaches the change-planning process what to do with a proposal that's too big to build in one pass.

RFC 0031's planning package (merged in #454) is the first proposal scoped to just one phase of a larger, multi-phase design — with the rest of the phases still to come. The convention only described a single planning cycle that always ends with the change marked "done," so this fills that gap: how to plan, build, and verify one phase at a time, and how the change stays marked "in progress" until every phase it commits to has actually shipped.

Documentation only — no product behavior changes.

## Details

### `docs/change-planning-convention.md`

- New **"Multi-phase changes"** section (after Stage 5 — Collapse): Stages 2–5 (plan → implement → verify → collapse) loop once per phase instead of running once for the whole proposal. Covers: naming the phase's scope explicitly in the planning package; `status` reflecting the whole proposal (staying `accepted` between phases, not flipping to `implemented` until the last planned phase ships); the phase table surviving every collapse so the next phase starts from an accurate picture; a dropped or reshaped phase getting written down rather than left as a stale commitment; and re-expansion being Stage 2 again.
- A footnote off the lifecycle diagram points readers at the new section, and a 6th principle summarizes the rule.
- **Fixed a pre-existing naming collision**: the doc's own illustrative "collapsed proposal" example used `# 0031. Tasks extension` — a placeholder chosen before the real RFC 0031 existed, which now happens to share both number and title with the actual, still-in-progress multi-phase RFC. Renamed the example to `0099. Notes extension` so it no longer reads as documenting the real one.

### `docs/proposals/planning-template/*.md`

One-line pointers added to each template: name phases as a table in `proposal.md`; scope `requirements.md` / `design.md` to the phase being planned; `tasks.md`'s collapse checkbox now branches on whether phases remain.

### `AGENTS.md`

Its terse "Planning a substantial change" summary previously stated flatly that collapse always produces `status: implemented`. Corrected: that's true once every phase has shipped; otherwise collapse keeps `status: accepted` and the package re-expands for the next phase.

### Not changed

**ADR 0045** (the decision to adopt ephemeral change planning) is untouched. This is a refinement of that decision, not a reversal, and 0045 already delegates all mechanical detail to `change-planning-convention.md` — ADRs in this repo are never rewritten, only superseded, so a refinement belongs in the doc it already points to.

### Verification

Docs only. `pnpm lint`, `pnpm test` (including the doc-index sync check), and prettier all pass via the pre-commit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHZLX37n6XQJnZAfgygZ6i
