### PR TITLE
fix(release): resync release-please manifest after sdk 0.42.0 shipped

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "0.59.0",
-  "packages/sdk": "0.41.0",
+  "packages/sdk": "0.42.0",
   "packages/git-api": "0.5.0"
 }

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "silo"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "base64 0.22.1",
  "block2",


### PR DESCRIPTION
## Summary

- Restore `.release-please-manifest.json` `packages/sdk` to `0.42.0` (already on npm and merged via #459)
- Sync `Cargo.lock` `silo` entry to `0.59.0` (same drift from #460)

## Why PR #465 reopened

#459 merged sdk 0.42.0 at 19:24 UTC. Nine minutes later, #460 (silo 0.59.0) merged with a release-please branch that still had `packages/sdk: 0.41.0`, clobbering the manifest. Release-please then thought 0.42.0 was unreleased and reopened #465.

Merging #465 would duplicate the CHANGELOG entry; this PR only fixes the manifest/lock.

## Test plan

- [ ] Merge and close #465 manually after this lands
- [ ] Confirm release-please does not reopen sdk 0.42.0 on the next main push


Made with [Cursor](https://cursor.com)