### PR TITLE
feat(agents): repair drifted session hooks on app startup, not just Settings

### DIFF
--- a/packages/extensions-core/src/agents-settings/AgentsHooksPanel.tsx
+++ b/packages/extensions-core/src/agents-settings/AgentsHooksPanel.tsx
@@ -24,13 +24,16 @@ import {
 import {
   hookInstallableAgents,
   sessionFileAgents,
-  buildTrackSessionScript,
-  TRACK_SCRIPT_REL,
-  type AgentDefinition,
-  type AgentHookResume,
   type AgentExtraSettingsToggle,
 } from "@silo-code/extension-host/internal";
 import { installerFor } from "./install-strategy";
+import {
+  resolveHomeDir,
+  settingsPathFor,
+  ensureTrackScript,
+  healInstalledAgents,
+  type HookAgent,
+} from "./hook-self-heal";
 import {
   parseSettingsJsonText,
   writableSettingsOrThrow,
@@ -38,53 +41,11 @@ import {
 } from "./settings-json";
 import "./AgentsSettingsPage.css";
 
-type HookAgent = AgentDefinition & { resume: AgentHookResume };
-
 interface AgentRow {
   agent: HookAgent;
   installed: boolean;
   loaded: boolean;
   error?: string;
-}
-
-async function resolveHomeDir(ctx: ExtensionContext): Promise<string | null> {
-  try {
-    const { code, stdout } = await ctx.process.exec("sh", [
-      "-c",
-      "printf '%s' \"$HOME\"",
-    ]);
-    return code === 0 ? stdout.trim() || null : null;
-  } catch {
-    return null;
-  }
-}
-
-function settingsPathFor(agent: HookAgent, home: string): string {
-  return `${home}/${agent.resume.configPath}`;
-}
-
-async function ensureTrackScript(
-  ctx: ExtensionContext,
-  home: string,
-): Promise<boolean> {
-  const path = `${home}/${TRACK_SCRIPT_REL}`;
-  const body = buildTrackSessionScript();
-  const existing = (await ctx.files.pathExists(path))
-    ? await ctx.files.readText(path).catch(() => null)
-    : null;
-  if (existing === body) return false;
-  const dir = path.slice(0, path.lastIndexOf("/"));
-  if (dir) await ctx.files.createDir(dir);
-  await ctx.files.writeText(path, body);
-  return true;
-}
-
-async function refreshConfigIfDrifted(
-  ctx: ExtensionContext,
-  agent: HookAgent,
-  path: string,
-): Promise<boolean> {
-  return installerFor(agent.resume).refreshIfDrifted(ctx, agent.resume, path);
 }
 
 async function writeInstalled(
@@ -223,27 +184,13 @@ export function AgentsHooksPanel({ ctx }: { ctx: ExtensionContext }) {
     }
 
     try {
-      const installedAgents = next.filter((r) => r.installed);
-      if (installedAgents.length > 0) {
-        const scriptWrote = await ensureTrackScript(ctx, h);
-        const healed: string[] = [];
-        for (const r of installedAgents) {
-          const wrote = await refreshConfigIfDrifted(
-            ctx,
-            r.agent,
-            settingsPathFor(r.agent, h),
-          );
-          if (wrote) healed.push(r.agent.displayName);
-        }
-        if (scriptWrote || healed.length > 0) {
-          ctx.log.info(
-            "Refreshed Silo session hook to the shell-script runtime" +
-              (healed.length > 0 ? ` (config: ${healed.join(", ")})` : "") +
-              (scriptWrote ? " (wrote track-session.sh)" : "") +
-              ".",
-          );
-        }
-      }
+      // Also self-healed at app startup (core.agents-settings' activate,
+      // see hook-self-heal.ts) — this call is a harmless, idempotent repeat
+      // for whenever the page happens to be open too.
+      const installedAgents = next
+        .filter((r) => r.installed)
+        .map((r) => r.agent);
+      await healInstalledAgents(ctx, h, installedAgents);
     } catch (err) {
       ctx.log.warn(
         "Agent hook self-heal skipped: " +

--- a/packages/extensions-core/src/agents-settings/hook-self-heal.test.ts
+++ b/packages/extensions-core/src/agents-settings/hook-self-heal.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ExtensionContext } from "@silo-code/sdk";
+import {
+  hookInstallableAgents,
+  buildTrackSessionScript,
+  TRACK_SCRIPT_REL,
+} from "@silo-code/extension-host/internal";
+import { installerFor } from "./install-strategy";
+import {
+  resolveHomeDir,
+  ensureTrackScript,
+  selfHealInstalledHooks,
+  type HookAgent,
+} from "./hook-self-heal";
+
+const HOME = "/home/test";
+const catalog = hookInstallableAgents();
+const claude = catalog.find((a) => a.id === "claude") as HookAgent;
+const cursor = catalog.find((a) => a.id === "cursor") as HookAgent;
+const claudeConfigPath = `${HOME}/${claude.resume.configPath}`;
+
+/** In-memory `FileService` — every install strategy in this package only
+ * ever calls pathExists/readText/writeText/createDir. */
+function makeFileService(initial: Record<string, string> = {}) {
+  const files = new Map(Object.entries(initial));
+  return {
+    files,
+    async pathExists(path: string) {
+      return files.has(path);
+    },
+    async readText(path: string) {
+      const v = files.get(path);
+      if (v === undefined) throw new Error(`ENOENT: ${path}`);
+      return v;
+    },
+    async writeText(path: string, content: string) {
+      files.set(path, content);
+    },
+    async createDir() {
+      // no-op — the in-memory map has no real directory concept
+    },
+  };
+}
+
+function makeCtx(
+  opts: {
+    os?: "macos" | "windows" | "linux";
+    home?: string | null;
+    files?: Record<string, string>;
+  } = {},
+) {
+  const fileService = makeFileService(opts.files);
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    show: vi.fn(),
+    clear: vi.fn(),
+  };
+  const homeDir =
+    opts.home === null
+      ? vi.fn().mockRejectedValue(new Error("no $HOME"))
+      : vi.fn().mockResolvedValue(opts.home ?? HOME);
+  const ctx = {
+    files: fileService,
+    system: {
+      getInfo: vi.fn().mockResolvedValue({ os: opts.os ?? "macos" }),
+      homeDir,
+    },
+    log,
+  };
+  return { ctx: ctx as unknown as ExtensionContext, fileService, log };
+}
+
+describe("resolveHomeDir", () => {
+  it("resolves ctx.system.homeDir()", async () => {
+    const { ctx } = makeCtx({ home: HOME });
+    expect(await resolveHomeDir(ctx)).toBe(HOME);
+  });
+
+  it("resolves null rather than throwing when homeDir() rejects", async () => {
+    const { ctx } = makeCtx({ home: null });
+    expect(await resolveHomeDir(ctx)).toBeNull();
+  });
+});
+
+describe("ensureTrackScript", () => {
+  it("writes the script when the file is absent", async () => {
+    const { ctx, fileService } = makeCtx();
+    const wrote = await ensureTrackScript(ctx, HOME);
+    expect(wrote).toBe(true);
+    expect(fileService.files.get(`${HOME}/${TRACK_SCRIPT_REL}`)).toBe(
+      buildTrackSessionScript(),
+    );
+  });
+
+  it("writes when the existing content differs", async () => {
+    const { ctx, fileService } = makeCtx({
+      files: { [`${HOME}/${TRACK_SCRIPT_REL}`]: "#!/bin/sh\n# stale\n" },
+    });
+    const wrote = await ensureTrackScript(ctx, HOME);
+    expect(wrote).toBe(true);
+    expect(fileService.files.get(`${HOME}/${TRACK_SCRIPT_REL}`)).toBe(
+      buildTrackSessionScript(),
+    );
+  });
+
+  it("is a silent no-op when the content already matches", async () => {
+    const { ctx, fileService } = makeCtx({
+      files: { [`${HOME}/${TRACK_SCRIPT_REL}`]: buildTrackSessionScript() },
+    });
+    const writeSpy = vi.spyOn(fileService, "writeText");
+    const wrote = await ensureTrackScript(ctx, HOME);
+    expect(wrote).toBe(false);
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("selfHealInstalledHooks", () => {
+  it("does nothing on Windows — no POSIX hook/config drift to heal there", async () => {
+    const { ctx, fileService, log } = makeCtx({ os: "windows" });
+    await selfHealInstalledHooks(ctx);
+    expect(fileService.files.size).toBe(0);
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when $HOME can't be resolved", async () => {
+    const { ctx, fileService, log } = makeCtx({ home: null });
+    await selfHealInstalledHooks(ctx);
+    expect(fileService.files.size).toBe(0);
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no agent is installed — never installs anything new", async () => {
+    const { ctx, fileService, log } = makeCtx();
+    await selfHealInstalledHooks(ctx);
+    expect(fileService.files.size).toBe(0);
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it("is a silent no-op when an installed agent's hook and the shared script are both already current", async () => {
+    const { ctx, log } = makeCtx();
+    // Install for real, through the actual strategy, so the fixture is
+    // exactly what a genuine install produces.
+    await installerFor(claude.resume).write(
+      ctx,
+      claude.resume,
+      claudeConfigPath,
+      true,
+    );
+    await ensureTrackScript(ctx, HOME);
+    log.info.mockClear();
+
+    await selfHealInstalledHooks(ctx);
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it("rewrites a stale shared script for an installed agent and logs it", async () => {
+    const { ctx, fileService, log } = makeCtx();
+    await installerFor(claude.resume).write(
+      ctx,
+      claude.resume,
+      claudeConfigPath,
+      true,
+    );
+    fileService.files.set(
+      `${HOME}/${TRACK_SCRIPT_REL}`,
+      "#!/bin/sh\n# stale\n",
+    );
+
+    await selfHealInstalledHooks(ctx);
+
+    expect(fileService.files.get(`${HOME}/${TRACK_SCRIPT_REL}`)).toBe(
+      buildTrackSessionScript(),
+    );
+    expect(log.info).toHaveBeenCalledTimes(1);
+    expect(log.info.mock.calls[0][0]).toContain("wrote track-session.sh");
+    expect(log.info.mock.calls[0][0]).not.toContain("config:");
+  });
+
+  it("repairs a drifted config entry for an installed agent and names it in the log", async () => {
+    const { ctx, fileService, log } = makeCtx();
+    await installerFor(claude.resume).write(
+      ctx,
+      claude.resume,
+      claudeConfigPath,
+      true,
+    );
+    await ensureTrackScript(ctx, HOME);
+    // Simulate drift: the marker is still there (so it still reads as
+    // Silo's own entry), but the command body is an older one.
+    const settings = JSON.parse(
+      fileService.files.get(claudeConfigPath) ?? "{}",
+    );
+    settings.hooks.SessionStart[0].hooks[0].command = `echo old-command # ${claude.resume.marker}`;
+    fileService.files.set(claudeConfigPath, JSON.stringify(settings));
+
+    await selfHealInstalledHooks(ctx);
+
+    const healed = JSON.parse(fileService.files.get(claudeConfigPath) ?? "{}");
+    expect(healed.hooks.SessionStart[0].hooks[0].command).toBe(
+      claude.resume.buildCommand(),
+    );
+    expect(log.info).toHaveBeenCalledTimes(1);
+    expect(log.info.mock.calls[0][0]).toContain("config: Claude Code");
+    expect(log.info.mock.calls[0][0]).not.toContain("wrote track-session.sh");
+  });
+
+  it("skips an agent whose config can't even be read, without blocking the others", async () => {
+    const { ctx, fileService, log } = makeCtx();
+    await installerFor(claude.resume).write(
+      ctx,
+      claude.resume,
+      claudeConfigPath,
+      true,
+    );
+    const cursorConfigPath = `${HOME}/${cursor.resume.configPath}`;
+    await installerFor(cursor.resume).write(
+      ctx,
+      cursor.resume,
+      cursorConfigPath,
+      true,
+    );
+    // Corrupt Claude's config; Cursor's stays healthy.
+    fileService.files.set(claudeConfigPath, "{ not valid json");
+    fileService.files.set(
+      `${HOME}/${TRACK_SCRIPT_REL}`,
+      "#!/bin/sh\n# stale\n",
+    );
+
+    await selfHealInstalledHooks(ctx);
+
+    // The shared script still gets rewritten — Cursor's install is enough
+    // to put at least one agent in the "installed" set.
+    expect(fileService.files.get(`${HOME}/${TRACK_SCRIPT_REL}`)).toBe(
+      buildTrackSessionScript(),
+    );
+    // Claude's corrupt file is left exactly as it was — never overwritten
+    // just because it couldn't be parsed.
+    expect(fileService.files.get(claudeConfigPath)).toBe("{ not valid json");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("never throws — an unexpected failure is logged as a warning instead", async () => {
+    const { ctx, log } = makeCtx();
+    await installerFor(claude.resume).write(
+      ctx,
+      claude.resume,
+      claudeConfigPath,
+      true,
+    );
+    (ctx.files.writeText as ReturnType<typeof vi.fn>) = vi
+      .fn()
+      .mockRejectedValue(new Error("disk full"));
+
+    await expect(selfHealInstalledHooks(ctx)).resolves.toBeUndefined();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn.mock.calls[0][0]).toContain("disk full");
+  });
+});

--- a/packages/extensions-core/src/agents-settings/hook-self-heal.ts
+++ b/packages/extensions-core/src/agents-settings/hook-self-heal.ts
@@ -1,0 +1,145 @@
+/**
+ * Self-heal for Silo's session hook: rewrites `track-session.sh` when its
+ * content has drifted from what the running Silo would generate, and repairs
+ * each already-installed agent's own hook config the same way — never
+ * installs anything new. See the "Hook Reconcile" roadmap item: today this
+ * only runs when {@link AgentsHooksPanel} happens to mount; the point of
+ * pulling it out here is so `core.agents-settings`'s `activate()` can also
+ * run it once per app launch, so a hook-body change ships and repairs
+ * itself on the next launch without anyone opening Settings.
+ *
+ * Silent and idempotent on a no-op — an already-current install touches no
+ * files and logs nothing. `selfHealInstalledHooks` never throws; a self-heal
+ * must not block either of its call sites.
+ */
+import type { ExtensionContext } from "@silo-code/sdk";
+import {
+  hookInstallableAgents,
+  buildTrackSessionScript,
+  TRACK_SCRIPT_REL,
+  type AgentDefinition,
+  type AgentHookResume,
+} from "@silo-code/extension-host/internal";
+import { installerFor } from "./install-strategy";
+
+export type HookAgent = AgentDefinition & { resume: AgentHookResume };
+
+/** Absolute `$HOME`, or `null` if it can't be resolved (rare) — the same
+ * "skip rather than surface an error" contract both call sites rely on. */
+export async function resolveHomeDir(
+  ctx: ExtensionContext,
+): Promise<string | null> {
+  try {
+    return await ctx.system.homeDir();
+  } catch {
+    return null;
+  }
+}
+
+export function settingsPathFor(agent: HookAgent, home: string): string {
+  return `${home}/${agent.resume.configPath}`;
+}
+
+/** Rewrites the shared capture script if its content has drifted. Returns
+ * whether a write happened. */
+export async function ensureTrackScript(
+  ctx: ExtensionContext,
+  home: string,
+): Promise<boolean> {
+  const path = `${home}/${TRACK_SCRIPT_REL}`;
+  const body = buildTrackSessionScript();
+  const existing = (await ctx.files.pathExists(path))
+    ? await ctx.files.readText(path).catch(() => null)
+    : null;
+  if (existing === body) return false;
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  if (dir) await ctx.files.createDir(dir);
+  await ctx.files.writeText(path, body);
+  return true;
+}
+
+/** Rewrites one agent's own config if its hook entry has drifted. Returns
+ * whether a write happened. */
+export async function refreshConfigIfDrifted(
+  ctx: ExtensionContext,
+  agent: HookAgent,
+  path: string,
+): Promise<boolean> {
+  return installerFor(agent.resume).refreshIfDrifted(ctx, agent.resume, path);
+}
+
+/**
+ * The heal itself, given an already-resolved `home` and the agents already
+ * known to be installed — the shape {@link AgentsHooksPanel}'s own `load()`
+ * already computes in one pass, so it calls this directly rather than
+ * re-deriving "installed" a second time.
+ */
+export async function healInstalledAgents(
+  ctx: ExtensionContext,
+  home: string,
+  installedAgents: readonly HookAgent[],
+): Promise<void> {
+  if (installedAgents.length === 0) return;
+  const scriptWrote = await ensureTrackScript(ctx, home);
+  const healed: string[] = [];
+  for (const agent of installedAgents) {
+    const wrote = await refreshConfigIfDrifted(
+      ctx,
+      agent,
+      settingsPathFor(agent, home),
+    );
+    if (wrote) healed.push(agent.displayName);
+  }
+  if (scriptWrote || healed.length > 0) {
+    ctx.log.info(
+      "Refreshed Silo session hook to the shell-script runtime" +
+        (healed.length > 0 ? ` (config: ${healed.join(", ")})` : "") +
+        (scriptWrote ? " (wrote track-session.sh)" : "") +
+        ".",
+    );
+  }
+}
+
+/**
+ * Standalone entry point for `activate()`: resolves everything itself (OS,
+ * `$HOME`, which agents are installed) rather than reusing a caller's
+ * already-loaded state, since at app startup there is none. Scoped to
+ * agents already managed — no new installs, no consent-model change.
+ *
+ * A per-agent `isInstalled` failure (e.g. a corrupt config) is treated the
+ * same as "not installed" and skipped, matching the panel's own per-row
+ * error handling — it never blocks healing the other agents.
+ */
+export async function selfHealInstalledHooks(
+  ctx: ExtensionContext,
+): Promise<void> {
+  try {
+    const { os } = await ctx.system.getInfo();
+    if (os === "windows") return; // no POSIX hook/config drift to heal there
+
+    const home = await resolveHomeDir(ctx);
+    if (!home) return;
+
+    const installed: HookAgent[] = [];
+    for (const agent of hookInstallableAgents()) {
+      try {
+        const isInstalled = await installerFor(agent.resume).isInstalled(
+          ctx,
+          agent.resume,
+          settingsPathFor(agent, home),
+        );
+        if (isInstalled) installed.push(agent);
+      } catch {
+        // Same treatment as the panel's per-row error case: nothing to heal
+        // if we can't even tell whether it's installed.
+      }
+    }
+
+    await healInstalledAgents(ctx, home, installed);
+  } catch (err) {
+    ctx.log.warn(
+      "Agent hook self-heal skipped: " +
+        (err instanceof Error ? err.message : String(err)),
+    );
+  }
+}

--- a/packages/extensions-core/src/agents-settings/index.tsx
+++ b/packages/extensions-core/src/agents-settings/index.tsx
@@ -18,6 +18,7 @@ import type { Extension, ExtensionContext, TabItem } from "@silo-code/sdk";
 import { Section, Tabs, TabPanel, SettingRow, Switch } from "@silo-code/sdk";
 import { store, setTerminalSetting } from "@silo-code/extension-host/internal";
 import { AgentsHooksPanel } from "./AgentsHooksPanel";
+import { selfHealInstalledHooks } from "./hook-self-heal";
 import "./AgentsSettingsPage.css";
 
 /** Mirror of `silo.agents`' {@link AgentsExtensionAPI} — core cannot import silo. */
@@ -123,5 +124,9 @@ export const extension: Extension = {
       order: 1,
       component: () => <AgentsSettingsPage ctx={ctx} />,
     });
+    // Hook Reconcile: repair already-installed hooks on every launch, not
+    // only when this settings page happens to be opened. Fire-and-forget —
+    // never blocks activation, and is silent on a no-op.
+    void selfHealInstalledHooks(ctx);
   },
 };

--- a/packages/extensions-core/src/test/setup.ts
+++ b/packages/extensions-core/src/test/setup.ts
@@ -1,3 +1,17 @@
 // Global test setup — adds jest-dom matchers (toBeInTheDocument, etc.) and
 // runs before every test file (see vitest.config.ts `setupFiles`).
 import "@testing-library/jest-dom/vitest";
+
+// Monaco's clipboard contribution probes `document.queryCommandSupported` at
+// import time; jsdom doesn't implement it. Stub it so any test whose import
+// graph reaches monaco (e.g. a value import from
+// `@silo-code/extension-host/internal`) can load. Mirrors the same shim in
+// `packages/extension-host/src/test/setup.ts` and `apps/desktop/src/test/setup.ts`.
+if (
+  typeof document !== "undefined" &&
+  typeof document.queryCommandSupported !== "function"
+) {
+  (
+    document as unknown as { queryCommandSupported: () => boolean }
+  ).queryCommandSupported = () => false;
+}


### PR DESCRIPTION
## Summary

If Silo ships a fix to the small script it uses to track agent sessions (for exact "resume"), an install that's already out there used to only pick up the fix if you happened to open Settings → Agents. Now it repairs itself the next time you launch Silo, with no action needed.

This changes nothing about who has hooks installed or how — it only keeps what's already there current.

## Details

### Hook Reconcile (roadmap item #4)

The self-heal logic (rewrite `track-session.sh` if its content drifted, repair a drifted per-agent hook config) lived entirely inside `AgentsHooksPanel.tsx`'s `load()`, so it only ran on mount. Extracted it into a new shared module, `hook-self-heal.ts`, with two entry points:

- `healInstalledAgents(ctx, home, installedAgents)` — the actual heal (script + per-agent config), given an already-resolved home dir and agent list. `AgentsHooksPanel`'s `load()` now calls this directly instead of duplicating the loop, reusing the `installed` rows it already computed.
- `selfHealInstalledHooks(ctx)` — the standalone entry point for `core.agents-settings`'s `activate()`: resolves OS/`$HOME`/which agents are installed itself, then delegates to `healInstalledAgents`. Called once, fire-and-forget, on every app launch.

Scoped to agents already managed — never installs anything new, matching the roadmap item's requirement. Windows is skipped (no POSIX hook/config drift to heal there, same as the panel already did). A per-agent `isInstalled` failure (e.g. a corrupt config) is treated as "not installed" and skipped without blocking the others, matching the panel's existing per-row error handling.

Small drive-by: `resolveHomeDir` now calls the SDK's `ctx.system.homeDir()` instead of round-tripping through a `sh -c` subprocess — that method already existed and does the same thing more directly, and using it made the new module trivially fakeable in tests (no `ctx.process.exec` mock needed).

### Tests

New `hook-self-heal.test.ts` (13 cases) covers: `resolveHomeDir`'s error handling, `ensureTrackScript`'s write/no-op behavior, and `selfHealInstalledHooks` end-to-end — Windows skip, no-`$HOME` skip, no-installs no-op, silent no-op when already current, script drift, config drift (using the real `claude` install strategy end-to-end, not a hand-rolled fixture), a corrupt agent's config not blocking another agent's heal, and never throwing on an unexpected failure.

Also added the `document.queryCommandSupported` jsdom shim to `extensions-core`'s test setup (already present in `extension-host` and `apps/desktop`'s) — this is the first test in this package to do a value import (not type-only) from `@silo-code/extension-host/internal`, which pulls in Monaco's clipboard contribution at import time.

`npx tsc --noEmit`, `pnpm lint`, and the full monorepo `pnpm test` (11/11 packages, including the new suite) all pass.