### PR TITLE
fix(agents): detect installed agents by install location, not PATH

### DIFF
--- a/docs/proposals/0033-agent-profiles.md
+++ b/docs/proposals/0033-agent-profiles.md
@@ -280,10 +280,26 @@ global default → system `~/.claude`) worth returning to at phase 8.
 - **A "Test launch" button.** Copying the launch line proves more (it exercises
   the user's real shell) and doesn't pull the user out of Settings or need a
   cleanup rule.
-- **Seeding profiles automatically on first run.** Probing `command -v` misses
-  aliases; probing an interactive shell means running the user's rc file
-  unprompted. The empty `+` menu entry plus "Found on this machine" cards get
-  the same result at the moment of intent, with a click behind it.
+- **Seeding profiles automatically on first run.** No detection is complete
+  enough to seed from silently — a directory probe misses an unusual prefix, and
+  probing an interactive shell to do better means running the user's rc file
+  unprompted (see "Detecting agents through `PATH`" below). The empty `+` menu
+  entry plus "Found on this machine" cards get the same result at the moment of
+  intent, with a click behind it.
+- **Detecting agents through `PATH`.** What phase 1 shipped, and it found
+  nothing in a release build: a `.app` launched from Finder/Dock inherits
+  launchd's minimal `PATH`, so `command -v` missed all seven catalog agents,
+  and "Found on this machine" hid itself as designed. Silo's terminals never hit
+  this because they run `$SHELL -l`; the scan runs in the app process, which
+  doesn't. Resolving the login shell's `PATH` at startup instead (VS Code's
+  approach, which Paseo adapts) was rejected: ~9s of interactive shell startup
+  measured with nvm in `.zshrc`, it runs the user's rc files unprompted — the
+  same objection as auto-seeding above — and it still reports an alias-only
+  agent as alias text rather than a binary. Detection now probes known install
+  directories directly (`agent-install-locations.ts`): ~40ms, no subprocess, and
+  it found one _more_ agent than the shell did. The cost is a curated list that
+  can miss an unusual prefix, which is what the hand-typed "Add an agent
+  profile…" row is for.
 - **Extension-contributed profiles.** A marketplace of extensions injecting
   shell commands into a user's terminal is a real trust surface. Rejected for
   v1; an extension that wants a different agent asks the user.

--- a/packages/extension-host/src/extension-host/agents/agent-install-locations.test.ts
+++ b/packages/extension-host/src/extension-host/agents/agent-install-locations.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  candidateBinDirs,
+  executableFileNames,
+  nvmVersionsDir,
+} from "./agent-install-locations";
+
+const HOME = "/Users/x";
+
+describe("candidateBinDirs (RFC 0033 R12)", () => {
+  it("covers the locations real agent installers use on macOS", () => {
+    const dirs = candidateBinDirs({ os: "macos", home: HOME });
+    // The three that between them held every agent on the machine this was
+    // measured against — official install scripts, Homebrew arm64, Homebrew
+    // Intel / npm's default prefix.
+    expect(dirs).toContain(`${HOME}/.local/bin`);
+    expect(dirs).toContain("/opt/homebrew/bin");
+    expect(dirs).toContain("/usr/local/bin");
+  });
+
+  it("probes per-user install scripts before package managers", () => {
+    const dirs = candidateBinDirs({ os: "macos", home: HOME });
+    expect(dirs.indexOf(`${HOME}/.local/bin`)).toBeLessThan(
+      dirs.indexOf("/opt/homebrew/bin"),
+    );
+  });
+
+  it("appends nvm version dirs last so a stable install wins", () => {
+    const nvm = `${HOME}/.nvm/versions/node/v24.19.0/bin`;
+    const dirs = candidateBinDirs({
+      os: "macos",
+      home: HOME,
+      nvmBinDirs: [nvm],
+    });
+    expect(dirs).toContain(nvm);
+    expect(dirs.indexOf(nvm)).toBeGreaterThan(
+      dirs.indexOf(`${HOME}/.local/bin`),
+    );
+  });
+
+  it("de-duplicates, so a repeated nvm dir can't double the probe", () => {
+    const dirs = candidateBinDirs({
+      os: "macos",
+      home: HOME,
+      nvmBinDirs: [`${HOME}/.local/bin`],
+    });
+    expect(dirs.filter((d) => d === `${HOME}/.local/bin`)).toHaveLength(1);
+    expect(new Set(dirs).size).toBe(dirs.length);
+  });
+
+  it("swaps MacPorts for linuxbrew off macOS", () => {
+    const mac = candidateBinDirs({ os: "macos", home: HOME });
+    const linux = candidateBinDirs({ os: "linux", home: HOME });
+    expect(mac).toContain("/opt/local/bin");
+    expect(mac).not.toContain("/home/linuxbrew/.linuxbrew/bin");
+    expect(linux).toContain("/home/linuxbrew/.linuxbrew/bin");
+    expect(linux).not.toContain("/opt/local/bin");
+  });
+
+  it("uses the npm prefix Windows actually installs into", () => {
+    const dirs = candidateBinDirs({ os: "windows", home: "C:/Users/x" });
+    expect(dirs).toContain("C:/Users/x/AppData/Roaming/npm");
+    expect(dirs).not.toContain("/opt/homebrew/bin");
+  });
+
+  it("tolerates a home directory with a trailing separator", () => {
+    for (const home of [`${HOME}/`, `${HOME}\\`]) {
+      expect(candidateBinDirs({ os: "macos", home })).toContain(
+        `${HOME}/.local/bin`,
+      );
+    }
+  });
+
+  it("joins with forward slashes on every platform", () => {
+    const dirs = candidateBinDirs({ os: "windows", home: "C:/Users/x" });
+    expect(dirs.some((d) => d.includes("\\"))).toBe(false);
+  });
+});
+
+describe("executableFileNames", () => {
+  it("is just the bare name on POSIX", () => {
+    expect(executableFileNames("claude", "macos")).toEqual(["claude"]);
+    expect(executableFileNames("claude", "linux")).toEqual(["claude"]);
+  });
+
+  it("checks the npm `.cmd` shim before the extensionless script on Windows", () => {
+    const names = executableFileNames("claude", "windows");
+    expect(names).toContain("claude.cmd");
+    expect(names).toContain("claude.exe");
+    expect(names.indexOf("claude.cmd")).toBeLessThan(names.indexOf("claude"));
+  });
+});
+
+describe("nvmVersionsDir", () => {
+  it("points at nvm's per-version root", () => {
+    expect(nvmVersionsDir(HOME)).toBe(`${HOME}/.nvm/versions/node`);
+    expect(nvmVersionsDir(`${HOME}/`)).toBe(`${HOME}/.nvm/versions/node`);
+  });
+});

--- a/packages/extension-host/src/extension-host/agents/agent-install-locations.ts
+++ b/packages/extension-host/src/extension-host/agents/agent-install-locations.ts
@@ -1,0 +1,112 @@
+// Where agent CLIs actually land on disk (RFC 0033 R12) — the candidate
+// directories "Found on this machine" probes, and the filenames to look for in
+// each. Pure string math; the probe itself lives in `agent-installed-scan.ts`.
+//
+// **Why not `PATH`.** A macOS `.app` launched from Finder/Dock inherits
+// launchd's minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin`) —
+// not the one your shell builds. Measured on a developer machine, that made
+// every one of the seven catalog agents invisible to `command -v`, because they
+// live in `~/.local/bin`, `/opt/homebrew/bin`, and an nvm version dir. Silo's
+// terminals never hit this: they run `$SHELL -l` (see `main.rs`), which
+// re-derives `PATH`. This scan runs in the app process, which does not.
+//
+// **Why not resolve the login shell's `PATH` instead.** That is what VS Code
+// does, and it works, but it costs a full interactive shell startup — measured
+// at ~9s with nvm in `.zshrc` — runs the user's rc files unprompted (which RFC
+// 0033 rejected under "Alternatives considered"), and still reports an
+// alias-only agent as its alias text rather than a binary. Probing these
+// directories took ~40ms and found one *more* agent.
+//
+// The cost is that this list is curated rather than derived: an agent installed
+// under an unusual prefix won't be detected. That is what the hand-typed "Add an
+// agent profile…" row is for — detection is a convenience, not the only way in.
+
+/** Platform vocabulary shared with `SystemInfo["os"]`. */
+export type OsName = "macos" | "linux" | "windows";
+
+export interface CandidateBinDirsInput {
+  os: OsName;
+  /** Absolute home directory, as `ctx.system.homeDir()` reports it. */
+  home: string;
+  /**
+   * Concrete `<home>/.nvm/versions/node/<version>/bin` directories found on
+   * disk. Version-managed installs can't be named statically, so the caller
+   * enumerates them and passes them in; probed last so a stable install wins.
+   */
+  nvmBinDirs?: readonly string[];
+}
+
+/** The directory nvm keeps its per-version installs under. */
+export function nvmVersionsDir(home: string): string {
+  return `${trimTrailingSlash(home)}/.nvm/versions/node`;
+}
+
+/**
+ * Ordered, de-duplicated directories to probe for an agent binary. Order is
+ * precedence: the first hit wins, so official per-user installers come before
+ * package managers, and version-manager shims come last.
+ *
+ * Paths are joined with `/` on every platform — the Rust fs commands normalize
+ * separators to POSIX for the TypeScript layer (see `normalize_path`), and
+ * Windows accepts forward slashes.
+ */
+export function candidateBinDirs({
+  os,
+  home,
+  nvmBinDirs = [],
+}: CandidateBinDirsInput): string[] {
+  const h = trimTrailingSlash(home);
+  const dirs =
+    os === "windows"
+      ? [
+          `${h}/AppData/Roaming/npm`,
+          `${h}/.local/bin`,
+          `${h}/.bun/bin`,
+          `${h}/.cargo/bin`,
+          `${h}/scoop/shims`,
+          `${h}/AppData/Local/Microsoft/WindowsApps`,
+          "C:/ProgramData/chocolatey/bin",
+        ]
+      : [
+          // Official per-user install scripts (Claude Code, cursor-agent, grok,
+          // `uv tool install`) all target this one.
+          `${h}/.local/bin`,
+          "/opt/homebrew/bin",
+          "/opt/homebrew/sbin",
+          "/usr/local/bin",
+          `${h}/.bun/bin`,
+          `${h}/.deno/bin`,
+          `${h}/.cargo/bin`,
+          `${h}/.volta/bin`,
+          `${h}/.npm-global/bin`,
+          // Grok's installer keeps its own prefix as well as `~/.local/bin`.
+          `${h}/.grok/bin`,
+          "/usr/bin",
+          ...(os === "macos"
+            ? ["/opt/local/bin"]
+            : ["/home/linuxbrew/.linuxbrew/bin", `${h}/.linuxbrew/bin`]),
+          // Shims resolve to whatever version is selected, so they answer
+          // "installed?" correctly even though the real binary sits elsewhere.
+          `${h}/.asdf/shims`,
+        ];
+  return dedupe([...dirs, ...nvmBinDirs]);
+}
+
+/**
+ * Filenames that would constitute an install of `name` in a candidate
+ * directory. POSIX has exactly one; Windows npm shims arrive as `.cmd` next to
+ * an extensionless shell script, and native builds as `.exe`.
+ */
+export function executableFileNames(name: string, os: OsName): string[] {
+  return os === "windows"
+    ? [`${name}.cmd`, `${name}.exe`, `${name}.bat`, name]
+    : [name];
+}
+
+function trimTrailingSlash(path: string): string {
+  return path.replace(/[/\\]+$/, "");
+}
+
+function dedupe(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}

--- a/packages/extension-host/src/extension-host/agents/agent-installed-scan.test.ts
+++ b/packages/extension-host/src/extension-host/agents/agent-installed-scan.test.ts
@@ -1,41 +1,114 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { exec } = vi.hoisted(() => ({ exec: vi.fn() }));
-vi.mock("../process-service", () => ({
-  getProcessService: () => ({ exec }),
+const { fsStat, fsReadDir, systemInfo, homeDir, exec } = vi.hoisted(() => ({
+  fsStat: vi.fn(),
+  fsReadDir: vi.fn(),
+  systemInfo: vi.fn(),
+  homeDir: vi.fn(),
+  exec: vi.fn(),
 }));
+
+vi.mock("../../services/tauri-fs", () => ({ fsStat, fsReadDir }));
+vi.mock("../../services/tauri-system", () => ({ systemInfo }));
+vi.mock("../platform", () => ({ homeDir }));
+vi.mock("../process-service", () => ({ getProcessService: () => ({ exec }) }));
 
 import { scanInstalledAgents } from "./agent-installed-scan";
 
-beforeEach(() => exec.mockReset());
+const HOME = "/Users/x";
+
+/** A `fsStat` that reports a file at exactly `paths`, and nothing else. */
+function statsFor(paths: readonly string[]) {
+  return (path: string) =>
+    Promise.resolve(
+      paths.includes(path)
+        ? { name: "x", path, isDir: false, size: 1, modifiedMs: 0 }
+        : null,
+    );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  systemInfo.mockResolvedValue({ os: "macos", arch: "aarch64" });
+  homeDir.mockResolvedValue(HOME);
+  fsReadDir.mockRejectedValue(new Error("ENOENT"));
+  fsStat.mockResolvedValue(null);
+});
 
 describe("scanInstalledAgents (RFC 0033 R12)", () => {
-  it("uses non-interactive `sh -c 'command -v …'`, never the interactive shell", async () => {
-    exec.mockResolvedValue({ stdout: "", stderr: "", code: 1 });
+  it("never shells out — detection must not depend on the app's PATH", async () => {
     await scanInstalledAgents();
-    for (const call of exec.mock.calls) {
-      expect(call[0]).toBe("sh");
-      expect(call[1][0]).toBe("-c");
-      expect(call[1][1]).toMatch(/^command -v /);
-      expect(call[1]).not.toContain("-i");
-    }
+    expect(exec).not.toHaveBeenCalled();
   });
 
-  it("maps PATH hits to catalog ids with the resolved path", async () => {
-    exec.mockImplementation((...callArgs: unknown[]) => {
-      const script = String((callArgs[1] as string[])?.[1] ?? "");
-      const hit = script.includes("claude") || script.includes("codex");
-      return Promise.resolve({
-        stdout: hit ? "/opt/homebrew/bin/x\n" : "",
-        stderr: "",
-        code: hit ? 0 : 1,
-      });
+  it("maps a binary in a known install dir to its catalog id", async () => {
+    fsStat.mockImplementation(
+      statsFor([`${HOME}/.local/bin/claude`, "/opt/homebrew/bin/codex"]),
+    );
+    const found = await scanInstalledAgents();
+    expect(found.map((f) => f.id).sort()).toEqual(["claude", "codex"]);
+    const claude = found.find((f) => f.id === "claude")!;
+    expect(claude.resolvedPath).toBe(`${HOME}/.local/bin/claude`);
+    expect(claude.command).toBe("claude");
+    expect(claude.displayName).toBeTruthy();
+  });
+
+  it("reports nothing when no candidate directory holds an agent", async () => {
+    expect(await scanInstalledAgents()).toEqual([]);
+  });
+
+  it("finds an agent installed only under an nvm version dir", async () => {
+    const bin = `${HOME}/.nvm/versions/node/v24.19.0/bin`;
+    fsReadDir.mockResolvedValue([
+      {
+        name: "v24.19.0",
+        path: `${HOME}/.nvm/versions/node/v24.19.0`,
+        isDir: true,
+        size: 0,
+        modifiedMs: 0,
+      },
+    ]);
+    fsStat.mockImplementation(statsFor([`${bin}/pi`]));
+    const found = await scanInstalledAgents();
+    expect(found.map((f) => f.id)).toContain("pi");
+    expect(found.find((f) => f.id === "pi")!.resolvedPath).toBe(`${bin}/pi`);
+  });
+
+  it("ignores a directory that merely shares the agent's name", async () => {
+    fsStat.mockImplementation((path: string) =>
+      Promise.resolve(
+        path === `${HOME}/.local/bin/claude`
+          ? { name: "claude", path, isDir: true, size: 0, modifiedMs: 0 }
+          : null,
+      ),
+    );
+    expect(await scanInstalledAgents()).toEqual([]);
+  });
+
+  it("keeps probing past an unreadable directory", async () => {
+    fsStat.mockImplementation((path: string) => {
+      if (path.startsWith(`${HOME}/.local/bin`)) {
+        return Promise.reject(new Error("EACCES"));
+      }
+      return statsFor(["/opt/homebrew/bin/codex"])(path);
     });
     const found = await scanInstalledAgents();
-    const ids = found.map((f) => f.id).sort();
-    expect(ids).toEqual(["claude", "codex"]);
-    expect(found[0].resolvedPath).toBe("/opt/homebrew/bin/x");
-    expect(found[0].command).toBeTruthy();
-    expect(found[0].displayName).toBeTruthy();
+    expect(found.map((f) => f.id)).toContain("codex");
+  });
+
+  it("takes the first directory in probe order when an agent is in two", async () => {
+    fsStat.mockImplementation(
+      statsFor([`${HOME}/.local/bin/claude`, "/opt/homebrew/bin/claude"]),
+    );
+    const found = await scanInstalledAgents();
+    expect(found.find((f) => f.id === "claude")!.resolvedPath).toBe(
+      `${HOME}/.local/bin/claude`,
+    );
+  });
+
+  it("reports nothing rather than guessing when home can't be resolved", async () => {
+    homeDir.mockRejectedValue(new Error("no home"));
+    expect(await scanInstalledAgents()).toEqual([]);
+    expect(fsStat).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension-host/src/extension-host/agents/agent-installed-scan.ts
+++ b/packages/extension-host/src/extension-host/agents/agent-installed-scan.ts
@@ -1,11 +1,21 @@
 // "Found on this machine" detection for the Profiles tab (RFC 0033 R12). A
-// plain, non-interactive `PATH` lookup per catalog agent — POSIX `sh -c
-// 'command -v …'` sources nothing, so this deliberately CANNOT see aliases and
-// never runs the user's rc file. Run on tab mount and explicit refresh only.
+// direct probe of known install directories (`agent-install-locations.ts`) — no
+// subprocess, no shell, so it never runs the user's rc file and never depends on
+// the `PATH` the app happened to inherit. See that module for why `command -v`
+// can't do this job from inside a GUI-launched app.
+//
+// Run on tab mount and explicit refresh only.
 
-import { getProcessService } from "../process-service";
+import { fsReadDir, fsStat } from "../../services/tauri-fs";
+import { systemInfo } from "../../services/tauri-system";
+import { homeDir } from "../platform";
 import { AGENT_CATALOG } from "./agent-catalog";
-import { posixSingleQuote } from "./agent-profile-model";
+import {
+  candidateBinDirs,
+  executableFileNames,
+  nvmVersionsDir,
+  type OsName,
+} from "./agent-install-locations";
 
 export interface InstalledAgent {
   /** Catalog agent id (also the profile's `assumedAgentId`). */
@@ -14,41 +24,99 @@ export interface InstalledAgent {
   displayName: string;
   /** The leader name that resolved — the created profile's `command`. */
   command: string;
-  /** Absolute path `command -v` reported, for the card's subtitle. */
+  /** Absolute path the probe found, for the card's subtitle. */
   resolvedPath: string;
 }
 
 /**
- * For each catalog agent, the first `leaderNames` entry that resolves on
- * `PATH`. Agents already covered by a profile are still returned — the caller
- * filters those out so the list can update as profiles are added.
+ * For each catalog agent, the first `leaderNames` entry found in a known
+ * install directory. Agents already covered by a profile are still returned —
+ * the caller filters those out so the list can update as profiles are added.
+ *
+ * The profile this seeds stores the bare command name, not `resolvedPath`: the
+ * command is typed into a Silo terminal, which is an interactive login shell
+ * with the user's real `PATH` (and their aliases). The absolute path is for
+ * display only.
  */
 export async function scanInstalledAgents(): Promise<InstalledAgent[]> {
-  const proc = getProcessService();
-  const results = await Promise.all(
+  const probe = await resolveProbe();
+  if (!probe) return [];
+
+  const found = await Promise.all(
     AGENT_CATALOG.map(async (agent) => {
       for (const name of agent.leaderNames) {
-        try {
-          const { stdout, code } = await proc.exec(
-            "sh",
-            ["-c", `command -v ${posixSingleQuote(name)}`],
-            { timeoutMs: 3000 },
-          );
-          const path = stdout.trim();
-          if (code === 0 && path) {
-            return {
-              id: agent.id,
-              displayName: agent.displayName,
-              command: name,
-              resolvedPath: path,
-            } satisfies InstalledAgent;
-          }
-        } catch {
-          // ignore — try the next leader name / agent
+        const resolvedPath = await findInDirs(name, probe);
+        if (resolvedPath) {
+          return {
+            id: agent.id,
+            displayName: agent.displayName,
+            command: name,
+            resolvedPath,
+          } satisfies InstalledAgent;
         }
       }
       return null;
     }),
   );
-  return results.filter((r): r is InstalledAgent => r !== null);
+  return found.filter((f): f is InstalledAgent => f !== null);
+}
+
+/** What one scan needs to look anything up: the platform and its probe list. */
+interface Probe {
+  os: OsName;
+  dirs: string[];
+}
+
+/** The probe list for this machine, or `null` if the platform is unknowable. */
+async function resolveProbe(): Promise<Probe | null> {
+  let os: OsName;
+  let home: string;
+  try {
+    const [info, resolvedHome] = await Promise.all([systemInfo(), homeDir()]);
+    // `system_info` reports Rust's compile-time `OS` constant, so this is the
+    // same narrowing `system-service.ts` does on the public `SystemInfo`.
+    os = info.os as OsName;
+    home = resolvedHome;
+  } catch {
+    // Without a home directory there is no per-user install location to probe,
+    // and a wrong guess would report agents the user doesn't have.
+    return null;
+  }
+  const dirs = candidateBinDirs({
+    os,
+    home,
+    nvmBinDirs: await nvmBinDirs(home, os),
+  });
+  return { os, dirs };
+}
+
+/** `<home>/.nvm/versions/node/<version>/bin` for every installed version. */
+async function nvmBinDirs(home: string, os: OsName): Promise<string[]> {
+  if (os === "windows") return [];
+  try {
+    const versions = await fsReadDir(nvmVersionsDir(home));
+    return versions.filter((v) => v.isDir).map((v) => `${v.path}/bin`);
+  } catch {
+    // nvm isn't installed — the common case, not an error.
+    return [];
+  }
+}
+
+/** First directory holding an executable file for `name`, in probe order. */
+async function findInDirs(
+  name: string,
+  { os, dirs }: Probe,
+): Promise<string | null> {
+  for (const dir of dirs) {
+    for (const filename of executableFileNames(name, os)) {
+      try {
+        const meta = await fsStat(`${dir}/${filename}`);
+        // A directory named `claude` is not an install of `claude`.
+        if (meta && !meta.isDir) return meta.path;
+      } catch {
+        // Unreadable directory (permissions, a dead symlink) — keep looking.
+      }
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

The "Found on this machine" section in Settings → Agents → Profiles never showed
up in the installed app. It was supposed to list the coding agents you already
have and let you add a profile for each in one click, but in a real installed
build it found nothing and hid itself — so the feature was effectively invisible
to everyone except developers running Silo from a terminal.

The cause was how Silo looked for agents. It asked the shell "where is `claude`?",
which only works if the app knows where your tools live. An app launched from
Finder or the Dock doesn't — macOS gives it a bare-bones search path that
excludes Homebrew, npm, and the locations the official agent installers use. So
every agent came back "not found."

Silo now looks in the places these tools actually install to instead of asking
the shell. On a test machine this found all seven supported agents in about 40
milliseconds, including one the old approach could never have found correctly.

The alternative — having Silo work out your shell's real search path at startup,
which is what VS Code does — was measured at roughly 9 seconds of added startup
time on a developer machine, and would run your shell startup files without
asking. It also still found fewer agents.

No migration or user action needed; this only affects what the detection list
shows. Users who already added profiles by hand are unaffected.

## Details

### Root cause

A macOS `.app` launched from Finder/Dock inherits launchd's minimal `PATH`
(`/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin`), confirmed via `ps eww` against
a running production install. `scanInstalledAgents()` used
`sh -c 'command -v <name>'` through `ctx.process.exec`, which inherits that
`PATH`, so all seven catalog agents resolved to nothing and
`FoundOnThisMachine` returned `null` for an empty result — working as coded.

Silo's terminals never hit this because the session host runs `$SHELL -l`
(`main.rs`), which re-derives `PATH`. The agent hooks don't hit it either: the
installed hook command is `sh "$HOME/…"` and the script body uses only builtins
plus `ps`/`date`/`mkdir`/`cat`/`tr`, all under `/bin` and `/usr/bin`. The scan is
the first agent-related code to run in the app process rather than in a terminal,
which is why it's the first to be affected.

### Change

- **`agent-install-locations.ts`** (new, pure) — `candidateBinDirs()` returns an
  ordered, de-duplicated probe list: per-user install scripts (`~/.local/bin`)
  before package managers (`/opt/homebrew/bin`, `/usr/local/bin`), with nvm
  version dirs appended last so a stable install wins. `executableFileNames()`
  handles Windows `.cmd`/`.exe`/`.bat` shims; `nvmVersionsDir()` locates nvm's
  per-version root. Paths join with `/` on all platforms, matching
  `normalize_path`'s POSIX-for-the-TS-layer contract.
- **`agent-installed-scan.ts`** — probes those directories with `fsStat`,
  rejecting directories that share an agent's name. No subprocess, no shell, no
  rc files, no `PATH` read. Returns `[]` rather than guessing if `homeDir()`
  fails. The seeded profile still stores the bare command name, not the resolved
  path: the command is typed into a terminal that has the user's real `PATH` and
  aliases, so the absolute path is display-only.
- **`docs/proposals/0033-agent-profiles.md`** — new "Alternatives considered"
  entry recording why detection probes install directories rather than `PATH`,
  and why the login-shell approach was rejected. The adjacent auto-seed bullet
  was reworded, since it argued from `command -v` semantics no longer in use.

### Prior art checked

Paseo (one of the eight tools surveyed for RFC 0033) resolves the login shell
environment at startup in `login-shell-env.ts`, adapted from VS Code's
`shellEnv.ts`: `-i -l -c`, a UUID marker to survive rc-file chatter on stdout, a
30s timeout, blocking GUI bootstrap. Measured locally at ~9-10s with nvm in
`.zshrc`. Rejected here for that cost, for running rc files unprompted (the same
objection RFC 0033 already raised against auto-seeding), and because it reports
an alias-only agent as alias text rather than a binary — `copilot` is found by
the directory probe but not usefully by `command -v`.

### Test plan

- 19 new unit tests across the two modules, covering probe ordering, nvm
  handling, de-duplication, per-OS lists, Windows shim extensions, a directory
  sharing an agent's name, an unreadable directory mid-probe, and the
  no-home fallback. One test pins the regression directly: detection must never
  shell out.
- `pnpm test` green (1549 tests), `tsc --noEmit` clean, `pnpm lint` clean.
- Static check: no `PATH`, `process.env`, or exec read anywhere in the scan path
  or its three leaf services.
- **Runtime A/B** against the dev app via the automation bridge. The original
  implementation restored from `HEAD`, with the child's `PATH` pinned to
  launchd's default, renders the Profiles panel with the section absent and 0
  cards — guarded by asserting the settings rail, `.apf-panel`, and the profiles
  empty-state text were all present, so the zero is a real negative and not an
  unrendered panel. The new code renders 7 cards with correct paths.

### Follow-up, not included

`apps/desktop/src-tauri/Cargo.lock` still pins `silo` at 0.59.0 while
`Cargo.toml` says 0.60.0 — release-please bumps the manifest and the lock only
catches up when someone builds. A dev build regenerated it during this work; it
has been kept out of this diff as unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m7TLgYU4Pmg6AVZm9MckV
