### PR TITLE
fix(agents): stop the Hook Guard test flaking on EPIPE

### DIFF
--- a/packages/extension-host/src/extension-host/agents/agent-catalog.test.ts
+++ b/packages/extension-host/src/extension-host/agents/agent-catalog.test.ts
@@ -377,11 +377,23 @@ describe("buildTrackSessionScript", () => {
       const scriptPath = join(dir, "track-session.sh");
       writeFileSync(scriptPath, buildTrackSessionScript());
       const home = join(dir, "home");
-      execFileSync("sh", [scriptPath, "claude"], {
-        input: '{"session_id":"019fa9d2-1234-7abc-8def-0123456789ab"}',
-        env: { ...withoutSilo, HOME: home },
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      try {
+        execFileSync("sh", [scriptPath, "claude"], {
+          input: '{"session_id":"019fa9d2-1234-7abc-8def-0123456789ab"}',
+          env: { ...withoutSilo, HOME: home },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (err) {
+        // EPIPE here is a *symptom of the guard working*, not a failure. The
+        // guard is the script's first statement (`[ -n "$SILO" ] || exit 0`),
+        // so with $SILO absent the script exits before it ever reaches
+        // `payload=$(cat)` — it never drains stdin. Whether our write lands in
+        // the pipe buffer before the child is reaped is pure scheduling, so
+        // this raced green locally and flaked on a loaded CI runner. Keep
+        // sending the payload (a real hook invocation gets one) and treat the
+        // broken pipe as expected; the assertion that matters is below.
+        if ((err as NodeJS.ErrnoException).code !== "EPIPE") throw err;
+      }
       let wrote = true;
       try {
         readFileSync(join(home, ".silo/agent-hooks/events.jsonl"), "utf8");


### PR DESCRIPTION
## Summary

A test in the agent session-capture suite fails at random on CI — roughly once
every few dozen runs, and never on a developer's machine. It just did it on a
documentation-only PR, which is how it got noticed.

The cause is a race that has nothing to do with what the test is checking. The
test is verifying that Silo's session-capture hook stays silent when it's run
outside a Silo terminal, and the hook does that by quitting immediately. The test
hands it a chunk of data on the way in, but the hook quits before reading any of
it — so whether the handoff completes or errors out is down to which side the
operating system happens to schedule first. Fast machine, no problem; busy CI
runner, occasional failure.

This makes the test tolerate that specific error, since it's actually a sign the
hook did the right thing. The real check — that no session file gets written — is
unchanged, so a genuine regression still fails the test.

## Details

### Cause

The Hook Guard added in #461 is the first statement in the generated capture
script:

```sh
[ -n "$SILO" ] || exit 0
```

With `$SILO` absent — exactly the condition
`"is inert outside a Silo terminal (Hook Guard, RFC 0028)"` exists to exercise —
the script exits before reaching `payload=$(cat | tr '\n' ' ')`, so it never
drains stdin. The test nonetheless passes a payload via `execFileSync`'s `input`.
Writing to a pipe whose reader has exited raises `EPIPE`, and whether the 52-byte
write reaches the pipe buffer before the child is reaped is pure scheduling.

Observed on [#467](https://github.com/silo-code/silo/pull/467) (documentation
only, no code in the diff):

```
FAIL  src/extension-host/agents/agent-catalog.test.ts > buildTrackSessionScript >
      is inert outside a Silo terminal (Hook Guard, RFC 0028)
Error: spawnSync sh EPIPE
```

That job spent 167s on environment setup alone. The same test passed 8/8 locally,
and re-running the CI job turned it green — which is what a flake looks like, not
evidence against one.

### Fix

Wrap the `execFileSync` and swallow `EPIPE` only, rethrowing anything else. The
payload is still sent, because a real hook invocation gets one and the test should
keep mirroring that. The assertion is untouched: `events.jsonl` must not exist.

A regression that dropped the guard would reach `payload=$(cat)`, drain stdin
(no `EPIPE`), write the event file, and fail on the assertion — so the fix does
not weaken what the test detects.

### Scope

One call site. The three sibling tests that pipe a payload set `SILO: "1"`, so
their script reaches `payload=$(cat)` and drains stdin; they carry no `EPIPE`
risk and are untouched.

### Verifying the mechanism

Reproduced deliberately outside the repo with the same shape — a script that
exits before reading, plus a payload larger than the 64KB pipe buffer to
guarantee the write outlives it:

```
threw, code = EPIPE — caught by our guard? true
```

Confirms both that `EPIPE` is what surfaces and that `err.code` is the right
thing to match on.

### Test plan

`pnpm --filter @silo-code/extension-host exec vitest run src/extension-host/agents/agent-catalog.test.ts`
— 76 passing. `pnpm --filter silo exec tsc --noEmit` clean. Prettier clean.
Pre-commit hooks (boundary lint, full unit suite) passed.

### Issue keys

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5TQvWW3banmgCknGCP9go
