### PR TITLE
fix(extension-host): recognize Windows absolute paths in ctx.files scoping

### DIFF
--- a/docs/proposals/0031-tasks-extension/design.md
+++ b/docs/proposals/0031-tasks-extension/design.md
@@ -627,7 +627,9 @@ reformatting is theatre. `boundaries.test.ts` reads source from disk with
   the strategy works, but it is not the POSIX atomicity guarantee and it fails
   outright on a sharing violation (an editor or antivirus holding the file). The
   CAS retry absorbs the transient case; a persistent one surfaces as a write
-  error. (2) `resolve-path.ts` states in its own header that paths are treated
-  as POSIX and "Windows scoping is future work", so `permissions: []` over an
-  own-dir path is untested there. Both are verified before phase 1 is called
-  done; if either fails it is filed against RFC 0032, not worked around here.
+  error. (2) `resolve-path.ts` treated every path as POSIX, so a `permissions: []`
+  own-dir write with the drive-absolute path `ctx.storage.workspaceDir()` hands
+  back on Windows was spliced onto the workspace root and failed with
+  `ERROR_INVALID_NAME` (`os error 123`). **Fixed in RFC 0032**, not here: that
+  module now recognizes a Windows drive and a UNC prefix as absolute anchors.
+  Assumption (1) still stands and is verified before phase 1 is called done.

--- a/docs/proposals/0031-tasks-extension/requirements.md
+++ b/docs/proposals/0031-tasks-extension/requirements.md
@@ -349,12 +349,13 @@ agents.
 - [ ] It is installable from a built folder; it is not published to the registry
       in phase 1.
 - [ ] Behavior is confirmed on Windows, or the gap is recorded. Windows is a
-      shipped target, and two phase-1 assumptions are unverified there: the
-      host's `resolvePath` treats paths as POSIX by its own admission, so
-      `permissions: []` over an own-dir path is untested; and `fs_rename` maps
-      to `MoveFileEx`, which overwrites but is not the POSIX atomicity
-      guarantee and fails outright on a sharing violation. If either fails, file
-      it against RFC 0032 rather than working around it here.
+      shipped target. The POSIX-only `resolvePath` gap — a `permissions: []`
+      own-dir write with a drive-absolute path failed with `ERROR_INVALID_NAME`
+      — is **fixed in RFC 0032**: `resolve-path.ts` now recognizes Windows drive
+      and UNC anchors. Still unverified: `fs_rename` maps to `MoveFileEx`, which
+      overwrites but is not the POSIX atomicity guarantee and fails outright on a
+      sharing violation — if it fails, file it against RFC 0032 rather than
+      working around it here.
 
 ## R14 — Documentation
 

--- a/docs/proposals/0032-ctx-extension-storage-directory.md
+++ b/docs/proposals/0032-ctx-extension-storage-directory.md
@@ -89,6 +89,15 @@ lazily on first `globalDir()` call — an extension can cache its absolute path
 in `ctx.storage.global` in one session and use it at the top of `activate()` in
 the next without ever calling `globalDir()` again.
 
+On Windows the directory paths handed back are drive-absolute (`C:/Users/…`).
+`resolve-path.ts` recognizes a Windows drive (`C:/`, `C:\`) and a UNC prefix
+(`//`, `\\`) as absolute anchors alongside the POSIX root, normalizing `\` to
+`/` and comparing the drive letter case-insensitively. Without this an untrusted
+extension's `C:/…` own-dir path was treated as workspace-relative and spliced
+onto the workspace root, so every own-dir write failed with `ERROR_INVALID_NAME`
+— the first symptoms being `silo.tasks` (RFC 0031 phase 1) and the
+`storage-demo` example both unable to write their `.jsonl` on Windows.
+
 The workspace file watcher's project-tree noise filter
 (`node_modules/`, `dist/`, `cache/`, …) is bypassed for paths inside extension
 storage: an extension is free to name a subfolder `cache/`, and a watcher that

--- a/packages/extension-host/src/extension-host/extension-storage-dirs.ts
+++ b/packages/extension-host/src/extension-host/extension-storage-dirs.ts
@@ -35,7 +35,7 @@ import {
   fsRename,
 } from "../services/tauri-fs";
 import { extHostLog } from "./extension-host-logger";
-import { normalizePosix, withinRoots } from "./security/resolve-path";
+import { normalizePath, withinRoots } from "./security/resolve-path";
 
 /** The directory name under the user-config root. */
 const STORAGE_DIR_NAME = "extension-storage";
@@ -153,7 +153,7 @@ export function ownDirPaths(
 export function isStoragePath(path: string): boolean {
   const root = storageRoot;
   if (!root) return false;
-  return withinRoots([root], normalizePosix(path));
+  return withinRoots([root], normalizePath(path));
 }
 
 /** Create-on-first-call; the body behind `ctx.storage.globalDir()`. */

--- a/packages/extension-host/src/extension-host/security/resolve-path.test.ts
+++ b/packages/extension-host/src/extension-host/security/resolve-path.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import { PathDeniedError } from "@silo-code/sdk";
 import type { Permission } from "@silo-code/sdk";
 import {
-  normalizePosix,
+  isAbsolutePath,
+  normalizePath,
   toAbsolute,
   withinRoots,
   resolvePath,
@@ -19,21 +20,63 @@ function scope(over: Partial<PathScope> = {}): PathScope {
   };
 }
 
-describe("normalizePosix", () => {
+describe("normalizePath", () => {
   it("collapses slashes and drops '.'", () => {
-    expect(normalizePosix("/work//project/./src")).toBe("/work/project/src");
+    expect(normalizePath("/work//project/./src")).toBe("/work/project/src");
   });
   it("resolves '..' segments", () => {
-    expect(normalizePosix("/work/project/src/../lib")).toBe(
-      "/work/project/lib",
-    );
+    expect(normalizePath("/work/project/src/../lib")).toBe("/work/project/lib");
   });
   it("does not ascend above the root for absolute paths", () => {
-    expect(normalizePosix("/work/../../etc")).toBe("/etc");
-    expect(normalizePosix("/..")).toBe("/");
+    expect(normalizePath("/work/../../etc")).toBe("/etc");
+    expect(normalizePath("/..")).toBe("/");
   });
   it("keeps leading '..' for relative paths", () => {
-    expect(normalizePosix("../sibling/file")).toBe("../sibling/file");
+    expect(normalizePath("../sibling/file")).toBe("../sibling/file");
+  });
+  it("returns '' for an empty relative path", () => {
+    expect(normalizePath("")).toBe("");
+  });
+
+  // Windows: drive-letter and UNC anchors.
+  it("converts '\\' to '/'", () => {
+    expect(normalizePath("C:\\Users\\dave\\notes.txt")).toBe(
+      "C:/Users/dave/notes.txt",
+    );
+  });
+  it("upper-cases the drive letter", () => {
+    expect(normalizePath("c:/work/project")).toBe("C:/work/project");
+  });
+  it("treats a drive as an anchor '..' cannot escape", () => {
+    expect(normalizePath("C:/work/../../etc")).toBe("C:/etc");
+    expect(normalizePath("C:/..")).toBe("C:/");
+  });
+  it("resolves '..' within a drive path", () => {
+    expect(normalizePath("C:/work/project/src/../lib")).toBe(
+      "C:/work/project/lib",
+    );
+  });
+  it("preserves a UNC prefix as an anchor", () => {
+    expect(normalizePath("\\\\server\\share\\dir\\file")).toBe(
+      "//server/share/dir/file",
+    );
+    expect(normalizePath("//server/share/a/../b")).toBe("//server/share/b");
+  });
+});
+
+describe("isAbsolutePath", () => {
+  it("accepts POSIX, drive, and UNC forms", () => {
+    expect(isAbsolutePath("/etc/hosts")).toBe(true);
+    expect(isAbsolutePath("C:/Users/dave")).toBe(true);
+    expect(isAbsolutePath("c:\\Users\\dave")).toBe(true);
+    expect(isAbsolutePath("\\\\server\\share")).toBe(true);
+    expect(isAbsolutePath("//server/share")).toBe(true);
+  });
+  it("rejects relative paths and drive-relative 'C:foo'", () => {
+    expect(isAbsolutePath("src/index.ts")).toBe(false);
+    expect(isAbsolutePath("./notes.md")).toBe(false);
+    expect(isAbsolutePath("../up")).toBe(false);
+    expect(isAbsolutePath("C:foo")).toBe(false);
   });
 });
 
@@ -52,6 +95,23 @@ describe("toAbsolute", () => {
   it("returns null for a relative path with no roots", () => {
     expect(toAbsolute([], "src/index.ts")).toBeNull();
   });
+  it("keeps a Windows drive-absolute path absolute, not workspace-relative", () => {
+    // The RFC 0032 bug: a drive-absolute own-dir path was treated as relative
+    // and spliced onto roots[0].
+    expect(
+      toAbsolute(
+        ["C:/dev/silo"],
+        "C:/Users/dave/.config/silo/extension-storage/silo.tasks/tasks.jsonl",
+      ),
+    ).toBe(
+      "C:/Users/dave/.config/silo/extension-storage/silo.tasks/tasks.jsonl",
+    );
+  });
+  it("resolves a relative path against a Windows root", () => {
+    expect(toAbsolute(["C:\\dev\\silo"], "src/index.ts")).toBe(
+      "C:/dev/silo/src/index.ts",
+    );
+  });
 });
 
 describe("withinRoots", () => {
@@ -65,6 +125,23 @@ describe("withinRoots", () => {
     expect(withinRoots(roots, "/work/project-evil/x")).toBe(false);
     expect(withinRoots(roots, "/work")).toBe(false);
     expect(withinRoots(roots, "/etc/hosts")).toBe(false);
+  });
+  it("matches a Windows path regardless of drive-letter case", () => {
+    expect(withinRoots(["C:/work/project"], "c:/work/project/src/a.ts")).toBe(
+      true,
+    );
+    expect(withinRoots(["c:\\work\\project"], "C:/work/project")).toBe(true);
+  });
+  it("rejects a same-path on a different drive", () => {
+    expect(withinRoots(["C:/work/project"], "D:/work/project/a.ts")).toBe(
+      false,
+    );
+  });
+  it("handles a root with a trailing separator", () => {
+    expect(withinRoots(["/work/project/"], "/work/project/a.ts")).toBe(true);
+    expect(withinRoots(["C:/work/project/"], "C:/work/project/a.ts")).toBe(
+      true,
+    );
   });
 });
 
@@ -217,6 +294,56 @@ describe("resolvePath — own storage directories", () => {
     );
     expect(resolvePath(s, "src/app.tsx", "read")).toBe(
       "/work/project/src/app.tsx",
+    );
+  });
+});
+
+// RFC 0032 on Windows — a zero-permission extension writing into its own
+// drive-absolute storage directory. Regression cases for the bug where the
+// drive-absolute path was treated as relative and spliced onto roots[0].
+describe("resolvePath — own storage directories on Windows", () => {
+  const OWN = "C:/Users/dave/.config/silo/extension-storage/silo.tasks";
+  const win = (over: Partial<PathScope> = {}) =>
+    scope({
+      roots: ["C:/dev/silo"],
+      ownDirs: [`${OWN}/global`, `${OWN}/workspaces/ws_1`],
+      ...over,
+    });
+
+  it("allows a write into the workspace storage dir with no permissions", () => {
+    expect(
+      resolvePath(win(), `${OWN}/workspaces/ws_1/tasks.jsonl`, "write"),
+    ).toBe(`${OWN}/workspaces/ws_1/tasks.jsonl`);
+  });
+
+  it("allows a write into the global storage dir with no workspace open", () => {
+    expect(
+      resolvePath(win({ roots: [] }), `${OWN}/global/notes.log`, "write"),
+    ).toBe(`${OWN}/global/notes.log`);
+  });
+
+  it("accepts a backslash-separated own-dir path", () => {
+    const backslashed = `${OWN}/global/cache/probe.txt`.replace(/\//g, "\\");
+    expect(resolvePath(win(), backslashed, "write")).toBe(
+      `${OWN}/global/cache/probe.txt`,
+    );
+  });
+
+  it("still denies a prefix-sibling of the storage dir", () => {
+    expect(() => resolvePath(win(), `${OWN}/global-evil/x`, "write")).toThrow(
+      PathDeniedError,
+    );
+  });
+
+  it("still denies an out-of-workspace path without fs:write", () => {
+    expect(() =>
+      resolvePath(win(), "C:/Windows/System32/drivers/etc/hosts", "write"),
+    ).toThrow(PathDeniedError);
+  });
+
+  it("still resolves a relative path against the Windows workspace root", () => {
+    expect(resolvePath(win(), "src/app.tsx", "read")).toBe(
+      "C:/dev/silo/src/app.tsx",
     );
   });
 });

--- a/packages/extension-host/src/extension-host/security/resolve-path.ts
+++ b/packages/extension-host/src/extension-host/security/resolve-path.ts
@@ -9,8 +9,13 @@
  * **not** a sandbox — in-realm code can bypass `ctx` entirely (see RFC 0006) — so
  * it constrains the `ctx.files`/`ctx.process` surface, nothing more.
  *
- * No Tauri or platform imports: paths are treated as POSIX (Silo's terminals and
- * fs are Unix-only for now; Windows scoping is future work). Kept pure so the
+ * No Tauri or platform imports. Paths are normalized to a forward-slash form and
+ * compared structurally: a POSIX root (`/`), a Windows drive (`C:/`, `C:\`), and
+ * a UNC prefix (`//`, `\\`) are each recognized as an absolute anchor that `..`
+ * cannot ascend above. This matters on Windows because `ctx.storage.globalDir()`
+ * / `workspaceDir()` (RFC 0032) hand an untrusted extension a drive-absolute
+ * path back: treating `C:/…` as relative would splice it onto the workspace root
+ * and every own-dir write would fail (`ERROR_INVALID_NAME`). Kept pure so the
  * rules are exhaustively unit-testable.
  *
  * @internal
@@ -47,24 +52,50 @@ export interface PathScope {
 }
 
 /**
- * Normalize a POSIX path: collapse `//`, drop `.`, and resolve `..` segments.
- * An absolute path can't ascend above `/`; a relative one keeps leading `..`.
+ * True if `p` is an absolute path: a POSIX root (`/`), a Windows drive letter
+ * followed by a separator (`C:/`, `C:\`), or a UNC path (`//`, `\\`). A
+ * drive-relative `C:foo` (no separator) is **not** absolute.
  */
-export function normalizePosix(path: string): string {
-  const isAbsolute = path.startsWith("/");
+export function isAbsolutePath(p: string): boolean {
+  const s = p.replace(/\\/g, "/");
+  return s.startsWith("/") || /^[A-Za-z]:\//.test(s);
+}
+
+/**
+ * Normalize a path to forward-slash form: convert `\` to `/`, collapse `//`,
+ * drop `.`, and resolve `..` segments. Three anchors are recognized as absolute
+ * and `..` can never ascend above them — a POSIX root (`/`), a Windows drive
+ * (`C:/`), and a UNC prefix (`//`). A relative path keeps its leading `..`. The
+ * drive letter is upper-cased so containment comparisons are case-insensitive on
+ * it, as Windows drive letters are.
+ *
+ * Kept self-contained rather than routed through the SDK's `path.normalize` (its
+ * close twin) so this security boundary's rules stay auditable in one file with
+ * no cross-package coupling.
+ */
+export function normalizePath(input: string): string {
+  const path = input.replace(/\\/g, "/");
+  const driveMatch = /^([A-Za-z]):\//.exec(path);
+  const drive = driveMatch ? `${driveMatch[1].toUpperCase()}:` : "";
+  const afterDrive = drive ? path.slice(drive.length) : path;
+  const isUnc = !drive && afterDrive.startsWith("//");
+  const isAbsolute = drive !== "" || afterDrive.startsWith("/");
+
   const stack: string[] = [];
-  for (const segment of path.split("/")) {
+  for (const segment of afterDrive.split("/")) {
     if (segment === "" || segment === ".") continue;
     if (segment === "..") {
       const top = stack[stack.length - 1];
       if (stack.length && top !== "..") stack.pop();
       else if (!isAbsolute) stack.push("..");
-      // absolute + nothing to pop → stay at root
+      // absolute + nothing to pop → stay at the anchor
     } else {
       stack.push(segment);
     }
   }
   const joined = stack.join("/");
+  if (drive) return `${drive}/${joined}`;
+  if (isUnc) return `//${joined}`;
   return isAbsolute ? `/${joined}` : joined;
 }
 
@@ -77,18 +108,24 @@ export function toAbsolute(
   roots: readonly string[],
   rawPath: string,
 ): string | null {
-  if (rawPath.startsWith("/")) return normalizePosix(rawPath);
+  if (isAbsolutePath(rawPath)) return normalizePath(rawPath);
   const base = roots[0];
   if (base === undefined) return null;
-  return normalizePosix(`${base}/${rawPath}`);
+  return normalizePath(`${base}/${rawPath}`);
 }
 
-/** True if the absolute, normalized `path` is a root or nested under one. */
+/**
+ * True if the absolute, normalized `path` is a root or nested under one. Both
+ * sides are re-normalized (so a raw root with a trailing slash or `\` separators
+ * still compares correctly), which also upper-cases a Windows drive letter on
+ * both — `c:/work` and `C:/work` are the same root.
+ */
 export function withinRoots(roots: readonly string[], path: string): boolean {
+  const target = normalizePath(path);
   for (const root of roots) {
-    const r = normalizePosix(root);
-    const prefix = r === "/" ? "/" : `${r}/`;
-    if (path === r || path.startsWith(prefix)) return true;
+    const r = normalizePath(root);
+    const prefix = r.endsWith("/") ? r : `${r}/`;
+    if (target === r || target.startsWith(prefix)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

On Windows, an extension that stores data in its own storage directory (the feature added in RFC 0032) could not write anything — every write failed with "The filename, directory name, or volume label syntax is incorrect." The Tasks extension (proposal 0031, phase 1) hit this when adding a task, and the bundled Storage Demo example hit it too.

The cause was that Silo's file-access checks only understood Unix-style paths. On Windows they mistook a real absolute path like `C:\Users\...` for a location *inside* the current project folder and glued the two together into nonsense, so the file could never be written. This change teaches those checks to recognise Windows drive letters and network paths.

The fix is entirely inside Silo's runtime; no extension needs to change. It has no effect on macOS or Linux behaviour. **Please verify on a Windows build before merging** — the change is covered by unit tests but the original failure was only observed on Windows.

## Details

### Root cause

`packages/extension-host/src/extension-host/security/resolve-path.ts` — the JS-side path-scoping for `ctx.files` / `ctx.process` (ADR 0015 phase 2) — treated every path as POSIX by its own admission. `toAbsolute` recognised only a leading `/` as absolute.

On Windows, `ctx.storage.globalDir()` / `workspaceDir()` return a drive-absolute path (`C:/Users/dave/.config/silo/extension-storage/<id>/...`). For an untrusted extension that path flows through `resolvePath` → `toAbsolute`, which saw no leading `/`, treated it as workspace-relative, and joined it onto `roots[0]`:

```
C:/dev/silo  +  C:/Users/dave/.config/silo/extension-storage/silo.tasks/workspaces/ws_.../tasks.jsonl
= C:/dev/silo/C:/Users/dave/.config/silo/extension-storage/silo.tasks/workspaces/ws_.../tasks.jsonl
```

Windows rejects that with `ERROR_INVALID_NAME` (os error 123). Trusted (bundled) extensions were unaffected — they bypass `resolvePath` entirely — so this only bit third-party extensions, and `silo.tasks` / `storage-demo` are the first consumers of `ctx.storage.*Dir()`.

RFC 0031's `design.md` predicted exactly this ("`permissions: []` over an own-dir path is untested there [on Windows]") and directed that it be fixed against RFC 0032 rather than worked around in the extension.

### Change

- **`isAbsolutePath(p)`** — new exported helper. Absolute = POSIX `/`, a Windows drive followed by a separator (`C:/`, `C:\`), or a UNC prefix (`//`, `\\`). Drive-relative `C:foo` (no separator) is deliberately **not** absolute. `toAbsolute` now uses this instead of `p.startsWith("/")`.
- **`normalizePosix` → `normalizePath`** — converts `\` to `/`, and recognises three absolute anchors that `..` can never ascend above: POSIX root, Windows drive, UNC prefix. The drive letter is upper-cased so containment comparisons are case-insensitive on it (as Windows drive letters are). POSIX behaviour is unchanged; the one visible difference is that a leading `//` is now treated as a UNC anchor rather than collapsed to `/` (POSIX leaves `//` implementation-defined and Silo never emits it).
- **`withinRoots`** — re-normalises both sides, so a root carrying a trailing separator or `\` separators still compares correctly, and `c:/work` vs `C:/work` are the same root.
- **`extension-storage-dirs.ts`** — updated for the `normalizePath` rename.

`ctx.process` / `ctx.search` cwd guards call the same `toAbsolute` and are fixed by the same change; `scoped-services.test.ts` continues to pin that the storage lift does not widen `process`.

Kept self-contained rather than routed through the SDK's `path.normalize` twin (`packages/sdk/src/path.ts`) so the security boundary's rules stay auditable in one file with no cross-package coupling.

### Tests

`resolve-path.test.ts` grows from ~30 to 48 cases:

- `normalizePath` — backslash conversion, drive-letter upper-casing, drive/UNC as anchors `..` can't escape, `..` resolution within a drive path.
- `isAbsolutePath` — POSIX / drive / UNC accepted; relative and `C:foo` rejected.
- `toAbsolute` — the exact bug repro: `toAbsolute(["C:/dev/silo"], "C:/Users/.../tasks.jsonl")` stays absolute; relative paths still resolve against a Windows root.
- `withinRoots` — drive-letter case-insensitivity, different-drive rejection, trailing-separator roots.
- New block **`resolvePath — own storage directories on Windows`** — zero-permission writes into `workspaceDir()` / `globalDir()` (with and without a workspace open), backslash own-dir paths, and confirmation that prefix-siblings (`...-evil`) and out-of-workspace paths are still denied.

Verification (from the worktree):

- `pnpm --filter @silo-code/extension-host test` — 1476 passed
- `pnpm --filter @silo-code/sdk test` — 114 passed
- `pnpm --filter silo exec tsc --noEmit` — clean
- `pnpm lint` — clean
- pre-commit hook (boundary lint + full `pnpm test`) — passed

### Docs

- `docs/proposals/0032-ctx-extension-storage-directory.md` — documents the Windows drive/UNC anchor handling and names the two extensions that surfaced the bug.
- `docs/proposals/0031-tasks-extension/design.md` + `requirements.md` — the predicted `resolvePath` POSIX gap is marked resolved (fixed in RFC 0032); the separate `fs_rename` → `MoveFileEx` atomicity caveat stays open and still needs Windows verification.

### Windows test checklist

On a Windows build, with a third-party extension installed from a folder (e.g. `storage-demo` or `silo.tasks`):

1. Open the Storage Demo panel → **Append a line** (global and workspace scopes) → file is written; **Read file** shows the content; **List directory** shows the entry.
2. Tasks extension → add a task → it persists to `...\extension-storage\silo.tasks\workspaces\ws_...\tasks.jsonl` and survives a reload.
3. Storage Demo → **Sandbox boundary** section → all three checks still report ✅ (out-of-dir write denied, prefix-sibling denied, `process` cwd denied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
