### PR TITLE
fix(extension-host): stage URL/npm installs correctly when tempDir has no trailing slash

### DIFF
--- a/apps/desktop/src-tauri/src/commands/fs.rs
+++ b/apps/desktop/src-tauri/src/commands/fs.rs
@@ -48,7 +48,7 @@ pub fn fs_read_bytes(path: String) -> Result<Response, String> {
 pub fn fs_write_text(path: String, content: String) -> Result<(), String> {
     if let Some(parent) = Path::new(&path).parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
-            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            std::fs::create_dir_all(parent).map_err(|e| format!("{}: {}", parent.display(), e))?;
         }
     }
     std::fs::write(&path, content).map_err(|e| format!("{}: {}", path, e))
@@ -58,7 +58,7 @@ pub fn fs_write_text(path: String, content: String) -> Result<(), String> {
 pub fn fs_write_bytes(path: String, data: Vec<u8>) -> Result<(), String> {
     if let Some(parent) = Path::new(&path).parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
-            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            std::fs::create_dir_all(parent).map_err(|e| format!("{}: {}", parent.display(), e))?;
         }
     }
     std::fs::write(&path, data).map_err(|e| format!("{}: {}", path, e))
@@ -163,7 +163,7 @@ pub fn fs_read_dir(path: String) -> Result<Vec<FileMeta>, String> {
 
 #[tauri::command]
 pub fn fs_create_dir(path: String) -> Result<(), String> {
-    std::fs::create_dir_all(&path).map_err(|e| e.to_string())
+    std::fs::create_dir_all(&path).map_err(|e| format!("{}: {}", path, e))
 }
 
 #[tauri::command]

--- a/packages/extension-host/src/extension-host/extension-manager.test.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.test.ts
@@ -5,38 +5,49 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const { fsMap, fsDirs, loaderMock, invokeMock, fsDeleteSpy, defaultFsDelete } =
-  vi.hoisted(() => {
-    const fsMap = new Map<string, string>();
-    // Directories with no files in them — the flat map can't represent those,
-    // and the storage-directory tests need "exists but empty" to be a real
-    // state.
-    const fsDirs = new Set<string>();
-    const defaultFsDelete = async (p: string) => {
-      for (const key of [...fsMap.keys()]) {
-        if (key === p || key.startsWith(`${p}/`)) fsMap.delete(key);
-      }
-      for (const d of [...fsDirs]) {
-        if (d === p || d.startsWith(`${p}/`)) fsDirs.delete(d);
-      }
-    };
-    return {
-      fsMap,
-      fsDirs,
-      defaultFsDelete,
-      loaderMock: {
-        loadExtension: vi.fn(async () => {}),
-        unloadExtension: vi.fn(),
-        isLoaded: vi.fn(() => false),
-        needsReload: vi.fn(() => false),
-      },
-      invokeMock: vi.fn(async () => {}),
-      // Directory semantics over the flat map: deleting a path also deletes
-      // everything under it (the update flow deletes/renames whole install
-      // dirs).
-      fsDeleteSpy: vi.fn(defaultFsDelete),
-    };
-  });
+const {
+  fsMap,
+  fsDirs,
+  loaderMock,
+  invokeMock,
+  fsDeleteSpy,
+  defaultFsDelete,
+  tempDirState,
+} = vi.hoisted(() => {
+  const fsMap = new Map<string, string>();
+  // Directories with no files in them — the flat map can't represent those,
+  // and the storage-directory tests need "exists but empty" to be a real
+  // state.
+  const fsDirs = new Set<string>();
+  const defaultFsDelete = async (p: string) => {
+    for (const key of [...fsMap.keys()]) {
+      if (key === p || key.startsWith(`${p}/`)) fsMap.delete(key);
+    }
+    for (const d of [...fsDirs]) {
+      if (d === p || d.startsWith(`${p}/`)) fsDirs.delete(d);
+    }
+  };
+  return {
+    fsMap,
+    fsDirs,
+    defaultFsDelete,
+    loaderMock: {
+      loadExtension: vi.fn(async () => {}),
+      unloadExtension: vi.fn(),
+      isLoaded: vi.fn(() => false),
+      needsReload: vi.fn(() => false),
+    },
+    invokeMock: vi.fn(async () => {}),
+    // Directory semantics over the flat map: deleting a path also deletes
+    // everything under it (the update flow deletes/renames whole install
+    // dirs).
+    fsDeleteSpy: vi.fn(defaultFsDelete),
+    // `tempDir()`'s return value, varied per-test to cover each platform's
+    // shape. Default is the Linux form (no trailing slash) — the one the
+    // pre-fix code broke on.
+    tempDirState: { value: "/tmp" },
+  };
+});
 
 vi.mock("../services/user-config", () => ({
   userConfigDir: async () => "/cfg",
@@ -124,7 +135,10 @@ vi.mock("./menu-items", async (orig) => ({
   syncMenu: vi.fn(async () => {}),
 }));
 vi.mock("@tauri-apps/api/path", () => ({
-  tempDir: async () => "/tmp/",
+  // `tempDir()`'s shape is platform-dependent (Linux `/tmp`, macOS
+  // `/var/folders/…/T/`, Windows `C:\…\Temp\`). `tempDirState.value` is set
+  // per-test; `stageFromUrl` must handle every shape.
+  tempDir: async () => tempDirState.value,
 }));
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: invokeMock,
@@ -179,6 +193,7 @@ beforeEach(() => {
   invokeMock.mockClear().mockResolvedValue(undefined);
   fsDeleteSpy.mockClear().mockImplementation(defaultFsDelete);
   toastStore.toasts.splice(0, toastStore.toasts.length);
+  tempDirState.value = "/tmp";
   // Reset the built-in registry so merged rows / dispatch start clean.
   registerBuiltins([], new Set());
 });
@@ -654,6 +669,39 @@ describe("installFromUrl (integration)", () => {
       "download_extract",
       expect.objectContaining({ url: tarball }),
     );
+  });
+
+  // Regression: `${await tempDir()}silo-install-…` assumed a trailing slash.
+  // On Linux `tempDir()` is `/tmp`, so the path became `/tmpsilo-install-…` and
+  // the install died trying to mkdir at `/`. The staging dir must come out
+  // well-formed for every platform's `tempDir()` shape.
+  it.each([
+    ["Linux", "/tmp", /^\/tmp\/silo-install-\d+$/],
+    [
+      "macOS",
+      "/var/folders/ab/cd/T/",
+      /^\/var\/folders\/ab\/cd\/T\/silo-install-\d+$/,
+    ],
+    [
+      "Windows",
+      "C:\\Users\\d\\AppData\\Local\\Temp\\",
+      /^C:\/Users\/d\/AppData\/Local\/Temp\/silo-install-\d+$/,
+    ],
+  ])("builds a well-formed staging dir on %s", async (_os, tmp, expected) => {
+    tempDirState.value = tmp;
+    let destDir = "";
+    invokeMock.mockImplementation(
+      async (_cmd: string, args: { destDir?: string }) => {
+        if (args.destDir) {
+          destDir = args.destDir;
+          populateStaging(args.destDir);
+        }
+      },
+    );
+
+    await mgr.installFromUrl("https://example.com/ext.tgz", async () => true);
+
+    expect(destDir).toMatch(expected);
   });
 });
 

--- a/packages/extension-host/src/extension-host/extension-manager.ts
+++ b/packages/extension-host/src/extension-host/extension-manager.ts
@@ -732,8 +732,14 @@ async function stageFromUrl(
   url: string,
   expectedSha256?: string,
 ): Promise<string> {
-  const tmp = await tempDir();
-  const stagingDir = `${tmp}silo-install-${Date.now()}`;
+  // `tempDir()`'s shape varies by platform: a trailing slash on macOS
+  // (`/var/folders/…/T/`), none on Linux (`/tmp`), and a trailing backslash on
+  // Windows (`C:\…\Temp\`). Normalize to a forward-slash path with no trailing
+  // separator and join explicitly — the old `${tmp}silo-install-…` produced
+  // `/tmpsilo-install-…` on Linux and failed every URL/npm/registry install
+  // trying to mkdir at the filesystem root.
+  const tmp = (await tempDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+  const stagingDir = `${tmp}/silo-install-${Date.now()}`;
   await fsCreateDir(stagingDir);
   await invoke("download_extract", {
     url,


### PR DESCRIPTION
## Summary

On Linux, installing an extension from Browse, an npm package, or a GitHub URL failed immediately with "Permission denied (os error 13)" and nothing useful in the logs. Installing from a local folder worked. The cause was a path built assuming macOS's temp-directory format; on Linux it pointed at the wrong place and the install could never write its download.

This fixes the path and also makes the underlying "create directory" errors report *which* directory failed, so the next problem like this is diagnosable from the Output panel instead of a bare message.

**Please verify on a Linux build before merging** — install an extension via Browse / npm / a GitHub URL and confirm it succeeds. macOS and Windows behaviour is analysed below and covered by a per-platform test, but a manual smoke on each is worthwhile since CI runs the JS suite on Linux only.

## Details

### Cause

`stageFromUrl` (`packages/extension-host/src/extension-host/extension-manager.ts`) built the staging directory as:

```ts
const tmp = await tempDir();
const stagingDir = `${tmp}silo-install-${Date.now()}`;
```

`@tauri-apps/api`'s `tempDir()` resolves to `std::env::temp_dir()`, whose trailing separator differs by platform:

| Platform | `tempDir()` | old `${tmp}silo-install-…` |
| --- | --- | --- |
| macOS | `/var/folders/…/T/` | `/var/folders/…/T/silo-install-…` ✅ |
| Windows | `C:\Users\…\Temp\` | `C:\Users\…\Temp\silo-install-…` ✅ |
| Linux | `/tmp` | `/tmpsilo-install-…` ❌ |

On Linux the path became `/tmpsilo-install-<ts>`, and `fsCreateDir` → `create_dir_all("/tmpsilo-install-<ts>")` needs to write at the filesystem root `/` → `EACCES`.

The error surfaced as a bare `Permission denied (os error 13)` because `fs_create_dir` mapped the error with `e.to_string()`, dropping the path — so the Output panel showed nothing actionable.

`installFromFolder` was unaffected: it copies the source directory straight into `~/.config/silo/extensions/<id>/` with no staging dir.

### Fix

```ts
const tmp = (await tempDir()).replace(/\\/g, "/").replace(/\/+$/, "");
const stagingDir = `${tmp}/silo-install-${Date.now()}`;
```

Normalize `tempDir()` to a forward-slash path with no trailing separator, then join with `/` explicitly.

### Why this is safe on macOS and Windows

The change is a pure string transform on the value of `tempDir()`; it does no I/O and touches nothing else.

- **macOS** — `/var/folders/…/T/` has no backslashes; the trailing `/` is stripped and re-added by the join. Output is byte-for-byte identical to before: `/var/folders/…/T/silo-install-<ts>`.
- **Windows** — `C:\Users\…\Temp\` → `C:/Users/…/Temp/silo-install-<ts>`. It worked before with backslashes; it works now with forward slashes. Every consumer of the returned path accepts `/` on Windows:
  - `fsCreateDir` → `std::fs::create_dir_all` (Rust std accepts `/` on Windows)
  - `download_extract` → `tar::Archive::unpack` (the `tar` crate builds paths with `Path::join`)
  - `findPackageRoot` → further `fs_*` reads, and `fsDelete` → `remove_dir_all`
  
  Forward-slash is also the convention the rest of the TypeScript layer already uses on Windows — see the doc comment on `fs.rs::normalize_path` ("the entire TypeScript layer can assume POSIX-style paths").
- **Linux** — `/tmp` → `/tmp/silo-install-<ts>` (the bug fix).

### Secondary: error messages

- `fs_create_dir` (`apps/desktop/src-tauri/src/commands/fs.rs`) — error now includes the path, matching `fs_read_text` / `fs_write_text` / `fs_read_dir`.
- `fs_write_text` / `fs_write_bytes` — the `create_dir_all(parent)` calls (same bare-error problem) now include the parent path.

### Tests

`extension-manager.test.ts`:

- The `@tauri-apps/api/path` mock's `tempDir()` is now varied per test (was hard-coded `/tmp/`, which masked the bug).
- New parametrized regression test — `it.each(["Linux", "macOS", "Windows"])` — asserts the staging dir is well-formed for each platform's `tempDir()` shape:
  - `/tmp` → `/tmp/silo-install-<n>`
  - `/var/folders/ab/cd/T/` → `/var/folders/ab/cd/T/silo-install-<n>`
  - `C:\Users\d\AppData\Local\Temp\` → `C:/Users/d/AppData/Local/Temp/silo-install-<n>`
  
  This runs on Linux CI but encodes the expected output for all three platforms, so a future regression in the path shape on any OS fails the suite.

### Verification

- `pnpm --filter @silo-code/extension-host test` — 1460 passed
- `pnpm --filter silo exec tsc --noEmit` — clean
- `cargo check` (`apps/desktop/src-tauri`) — no new errors; `rustfmt --check` clean on `fs.rs`
- `pnpm lint` — clean
- pre-commit hook (boundary lint + full `pnpm test`) — passed

### Test checklist

**Linux** (the fix):
1. Settings → Extensions → **Browse**, install any registry extension → succeeds, appears in the list, loads.
2. Install from a GitHub URL and from an npm spec → both succeed.
3. `/tmp/silo-install-*` is cleaned up afterwards.
4. Install-from-folder still works.

**macOS / Windows** (regression smoke):
5. Browse-install one extension → still succeeds, no change in behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
