### PR TITLE
refactor(navigator): unify side-pane font scale, retune Navigator + Agents typography

### DIFF
--- a/apps/docs/.vitepress/theme/silo-demos.css
+++ b/apps/docs/.vitepress/theme/silo-demos.css
@@ -1036,12 +1036,12 @@ html.dark .silo-demo {
   color: var(--silo-activity-none);
 }
 .silo-demo .silo-activity-sm {
-  width: 6px;
-  height: 6px;
+  width: round(var(--silo-font-size-base) * 0.55, 2px);
+  height: round(var(--silo-font-size-base) * 0.55, 2px);
 }
 .silo-demo .silo-activity-md {
-  width: 8px;
-  height: 8px;
+  width: round(var(--silo-font-size-base) * 0.7, 2px);
+  height: round(var(--silo-font-size-base) * 0.7, 2px);
 }
 .silo-demo .silo-activity-working {
   color: var(--silo-activity-working);

--- a/apps/docs/api/types/functions/activityFromAgent.md
+++ b/apps/docs/api/types/functions/activityFromAgent.md
@@ -4,7 +4,7 @@
 function activityFromAgent(a): Activity | null;
 ```
 
-Defined in: [packages/sdk/src/activity.ts:30](https://github.com/silo-code/silo/blob/main/packages/sdk/src/activity.ts#L30)
+Defined in: [packages/sdk/src/activity.ts:33](https://github.com/silo-code/silo/blob/main/packages/sdk/src/activity.ts#L33)
 
 Map [AgentActivity](../type-aliases/AgentActivity.md) onto UI [Activity](../type-aliases/Activity.md). Returns `null` when there
 is nothing to paint (`none` / `dead` — callers may map `dead` → `"error"`

--- a/apps/docs/api/types/type-aliases/ActivitySize.md
+++ b/apps/docs/api/types/type-aliases/ActivitySize.md
@@ -4,7 +4,10 @@
 type ActivitySize = "sm" | "md";
 ```
 
-Defined in: [packages/sdk/src/activity.ts:20](https://github.com/silo-code/silo/blob/main/packages/sdk/src/activity.ts#L20)
+Defined in: [packages/sdk/src/activity.ts:23](https://github.com/silo-code/silo/blob/main/packages/sdk/src/activity.ts#L23)
 
-Glyph size for [Activity](Activity.md). `"sm"` matches workspace status rows (~6px);
-`"md"` is slightly larger for CenterDock / SideDock tabs.
+Glyph size for [Activity](Activity.md). `"sm"` (8px at the default `uiFontSize`) is
+the workbench size — workspace status rows and CenterDock / SideDock tabs;
+`"md"` (10px) is the roomier one, for a list that leads with the dot rather
+than tucking it into chrome. Both scale with `uiFontSize` rather than being
+fixed pixels.

--- a/apps/docs/design/components/activity.md
+++ b/apps/docs/design/components/activity.md
@@ -43,10 +43,10 @@ import { ActivityGlyph, type Activity } from "@silo-code/sdk";
 <ActivityGlyph size="sm" />  // omit activity → gray neutral
 ```
 
-| Prop       | Type                                         | Default | Notes                                          |
-| ---------- | -------------------------------------------- | ------- | ---------------------------------------------- |
-| `activity` | `"working" \| "ready" \| "warn" \| "error"`? | —       | Omit only for the gray neutral fallback        |
-| `size`     | `"sm" \| "md"`                               | `"sm"`  | `sm` ≈ workspace rows (6px); `md` ≈ tabs (8px) |
+| Prop       | Type                                         | Default | Notes                                                                                                                                                                                                                            |
+| ---------- | -------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activity` | `"working" \| "ready" \| "warn" \| "error"`? | —       | Omit only for the gray neutral fallback                                                                                                                                                                                          |
+| `size`     | `"sm" \| "md"`                               | `"sm"`  | `sm` (8px at default) is the workbench size — workspace status rows and tabs; `md` (10px) is for a list that leads with the dot. Both track `uiFontSize` — a proportion of the base size rounded to an even pixel, not fixed px. |
 
 ## Kinds
 

--- a/docs/decisions/0030-activity-chrome.md
+++ b/docs/decisions/0030-activity-chrome.md
@@ -27,9 +27,16 @@ everywhere.
    palette** (today’s `--ws-status-*` values), not per-theme-preset
    `--silo-color-*` tokens — so `working` is recognizably blue across the app
    within a theme.
-3. Paint is size-scaled by placement (`sm` ≈ workspace 6px, `md` ≈ CenterDock
-   tabs) via a public SDK `ActivityGlyph` component (same `.silo-activity*` class
-   contract as the rest of the kit).
+3. Paint is size-scaled by placement (`sm` for workbench chrome — workspace
+   rows and CenterDock tabs; `md` where a list leads with the dot, today the
+   Agents Navigator view) via a public SDK `ActivityGlyph` component (same `.silo-activity*` class
+   contract as the rest of the kit). Diameters are a proportion of
+   `--silo-font-size-base`, rounded to an even whole pixel (8px / 10px at the
+   default), so the dots track
+   `uiFontSize` like the rest of the UI. _(Amended 2026-09-02: originally a fixed
+   6px / 8px. Even, not merely whole: the `working` wave ring is the
+   dot scaled 3.4x, so an even diameter keeps ring and dot on one subpixel
+   phase.)_
 4. **CenterDock** gets adorn verbs `setActivity` / `clearActivity` /
    `flashActivity` / `bindActivity` on `ctx.editors` and `ctx.terminals`.
    Tab `animation` presets are removed; trailing **indicators** stay

--- a/docs/side-panel-design.md
+++ b/docs/side-panel-design.md
@@ -38,16 +38,17 @@ The host owns absolute size. Extensions inherit and step relatively.
 
 At default `uiFontSize` (13px):
 
-| Slot              | Host rule                                            | Computed |
-| ----------------- | ---------------------------------------------------- | -------- |
-| App / editor base | `--silo-font-size-base`                              | 13px     |
-| Left side pane    | `--silo-internal-font-size-left-panel` = base + 1px  | 14px     |
-| Right side pane   | `--silo-internal-font-size-right-panel` = base + 2px | 15px     |
+| Slot              | Host rule                                           | Computed |
+| ----------------- | --------------------------------------------------- | -------- |
+| App / editor base | `--silo-font-size-base`                             | 13px     |
+| Side pane         | `--silo-internal-font-size-side-panel` = base + 2px | 15px     |
 
-Applied in `SideColumn.css` on `.side-pane[data-location]`. Files / Git / Search
-**do not pin a root `font-size`** — they inherit the pane. Primary row labels
-are `1em` (15px on the right); secondary lines use `calc(1em - 1px)` (14px) or
-`calc(1em - 2px)` for denser chrome (file-tree roots).
+**One scale for both columns** — the left and right panes are identical (15px
+at defaults), so a panel reads the same wherever it is docked. Applied in
+`SideColumn.css` on `.side-pane[data-location="left"], [data-location="right"]`.
+Files / Git / Search **do not pin a root `font-size`** — they inherit the pane.
+Primary row labels are `1em` (15px); secondary lines use `calc(1em - 1px)`
+(14px) or `calc(1em - 2px)` for denser chrome (file-tree roots).
 
 | Role                       | Rule                                                                    |
 | -------------------------- | ----------------------------------------------------------------------- |
@@ -60,7 +61,7 @@ are `1em` (15px on the right); secondary lines use `calc(1em - 1px)` (14px) or
 
 **Kit `List` gotcha:** `.silo-list-row` is styled with
 `font-size: var(--silo-font-size-sm)` (absolute — 12px at default), so a List
-inside a right pane renders ~3px smaller than Files/Git trees. Until the kit
+inside a side pane renders ~3px smaller than Files/Git trees. Until the kit
 inherits, override in the panel:
 
 ```css
@@ -70,9 +71,10 @@ inherits, override in the panel:
 ```
 
 **Sheets** portal outside the pane, so they lose inheritance. Re-apply the
-matching slot formula on the sheet body (right-dock companion →
-`calc(var(--silo-font-size-base) + 2px)`), and pull `.silo-sheet-title` up to
-`1em` under a sheet className so the header matches.
+side-pane scale on the sheet body —
+`font-size: calc(var(--silo-font-size-base) + 2px)` (the internal token is
+lint-blocked for extensions, so copy the formula) — and pull `.silo-sheet-title`
+up to `1em` under a sheet className so the header matches.
 
 Avoid `--silo-font-size-sm` as a blanket secondary size in panels — it is an
 absolute token off app base, not off the pane.
@@ -299,8 +301,8 @@ The drill-in header is **two rows**, shared by github-prs, github-issues, and
 2. **Title row** (`align-items: flex-start`, `gap: 10px`) — the entity title
    (`flex: 1`, wraps) and, right-aligned, the primary action button(s).
 
-**Title text** is body, not chrome: `font-size: 1em` (the pane scale — 15px in
-the right column), `font-weight: 600`, `line-height: 1.35`,
+**Title text** is body, not chrome: `font-size: 1em` (the pane scale — 15px at
+defaults), `font-weight: 600`, `line-height: 1.35`,
 `color: var(--silo-color-text-hi)`. When the title is an `InlineEdit`, override
 its value span — `.silo-inline-edit-value` pins itself to
 `--silo-font-size-base` (13px) and would otherwise render a step small:
@@ -463,3 +465,4 @@ Record concrete tweaks as we learn them so the table above stays honest.
 | 2026-08-31 | **`silo.tasks` detail field order + identity footer** — core `Labels` field moved to sit directly under the provider's free-form `Description` (not up with the Lane / Priority pickers); the old subtitle line (lane · list · id) removed — lane duplicates the Lane control, and `List` / `Workspace` / `ID` now render as read-only `.silo-section-label` rows at the **foot**, beside the provider's `Created`.                                                                                                                                                     | Order fields by reading priority, not core-vs-provider origin; task id / list are reference facts, not header material.                                                                                                                                                                                                         |
 | 2026-08-31 | **Filled derived-color label chips** — a colorless string tag (`silo.tasks` label) renders as a solid chip, hue hashed from the text (`hsl(h 65% 45%)`, `#161616` / `#fff` text picked by luma), `radius-sm` rectangle like github-issues `.ghi-chip--label`. **Not** the kit `Badge` — its `color` prop is a 20% tint, too faint for a content chip. `LabelsField` + `lib/labels.ts`; new "Label / tag chips" note under Inputs.                                                                                                                                       | Wanted the github-issues label look; task labels carry no color of their own, so derive it; `Badge` tint didn't read as filled.                                                                                                                                                                                                 |
 | 2026-08-31 | **`InlineEdit` in a hand-rolled panel needs `yieldEscapeToInlineEdit()`** — the panel's own document-level Escape handler must call it first and bail on `true`, else the first Escape pops the detail page instead of cancelling the edit. `silo.tasks` `TasksPanel` fixed; `LabelsField` registers `setActiveInlineEditCancel` like `InlineEdit` does. Also: a hand-rolled edit `Input` must set the `autoCapitalize` / `autoCorrect` / `spellCheck` off trio itself (tasks' Labels input was missing it).                                                            | `Modal.tsx` wires the two-stage Escape; a side panel with its own keydown listener doesn't inherit it.                                                                                                                                                                                                                          |
+| 2026-09-02 | **Left and right side panes unified to one scale** — the two internal tokens (`--silo-internal-font-size-left-panel` = base+1px, `-right-panel` = base+2px) collapsed into `--silo-internal-font-size-side-panel` = base+2px (15px). `SideColumn.css` now applies it to both `data-location`s; `EmptyWatermark` follows the rename. Regressing absolute pins fixed to relative: Navigator `.nav-view-row` (`base+1px` → `1em`), agent-monitor `.ap-row-workspace` / `-sep` / `-elapsed` (`--silo-font-size-sm` → `calc(1em - 1px)`).                                    | The left pane rendered a step smaller than the right for no reason a user could name; Navigator / agent views read undersized next to Files / Git. One number, right pane as the reference.                                                                                                                                     |

--- a/packages/extension-host/src/layout/SideColumn.css
+++ b/packages/extension-host/src/layout/SideColumn.css
@@ -147,16 +147,15 @@
 
 /* The column owns its panel font size (theming-contract.md › the sizing rule):
    the dock sets it here and panel content inherits + sizes relatively (em), so
-   panels never name the internal token and a panel adopts its column's scale
-   wherever it's docked. Left/right are intentionally different scales.
+   panels never name the internal token and a panel adopts the side-panel scale
+   wherever it's docked. Left and right share one scale — a panel reads the same
+   in either column.
    Keyed off `data-location`, not `data-slot`: a pane id is opaque (RFC 0027),
    so a prefix match on the slot would silently stop applying the moment a pane
-   is named anything but the legacy left*/
-right* strings. */ .side-pane[data-location="left"] {
-  font-size: var(--silo-internal-font-size-left-panel);
-}
+   is named anything but the legacy "left"/"right" slot strings. */
+.side-pane[data-location="left"],
 .side-pane[data-location="right"] {
-  font-size: var(--silo-internal-font-size-right-panel);
+  font-size: var(--silo-internal-font-size-side-panel);
 }
 
 .side-tab-host {

--- a/packages/extension-host/src/layout/components.css
+++ b/packages/extension-host/src/layout/components.css
@@ -586,14 +586,27 @@
   color: var(--silo-activity-none);
 }
 
+/* Diameters track `uiFontSize` (a proportion of the base size, not a fixed px)
+   so the dots grow and shrink with the rest of the UI on `Cmd/Ctrl +/-`.
+   8px / 10px at the 13px default.
+
+   Rounded to an *even* whole pixel, not just a whole one. The `working` wave
+   rings are the dot's own box scaled by `silo-activity-wave`'s 3.4, so the
+   ring's size is `diameter × 3.4` — fractional for most diameters (9 → 30.6),
+   which lands the ring's edges on a different subpixel phase than the dot's
+   and reads as an off-centre ring wherever the dot itself sits at a fractional
+   x. That happens on the agents rows, which right-align the dot against a
+   user-resizable (so fractionally-wide) side panel, and it's plainly visible
+   at devicePixelRatio 1. An even diameter keeps `md` at 10 → 34, an integer,
+   so ring and dot share one phase. */
 .silo-activity-sm {
-  width: 6px;
-  height: 6px;
+  width: round(var(--silo-font-size-base) * 0.55, 2px);
+  height: round(var(--silo-font-size-base) * 0.55, 2px);
 }
 
 .silo-activity-md {
-  width: 8px;
-  height: 8px;
+  width: round(var(--silo-font-size-base) * 0.7, 2px);
+  height: round(var(--silo-font-size-base) * 0.7, 2px);
 }
 
 .silo-activity-working {

--- a/packages/extension-host/src/layout/theme.css
+++ b/packages/extension-host/src/layout/theme.css
@@ -232,10 +232,10 @@
    * never a contract — lint-blocked for extensions. The panel-derived sizes are
    * applied to the panel slot wrapper; extension content inherits them (see the
    * sizing rule) and never names them. */
-  /* Right/left panel content (file tree, git status rows) — intentionally a bit
-   * larger than terminal/editor base for legibility. */
-  --silo-internal-font-size-right-panel: calc(var(--silo-font-size-base) + 2px);
-  --silo-internal-font-size-left-panel: calc(var(--silo-font-size-base) + 1px);
+  /* Side-panel content (file tree, git status rows, Navigator) — intentionally a
+   * bit larger than terminal/editor base for legibility. One scale for both the
+   * left and right columns: a panel reads the same wherever it is docked. */
+  --silo-internal-font-size-side-panel: calc(var(--silo-font-size-base) + 2px);
   --silo-internal-titlebar-h: 36px;
   --silo-internal-statusbar-h: 36px;
 }

--- a/packages/extension-host/src/panels/DockTab.tsx
+++ b/packages/extension-host/src/panels/DockTab.tsx
@@ -291,7 +291,7 @@ export function DockTab(props: IDockviewPanelHeaderProps) {
           disabled={!act.tooltip}
         >
           <span className="dvi-tab-activity" aria-label={act.tooltip}>
-            <ActivityGlyph activity={act.activity} size="md" />
+            <ActivityGlyph activity={act.activity} size="sm" />
           </span>
         </Tooltip>
       ))}

--- a/packages/extension-host/src/panels/EmptyWatermark.tsx
+++ b/packages/extension-host/src/panels/EmptyWatermark.tsx
@@ -42,7 +42,7 @@ export function EmptyWatermark() {
     borderRadius: 0,
     padding: "4px 0",
     color: "var(--silo-color-accent)",
-    fontSize: "var(--silo-internal-font-size-right-panel)",
+    fontSize: "var(--silo-internal-font-size-side-panel)",
     cursor: "pointer",
     textAlign: "left",
     width: "100%",

--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -37,10 +37,10 @@
   border-radius: var(--silo-radius-sm);
   color: var(--silo-color-text-hi);
   font-family: var(--silo-font-ui);
-  /* Matches the surrounding left-panel size (SideColumn.css sets that to
-     base + 1px) so the destinations sit level with the view bodies they lead
-     to. The icon column and `size={19}` glyphs are scaled to match. */
-  font-size: calc(var(--silo-font-size-base) + 1px);
+  /* Inherit the side-pane scale (SideColumn.css) so the destinations sit level
+     with the view bodies they lead to. The icon column and `size={19}` glyphs
+     are scaled to match. */
+  font-size: 1em;
   cursor: pointer;
   user-select: none;
 }

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -114,7 +114,9 @@
 }
 
 .ws-item .ws-name {
-  font-weight: 600;
+  /* Matches the row title in github-prs / github-issues (`.ghpr-row__title`):
+     pane size (1em, inherited), medium weight — not bold — and `text-hi`. */
+  font-weight: 500;
   color: var(--silo-color-text-hi);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -243,7 +245,9 @@
   gap: 5px;
   margin-top: 2px;
   font-family: var(--silo-font-ui);
-  font-size: calc(1em - 1.5px);
+  /* Secondary line — one step below the pane (14px at defaults), matching
+     `.ws-folder` and the ghpr/ghi row meta line. */
+  font-size: calc(1em - 1px);
   color: var(--silo-color-text-lo);
   min-width: 0;
 }

--- a/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
@@ -3,6 +3,7 @@ import type { AgentRow } from "./agents-panel-view";
 import {
   buildAgeSections,
   buildStatusSections,
+  buildWorkspaceSections,
   staleSectionStartsExpanded,
 } from "./agents-panel";
 
@@ -390,5 +391,42 @@ describe("staleSectionStartsExpanded", () => {
       8,
     );
     expect(staleSectionStartsExpanded(sections)).toBe(true);
+  });
+});
+
+describe("subtitle axis", () => {
+  const r = row({ section: "done", workspaceName: "Silo Dev" });
+
+  it("is the bare workspace name in the Recent view — no status prefix", () => {
+    // The row's activity dot already carries the state, and sorted by age
+    // nearly every row reads "Idle".
+    const [age] = buildAgeSections([r], false, 8, []);
+    expect(age.subtitle(r)).toBe("Silo Dev");
+    expect(age.subtitleIsWorkspace).toBe(true);
+  });
+
+  it("is the workspace name in the by-status view, where status is the heading", () => {
+    const sections = buildStatusSections([r], false, 8);
+    const idle = sections.find((s) => s.header === "Idle");
+    expect(idle?.subtitle(r)).toBe("Silo Dev");
+    expect(idle?.subtitleIsWorkspace).toBe(true);
+  });
+
+  it("is the status label in the by-workspace view, and is not marked as a workspace", () => {
+    // The workspace is already the heading here, so a workspace glyph on the
+    // subtitle would label the status as something it isn't.
+    const [group] = buildWorkspaceSections([r]);
+    expect(group.subtitle(r)).toBe("Idle");
+    expect(group.subtitleIsWorkspace).toBe(false);
+  });
+
+  it("marks the stale heading the same way as the section it splits from", () => {
+    const stale = row({ section: "done", since: hoursAgo(9) });
+    for (const sections of [
+      buildStatusSections([stale], true, 8),
+      buildAgeSections([stale], true, 8, []),
+    ]) {
+      expect(sections.every((s) => s.subtitleIsWorkspace)).toBe(true);
+    }
   });
 });

--- a/packages/extensions-silo/src/agents/agents-panel.tsx
+++ b/packages/extensions-silo/src/agents/agents-panel.tsx
@@ -4,7 +4,11 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import { CaretRight, DotsSixVertical } from "@phosphor-icons/react";
+import {
+  CaretRight,
+  DotsSixVertical,
+  SquaresFour,
+} from "@phosphor-icons/react";
 import type { Activity, ExtensionContext, MenuEntry } from "@silo-code/sdk";
 import { ActivityGlyph, Badge, useServiceState } from "@silo-code/sdk";
 import {
@@ -54,6 +58,14 @@ export interface PanelSection {
   header: string;
   rows: AgentRow[];
   subtitle: (row: AgentRow) => string;
+  /**
+   * Whether `subtitle` yields a **workspace name** (so the row can mark it with
+   * the workspace glyph) rather than a status label. The by-workspace view is
+   * the one that answers `false`: there the workspace is already the heading,
+   * so the subtitle carries the status instead — marking it with a workspace
+   * glyph would label it as something it isn't.
+   */
+  subtitleIsWorkspace: boolean;
   /** Whether the render below collapses this heading's rows by default,
    * revealing them on hover or on click of the heading (see
    * `staleHoverExpandEnabled`) — only the "N+ hours old" heading does, since
@@ -110,6 +122,7 @@ export function buildStatusSections(
         ? groups.done.filter((row) => !isStaleDone(row, staleDoneHours))
         : groups[section],
     subtitle,
+    subtitleIsWorkspace: true,
   }));
   if (!staleDoneEnabled) return statusSections;
   return [
@@ -119,6 +132,7 @@ export function buildStatusSections(
       header: `${staleDoneHours}+ hours old`,
       rows: groups.done.filter((row) => isStaleDone(row, staleDoneHours)),
       subtitle,
+      subtitleIsWorkspace: true,
       collapsible: true,
     },
   ];
@@ -132,6 +146,7 @@ export function buildWorkspaceSections(
     header: group.workspaceName,
     rows: group.rows,
     subtitle: (row) => SECTION_LABELS[row.section],
+    subtitleIsWorkspace: false,
   }));
 }
 
@@ -156,8 +171,10 @@ export function buildAgeSections(
   staleDoneHours: number,
   manualOrder: readonly string[],
 ): PanelSection[] {
-  const subtitle = (row: AgentRow) =>
-    `${SECTION_LABELS[row.section]} · ${row.workspaceName}`;
+  // Workspace only — no status prefix. The row's activity dot already says
+  // what state the agent is in, and with this view sorted by age nearly every
+  // row reads "Idle", so the label cost a line of width to repeat the glyph.
+  const subtitle = (row: AgentRow) => row.workspaceName;
   const isStale = (row: AgentRow) =>
     staleDoneEnabled &&
     row.section === "done" &&
@@ -174,6 +191,7 @@ export function buildAgeSections(
     header: "",
     rows: activeRows,
     subtitle,
+    subtitleIsWorkspace: true,
   };
   if (!staleDoneEnabled) return [ageSection];
   return [
@@ -183,6 +201,7 @@ export function buildAgeSections(
       header: `${staleDoneHours}+ hours old`,
       rows: rows.filter(isStale).slice().sort(compareRows),
       subtitle,
+      subtitleIsWorkspace: true,
       collapsible: true,
     },
   ];
@@ -228,6 +247,7 @@ interface RowDrag {
 function AgentRowItem({
   row,
   subtitle,
+  subtitleIsWorkspace,
   active,
   icon,
   iconMode,
@@ -237,9 +257,12 @@ function AgentRowItem({
   drag,
 }: {
   row: AgentRow;
-  /** Workspace name in the "by status" view; status label in the "by
-   * workspace" view — whichever isn't already the enclosing section header. */
+  /** Workspace name in the "by status" and "Recent" views; status label in the
+   * "by workspace" view — whichever isn't already the enclosing section
+   * header. */
   subtitle: string;
+  /** See `PanelSection.subtitleIsWorkspace` — gates the workspace glyph. */
+  subtitleIsWorkspace: boolean;
   active: boolean;
   icon: AgentIcon | undefined;
   iconMode: IconMode;
@@ -269,7 +292,14 @@ function AgentRowItem({
         onContextMenu(row, { x: e.clientX, y: e.clientY });
       }}
     >
-      <ActivityGlyph activity={glyphFor(row)} className="ap-row-glyph" />
+      {/* `md`, not the default `sm`: on the row's trailing edge the dot is the
+          only thing carrying state, so it needs the weight the leading slot's
+          smaller glyph used to borrow from its position. */}
+      <ActivityGlyph
+        activity={glyphFor(row)}
+        size="md"
+        className="ap-row-glyph"
+      />
       <div className="ap-row-text">
         <span className="ap-row-title-line">
           <AgentIconGlyph
@@ -281,6 +311,14 @@ function AgentRowItem({
           <span className="ap-row-title">{row.title}</span>
         </span>
         <span className="ap-row-subtitle">
+          {subtitleIsWorkspace && (
+            <SquaresFour
+              className="ap-row-ws-icon"
+              size={12}
+              weight="fill"
+              aria-hidden="true"
+            />
+          )}
           <span className="ap-row-workspace">{subtitle}</span>
           {row.since && (
             <>
@@ -732,6 +770,7 @@ export function AgentsPanel({
                     key={row.terminalId}
                     row={row}
                     subtitle={section.subtitle(row)}
+                    subtitleIsWorkspace={section.subtitleIsWorkspace}
                     active={row.terminalId === activeTerminalId}
                     icon={
                       ctx.agents.catalog().find((c) => c.id === row.agentId)

--- a/packages/extensions-silo/src/agents/styles.css
+++ b/packages/extensions-silo/src/agents/styles.css
@@ -87,8 +87,10 @@
 }
 
 /* Agent views in the Navigator — all classes prefixed ap-; tokens
-   only. Root inherits the column font size from `.side-pane`, so no absolute
-   font-size here. Deliberately NOT its own scroll container: the host's
+   only. The root pins no font-size — it inherits the side-pane scale, and rows
+   step relative to it (`1em`, `calc(1em - 1px)`); only the uppercase section
+   heading uses a fixed chrome size. Deliberately NOT its own scroll container:
+   the host's
    `.tab-pane` (the panel's scrolling ancestor) already scrolls, persists, and
    styles scroll position for whatever renders inside it. Giving `.ap-body`
    its own nested `overflow-y: auto` stacked TWO scrollable regions at the
@@ -115,10 +117,15 @@
      aren't interactive rows, so they align with the chrome above them
      instead of with the rows below. */
   padding: 4px 12px;
-  font-size: var(--silo-font-size-sm);
+  /* The canonical side-panel group heading (git `.section-head`,
+     skills-manager, `silo.tasks`): chrome tier, 600, uppercase, `0.06em`,
+     muted to `text-lo`. Chrome size is absolute off app base on purpose —
+     a group label is chrome, so it stays put while the rows it groups scale
+     with the pane. */
+  font-size: var(--silo-font-size-chrome);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   color: var(--silo-color-text-lo);
 }
 .ap-section-title-clickable {
@@ -132,16 +139,27 @@
   transform: rotate(90deg);
 }
 /* The heading is uppercase + letter-spaced; a count inside it isn't. Geometry
-   and color come from the kit's `size="sm"` chip. */
+   and color come from the kit's `size="sm"` chip.
+
+   Pushed to the heading's trailing edge like git's `.section-count` and
+   skills-manager's, so counts line up down the panel's right edge instead of
+   floating at the end of each label. */
 .ap-section-count {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
   text-transform: none;
   letter-spacing: normal;
 }
 .ap-row {
   display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 6px 12px;
+  /* Centred, not top-aligned: the activity dot sits on the row's trailing edge
+     (see `.ap-row-glyph`), where it has to read level with the whole two-line
+     block rather than against the title's first line. */
+  align-items: center;
+  gap: 9px;
+  padding: 7px 12px;
   /* Match WorkspacesView `.ws-item` inset so hover/active backgrounds don't
      flush to the pane edges. */
   margin: 0 4px 2px;
@@ -154,8 +172,14 @@
 .ap-row.active {
   background: var(--silo-color-bg-active);
 }
+
+/* Trailing edge, after the text block — the agent's own icon leads the row, so
+   the status dot reads as the row's outcome rather than competing with the
+   identity mark for the leading slot. `order` rather than DOM position keeps
+   the glyph first in the reading order for assistive tech. */
 .ap-row-glyph {
-  margin-top: 4px;
+  order: 3;
+  margin-left: auto;
   flex-shrink: 0;
 }
 .ap-row-text {
@@ -171,8 +195,10 @@
 }
 .ap-row-icon {
   flex-shrink: 0;
-  width: 12px;
-  height: 12px;
+  /* The row's primary identifier — which agent this is — so it carries real
+     weight rather than sitting as a hint beside the title. */
+  width: 16px;
+  height: 16px;
   /* "Monotone" mode's color (unset when "color" mode overrides it inline) —
      the middle text tier: lighter than text-hi (the title's own color, which
      read too heavy for a small glyph) but still darker/more solid than
@@ -186,17 +212,39 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Centred rather than baseline-aligned: the workspace mark below is an SVG,
+   whose baseline is its bottom edge — on a baseline row it would hang low
+   against the text. Every text part here is the same size, so centring reads
+   identically for them. */
 .ap-row-subtitle {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 4px;
   min-width: 0;
+  /* Set here, not only on each part, so the workspace mark's `currentColor`
+     resolves to the line's own color. */
+  color: var(--silo-color-text-lo);
 }
+
+/* Workspace mark before the name — the same Phosphor `SquaresFour` the
+   Workspaces view uses for a workspace, so one glyph means one thing across
+   the Navigator. Inherits `currentColor` from the subtitle so it can never
+   drift from the line it sits on; only shown where the subtitle really is a
+   workspace name (see `subtitleIsWorkspace` in agents-panel.tsx). */
+.ap-row-ws-icon {
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  opacity: 0.75;
+}
+
 .ap-row-workspace {
   min-width: 0;
   flex-shrink: 1;
   color: var(--silo-color-text-lo);
-  font-size: var(--silo-font-size-sm);
+  /* Secondary line, one step below the row title — relative to the pane, not
+     the absolute `--silo-font-size-sm` (which is off app base, a step small). */
+  font-size: calc(1em - 1px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -204,12 +252,12 @@
 .ap-row-sep {
   flex-shrink: 0;
   color: var(--silo-color-text-lo);
-  font-size: var(--silo-font-size-sm);
+  font-size: calc(1em - 1px);
 }
 .ap-row-elapsed {
   flex-shrink: 0;
   color: var(--silo-color-text-lo);
-  font-size: var(--silo-font-size-sm);
+  font-size: calc(1em - 1px);
 }
 /* The "Recent" view's drag affordance — only that view passes `drag` to
    AgentRowItem, so this only ever appears there. Hidden until the row is

--- a/packages/extensions-silo/src/agents/styles.css
+++ b/packages/extensions-silo/src/agents/styles.css
@@ -176,14 +176,16 @@
 /* Trailing edge, after the text block — the agent's own icon leads the row, so
    the status dot reads as the row's outcome rather than competing with the
    identity mark for the leading slot. `order` rather than DOM position keeps
-   the glyph first in the reading order for assistive tech. */
+   the glyph first in the reading order for assistive tech. The text block's
+   `flex: 1` (below) takes the row's slack, so the dot — and the grip beside
+   it — sit against the right edge without an auto margin of their own. */
 .ap-row-glyph {
   order: 3;
-  margin-left: auto;
   flex-shrink: 0;
 }
 .ap-row-text {
   display: flex;
+  flex: 1;
   flex-direction: column;
   min-width: 0;
 }
@@ -261,13 +263,12 @@
 }
 /* The "Recent" view's drag affordance — only that view passes `drag` to
    AgentRowItem, so this only ever appears there. Hidden until the row is
-   hovered, and pinned to the row's right edge via the auto margin rather
-   than a fixed position, so it still lines up if the row's content is
-   short. */
+   hovered. Sits directly left of the status dot in the trailing cluster
+   (`order: 2`, between the text block and the `order: 3` glyph); the text
+   block's `flex: 1` holds it there whatever the row's content width. */
 .ap-row-grip {
+  order: 2;
   flex-shrink: 0;
-  margin-left: auto;
-  padding-left: 4px;
   display: flex;
   align-items: center;
   color: var(--silo-color-text-lo);

--- a/packages/extensions-silo/src/file-search/FileSearchPanel.css
+++ b/packages/extensions-silo/src/file-search/FileSearchPanel.css
@@ -4,7 +4,7 @@
   height: 100%;
   overflow: hidden;
   font-family: var(--silo-font-ui);
-  /* Inherit the host's side-panel font size (it sets the right-panel size on the
+  /* Inherit the host's side-panel font size (it sets the side-pane scale on the
      column body) — don't pin it, or the panel renders smaller than its siblings.
      Secondary text below scales down with `em` so it tracks that size. */
   color: var(--silo-color-text);

--- a/packages/sdk/src/activity.ts
+++ b/packages/sdk/src/activity.ts
@@ -11,8 +11,11 @@ import type { AgentActivity } from "./agents-service";
 export type Activity = "working" | "ready" | "warn" | "error";
 
 /**
- * Glyph size for {@link Activity}. `"sm"` matches workspace status rows (~6px);
- * `"md"` is slightly larger for CenterDock / SideDock tabs.
+ * Glyph size for {@link Activity}. `"sm"` (8px at the default `uiFontSize`) is
+ * the workbench size — workspace status rows and CenterDock / SideDock tabs;
+ * `"md"` (10px) is the roomier one, for a list that leads with the dot rather
+ * than tucking it into chrome. Both scale with `uiFontSize` rather than being
+ * fixed pixels.
  *
  * @category Core Types
  * @public


### PR DESCRIPTION
## Summary

A typography pass over the left-hand Navigator and its Agents view, so the side panels read as one consistent system.

1. **The left and right side panels now use the same text size.** The left panel was rendering one pixel smaller than the right for no reason anyone could name, which made the Navigator and Agents lists look slightly undersized next to Files, Git, and Search. Both columns are now 15px at the default zoom, so a panel looks the same wherever it is docked.
2. **The Agents list was retuned.** The status dot moves to the right-hand edge of each row where it reads as the agent's current state, the agent's own icon gets a little larger as the primary "which agent is this" marker, and a small workspace icon now precedes the workspace name — the same icon the Workspaces view uses — except in the "by workspace" grouping where the workspace is already the section heading. Section headings and their counts were aligned to match Git and the other panels.
3. **Activity dots now grow and shrink with the rest of the UI.** They were a fixed pixel size, so they stayed put when you zoomed the interface with Cmd/Ctrl +/-. They now scale like everything else.
4. **Workspace names in the Workspaces list** use the same weight and secondary-line size as the GitHub PR and Issue lists.

No new SDK surface and nothing behind a flag — this is visual-only and ships as-is.

## Details

### Side-pane font scale

- `--silo-internal-font-size-left-panel` (base + 1px) and `--silo-internal-font-size-right-panel` (base + 2px) collapse into one `--silo-internal-font-size-side-panel` (base + 2px = 15px at the 13px default). `theme.css` defines it; `SideColumn.css` applies it to `.side-pane[data-location="left"], [data-location="right"]` together.
- `EmptyWatermark.tsx` follows the token rename. `FileSearchPanel.css` comment updated (no rule change — it already inherits).
- Absolute pins that the left/right split had forced are regressed to relative: Navigator `.nav-view-row` `calc(base + 1px)` → `1em`; agent-monitor `.ap-row-workspace` / `-sep` / `-elapsed` `--silo-font-size-sm` → `calc(1em - 1px)`.
- `docs/side-panel-design.md` rewritten for the single scale, with a dated changelog row.

### Agents Navigator view (`packages/extensions-silo/src/agents/`)

- `AgentRowItem`: the `ActivityGlyph` moves to the row's trailing edge via `order: 3; margin-left: auto` (kept first in DOM order for assistive tech) and renders at `size="md"`. Rows switch to `align-items: center`; `gap` 8→9px, `padding` 6→7px.
- `.ap-row-icon` (the agent's own glyph) grows 12→16px — it is the row's primary identifier, not a hint beside the title.
- New `PanelSection.subtitleIsWorkspace: boolean`. `buildStatusSections` / `buildAgeSections` set `true`; `buildWorkspaceSections` sets `false` (the workspace is already the heading there, so the subtitle carries the status label instead and must not get a workspace glyph). `AgentRowItem` renders a `SquaresFour` mark (the same glyph `core.workspaces` uses) before the subtitle only when the flag is `true`.
- `buildAgeSections` subtitle drops the `"${SECTION_LABELS} · "` prefix — the activity dot already carries state and an age-sorted list is almost all "Idle".
- `.ap-section-title` moves from `--silo-font-size-sm` to `--silo-font-size-chrome` (the canonical side-panel group-heading tier — 600, uppercase, `0.06em`, `text-lo`, chrome-absolute so it stays put while rows scale). `.ap-section-count` gets `margin-left: auto` to sit on the heading's trailing edge like Git's `.section-count`.
- Tests: new `subtitle axis` block in `agents-panel-sections.test.ts` covering `subtitleIsWorkspace` across all three groupings plus the stale split.

### ActivityGlyph sizing (`packages/extension-host/src/layout/components.css`, `packages/sdk/src/activity.ts`)

- `.silo-activity-sm` / `-md` go from fixed `6px` / `8px` to `round(var(--silo-font-size-base) * 0.55, 2px)` / `* 0.7` — 8px / 10px at the default, tracking `uiFontSize`.
- Rounded to an **even** pixel: the `working` wave ring is the dot scaled 3.4×, so an even diameter (10 → 34) keeps ring and dot on one subpixel phase; odd diameters made the ring look off-centre where the dot sits at a fractional x (the right-aligned agents rows against a user-resizable panel, visible at DPR 1).
- `sm` is now the workbench size, so `DockTab.tsx` switches its tab glyph `size="md"` → `size="sm"`.
- ADR `0030-activity-chrome.md` amended (dated 2026-09-02) with the fixed→scaled rationale and the even-pixel note. SDK `ActivitySize` TSDoc rewritten; `apps/docs/api/**` and `apps/docs/design/components/activity.md` regenerated; `apps/docs/.vitepress/theme/silo-demos.css` demo classes follow the formula.

### WorkspacesView (`packages/extensions-core/src/workspaces/WorkspacesView.css`)

- `.ws-name` `font-weight` 600 → 500 and `.ws-item` meta line `calc(1em - 1.5px)` → `calc(1em - 1px)`, matching `.ghpr-row__title` / the github-prs / github-issues row meta.

### Verification

- `pnpm --filter silo exec tsc --noEmit` — clean.
- `pnpm lint` (ESLint boundary gate + stylelint design-token rule) — clean.
- `pnpm test` — 11 packages, all green; new agents subtitle-axis tests included.
- `pnpm docs:api` — no drift after regeneration.

### Follow-up (not in this PR)

The Navigator "+" button still follows the active view (via `stackedChromeHostId` / the `when` predicate on `core.workspaces.add`). Moving it to live solely on the Workspaces view-list row is a separate change that needs an RFC + an ADR 0038 amendment — tracked for next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLa3J2zMwUtyPT6yHJ4Knc
