### PR TITLE
docs(proposals): split RFC 0031 phase 2, plan the cross-workspace surfaces

### DIFF
--- a/docs/proposals/0031-tasks-extension/design.md
+++ b/docs/proposals/0031-tasks-extension/design.md
@@ -1,0 +1,341 @@
+# Design — 0031 phase 2. Cross-workspace view + Tasks app sheet
+
+Phase 2 only. Phase 1's design is the baseline (`providers/silo/`, the core
+`Task` schema, detail-section descriptors, the `source-set` store, the side
+panel). Working artifact — removed at collapse; durable pieces move into the
+collapsed proposal or an ADR.
+
+## Architecture
+
+All implementation is in `silo-code/silo-extensions`, `tasks/`, except a possible
+`@silo-code/sdk` + host change (see [SDK dependency](#sdk-dependency-workspacedir)).
+
+Phase 1's module layout is unchanged; phase 2 adds files, it does not
+restructure:
+
+```
+tasks/src/
+  model/            (unchanged)
+  lib/
+    view.ts         + a cross-source grouping path
+    prefs.ts        + the aggregated-surface prefs key
+  providers/silo/   (unchanged — reused verbatim)
+  sources/
+    source-set.ts   → resolves N workspace sources, not 1; multi-consumer
+  ui/
+    TasksPanel.tsx      (unchanged side panel)
+    CrossTasksView.tsx   NEW — Navigator view body
+    TasksAppSheet.tsx    NEW — sheet body
+    AggregatedList.tsx   NEW — shared list+toolbar+drill-in shell both use
+    TaskList.tsx / TaskRow.tsx / TaskDetail.tsx / DetailSections.tsx / glyphs
+                        (reused unchanged)
+  index.ts          + registerNavigatorView, + silo.tasks.open, + nav toolbar items
+```
+
+The load-bearing idea: **one `source-set`, three views**. Phase 1 already put
+the store in `activate` and documented this as its phase-2 payoff. Phase 2 cashes
+it in — no new store, no per-surface data ownership.
+
+## Components
+
+### `source-set` — from 2 sources to N+1
+
+Today `resolveSources()` returns the global source plus (if a workspace is
+active) the active workspace's. Phase 2:
+
+- One `await ctx.storage.workspaceDirs({ create: false })` call resolves a
+  directory for every workspace in `ctx.workspaces.getState().open`; build a Silo
+  source per entry — id `hashLocator("silo", locator)`, `scope: "workspace"`,
+  `workspaceId`, `name` from the matching `Workspace`, `locator:
+  <dir>/tasks.jsonl`. (Option B: the same loop over `resolveWorkspaceTasksDir(w)`.)
+- Keep the global source first.
+- Re-run resolution on `ctx.workspaces.subscribe` (already wired) — now it reacts
+  to **any** open/close, not just an active-id change.
+- `syncWatches` already diffs live vs. watched source ids and adds/removes
+  watches; it needs no change beyond receiving the larger set.
+- Per-workspace resolution errors: catch per iteration, emit the source with an
+  `error` marker and an empty list, log via `ctx.log.error`, continue. The
+  existing single `error: string | null` on `SourceSetState` becomes
+  insufficient — move the error onto the per-source entry (`TaskSource.error?:
+string` or a parallel `errorsBySource` map) so one bad workspace doesn't blank
+  the whole model. The side panel keeps showing only global + active, so its
+  behavior is unaffected.
+
+The side panel keeps a **filtered read**: it selects the global source and the
+active workspace's from the full set (it already knows `ws.activeId`), so its
+UI is unchanged. The two new surfaces read the whole set.
+
+Watch cost: one directory watch per open workspace. At a realistic ceiling
+(dozens of workspaces) this is fine — the phase-1 watch is a debounced
+directory watch, not a poll. If it ever isn't, the fallback is to watch only
+sources with at least one mounted consumer; not built now.
+
+### `CrossTasksView` — the Navigator view
+
+```ts
+ctx.registerNavigatorView({
+  id: "silo.tasks.cross",
+  title: "Tasks",
+  icon: <ListChecks />,          // Phosphor, matching first-party view icons
+  order: 20,                      // after Workspaces (0) and Agents (10)
+  component: ({ active }) => <CrossTasksView paused={!active} ctx={ctx}
+    sourceSet={sourceSet} prefsStore={prefsStore} bridge={crossBridge} />,
+});
+```
+
+- Body is `<AggregatedList>` (below).
+- `active === false` → pass `paused` so the list throttles re-renders while off
+  screen (phase-1 panels already do this via `SidePanelProps.active`).
+- Header actions are **toolbar items on the `"navigator"` surface**, scoped with
+  `when: (ctx) => ctx.activeView === "silo.tasks.cross"` (ADR 0038 — one view,
+  controls are toolbar items, not a second view): `Group by ▾`, `Filter ▾`,
+  `Sort ▾`, and `New task`. Search is inline in the body, as in the side panel.
+
+### `TasksAppSheet` — the dock sheet
+
+```ts
+ctx.registerCommand({
+  id: "silo.tasks.open",
+  label: "Tasks: Open Tasks app",
+  run: () => {
+    if (sheetOpen) return ctx.layout.revealSidePanel(PANEL_ID); // re-reveal
+    sheetOpen = true;
+    void ctx.layout
+      .openPanelSheet(PANEL_ID, (close) =>
+        <TasksAppSheet ctx={ctx} sourceSet={sourceSet}
+          prefsStore={prefsStore} bridge={sheetBridge} onClose={close} />,
+        { title: "Tasks", width: 720, mode: "push" })
+      .finally(() => { sheetOpen = false; });
+  },
+});
+```
+
+- `mode: "push"` narrows the dock so the sheet takes real layout space — it is a
+  workbench surface, not a transient popover.
+- `bare: false` — the sheet keeps the host header (a title and the host's close
+  affordance); the body is `<AggregatedList>` with a `sheet` density flag if the
+  wider width warrants a roomier row (decide during build; default is identical
+  rows).
+- Non-modal is guaranteed by `openPanelSheet` itself (no scrim, Escape inert).
+  `Escape` inside `<AggregatedList>` still pops a drill-in page — same handler
+  the panel uses.
+- A single-instance guard (`sheetOpen`) — `openPanelSheet` has no singleton
+  option, so the command tracks it.
+
+### `AggregatedList` — the shared shell
+
+The one new UI unit both surfaces mount. Props: `ctx`, `sourceSet`,
+`prefsStore`, `bridge`, `paused?`, `density?`. Responsibilities:
+
+- `useServiceState(sourceSet)` → the full `sources` + `tasksBySource`.
+- Flatten to `Task[]`, run `buildView(tasks, sources, prefs)` with the
+  aggregated prefs.
+- Render group headers + `TaskList` / `TaskRow` (reused).
+- Own the drill-in stack (`bridge.drillTo`, `Escape` pops) — identical logic to
+  `TasksPanel`, extracted into a shared hook (`useDrillStack`) so there is one
+  copy. `TasksPanel` adopts the hook in the same change (small refactor, keeps
+  R5 "no forked copy" honest).
+- Inline `SearchInput`.
+
+The side panel's quick-add stays panel-only for phase 2 — creating into "the
+active workspace" from a cross-workspace surface is the "new tasks go to"
+question, which is **phase 3**. The `New task` toolbar action in the Navigator
+view reveals the side panel and focuses quick-add (the phase-1 command
+behavior), so nothing regresses and no destination picker is introduced early.
+
+## Data flow
+
+1. `activate` → `createSourceSet(ctx, providers)` → `start()` resolves global +
+   every open workspace, loads each list, opens one watch each.
+2. `ctx.workspaces` change → `resolve()` re-runs → sources added/removed, watches
+   synced, `commit()` emits a new `SourceSetState`.
+3. External file change → per-source watch fires → `loadSource` → `commit`.
+4. Any surface's mutation → `sourceSet.updateTask(...)` → provider writes that
+   source's file → `loadSource` → `commit` → all mounted surfaces re-render.
+5. Navigator view / sheet read the full `sources`; side panel reads its
+   two-source filtered slice. All three run the same `buildView`.
+
+## APIs / interfaces
+
+### SDK dependency — resolving other workspaces' storage dirs
+
+**The one open decision, and its sequencing gate.** The cross-workspace view
+needs the extension-storage directory for **every open workspace**, not just the
+active one. The phase-1 `ctx.storage.workspaceDir()` resolves the active
+workspace only, rejects with `NoWorkspaceError` otherwise, and **creates the
+directory as a side effect** ("created on first call").
+
+#### Option A (recommended) — extend `ctx.storage` in `silo-code/silo`
+
+Two additions to the existing `ExtensionStorageScopes` interface:
+
+```ts
+// existing method, two new optional params — fully backward compatible
+workspaceDir(
+  workspaceId?: string,
+  options?: { create?: boolean },
+): Promise<string>;
+
+// new: one call resolves a path for every open workspace
+workspaceDirs(
+  options?: { create?: boolean },
+): Promise<{ workspaceId: string; dir: string }[]>;
+```
+
+- **`workspaceId`** — omitted = the active workspace (today's behavior,
+  `NoWorkspaceError` when none). Passed = that workspace's dir, active or not.
+- **`options.create` defaults to `true`.** This is not a style choice — phase 1's
+  own `file-store` writes via `files.writeText(tmpPath, …)` into the
+  `workspaceDir()` result and never calls `createDir`, relying entirely on
+  `workspaceDir()` having made the directory. `writeText`'s contract is "creating
+  or overwriting **it**" — no parent creation (only `writeBytes` documents
+  `mkdir -p`). So `create: false` as the default would break every existing RFC
+  0032 writer, the Tasks extension included, with ENOENT on the tmp write.
+  `create: false` is opt-in for callers that only want the path.
+- **`workspaceDirs()`** resolves for every workspace in
+  `ctx.workspaces.getState().open` in one host round-trip — no fan-out of N
+  `workspaceDir(id)` calls. It carries the same `create` default (`true`), and
+  the aggregation path passes `{ create: false }`: it only ever **reads** each
+  `tasks.jsonl` (missing file → empty list, already handled in phase 1), and the
+  write path still goes through the active-workspace `workspaceDir()` with its
+  default `create: true`. No "which dirs already exist" filtering — knowing that
+  buys nothing when you read all N regardless.
+
+Cost: a `silo-code/silo` change (`@silo-code/sdk` + host), the `silo-docs-sync`
+workflow, an `@silo-code/sdk` + app release, and the extension bumps its
+`silo.engine` floor + `@silo-code/sdk` devDependency to match. `workspaceDir`'s
+new params are on an existing `@public` method; `workspaceDirs` is one new method
+on an existing interface (no new barrel export). `silo-docs-sync` scope: TSDoc +
+`@category` on both, the hand-authored `ctx` storage member page, `pnpm docs:api`,
+and a one-line roadmap note under the existing `ctx.storage` row. **No new
+roadmap primitive, no ADR** — it does not move an architectural boundary.
+
+Verdict: **recommended.** AGENTS.md — "if an extension needs a capability the SDK
+lacks, add it to `ctx`", don't reach into internals.
+
+#### Option B (fallback only) — derive the path in-extension
+
+```ts
+path.join(
+  path.dirname(await ctx.storage.globalDir()),
+  "workspaces",
+  w.id,
+  "tasks.jsonl",
+);
+```
+
+No cross-repo work, ships immediately. Rejected as the primary plan: the SDK
+documents that path shape as non-contractual ("always join onto the absolute
+path you get back"). Acceptable **only** as a temporary bridge if Option A's
+sign-off slips — behind a one-line helper (`resolveWorkspaceTasksDir`) whose body
+is swapped for the `workspaceDirs()` call when A ships, leaving call sites
+untouched — and then the coupling is noted as a known limitation in the extension
+README.
+
+#### Sequencing
+
+Option A gates the phase: land the SDK change in `silo-code/silo` → release
+`@silo-code/sdk` + app → bump the extension's pins → then build the phase-2
+extension UI. Starting the UI against Option B's helper in parallel is allowed;
+swapping to A later is a one-function change.
+
+### Extension surface
+
+- `ctx.registerNavigatorView` — used, not changed.
+- `ctx.layout.openPanelSheet` — used, not changed.
+- New command `silo.tasks.open`; new view id `silo.tasks.cross`; new
+  `"navigator"`-surface toolbar items `silo.tasks.nav.group|filter|sort|new`.
+
+## Persistence
+
+- No new files, no schema change. Tasks stay in the phase-1 NDJSON, one file per
+  source.
+- `lib/prefs.ts` gains a `"cross"` workspace-key sentinel: `viewKey("cross")` →
+  `"view:cross"`, alongside the existing `view:<id>` / `view:global`. The
+  `PrefsStore` grows a `setSurface("panel" | "cross")` (or the Navigator/sheet
+  instantiate a second `PrefsStore` bound to the `"cross"` key — decide during
+  build; a second store instance is simpler and the store is cheap).
+- Aggregated prefs live in `ctx.storage.global` — same bag, new key. Nothing in
+  `SidePanelProps.storage` / `ctx.storage.workspace` (phase-1 correction).
+
+## Error handling
+
+- **One workspace fails to resolve or load** → that source renders as an errored
+  row (a short "couldn't read this workspace's tasks" line, not a toast storm),
+  other sources unaffected. Per-source error state on the model (see
+  `source-set` above).
+- **A workspace has an unparsable `tasks.jsonl` line** → phase-1 behavior per
+  source: line preserved, one non-blocking notice naming the path, no re-notify
+  while unchanged. With many sources, the notice names which workspace.
+- **Sheet fails to open** (`openPanelSheet` rejects — no such panel id) → the
+  promise rejects; `sheetOpen` is reset in `.finally`; log and a notify. Can't
+  happen in practice (the panel id is registered in the same `activate`).
+- **`workspaceDirs()` omits or errors one entry** → treat as that workspace's
+  resolution failure (errored row), not a global fault. A `workspaceDirs()` call
+  that rejects wholesale is a real fault — surface it like a phase-1
+  `globalDir()` rejection.
+
+## Testing strategy
+
+Co-located Vitest, pure-logic style, `FileService` faked in-memory at the
+`ctx.files` seam (phase-1 harness).
+
+- `view.test.ts` — cross-source grouping: N workspace sources + global, grouped
+  by source; single non-empty source collapses; `groupByStatus` / `groupByLabel`
+  fan correctly across sources; a task filtered out appears in no group.
+- `source-set.test.ts` — resolves N+1 sources for N open workspaces; a
+  workspace with no file → empty source not an error; locator dedupe across
+  worktrees; open a workspace → source appears, others' loaded state and watches
+  intact; close a workspace → source and its watch gone, no leak; one
+  `workspaceDirs()` entry missing/errored → that source errors, others load;
+  deactivate → every watch disposed.
+- `prefs.test.ts` — `view:cross` key round-trips; reading/writing it never
+  touches `view:<id>` / `view:global`; the Navigator and sheet see the same
+  aggregated prefs.
+- `commands.test.ts` — `silo.tasks.open` opens the sheet once; a second call
+  re-reveals rather than stacking; `silo.tasks.open` with no workspace open
+  still opens (global-only).
+- `boundaries.test.ts` — extended: `providerId` / `"silo"` absent under the new
+  `ui/` files; `model/` + `lib/` gain no React/`ctx` import.
+- `useDrillStack` — extract as a pure-ish hook with a tested reducer (push/pop,
+  Escape pops one, never closes).
+- If Option A: SDK-side unit tests — `workspaceDir("other-id")` resolves the
+  right path; `workspaceDir()` with no args unchanged; `workspaceDir(id, { create: false })`
+  returns the path and does **not** create the dir; `workspaceDir(id)` (default)
+  still creates it; `workspaceDirs()` returns one entry per open workspace;
+  `workspaceDirs({ create: false })` creates nothing; `engine-compat` gate test.
+
+Manual runtime check (verifier-gui): two workspaces with tasks + a global list →
+open the Navigator "Tasks" view, confirm all three groups; edit a task in
+workspace B from the view while workspace A is active, confirm it persists;
+open the Tasks app sheet, confirm same content and non-modal behavior; append a
+line to workspace B's `tasks.jsonl` by hand, confirm it appears within ~0.5s.
+
+## Constraints and existing decisions
+
+- **ADR 0038** — the Navigator lists its views; register **one** view, controls
+  are `"navigator"`-surface toolbar items scoped with `when`, and set an `icon`.
+- **ADR 0026** — reach for the SDK design-system kit for content; the sheet and
+  Navigator chrome (`openPanelSheet` shell, view header) stay host-owned.
+- **ADR 0017 / theming** — extension CSS consumes design tokens only; the
+  stylelint rule runs over the new CSS.
+- **ADR 0021** — the Navigator view list is a roving-focus group; the view body
+  relies on the shared `:focus-visible` ring.
+- **ADR 0022 / RFC 0032** — task data is tier-1 user data reached only through
+  `ctx.files` within the extension's own storage dir; `permissions: []` holds.
+  Reading another workspace's dir is still inside the extension's own sandbox
+  subtree — no new permission.
+- **RFC 0031 durable proposal** — the LCD-core + descriptor seam, the
+  `providerId`-never-in-`ui` health check, "a task's workspace is derived from
+  its source, never stored", and "no ADR for the seam until a second aggregating
+  surface adopts it" — **phase 2 is that second aggregating surface**; re-evaluate
+  whether the seam now warrants an ADR (the durable proposal says to revisit at
+  exactly this point). Recommendation: still no ADR — the second consumer is the
+  same extension, not an independent one; note the re-evaluation in the collapse.
+- **`docs/side-panel-design.md`** governs the side panel; the **sheet** follows
+  `docs/modal-design.md` for content and its own non-modal chrome rules — check
+  both working logs for updates in the same change.
+- **`docs/domain-language.md`** — add **Tasks app** (the aggregated
+  cross-workspace surface: the Navigator "Tasks" view and the dock sheet are two
+  presentations of it) and, if useful, **aggregated view** vs the side panel's
+  scoped view. Same change, per the domain-modeling workflow.

--- a/docs/proposals/0031-tasks-extension/proposal.md
+++ b/docs/proposals/0031-tasks-extension/proposal.md
@@ -1,5 +1,5 @@
 ---
-status: accepted # phase 1 implemented; phases 2–4 remain
+status: accepted # phase 1 implemented; phase 2 in planning; phases 3–5 remain
 created: 2026-08-30
 ---
 
@@ -18,7 +18,75 @@ and consumes Silo only through the published `@silo-code/sdk`.
 
 **Phase 1 has shipped** — the Silo provider, the global and per-workspace lists,
 the side panel with group/filter/sort/search, drill-in detail, and
-create/edit/complete/delete. Phases 2–4 (below) are still planned.
+create/edit/complete/delete. Phases 2–5 (below) are still planned.
+
+## Planning scope
+
+**This package plans phase 2 only.** Phase 1 is implemented, verified, and
+collapsed; treat it as the current baseline. Phases 3–5 are not planned here.
+
+### What phase 2 delivers
+
+The two **aggregating surfaces** — the ones that show tasks from more than one
+source at once:
+
+1. **The Navigator cross-workspace view** — a registered Navigator view
+   (`ctx.registerNavigatorView`) that lists every open workspace's Silo tasks
+   plus the global list in one place, grouped by workspace, with the same
+   filter/sort/search/group controls and drill-in detail the side panel has.
+2. **The Tasks app dock sheet** — a dock-anchored, non-modal sheet
+   (`ctx.layout.openPanelSheet`) presenting the same aggregated list in a wider,
+   full-height layout, opened from a command.
+
+Both are pure UI over the **phase-1 provider seam**. The only new data-layer
+work is resolving a Silo `TaskSource` for **every open workspace** rather than
+just the active one — the payoff the phase-1 `source-set` store was built for
+("loaded and watched once, owned by the source set, not the panel — the
+multi-consumer payoff lands with phase 2's Navigator view").
+
+### What phase 2 explicitly does NOT touch
+
+No second provider. Beads and dex, tracker detection, per-workspace provider
+enablement, the "new tasks go to" destination choice, provider-rendered detail
+sections from a real second/third provider, and subprocess file-watched refresh
+are all **phase 3**. Writes across providers are phase 4; decorations are phase 5. (The original phase 2 bundled the aggregation surfaces with the Beads/dex
+work; they were split on 2026-09-01 — see the note under **Phases**.)
+
+### Phase-1 corrections phase 2 must preserve
+
+- **Preferences use `ctx.storage.global` keyed by workspace id**, never
+  `SidePanelProps.storage` / `ctx.storage.workspace` (which drop everything when
+  no workspace is open). The cross-workspace view is not per-workspace, so it
+  needs its own prefs key — it must not reuse or clobber a workspace's key.
+- **No `providerId` under `src/ui`** — the new view and sheet render through the
+  same generic seam; the `boundaries.test.ts` grep assertion extends to them.
+- **The global source always exists and is listable with no workspace open** —
+  the Navigator view and the sheet must both render in that state.
+- **No "new tasks go to" picker** — creating from a cross-workspace surface is
+  the phase-3 destination question; phase 2's `New task` action reuses the
+  phase-1 command (reveal the side panel, focus quick-add).
+
+### Cross-repository dependency (open decision)
+
+The phase-1 `ctx.storage.workspaceDir()` resolves the **active** workspace's
+directory only, and creating the directory is a side effect of the call. The
+cross-workspace view needs a path for **every** open workspace, without the
+create side effect. `design.md` weighs two options and recommends **Option A —
+extend `ctx.storage`** in **`silo-code/silo`**:
+
+- `workspaceDir(workspaceId?: string, options?: { create?: boolean })` — resolve
+  any workspace's dir (not just the active one); `options.create` **defaults to
+  `true`** because every existing RFC 0032 caller writes into the result without
+  calling `createDir` and `writeText` does not create parent dirs — so
+  `create: false` as the default would break them (the Tasks extension included).
+- `workspaceDirs(options?: { create?: boolean })` — one call resolves a path per
+  open workspace, so the aggregation layer does not fan out N calls.
+
+This triggers the `silo-docs-sync` workflow and an `@silo-code/sdk` + app
+release the extension then floors on. **It is the one decision that gates phase
+2's sequencing** and needs sign-off before implementation starts. Option B
+(derive the path in-extension) is a fallback only — the SDK documents the path
+shape as non-contractual.
 
 ## Motivation
 
@@ -56,6 +124,13 @@ tear down, so binding a task to one is nearly free. This proposal does not build
 that (see Non-goals), but it is why the architecture keeps a task's workspace
 association **derivable, never stored**.
 
+**Phase 2 specifically:** phase 1 gave each workspace a task list, but every list
+is walled inside its own workspace — to see what is outstanding across projects
+you switch workspaces one at a time. The cross-workspace view answers "what is on
+my plate everywhere" in one place, and the app sheet gives that same answer the
+room a ~250px side panel cannot. Both are the reason the phase-1 store was built
+as a shared, always-on resource rather than something the panel owns.
+
 ## Architecture
 
 ### The Task Source
@@ -66,12 +141,12 @@ source is identified by its **locator** and is either:
 - **Silo-managed** — a file Silo owns, outside any repo. One always-present
   **global** source ("Personal") and optionally one per workspace.
 - **Repo-derived** — a third-party tracker detected in a workspace folder (phase
-  2+).
+  3+).
 
 The provider (Silo, Beads, dex) is an implementation detail _of_ a source. Two
 workspaces that are worktrees of the same repository resolve to the **same**
 source — the locator is a dedupe key. Providers are **additive per workspace**: a
-workspace may have any number of sources enabled at once (phase 2+).
+workspace may have any number of sources enabled at once (phase 3+).
 
 ### The normalized model: LCD core, provider-rendered detail
 
@@ -191,20 +266,30 @@ Everything below is live in `silo-extensions/tasks/`.
 
 ## Phases
 
-| Phase     | Scope                                                                                                                                                                                                                                                                           | Status                                       |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| **1**     | Silo provider only — global + per-workspace lists, side panel, list with filter/sort/search, drill-in detail, create/edit/complete/delete. No provider UI, because there is nothing to choose.                                                                                  | **Implemented** — `silo-extensions` `tasks/` |
-| **2**     | Beads **and** dex together. Detection offers, per-workspace enablement, "new tasks go to", the Navigator cross-workspace view and the Tasks app dock sheet, provider-rendered detail sections from a real second/third provider, file-watched refresh for subprocess providers. | Planned                                      |
-| **3**     | Writes across providers; move/migrate between sources with lossy-field warnings and dependency-id remapping.                                                                                                                                                                    | Planned                                      |
-| **4**     | Decorations — workspace badges, status rows, status bar — all **default off**.                                                                                                                                                                                                  | Planned                                      |
-| **Later** | Backlog.md, Linear, GitHub Issues; Silo CLI for agent access; Start Task.                                                                                                                                                                                                       | Planned                                      |
+| Phase     | Scope                                                                                                                                                                                                                              | Status                                       |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| **1**     | Silo provider only — global + per-workspace lists, side panel, list with filter/sort/search, drill-in detail, create/edit/complete/delete. No provider UI, because there is nothing to choose.                                     | **Implemented** — `silo-extensions` `tasks/` |
+| **2**     | The **Navigator cross-workspace view** and the **Tasks app dock sheet** — two aggregating surfaces that show every workspace's list plus the global one in one place, built over the phase-1 Silo provider seam. No new providers. | **In planning** — this package               |
+| **3**     | Beads **and** dex together. Detection offers, per-workspace enablement, "new tasks go to", provider-rendered detail sections from a real second/third provider, file-watched refresh for subprocess providers.                     | Planned                                      |
+| **4**     | Writes across providers; move/migrate between sources with lossy-field warnings and dependency-id remapping.                                                                                                                       | Planned                                      |
+| **5**     | Decorations — workspace badges, status rows, status bar — all **default off**.                                                                                                                                                     | Planned                                      |
+| **Later** | Backlog.md, Linear, GitHub Issues; Silo CLI for agent access; Start Task.                                                                                                                                                          | Planned                                      |
 
-Phase 2 pairs Beads and dex deliberately: they are maximally different
+**Phase 2 was split out of the original phase 2** (2026-09-01). The original
+phase 2 bundled the cross-workspace aggregation surfaces with the Beads/dex
+provider work. They separate cleanly: the Navigator view and the Tasks app sheet
+are pure UI over the seam phase 1 already shipped and need no second provider to
+build or to prove, while Beads + dex is a self-contained chunk with its own risk.
+Splitting them lets the multi-consumer payoff the phase-1 `source-set` store was
+built for land first, on the one provider that already exists. Every later phase
+shifted down one number; nothing was dropped.
+
+Phase 3 pairs Beads and dex deliberately: they are maximally different
 (subprocess + Dolt + rich dependency graph vs. a plain file with no labels and no
 assignees), and with Silo as a superset that gives one provider _richer_ than the
 core schema and one _poorer_ — the actual test of whether the LCD line is drawn
-correctly. Phases 1–3 must each stand on their own for a human user; agent
-integration is additive and must not depend on the unshipped CLI work.
+correctly. Every phase must stand on its own for a human user; agent integration
+is additive and must not depend on the unshipped CLI work.
 
 Phase 1 built the **full provider seam** (`TaskSource`, the normalized core
 model, the optional-method `TaskProvider` interface, detail-section descriptors)
@@ -253,10 +338,10 @@ reshaping it under two is a worse test than designing it once.
   A two-Silo-source panel doesn't warrant a persisted default plus a one-off
   override menu. The active-workspace-with-global-fallback rule plus
   `silo.tasks.newInGlobal` covers it. A real destination choice returns in phase
-  2 when detected third-party providers make "which of several sources" a genuine
+  3 when detected third-party providers make "which of several sources" a genuine
   question.
 - **The Silo provider watches its own file in phase 1.** The phase table deferred
-  `ctx.files.watch` to phase 2; for a plain file the extension already owns, it's
+  `ctx.files.watch` to a later phase; for a plain file the extension already owns, it's
   a few lines and phase 1's storage pitch (an agent appends to the `.jsonl`)
   makes it mandatory.
 - **A patch's non-core fields travel through the descriptor channel** (`key` →
@@ -270,7 +355,9 @@ reshaping it under two is a worse test than designing it once.
   extension today, is not public SDK surface, and its rationale lives here.
   Revisit when a **second** aggregating surface adopts the same seam — at that
   point it becomes a contract with two implementations to generalize from rather
-  than one to guess at.
+  than one to guess at. **(Phase 2 is that second surface — re-evaluate at
+  collapse; the current recommendation in `design.md` is still no ADR, because
+  the second consumer is the same extension, not an independent one.)**
 - **Windows.** The predicted `resolve-path.ts` POSIX-only gap — a `permissions:
 []` own-dir write with a drive-absolute path failing with `ERROR_INVALID_NAME`
   — was **fixed in RFC 0032** (`silo-code/silo` #473): that module now recognizes
@@ -283,20 +370,26 @@ reshaping it under two is a worse test than designing it once.
 
 - **Repo / package:** `silo-code/silo-extensions`, `tasks/`, package
   `@silo-extensions/tasks`, manifest id `silo.tasks`, `publisher` `"Silo"`,
-  `permissions: []`. Added in `silo-extensions` #100.
+  `permissions: []`. Added in `silo-extensions` #100. **Phase 2's UI work lands
+  here too; the `ctx.storage` extension (Option A — `workspaceDir` params +
+  `workspaceDirs()`) lands in `silo-code/silo`** and ships in an `@silo-code/sdk`
+  - app release the extension
+    then floors on (`silo.engine` + the `@silo-code/sdk` devDependency).
 - **Layout:** `model/` (pure types), `lib/` (pure `ids` / `view` / `prefs`),
   `providers/silo/` (`jsonl`, `record`, `file-store`, `provider`) + `registry`,
   `sources/source-set` (the one reactive store), `ui/` (panel, toolbar, list,
   row, detail, generic descriptor renderer, quick-add, glyphs, CSS). Internal
   layering mirrors the repo's: `ui → {model, lib, sources}`, `sources → {model,
 providers}`, `providers → model`; nothing under `model/` or `lib/` imports
-  React or `ctx`.
+  React or `ctx`. Phase 2 adds `ui/CrossTasksView.tsx`, `ui/TasksAppSheet.tsx`,
+  and a shared `ui/AggregatedList.tsx`; `source-set` grows from 2 sources to
+  N + 1 (see `design.md`).
 - **Tests:** co-located Vitest, pure-logic style — `jsonl`, `record`, `view`,
   `ids`, `file-store` (absent file, tmp-then-rename, CAS reload/re-apply, retry
   exhaustion, serialization, content-based self-write suppression), `provider`,
   `source-set`, `prefs`, `commands`, and a grep-based `boundaries` assertion.
   `FileService` is faked in-memory at the `ctx.files` seam.
-- **Dependencies / sequencing:** requires RFC 0032's
+- **Dependencies / sequencing:** phase 1 requires RFC 0032's
   `ctx.storage.globalDir()` / `workspaceDir()` and the `ctx.files` own-dir
   sandbox lift — shipped in `@silo-code/sdk` **0.42.0** and Silo app **0.59.0**.
   The two pins are different numbers by design: `silo.engine: "^0.59.0"` is a
@@ -307,11 +400,14 @@ providers}`, `providers → model`; nothing under `model/` or `lib/` imports
   than 0.59.0 are gated by `silo.engine` until that release ships.
 - **Docs:** `docs/domain-language.md` gained a **Tasks** section (Task, Task
   Source, Lane, Ready; Task pinned to the intent, never an agent run; Task vs.
-  Follow-up; Beads' "beads workspace" must not reach the UI).
+  Follow-up; Beads' "beads workspace" must not reach the UI). Phase 2 adds
+  **Tasks app** (the aggregated cross-workspace surface).
   `docs/side-panel-design.md`'s working log records the token-styled native date
   input. `docs/silo-extensions-repo.md` and `silo-extensions/README.md` list
   `tasks/`. `silo.tasks` gets **no row** in `apps/docs/roadmap.md` — that table
-  is for bundled `core.*` / `silo.*` packages, and this ships external.
+  is for bundled `core.*` / `silo.*` packages, and this ships external. (The
+  phase-2 `ctx.storage` extension does get a one-line note under the existing
+  `ctx.storage` roadmap row.)
 
 ## Non-goals
 
@@ -349,27 +445,47 @@ init`'s repo modifications make Beads a poor default for repos you don't own.
 - **A generic `project` taxonomy that workspaces map into.** Rejected as a second
   taxonomy for a case labels already cover — labels are core, filterable, and
   cross-source.
+- **Phase 2: derive an inactive workspace's storage dir in-extension** (string
+  ops off `globalDir()`) instead of extending the SDK. Rejected as the primary
+  plan — the SDK documents the path shape as non-contractual; see `design.md`.
+  Kept only as a bridge (behind `resolveWorkspaceTasksDir`) if the SDK change
+  slips.
+- **Phase 2: default `workspaceDir`'s new `create` option to `false`.** Reads
+  cleaner in isolation, but `writeText` does not create parent directories and
+  every existing RFC 0032 caller relies on `workspaceDir()` having made the dir —
+  so `false` as the default breaks them. Default `true`; `false` is opt-in.
+- **Phase 2: fan out `workspaceDir(id)` per open workspace** instead of a
+  `workspaceDirs()` batch. Rejected — N host round-trips and, at the default
+  `create: true`, N empty directories littered for workspaces that have no
+  tasks.
+- **Phase 2: a dock panel kind (a real tab) instead of `openPanelSheet`.** The
+  proposal commits to a "dock sheet" — anchored, non-modal, dismissible — not a
+  persistent tab the user manages. `design.md` records the reasoning.
 
 ## Related decisions
 
-- [RFC 0032](./0032-ctx-extension-storage-directory.md) — the per-extension
-  storage directory and `ctx.files` own-dir sandbox lift this depends on.
-- [ADR 0022](./decisions/0022-on-disk-storage-layout.md) — three-tier on-disk
+- [RFC 0032](../0032-ctx-extension-storage-directory.md) — the per-extension
+  storage directory and `ctx.files` own-dir sandbox lift this depends on; phase 2
+  may extend its `workspaceDir()`.
+- [ADR 0022](../decisions/0022-on-disk-storage-layout.md) — three-tier on-disk
   layout; task data is tier 1, reached only via 0032's directories.
-- [ADR 0026](./decisions/0026-sdk-component-set.md) — the design-system kit is
-  the source for content components; panel chrome stays bespoke where
-  `docs/side-panel-design.md` says so.
-- [ADR 0017](./decisions/0017-css-theming-contract.md) — extension CSS uses
+- [ADR 0026](../decisions/0026-sdk-component-set.md) — the design-system kit is
+  the source for content components; panel and sheet chrome stay bespoke where
+  `docs/side-panel-design.md` / `docs/modal-design.md` say so.
+- [ADR 0017](../decisions/0017-css-theming-contract.md) — extension CSS uses
   design tokens only.
-- [ADR 0038](./decisions/0038-navigator-view-list.md) — `Group by` is a toolbar
-  control, not a second view.
-- [RFC 0021](./0021-follow-ups-extension-sdk.md) — Follow-ups, the adjacent
-  concept the glossary now disambiguates Task from.
-- [ADR 0045](./decisions/0045-ephemeral-change-planning.md) — the change-planning
+- [ADR 0038](../decisions/0038-navigator-view-list.md) — the Navigator lists its
+  views; register **one** view, controls are toolbar items, set an `icon`.
+- [RFC 0021](../0021-follow-ups-extension-sdk.md) — Follow-ups, the adjacent
+  concept the glossary disambiguates Task from.
+- [ADR 0045](../decisions/0045-ephemeral-change-planning.md) — the change-planning
   convention this proposal's phased collapse follows.
 
 ## Decision
 
 **Accepted** 2026-08-30. **Phase 1 implemented** and collapsed 2026-09-01;
-`status` stays `accepted` while phases 2–4 remain. Re-expand into a fresh
-planning package to plan phase 2.
+`status` stays `accepted` while phases 2–5 remain. The original phase 2 was
+split in two on 2026-09-01 (see the note under **Phases**); phases 3–5 are the
+old 2–4 shifted down. **Phase 2 re-expanded into this planning package on
+2026-09-01** — `requirements.md` / `design.md` / `tasks.md` are scoped to phase 2
+only and are deleted at collapse.

--- a/docs/proposals/0031-tasks-extension/requirements.md
+++ b/docs/proposals/0031-tasks-extension/requirements.md
@@ -1,0 +1,183 @@
+# Requirements — 0031 phase 2. Cross-workspace view + Tasks app sheet
+
+Behavioral spec for **phase 2 only**: the Navigator cross-workspace view and the
+Tasks app dock sheet, both over the phase-1 Silo provider. Phase 1's shipped
+behavior is the baseline and is not re-specified here. Working artifact — removed
+when the phase collapses.
+
+## R1 — Cross-workspace source resolution
+
+The extension must resolve a Silo `TaskSource` for the global list and for
+**every open workspace**, not only the active one, and load each source's tasks.
+
+### Acceptance criteria
+
+- [ ] With N open workspaces, the aggregated model exposes N + 1 sources (one per
+      open workspace plus the global "Personal" source), each with its resolved
+      task list.
+- [ ] A workspace with no `tasks.jsonl` yet resolves to a source with an empty
+      list, not an error and not a missing source.
+- [ ] Two workspaces that are worktrees of the same repo and resolve to the same
+      locator appear **once** (the phase-1 locator dedupe still applies).
+- [ ] Closed workspaces contribute no source to the aggregated model.
+- [ ] Opening or closing a workspace adds or removes its source within roughly a
+      second, with no manual refresh and without dropping the other sources'
+      loaded state or watches.
+- [ ] Resolution failure for one workspace surfaces that workspace as an errored
+      row and does not abort resolution of the others.
+
+## R2 — Per-workspace freshness
+
+An external change to any resolved workspace's `tasks.jsonl` (an agent or a
+hand-edit appends a line) must be reflected in every surface showing that source
+within roughly half a second, with no manual refresh.
+
+### Acceptance criteria
+
+- [ ] Each resolved source has exactly one directory watch (phase-1 rule: watch
+      the directory, filter to the `tasks.jsonl` basename, debounced).
+- [ ] The extension's own writes do not cause a reload loop (phase-1
+      content-based self-write suppression still applies, per source).
+- [ ] Watches are disposed when a workspace closes and when the extension
+      deactivates; no watch leaks across a workspace open/close cycle.
+
+## R3 — The Navigator cross-workspace view
+
+The extension must register one Navigator view (`ctx.registerNavigatorView`)
+titled "Tasks" that renders the aggregated task list.
+
+### Acceptance criteria
+
+- [ ] The view is listed in the Navigator's view list with a title and an icon
+      (ADR 0038 — `icon` is load-bearing beside the first-party views).
+- [ ] The view renders with **no workspace open** (global source only).
+- [ ] Default grouping is by source, one group header per workspace plus the
+      global list; a single non-empty source collapses to one unlabeled group
+      (phase-1 `groupBySource` rule).
+- [ ] `Group by`, `Filter`, and `Sort` are toolbar items on the `"navigator"`
+      surface, scoped to this view via `when`, and drive the same `buildView`
+      transformation the side panel uses.
+- [ ] Search is available within the view (inline, matching the side panel's
+      `SearchInput` placement conventions in `docs/side-panel-design.md`).
+- [ ] A row uses the phase-1 vocabulary exactly: status glyph · title · priority
+      mark, **no task id**, **no provider name**.
+- [ ] Selecting a row drills into the phase-1 `TaskDetail` page; `Escape` pops
+      one page and never closes the Navigator; the drilled-into task is not
+      persisted across a restart.
+- [ ] Edits made from the drill-in (title, lane, priority, labels, description,
+      due date, acceptance criteria) persist to that task's own source file and
+      are reflected in every other surface showing it.
+
+## R4 — The Tasks app dock sheet
+
+A command must open a dock-anchored, non-modal sheet
+(`ctx.layout.openPanelSheet`) presenting the same aggregated list in a wider,
+full-height layout.
+
+### Acceptance criteria
+
+- [ ] `silo.tasks.open` opens the sheet anchored to the tasks side panel's dock,
+      revealing that panel first (the documented `openPanelSheet` behavior).
+- [ ] The sheet is non-modal: no scrim, the rest of the workbench stays
+      interactive, and `Escape` does not close the sheet (it pops a drill-in
+      page, matching the panel).
+- [ ] The sheet shows the same sources, grouping, filtering, sorting, search, row
+      vocabulary, and drill-in detail as the Navigator view — one shared view
+      model, not a re-implementation.
+- [ ] The sheet renders with no workspace open.
+- [ ] `silo.tasks.open` with the sheet already open focuses / re-reveals it
+      rather than stacking a second sheet.
+- [ ] Closing the sheet leaves the Navigator view and side panel untouched and
+      loses no unsaved edits (edits persist immediately, per phase 1).
+
+## R5 — Shared view model across three surfaces
+
+The side panel, the Navigator view, and the sheet must read from **one**
+`source-set` store instance and one set of pure view functions.
+
+### Acceptance criteria
+
+- [ ] Exactly one `source-set` is created in `activate`; mounting or unmounting
+      any one surface neither reloads a source nor drops a watch.
+- [ ] A mutation from any surface updates all mounted surfaces without a manual
+      refresh.
+- [ ] `buildView`, `TaskRow`, the status glyphs, `TaskDetail`, and
+      `DetailSections` are reused unchanged except for an added cross-source
+      grouping path; no forked copy exists.
+
+## R6 — Preferences for the aggregated surfaces
+
+The Navigator view and the sheet must persist their own group/filter/sort/search
+/collapsed-group state, distinct from the side panel's per-workspace keys.
+
+### Acceptance criteria
+
+- [ ] Aggregated-surface prefs use a dedicated key (e.g. `view:cross`) in
+      `ctx.storage.global` and never read or write a `view:<workspaceId>` /
+      `view:global` key.
+- [ ] The Navigator view and the sheet **share** that one aggregated key (they
+      are the same list at two sizes), so a filter set in one shows in the other.
+- [ ] Prefs are read only after the store reports hydration and re-read when it
+      flips (phase-1 rule).
+- [ ] The side panel's existing per-workspace prefs behavior is unchanged.
+
+## R7 — Boundary and purity discipline holds
+
+Phase 2's new code obeys every phase-1 boundary rule.
+
+### Acceptance criteria
+
+- [ ] The bare token `providerId` (including `"silo"`) does not appear under
+      `src/ui` — the phase-1 grep assertion is extended to the new files and
+      still passes.
+- [ ] New CSS uses design tokens only (`silo/extension-design-tokens-only`
+      passes); no hard-coded colors, fonts, or px sizes.
+- [ ] Every tooltip uses the SDK `Tooltip`; the shared `:focus-visible` ring is
+      relied on, not re-implemented.
+- [ ] `model/` and `lib/` gain no React or `ctx` import; the internal layering
+      (`ui → {model, lib, sources}`, `sources → {model, providers}`) is intact.
+- [ ] Grouping/filtering/sorting/search over the aggregated `Task[]` remain pure
+      functions, unit-testable without rendering; sort stays stable.
+
+## R8 — SDK dependency, if taken (Option A)
+
+If phase 2 extends `ctx.storage` (the recommended path), the change is complete
+and documented in the same change in `silo-code/silo`: `workspaceDir` gains an
+optional `workspaceId` and an optional `options.create`, and a new
+`workspaceDirs(options?)` resolves a path per open workspace.
+
+### Acceptance criteria
+
+- [ ] `workspaceDir()` with no arguments behaves exactly as today — active
+      workspace, `NoWorkspaceError` when none, directory created.
+- [ ] `workspaceDir(id)` resolves that workspace's dir whether or not it is
+      active; `workspaceDir(id, { create: false })` returns the path and creates
+      nothing.
+- [ ] **`options.create` defaults to `true`** — every existing RFC 0032 caller
+      (which writes into the result without calling `createDir`) keeps working
+      unchanged; only an explicit `create: false` skips creation.
+- [ ] `workspaceDirs()` returns one `{ workspaceId, dir }` per workspace in
+      `ctx.workspaces.getState().open`, in a single host round-trip, carrying the
+      same `create` default; `workspaceDirs({ create: false })` creates nothing.
+- [ ] The `silo-docs-sync` workflow is run: TSDoc with `@public` + `@category` on
+      both methods, barrel re-export unchanged (same interface), the
+      hand-authored `ctx` storage member page updated, `pnpm docs:api`
+      regenerated, the one-line roadmap note added.
+- [ ] The extension's `silo.engine` floor and `@silo-code/sdk` devDependency are
+      bumped to the versions that carry it, and `engine-compat` gates older apps.
+- [ ] If phase 2 instead uses Option B (derive the path in-extension),
+      `design.md` records that decision and the coupling is documented as a known
+      limitation in the extension README, behind the `resolveWorkspaceTasksDir`
+      helper so the swap to Option A is one function body.
+
+## Out of scope
+
+- Beads / dex / any second provider, tracker detection, per-workspace provider
+  enablement, "new tasks go to", provider-rendered detail from a real second
+  provider, subprocess file-watched refresh — **phase 3**.
+- Writes across providers, move/migrate between sources — **phase 4**.
+- Decorations of any kind — **phase 5**.
+- Tasks from closed workspaces in the aggregated surfaces.
+- A kanban board, calendar, or any second persistent store.
+- Nesting UI, assignee pickers, or drag-reorder (`parentId` / `assignees` /
+  `rank` stay carried-but-unread, per phase 1).

--- a/docs/proposals/0031-tasks-extension/tasks.md
+++ b/docs/proposals/0031-tasks-extension/tasks.md
@@ -1,0 +1,122 @@
+# Tasks — 0031 phase 2. Cross-workspace view + Tasks app sheet
+
+Ordered where dependencies matter. Working artifact — removed at collapse.
+Phase 1 is the baseline; nothing here re-does phase-1 work.
+
+## 0. Decision gate (before implementation)
+
+- [ ] Sign-off on the SDK approach: **Option A** — extend `ctx.storage`
+      (`workspaceDir` gains `workspaceId?` + `options.create`, new
+      `workspaceDirs()`) in `silo-code/silo` — vs. Option B (derive in-extension).
+      See `design.md` → SDK dependency.
+- [ ] If Option A: confirm the release path (SDK version, app version, engine
+      floor) and that the extension work waits on that release or bridges with
+      Option B behind `resolveWorkspaceTasksDir`.
+
+## 1. SDK — extend `ctx.storage` (only if Option A; repo: `silo-code/silo`)
+
+- [ ] `workspaceDir(workspaceId?: string, options?: { create?: boolean })` —
+      `workspaceId` omitted = active (unchanged), `NoWorkspaceError` when none and
+      no id; `options.create` **defaults to `true`** (back-compat: existing
+      callers write into the result without `createDir`), `false` = resolve only.
+- [ ] `workspaceDirs(options?: { create?: boolean }): Promise<{ workspaceId, dir }[]>` —
+      one entry per workspace in `ctx.workspaces` open set, single round-trip,
+      same `create` default.
+- [ ] Host resolver returns `.../extension-storage/<extId>/workspaces/<workspaceId>`;
+      `mkdir` only when `create` is true.
+- [ ] `silo-docs-sync`: TSDoc + `@public`/`@category` on both, hand-authored
+      `ctx` storage member page, `pnpm docs:api`, one-line roadmap note under the
+      `ctx.storage` row.
+- [ ] Unit tests: `workspaceDir("other-id")` path; `workspaceDir()` unchanged;
+      `create: false` creates nothing; default still creates; `workspaceDirs()`
+      one-per-open-workspace; `workspaceDirs({ create: false })` creates nothing.
+- [ ] Release `@silo-code/sdk` + Silo app; note the versions.
+
+## 2. Cross-workspace source resolution (`sources/source-set.ts`)
+
+- [ ] `resolveSources()` builds one Silo source per open workspace (global source
+      stays first), matching each `{ workspaceId, dir }` to its `Workspace` for
+      the name.
+- [ ] Source of the dirs: `ctx.storage.workspaceDirs({ create: false })`
+      (Option A) or a loop over `resolveWorkspaceTasksDir(w)` (Option B bridge);
+      keep the phase-1 locator dedupe.
+- [ ] Move error state from the single `SourceSetState.error` to per-source
+      (`errorsBySource` map or `TaskSource.error?`); one workspace's failure
+      yields an errored, empty source and does not abort the rest.
+- [ ] Confirm `syncWatches` handles the larger set unchanged (add/remove diff).
+- [ ] Re-resolve on any `ctx.workspaces` open/close, not only active-id change.
+- [ ] Add a filtered selector the side panel uses (global + active) so its
+      behavior is unchanged.
+
+## 3. Shared UI shell (`ui/`)
+
+- [ ] Extract the drill-in stack from `TasksPanel` into `useDrillStack` (tested
+      reducer: push / pop / Escape-pops-one / never-closes); `TasksPanel` adopts it.
+- [ ] `AggregatedList.tsx` — props `{ ctx, sourceSet, prefsStore, bridge, paused?, density? }`;
+      reads the full source set, flattens, `buildView`, renders group headers +
+      `TaskList` / `TaskRow`, inline `SearchInput`, owns the drill stack.
+- [ ] Reuse `TaskDetail` / `DetailSections` / glyphs verbatim for drill-in.
+
+## 4. Navigator view (`ui/CrossTasksView.tsx`, `index.ts`)
+
+- [ ] `ctx.registerNavigatorView({ id: "silo.tasks.cross", title: "Tasks", icon, order: 20, component })`.
+- [ ] Body is `<AggregatedList paused={!active}>`.
+- [ ] Register `"navigator"`-surface toolbar items (`Group by` / `Filter` /
+      `Sort` / `New task`) scoped with `when: ctx.activeView === "silo.tasks.cross"`.
+- [ ] `New task` reveals the side panel and focuses quick-add (phase-1 command
+      behavior — no destination picker; that's phase 3).
+- [ ] Renders with no workspace open (global source only).
+
+## 5. Tasks app dock sheet (`ui/TasksAppSheet.tsx`, `index.ts`)
+
+- [ ] `silo.tasks.open` command → `ctx.layout.openPanelSheet(PANEL_ID, render, { title: "Tasks", width: 720, mode: "push" })`.
+- [ ] `sheetOpen` single-instance guard; a second call re-reveals via
+      `revealSidePanel(PANEL_ID)`; reset in `.finally`.
+- [ ] Body is `<AggregatedList density="sheet">`; host header kept (`bare: false`).
+- [ ] Escape pops a drill-in page, never closes the sheet.
+- [ ] Renders with no workspace open.
+
+## 6. Preferences (`lib/prefs.ts`)
+
+- [ ] `viewKey("cross")` → `"view:cross"`; Navigator + sheet share it.
+- [ ] A second `PrefsStore` bound to the `"cross"` key (simplest), or
+      `setSurface` on the existing store — pick one, keep it pure.
+- [ ] Reads gated on hydration; re-read on flip (phase-1 rule).
+- [ ] Verify the side panel's `view:<id>` / `view:global` behavior is untouched.
+
+## 7. Docs (same change)
+
+- [ ] `docs/domain-language.md` — add **Tasks app** (the aggregated
+      cross-workspace surface; Navigator view + sheet are two presentations).
+- [ ] `docs/side-panel-design.md` / `docs/modal-design.md` working logs — note
+      the sheet surface and any new control.
+- [ ] Extension `README.md` — document the cross-workspace view and the Tasks
+      app; if Option B was used, the storage-path coupling as a known limitation.
+- [ ] `apps/docs/roadmap.md` — the `ctx.storage` roadmap note (Option A only).
+- [ ] Re-evaluate whether the LCD-core + descriptor seam now warrants an ADR
+      (the durable proposal says to revisit when a second aggregating surface
+      adopts it). Record the outcome in the collapse.
+
+## 8. Tests
+
+- [ ] `view.test.ts` — cross-source grouping cases (per `design.md`).
+- [ ] `source-set.test.ts` — N+1 resolution, empty-file source, worktree dedupe,
+      open/close add/remove without leak, one-workspace failure isolated,
+      deactivate disposes every watch.
+- [ ] `prefs.test.ts` — `view:cross` round-trip and isolation from workspace keys.
+- [ ] `commands.test.ts` — `silo.tasks.open` open-once / re-reveal / no-workspace.
+- [ ] `boundaries.test.ts` — extended to the new `ui/` files and `model`/`lib`
+      import purity.
+- [ ] `useDrillStack` reducer tests.
+
+## 9. Verification
+
+- [ ] Every requirement in `requirements.md` (R1–R8) met or explicitly noted as not.
+- [ ] `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, `pnpm lint` pass
+      (extension: `npm` build per `docs/silo-extensions-repo.md`; `node build.mjs`).
+- [ ] Runtime check via `verifier-gui` — the scenario in `design.md` → Testing.
+- [ ] Durable decisions recorded (ADR only if the seam re-evaluation says so).
+- [ ] Collapse to a single curated `docs/proposals/0031-tasks-extension.md`,
+      mark phase 2 implemented in the phase table, keep `status: accepted`
+      (phases 3–5 remain), delete `requirements.md` / `design.md` / `tasks.md`,
+      repoint the index row to `./0031-tasks-extension.md`.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -120,6 +120,6 @@ don't get a proposal at all — see below.
 | [0028](./0028-terminal-identity-environment.md)               | Terminal identity in the environment                              | 2026-08-23 | implemented |
 | [0029](./0029-sdk-sheet-homedir-confirm-dont-show.md)         | Public SDK: `showSheet`, `homeDir`, `confirmWithDontShowAgain`    | 2026-08-25 | implemented |
 | [0030](./0030-navigator-view-arrangement.md)                  | Navigator view arrangement — reorder, disable, and a stacked mode | 2026-08-27 | implemented |
-| [0031](./0031-tasks-extension.md)                             | Tasks extension — Silo tasks, third-party trackers as sources     | 2026-08-30 | accepted    |
+| [0031](./0031-tasks-extension/proposal.md)                    | Tasks extension — Silo tasks, third-party trackers as sources     | 2026-08-30 | accepted    |
 | [0032](./0032-ctx-extension-storage-directory.md)             | A per-extension storage directory on `ctx`                        | 2026-08-30 | implemented |
 | [0033](./0033-agent-profiles.md)                              | Agent Profiles — naming how you start an agent                    | 2026-08-31 | accepted    |


### PR DESCRIPTION
## Summary

The Tasks extension (RFC 0031) ships in phases. Phase 1 — the Silo task lists and their side panel — is done. The original phase 2 tried to do two unrelated things at once: build the "see my tasks across every project" views, and add support for outside task trackers (Beads, dex). This splits them so the cross-project views can ship on their own, without waiting on the tracker-integration work.

1. **New phase 2** — the Navigator cross-workspace view and the "Tasks app" panel that grows out of the side dock. Both show every open project's task list plus the personal list in one place. Built entirely on what phase 1 already shipped; no outside trackers involved.
2. **New phase 3** — Beads and dex support, tracker auto-detection, per-project enablement, choosing where new tasks go. This is everything the old phase 2 also contained.
3. Everything after shifts down one number (old phase 3 → 4, old phase 4 → 5). Nothing was dropped.

This PR is **planning only** — it re-expands the proposal into a temporary planning package (requirements, design, task list) scoped to the new phase 2. No product code changes.

One decision needs sign-off before phase 2 implementation starts, and it may require a small companion change to the Silo SDK in a separate PR: the cross-workspace view needs to read every open workspace's task file, and the current SDK only hands an extension its *active* workspace's storage location. The plan recommends adding that capability to the SDK rather than having the extension guess at file paths. Details under `## Details`.

## Details

### What changed

- **`docs/proposals/0031-tasks-extension.md` → `docs/proposals/0031-tasks-extension/`** — re-expanded (Stage 2 of the change-planning convention) into `proposal.md` / `requirements.md` / `design.md` / `tasks.md`, all scoped to phase 2 only. `proposal.md` carries the full durable RFC plus a `## Planning scope` section; the three working files are deleted at collapse.
- **Phase table reshaped** in `proposal.md`: old phase 2 split into 2 (aggregation surfaces) + 3 (Beads/dex); old 3–4 become 4–5. A dated note under **Phases** explains the split; the **Decision** section records it.
- **`docs/proposals/README.md`** — index row repointed from `./0031-tasks-extension.md` to `./0031-tasks-extension/proposal.md`. Several other docs already linked to the directory form (they were briefly broken by the phase-1 collapse) and now resolve again.
- Phase references updated in prose (`phase 2+` → `phase 3+` for repo-derived sources, the "new tasks go to" note, etc.).

### The gating decision — cross-workspace storage resolution

`ctx.storage.workspaceDir()` resolves only the **active** workspace's extension-storage directory and creates it as a side effect. The cross-workspace view needs a path for every open workspace, read-only.

`design.md` weighs two options and recommends **Option A — extend `ctx.storage`** in `silo-code/silo`:

- `workspaceDir(workspaceId?: string, options?: { create?: boolean })` — resolve any workspace's dir; **`create` defaults to `true`** because every existing RFC 0032 caller writes into the result without calling `createDir`, and `writeText` does not create parent dirs — so `create: false` as the default would break them (the Tasks extension included).
- `workspaceDirs(options?: { create?: boolean })` — one host round-trip resolves a path per open workspace, so the aggregation layer does not fan out N calls or litter N empty directories.

**Option B** (derive the path in-extension from `globalDir()`) is a fallback only — the SDK documents that path shape as non-contractual. Kept behind a one-function helper so the swap to A is trivial if A's sign-off slips.

If Option A is taken, it's a companion PR against `silo-code/silo` (SDK + host + `silo-docs-sync` workflow + release), which phase 2's extension work then floors on via `silo.engine` + the `@silo-code/sdk` devDependency.

### Design highlights (phase 2)

- **One `source-set`, three surfaces.** The phase-1 store — created once in `activate`, explicitly built for this — becomes genuinely multi-consumer. The side panel keeps a filtered read (global + active); the Navigator view and sheet read the full set.
- **Navigator view** via `ctx.registerNavigatorView`, one view, grouped by workspace; `Group by / Filter / Sort / New task` as `"navigator"`-surface toolbar items scoped with `when` (ADR 0038).
- **Tasks app sheet** via `ctx.layout.openPanelSheet` anchored to the tasks panel, `mode: "push"`, non-modal, single-instance guarded.
- **Shared `AggregatedList` shell** + extracted `useDrillStack` hook so there is no forked list/drill-in copy (`TasksPanel` adopts the hook in the same change).
- **Prefs**: a dedicated `view:cross` key in `ctx.storage.global`, shared by the view and sheet, never touching the side panel's per-workspace keys (phase-1 correction preserved).
- **Boundary discipline**: the `providerId`-never-in-`ui` grep assertion and design-token-only CSS rule extend to the new files.

### Verification

- Doc-index sync test (`apps/docs/checks/doc-indexes.sync.test.ts`) — **162 passed**.
- Pre-commit hook (boundary lint, prettier, unit tests) — passed.
- No product code changed; nothing else to run.

### Not in this PR

Implementation of any kind. Beads/dex and everything else in phases 3–5. The companion SDK PR (created only once Option A is signed off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161gxcj8i2F6vFQojpz62ov