### PR TITLE
feat(navigator): move the Add-workspace "+" onto the Workspaces row

### DIFF
--- a/docs/decisions/0038-navigator-view-list.md
+++ b/docs/decisions/0038-navigator-view-list.md
@@ -74,6 +74,10 @@ rejection of that shape.
   the view header, not a moving row. An intentionally unscoped item (e.g.
   `core.workspaces.add`) stays in the same place as the user switches views,
   which the earlier active-row placement would not have given it.
+  **Revised by ADR [0048](./0048-navigator-unscoped-chrome-on-workspaces-row.md):**
+  the one unscoped item, the Add-workspace "+", now rides the **Workspaces row**
+  of the view list rather than following the user across every view header.
+  Scoped `"navigator"` items are unchanged — they stay in their view's header.
 - Which view is active is conveyed **visually by the header alone**; the rows carry
   `aria-selected` but no highlight. Assistive tech is told at the point of choice,
   sighted users read it off the header.

--- a/docs/decisions/0048-navigator-unscoped-chrome-on-workspaces-row.md
+++ b/docs/decisions/0048-navigator-unscoped-chrome-on-workspaces-row.md
@@ -1,0 +1,186 @@
+---
+status: accepted
+date: 2026-09-02
+---
+
+# 0048. Unscoped Navigator chrome rides the Workspaces row, not the active view
+
+## Context
+
+The Navigator's one interactive header contribution that isn't scoped to a
+single view is `core.workspaces.add` — the **Add-workspace "+"**. ADR
+[0038](./0038-navigator-view-list.md) placed it in the **View Header** (the bar
+naming the Active View) and made it _unscoped_: its `when` returns true for
+every view, so as the user switches views the "+" follows them and stays in one
+fixed screen position. ADR 0038 called that out as a deliberate consequence —
+"an intentionally unscoped item stays in the same place as the user switches
+views, which the earlier active-row placement would not have given it."
+
+In daily use that has worn the wrong way:
+
+- **The "+" is noise on every other view.** On Agents, on Tasks, on any
+  third-party view, a control that only ever creates a _workspace_ sits in the
+  header regardless. It reads as "an action for this view" when it isn't one.
+- **"Follows you everywhere" isn't a property this action needs.** Adding a
+  workspace is not so frequent, mid-task, that it must be one click from
+  wherever you happen to be. It is the Workspaces view's own primary action.
+- **The stacked arrangement already disagrees with one-at-a-time.** ADR
+  [0044](./0044-navigator-stacked-arrangement.md) / RFC 0030 shipped stacked
+  mode, where the "+" is pinned to a _single_ section (Workspaces, or the top
+  section if Workspaces is hidden) via `stackedChromeHostViewId()` — precisely
+  because repeating it on every section header was obviously wrong there. The
+  two arrangements place the same control by two different rules.
+
+The fix is to give the two arrangements one rule: the "+" belongs to the
+**Workspaces view's own affordance**, wherever that view is represented.
+
+## Decision
+
+Otherwise-unscoped `"navigator"`-surface toolbar chrome renders **once**, in a
+single **unscoped-chrome slot** that belongs to the Workspaces view:
+
+- **One-at-a-time, View List shown** — a trailing slot on the **Workspaces row**
+  of the View List.
+- **One-at-a-time, View List hidden** (only one view enabled) — the **View
+  Header**, which is the only place actions render in that case (unchanged from
+  ADR 0038's single-view fallback).
+- **Stacked** — the **Workspaces section header** (as ADR 0044 already did).
+
+If the **Workspaces view is disabled**, the slot is not rendered and the "+"
+does **not** appear in the Navigator at all. Recovery is the workspace
+status-bar item (bottom-left), which already offers "New workspace…". This
+drops ADR 0044's "…or the top section if Workspaces is hidden" fallback: the
+"+" is the Workspaces affordance, and if Workspaces isn't in the Navigator the
+"+" isn't either.
+
+Per-view header contributions (today `silo.agents.group-by`, scoped by `when`
+to `silo.agents.by-status`) are unaffected — they keep rendering in the View
+Header / section header of the view they belong to.
+
+### Mechanism (no `@silo-code/sdk` change)
+
+`core.navigator` renders two kinds of `ContributedToolbar` on the
+`"navigator"` surface:
+
+1. **Per-view**, as today — `target: { viewId: <real view id> }` — on each View
+   Header (one-at-a-time) or section header (stacked). Catches scoped items.
+2. **The unscoped-chrome slot** — `target: { viewId: <sentinel> }` — rendered
+   in the one place above. The sentinel is a reserved, non-real view-id string
+   owned by `core.navigator` and exposed on its bundled-only
+   `NavigatorExtensionAPI`:
+
+   ```ts
+   interface NavigatorExtensionAPI {
+     SettingsPanel: ComponentType;
+     /**
+      * The synthetic `ToolbarItemContext["navigator"].viewId` the Navigator
+      * passes from its single unscoped-chrome slot (the Add-workspace "+"'s
+      * home — the Workspaces View List row, its View Header when the list is
+      * hidden, or its stacked section header). `null` when the Workspaces view
+      * is disabled, so the slot isn't rendered. An item whose `when` matches
+      * this value renders there and nowhere else; a normal per-view item
+      * matches a real view id and never sees it.
+      */
+     unscopedChromeTarget(): string | null;
+   }
+   ```
+
+`core.workspaces.add`'s `when` collapses to
+`(_keys, target) => target.viewId === navApi.unscopedChromeTarget()`. When
+Workspaces is disabled that returns `null`, nothing matches, and the "+" is
+gone from the Navigator. The `core.navigator` → `core.workspaces` boundary is
+unchanged: `core.workspaces` reads `core.navigator`'s API (arrow points
+workspaces → navigator, as it already did for `stackedChromeHostViewId`);
+`core.navigator` still knows nothing of workspaces.
+
+`stackedChromeHostViewId()` and the internal `stackedChromeHostId()` helper are
+replaced by this one `unscopedChromeTarget()` path — the "stacked-only"
+qualifier is gone because the concept now spans both arrangements.
+
+### Keyboard and assistive tech
+
+The Workspaces row is a `role="tab"` in the View List's `role="tablist"` with
+`useFocusGroup` roving focus (ADR [0021](./0021-keyboard-navigation-architecture.md)).
+The "+" is rendered as a **sibling of the tab element inside a row wrapper**,
+not a child of the tab, so the tab stays a clean single selectable and the
+tablist stays one Tab stop. The "+" itself is `tabIndex={-1}` — a pointer
+affordance, like the CenterDock tab close button and the Agents "Recent"
+drag grip. Keyboard and AT users reach "new workspace" through the
+`workspace.new` command (command palette, and its keybinding) and the
+status-bar item — both already fully keyboard-accessible, and the same
+division ADR 0038 accepted when it noted "a keybinding remains worth adding
+alongside the list".
+
+## Consequences
+
+- **One placement rule for both arrangements.** The "+" attaches to the
+  Workspaces representation — row, header, or section — and to nothing else.
+  `core.workspaces`' `when` predicate goes from a three-branch host-state
+  check to a one-line equality.
+- **Reverses the relevant ADR 0038 consequence.** "Unscoped items keep a fixed
+  position in the View Header" is now "unscoped items ride the Workspaces
+  row." ADR 0038's core decision (list, not menu; header names the active
+  view) stands; a pointer at this ADR is added to that consequence bullet.
+- **The "+" can be absent from the Navigator.** If a user disables the
+  Workspaces view, the Navigator shows no "+". This is intended — but it means
+  the status-bar item is now the _only_ in-chrome path to "new workspace" for
+  that user, and `workspace.new` should carry a default keybinding so there's
+  always a keyboard path. (Filed as follow-up if it doesn't already.)
+- **"New workspace" via the "+" is pointer-only.** Keyboard/AT users use the
+  command or the status bar. Acceptable because two keyboard paths already
+  exist and the row's Tab-stop model (ADR 0038 / 0021) is worth more than a
+  third; revisit if the command-palette path proves too indirect in practice.
+- **A reserved sentinel view id exists.** `unscopedChromeTarget()` returns a
+  string that is deliberately not any real view's id. It's internal to the
+  bundled `core.navigator` ⇄ `core.workspaces` pair and never reaches
+  `@silo-code/sdk`; a third-party view contributing a `"navigator"` toolbar
+  item still only ever sees real view ids in its `when`.
+- **Third-party views cannot put a button on their own row.** Out of scope on
+  purpose (see Alternatives) — nothing asks for it, and the general version is
+  a public API with real a11y and publish-lag cost.
+- **Discoverability of "add workspace" drops slightly when you're on another
+  view.** From Agents, adding a workspace is now: click the Workspaces row
+  (which also switches you there), or use the status bar, or the command. It
+  was one click from anywhere. Judged worth it — the control stops masquerading
+  as an action for every other view, and the view whose action it _is_ always
+  shows it.
+
+## Alternatives considered
+
+- **A general per-row action API** — `NavigatorView.rowActions`, or a
+  `placement: "view-header" | "view-list-row"` hint on the toolbar
+  contribution, so any view can put an icon button on its own View List row.
+  **Rejected (not deferred):** exactly one consumer exists
+  (`core.workspaces.add`), it's a public `@silo-code/sdk` addition with the
+  usual third-party publish lag, and it widens the a11y surface to "a
+  focusable button inside every `role="tab"` row". The narrow mechanism here
+  costs no SDK surface and is not a one-way door — if a real second consumer
+  appears, the sentinel slot generalizes into a placement hint without
+  breaking the first.
+- **Keep it in the View Header, unscoped, as ADR 0038 has it.** The status quo.
+  Rejected per Context — it's visual noise on every non-Workspaces view and the
+  "follows you" property isn't one this action needs.
+- **Leave the "+" on the first enabled view when Workspaces is disabled**
+  (ADR 0044's current stacked fallback, kept for one-at-a-time too). Rejected:
+  it reattaches a workspace action to an unrelated view. Cleaner to say the
+  "+" is the Workspaces affordance and route recovery through the status bar.
+- **Put the "+" as a real focusable child of the tab** (roving-focus target or
+  its own Tab stop). Rejected: a focusable child inside `role="tab"` is
+  contrary to the APG tabs pattern, and interleaving extra Tab stops in the
+  tablist breaks ADR 0038's "one Tab stop, arrow between rows" model. The
+  sibling-in-a-wrapper structure keeps both clean.
+
+## References
+
+- ADR [0038](./0038-navigator-view-list.md) — the View List + View Header; the
+  "unscoped items keep a fixed position in the View Header" consequence this
+  revises.
+- ADR [0044](./0044-navigator-stacked-arrangement.md) — stacked arrangement;
+  `stackedChromeHostViewId()`, whose "…or the top section" fallback this drops.
+- ADR [0021](./0021-keyboard-navigation-architecture.md) — `useFocusGroup`, the
+  roving-focus primitive behind the View List tablist.
+- ADR [0029](./0029-adornments-vs-registration.md) — panel chrome is
+  contributed, not owned by the panel.
+- `packages/extensions-core/src/navigator/` — the panel, its pure view model,
+  and `navigator-api.ts`.
+- `packages/extensions-core/src/workspaces/index.tsx` — `core.workspaces.add`.

--- a/docs/decisions/0048-navigator-unscoped-chrome-on-workspaces-row.md
+++ b/docs/decisions/0048-navigator-unscoped-chrome-on-workspaces-row.md
@@ -101,15 +101,21 @@ qualifier is gone because the concept now spans both arrangements.
 
 The Workspaces row is a `role="tab"` in the View List's `role="tablist"` with
 `useFocusGroup` roving focus (ADR [0021](./0021-keyboard-navigation-architecture.md)).
-The "+" is rendered as a **sibling of the tab element inside a row wrapper**,
-not a child of the tab, so the tab stays a clean single selectable and the
-tablist stays one Tab stop. The "+" itself is `tabIndex={-1}` — a pointer
-affordance, like the CenterDock tab close button and the Agents "Recent"
-drag grip. Keyboard and AT users reach "new workspace" through the
-`workspace.new` command (command palette, and its keybinding) and the
-status-bar item — both already fully keyboard-accessible, and the same
-division ADR 0038 accepted when it noted "a keybinding remains worth adding
-alongside the list".
+The "+" is rendered as a **sibling of the tab element**, inside a
+`role="presentation"` row wrapper — not a child of the tab. A focusable control
+inside a `role="tab"` is contrary to the APG tabs pattern; as a sibling it is
+an ordinary `<button>` that:
+
+- stays out of the arrow-key roving set (`useFocusGroup`'s `count` is the view
+  count, unchanged), so ↑/↓ still move only between view rows — ADR 0038's
+  "one Tab stop, arrow between rows" model for the list itself is intact;
+- is its own Tab stop, reached right after the Workspaces row — the normal
+  behaviour for a per-row action button, and it makes "new workspace"
+  keyboard-reachable from the Navigator.
+
+`workspace.new` also gains a default keybinding (`cmd+shift+n`, mirroring the
+native File-menu `cmd+n`), so the command path works even when the Workspaces
+view — and therefore the "+" — is disabled.
 
 ## Consequences
 
@@ -122,14 +128,11 @@ alongside the list".
   row." ADR 0038's core decision (list, not menu; header names the active
   view) stands; a pointer at this ADR is added to that consequence bullet.
 - **The "+" can be absent from the Navigator.** If a user disables the
-  Workspaces view, the Navigator shows no "+". This is intended — but it means
-  the status-bar item is now the _only_ in-chrome path to "new workspace" for
-  that user, and `workspace.new` should carry a default keybinding so there's
-  always a keyboard path. (Filed as follow-up if it doesn't already.)
-- **"New workspace" via the "+" is pointer-only.** Keyboard/AT users use the
-  command or the status bar. Acceptable because two keyboard paths already
-  exist and the row's Tab-stop model (ADR 0038 / 0021) is worth more than a
-  third; revisit if the command-palette path proves too indirect in practice.
+  Workspaces view, the Navigator shows no "+". This is intended; recovery is
+  the status-bar item and the new `workspace.new` keybinding (`cmd+shift+n`).
+- **The View List region gains one Tab stop** (the "+", after the Workspaces
+  row) — only when the Workspaces view is enabled. The arrow-key model for the
+  rows is unchanged.
 - **A reserved sentinel view id exists.** `unscopedChromeTarget()` returns a
   string that is deliberately not any real view's id. It's internal to the
   bundled `core.navigator` ⇄ `core.workspaces` pair and never reaches

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -38,52 +38,53 @@ A small, obvious choice needs neither.
 
 ## Index
 
-| ADR                                                     | Title                                                              | Date       | Status   |
-| ------------------------------------------------------- | ------------------------------------------------------------------ | ---------- | -------- |
-| [0001](./0001-in-process-extension-architecture.md)     | In-process, registry-based extension architecture                  | 2026-05-23 | accepted |
-| [0002](./0002-imperative-registration-no-manifest.md)   | Imperative registration; no static manifest (v1)                   | 2026-05-23 | accepted |
-| [0003](./0003-monorepo-pnpm.md)                         | Monorepo with pnpm workspaces                                      | 2026-05-29 | accepted |
-| [0004](./0004-sdk-types-first.md)                       | Public `@silo-code/sdk` is types-first                             | 2026-05-29 | accepted |
-| [0005](./0005-ui-library-internal.md)                   | Component library (`@silo-code/ui`) stays internal                 | 2026-05-29 | accepted |
-| [0006](./0006-open-platform-licensing.md)               | Open-platform MIT licensing                                        | 2026-05-30 | accepted |
-| [0007](./0007-core-primitive-vs-extension-test.md)      | Core-primitive vs extension-feature test                           | 2026-05-31 | accepted |
-| [0008](./0008-extension-decomposition-provider-view.md) | Extension decomposition; provider/view split                       | 2026-05-31 | accepted |
-| [0009](./0009-extension-communication-and-events.md)    | Extension communication: typed APIs + domain events                | 2026-05-31 | accepted |
-| [0010](./0010-persistent-process-sessions.md)           | Persistent process sessions as a core primitive                    | 2026-05-31 | accepted |
-| [0011](./0011-editor-and-terminal-are-core.md)          | Editor and terminal are core surfaces                              | 2026-05-31 | accepted |
-| [0012](./0012-dev-automation-rpc.md)                    | Dev-only automation RPC                                            | 2026-06-01 | accepted |
-| [0013](./0013-trust-tiers-two-barrel-sdk.md)            | Extension trust tiers + two-barrel SDK                             | 2026-06-02 | accepted |
-| [0014](./0014-per-extension-enablement.md)              | Per-extension enablement config (Obsidian-style)                   | 2026-06-02 | accepted |
-| [0015](./0015-phased-security-model.md)                 | Phased security model for privileged primitives                    | 2026-06-02 | accepted |
-| [0016](./0016-ctx-dnd-primitive.md)                     | First-class drag-and-drop primitive (`ctx.dnd`)                    | 2026-06-02 | accepted |
-| [0017](./0017-css-theming-contract.md)                  | CSS theming contract (`--silo-*` token tiers)                      | 2026-06-02 | accepted |
-| [0018](./0018-host-owned-chrome.md)                     | Host-owned UI chrome: modals + unified menu                        | 2026-06-03 | accepted |
-| [0019](./0019-runtime-extension-loading.md)             | Runtime extension loading + manifest validation                    | 2026-06-04 | accepted |
-| [0020](./0020-silo-extensions-bundled.md)               | Ship `silo.*` bundled, surfaced as disable-able                    | 2026-06-04 | accepted |
-| [0021](./0021-keyboard-navigation-architecture.md)      | Keyboard nav: headless focus-group + region model                  | 2026-06-08 | accepted |
-| [0022](./0022-on-disk-storage-layout.md)                | On-disk storage layout: config / app-state / runtime               | 2026-06-10 | accepted |
-| [0023](./0023-workspace-groups-host-internal.md)        | Workspace panel groups are host-internal                           | 2026-06-30 | accepted |
-| [0024](./0024-release-channels.md)                      | Two release channels: stable and nightly                           | 2026-07-01 | accepted |
-| [0025](./0025-pending-remove-worktree.md)               | Pending remove worktree: close folder on start                     | 2026-07-17 | accepted |
-| [0026](./0026-sdk-component-set.md)                     | A curated presentational component set joins the SDK               | 2026-07-18 | accepted |
-| [0027](./0027-terminal-link-policy.md)                  | Unified terminal link policy: modifier-click to open               | 2026-07-21 | accepted |
-| [0028](./0028-sealed-agent-detection.md)                | Sealed agent detection and honest resume                           | 2026-07-29 | accepted |
-| [0029](./0029-adornments-vs-registration.md)            | Adornments vs registration                                         | 2026-07-31 | accepted |
-| [0030](./0030-activity-chrome.md)                       | Activity as first-class chrome                                     | 2026-07-31 | accepted |
-| [0031](./0031-update-check-analytics.md)                | Update-check analytics via a Cloudflare Worker proxy               | 2026-08-01 | accepted |
-| [0032](./0032-dock-active-panel-authority.md)           | One authority decides a dock's active panel                        | 2026-08-04 | accepted |
-| [0033](./0033-laptop-mode-independent-layout.md)        | Laptop Mode is a second independent layout                         | 2026-08-06 | accepted |
-| [0034](./0034-focus-and-activation-authority.md)        | Focus/activation: the live dock, and only the active panel         | 2026-08-07 | proposed |
-| [0035](./0035-global-side-panel-layout.md)              | Global Side Panel Layout is an opt-in shared arrangement           | 2026-08-08 | accepted |
-| [0036](./0036-unified-update-ui-and-changelog.md)       | Unified update UI, in-app changelog, and skip-version              | 2026-08-10 | accepted |
-| [0037](./0037-git-repo-watch-session.md)                | A published, live git-state session (`GitAPI.watchRepo`)           | 2026-08-12 | accepted |
-| [0038](./0038-navigator-view-list.md)                   | The Navigator lists its views instead of hiding them               | 2026-08-13 | accepted |
-| [0039](./0039-self-contained-agent-docs.md)             | Self-contained agent docs, no external skill dependency            | 2026-08-15 | accepted |
-| [0040](./0040-skills-canonical-location-symlink.md)     | Skills live in `.agents/skills/`, `.claude/skills/` symlinks       | 2026-08-16 | accepted |
-| [0041](./0041-pi-hook-as-installed-extension.md)        | Pi's session hook ships as an installed TypeScript extension       | 2026-08-22 | accepted |
-| [0042](./0042-agent-catalog-modularization.md)          | Agent catalog modularization and declarative runtime policy        | 2026-08-22 | accepted |
-| [0043](./0043-opencode-tiered-support.md)               | OpenCode: zero-install activity now, resume deferred               | 2026-08-26 | accepted |
-| [0044](./0044-navigator-stacked-arrangement.md)         | The Navigator can stack its views instead of one at a time         | 2026-08-27 | accepted |
-| [0045](./0045-ephemeral-change-planning.md)             | Substantial changes are planned in an ephemeral proposal expansion | 2026-08-30 | accepted |
-| [0046](./0046-never-delete-user-data-unprompted.md)     | The host never deletes user data without asking                    | 2026-08-30 | accepted |
-| [0047](./0047-cli-command-grammar.md)                   | CLI command grammar: an agent-first `silo` namespace               | 2026-09-01 | accepted |
+| ADR                                                           | Title                                                              | Date       | Status   |
+| ------------------------------------------------------------- | ------------------------------------------------------------------ | ---------- | -------- |
+| [0001](./0001-in-process-extension-architecture.md)           | In-process, registry-based extension architecture                  | 2026-05-23 | accepted |
+| [0002](./0002-imperative-registration-no-manifest.md)         | Imperative registration; no static manifest (v1)                   | 2026-05-23 | accepted |
+| [0003](./0003-monorepo-pnpm.md)                               | Monorepo with pnpm workspaces                                      | 2026-05-29 | accepted |
+| [0004](./0004-sdk-types-first.md)                             | Public `@silo-code/sdk` is types-first                             | 2026-05-29 | accepted |
+| [0005](./0005-ui-library-internal.md)                         | Component library (`@silo-code/ui`) stays internal                 | 2026-05-29 | accepted |
+| [0006](./0006-open-platform-licensing.md)                     | Open-platform MIT licensing                                        | 2026-05-30 | accepted |
+| [0007](./0007-core-primitive-vs-extension-test.md)            | Core-primitive vs extension-feature test                           | 2026-05-31 | accepted |
+| [0008](./0008-extension-decomposition-provider-view.md)       | Extension decomposition; provider/view split                       | 2026-05-31 | accepted |
+| [0009](./0009-extension-communication-and-events.md)          | Extension communication: typed APIs + domain events                | 2026-05-31 | accepted |
+| [0010](./0010-persistent-process-sessions.md)                 | Persistent process sessions as a core primitive                    | 2026-05-31 | accepted |
+| [0011](./0011-editor-and-terminal-are-core.md)                | Editor and terminal are core surfaces                              | 2026-05-31 | accepted |
+| [0012](./0012-dev-automation-rpc.md)                          | Dev-only automation RPC                                            | 2026-06-01 | accepted |
+| [0013](./0013-trust-tiers-two-barrel-sdk.md)                  | Extension trust tiers + two-barrel SDK                             | 2026-06-02 | accepted |
+| [0014](./0014-per-extension-enablement.md)                    | Per-extension enablement config (Obsidian-style)                   | 2026-06-02 | accepted |
+| [0015](./0015-phased-security-model.md)                       | Phased security model for privileged primitives                    | 2026-06-02 | accepted |
+| [0016](./0016-ctx-dnd-primitive.md)                           | First-class drag-and-drop primitive (`ctx.dnd`)                    | 2026-06-02 | accepted |
+| [0017](./0017-css-theming-contract.md)                        | CSS theming contract (`--silo-*` token tiers)                      | 2026-06-02 | accepted |
+| [0018](./0018-host-owned-chrome.md)                           | Host-owned UI chrome: modals + unified menu                        | 2026-06-03 | accepted |
+| [0019](./0019-runtime-extension-loading.md)                   | Runtime extension loading + manifest validation                    | 2026-06-04 | accepted |
+| [0020](./0020-silo-extensions-bundled.md)                     | Ship `silo.*` bundled, surfaced as disable-able                    | 2026-06-04 | accepted |
+| [0021](./0021-keyboard-navigation-architecture.md)            | Keyboard nav: headless focus-group + region model                  | 2026-06-08 | accepted |
+| [0022](./0022-on-disk-storage-layout.md)                      | On-disk storage layout: config / app-state / runtime               | 2026-06-10 | accepted |
+| [0023](./0023-workspace-groups-host-internal.md)              | Workspace panel groups are host-internal                           | 2026-06-30 | accepted |
+| [0024](./0024-release-channels.md)                            | Two release channels: stable and nightly                           | 2026-07-01 | accepted |
+| [0025](./0025-pending-remove-worktree.md)                     | Pending remove worktree: close folder on start                     | 2026-07-17 | accepted |
+| [0026](./0026-sdk-component-set.md)                           | A curated presentational component set joins the SDK               | 2026-07-18 | accepted |
+| [0027](./0027-terminal-link-policy.md)                        | Unified terminal link policy: modifier-click to open               | 2026-07-21 | accepted |
+| [0028](./0028-sealed-agent-detection.md)                      | Sealed agent detection and honest resume                           | 2026-07-29 | accepted |
+| [0029](./0029-adornments-vs-registration.md)                  | Adornments vs registration                                         | 2026-07-31 | accepted |
+| [0030](./0030-activity-chrome.md)                             | Activity as first-class chrome                                     | 2026-07-31 | accepted |
+| [0031](./0031-update-check-analytics.md)                      | Update-check analytics via a Cloudflare Worker proxy               | 2026-08-01 | accepted |
+| [0032](./0032-dock-active-panel-authority.md)                 | One authority decides a dock's active panel                        | 2026-08-04 | accepted |
+| [0033](./0033-laptop-mode-independent-layout.md)              | Laptop Mode is a second independent layout                         | 2026-08-06 | accepted |
+| [0034](./0034-focus-and-activation-authority.md)              | Focus/activation: the live dock, and only the active panel         | 2026-08-07 | proposed |
+| [0035](./0035-global-side-panel-layout.md)                    | Global Side Panel Layout is an opt-in shared arrangement           | 2026-08-08 | accepted |
+| [0036](./0036-unified-update-ui-and-changelog.md)             | Unified update UI, in-app changelog, and skip-version              | 2026-08-10 | accepted |
+| [0037](./0037-git-repo-watch-session.md)                      | A published, live git-state session (`GitAPI.watchRepo`)           | 2026-08-12 | accepted |
+| [0038](./0038-navigator-view-list.md)                         | The Navigator lists its views instead of hiding them               | 2026-08-13 | accepted |
+| [0039](./0039-self-contained-agent-docs.md)                   | Self-contained agent docs, no external skill dependency            | 2026-08-15 | accepted |
+| [0040](./0040-skills-canonical-location-symlink.md)           | Skills live in `.agents/skills/`, `.claude/skills/` symlinks       | 2026-08-16 | accepted |
+| [0041](./0041-pi-hook-as-installed-extension.md)              | Pi's session hook ships as an installed TypeScript extension       | 2026-08-22 | accepted |
+| [0042](./0042-agent-catalog-modularization.md)                | Agent catalog modularization and declarative runtime policy        | 2026-08-22 | accepted |
+| [0043](./0043-opencode-tiered-support.md)                     | OpenCode: zero-install activity now, resume deferred               | 2026-08-26 | accepted |
+| [0044](./0044-navigator-stacked-arrangement.md)               | The Navigator can stack its views instead of one at a time         | 2026-08-27 | accepted |
+| [0045](./0045-ephemeral-change-planning.md)                   | Substantial changes are planned in an ephemeral proposal expansion | 2026-08-30 | accepted |
+| [0046](./0046-never-delete-user-data-unprompted.md)           | The host never deletes user data without asking                    | 2026-08-30 | accepted |
+| [0047](./0047-cli-command-grammar.md)                         | CLI command grammar: an agent-first `silo` namespace               | 2026-09-01 | accepted |
+| [0048](./0048-navigator-unscoped-chrome-on-workspaces-row.md) | Unscoped Navigator chrome rides the Workspaces row                 | 2026-09-02 | accepted |

--- a/docs/domain-language.md
+++ b/docs/domain-language.md
@@ -68,8 +68,9 @@ _Avoid_: Split view, multi view, sections view; "stacked panel" (it's one
 panel, not several)
 
 **Open Workspace menu**:
-The shared "saved workspaces / New workspace…" menu offered from the Navigator's
-View Header, the workspace status-bar item, and the empty CenterDock.
+The shared "saved workspaces / New workspace…" menu offered from the "+" on the
+Navigator's Workspaces row (its section header in the Stacked arrangement; ADR
+0048), the workspace status-bar item, and the empty CenterDock.
 _Avoid_: Add workspace menu, reopen picker (that's the closed-workspace path)
 
 ### Panels & Docking

--- a/docs/proposals/0030-navigator-view-arrangement.md
+++ b/docs/proposals/0030-navigator-view-arrangement.md
@@ -182,6 +182,9 @@ The View List is not rendered. Each enabled view, in `viewOrder`, is a
   to that in stacked mode only. A view's _own_ scoped items (e.g. the Agents
   view's "View by") are unaffected — they were already `when`-bound to their
   view.
+  _(Superseded by ADR 0048: the **+** now rides the Workspaces row/header/section
+  in **both** arrangements via `unscopedChromeTarget()`, with no top-section
+  fallback — absent from the Navigator when the Workspaces view is disabled.)_
 - **Sizing.** Each expanded section is content-height; the panel scrolls as one
   (preserving the "host tab-pane is the sole scroller" invariant every view
   assumes). A section body taller than a cap (proposed: ~60% of panel height)
@@ -290,7 +293,9 @@ is passed as always-`true` in stacked mode (collapse is purely visual); stacked
 sections cap at `60vh` with their own inner scroll; and `core.workspaces`'
 Add-workspace **+** stays unscoped in one-at-a-time mode but `when`-scopes to
 the single section named by `core.navigator`'s `stackedChromeHostViewId()` in
-stacked mode.
+stacked mode. _(That last detail was later revised by ADR 0048 — the **+** rides
+the Workspaces row/header/section in both arrangements via
+`unscopedChromeTarget()`.)_
 
 The crystallized decision — and the supersession of ADR 0038's deferred
 "stacked collapsible sections" alternative — is recorded in ADR

--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -24,17 +24,32 @@
   background: var(--silo-color-bg);
 }
 
+/* A `role="presentation"` flex line: the tab (`.nav-view-row`, `flex: 1`) plus,
+   on the Workspaces row only, the trailing Add-workspace "+"
+   (`.nav-view-row__chrome`). The wrapper — not the tab — carries the hover
+   background and radius so the whole line, "+" included, reads as one row. */
+.nav-view-row-wrap {
+  display: flex;
+  align-items: center;
+  border-radius: var(--silo-radius-sm);
+}
+
+/* Already the panel's brightest text, so hover moves the background only. */
+.nav-view-row-wrap:hover {
+  background: var(--silo-color-bg-hover);
+}
+
 /* Deliberately unhighlighted when selected — `.nav-view-header` below names
    the open view instead. Hover is the only row state, so the list reads as a
    set of destinations rather than a segmented control. */
 .nav-view-row {
   display: flex;
+  flex: 1;
   align-items: center;
   gap: 9px;
   min-width: 0;
   min-height: 30px;
   padding: 5px 10px;
-  border-radius: var(--silo-radius-sm);
   color: var(--silo-color-text-hi);
   font-family: var(--silo-font-ui);
   /* Inherit the side-pane scale (SideColumn.css) so the destinations sit level
@@ -45,9 +60,14 @@
   user-select: none;
 }
 
-/* Already the panel's brightest text, so hover moves the background only. */
-.nav-view-row:hover {
-  background: var(--silo-color-bg-hover);
+/* Trailing "+" cluster on the Workspaces row (ADR 0048). Flattened to just its
+   button the same way the view header's toolbar is — see the shared rules
+   below — and nudged off the pane edge to match the row's own inset. */
+.nav-view-row__chrome {
+  display: flex;
+  flex: none;
+  align-items: center;
+  padding-right: 6px;
 }
 
 /* Fixed width so titles line up whether or not a given view supplies an icon.
@@ -105,18 +125,19 @@
 }
 
 /* ContributedToolbar ships the editor breadcrumb's bar chrome — its own
-   background and bottom rule. Inside this header that reads as a bar within a
-   bar, so the cluster is flattened to just its buttons here; the header is
-   already the bar. */
-.nav-view-header .contributed-toolbar {
+   background and bottom rule. Inside the header (a bar within a bar) or on a
+   view-list row it reads as clutter, so the cluster is flattened to just its
+   buttons in both places. */
+.nav-view-header .contributed-toolbar,
+.nav-view-row__chrome .contributed-toolbar {
   min-height: 0;
   padding: 0;
   background: none;
   border-bottom: none;
 }
 
-/* Actions read as part of the header line rather than as controls sitting on
-   it, so they take the title's color instead of the toolbar surface's. Both
+/* Actions read as part of the header / row line rather than as controls sitting
+   on it, so they take the title's color instead of the toolbar surface's. Both
    control shapes are covered: text / icon+text / menu controls are
    `.contributed-toolbar__btn`, while icon-only ones are SDK IconButtons
    (`.silo-icon-button-toolbar`) — the workspaces + is one of those.
@@ -126,27 +147,27 @@
    checked-state rule — that rule is the same specificity as this one, so
    without the exclusion, load order (not intent) would decide whether the
    accent color survives. Excluding by selector means it always does. */
-.nav-view-header
+:is(.nav-view-header, .nav-view-row__chrome)
   .contributed-toolbar__btn:not([data-checked="true"]):not(
     [aria-pressed="true"]
   ),
-.nav-view-header
+:is(.nav-view-header, .nav-view-row__chrome)
   .contributed-toolbar__btn:hover:not(:disabled):not([data-checked="true"]):not(
     [aria-pressed="true"]
   ),
-.nav-view-header
+:is(.nav-view-header, .nav-view-row__chrome)
   .contributed-toolbar__btn:active:not(:disabled):not(
     [data-checked="true"]
   ):not([aria-pressed="true"]),
-.nav-view-header
+:is(.nav-view-header, .nav-view-row__chrome)
   .silo-icon-button-toolbar:not([data-checked="true"]):not(
     [aria-pressed="true"]
   ),
-.nav-view-header
+:is(.nav-view-header, .nav-view-row__chrome)
   .silo-icon-button-toolbar:hover:not(:disabled):not([data-checked="true"]):not(
     [aria-pressed="true"]
   ),
-.nav-view-header
+:is(.nav-view-header, .nav-view-row__chrome)
   .silo-icon-button-toolbar:active:not(:disabled):not(
     [data-checked="true"]
   ):not([aria-pressed="true"]) {

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -10,9 +10,11 @@ import { ContributedToolbar } from "../shared/ContributedToolbar";
 import {
   activeViewIndex,
   buildViewRows,
+  chromeHostViewId,
   resolveActiveView,
   resolveViewList,
   toggleIdInList,
+  UNSCOPED_CHROME_TARGET,
 } from "./navigator-views";
 import { navigatorPrefsService } from "./navigator-prefs";
 import "./NavigatorPanel.css";
@@ -27,6 +29,23 @@ const ACTIVE_VIEW_KEY = "activeView";
 // an HTML id, and nothing selects them from CSS (where they'd need escaping).
 const tabId = (viewId: string) => `nav-tab-${viewId}`;
 const tabPanelId = (viewId: string) => `nav-tabpanel-${viewId}`;
+
+/**
+ * The one place otherwise-unscoped `"navigator"` toolbar chrome renders — the
+ * Add-workspace "+" (ADR 0048). Placed by the caller on the Workspaces row, its
+ * View Header when the list is hidden, or its stacked section header; the
+ * `UNSCOPED_CHROME_TARGET` sentinel is what makes `core.workspaces.add`'s `when`
+ * match here and a per-view item's `when` never see it.
+ */
+function UnscopedChromeSlot({ ctx }: { ctx: ExtensionContext }) {
+  return (
+    <ContributedToolbar
+      surface="navigator"
+      target={{ viewId: UNSCOPED_CHROME_TARGET }}
+      showMenu={ctx.ui.showMenu}
+    />
+  );
+}
 
 /**
  * The Navigator panel. A thin dispatcher: it resolves the user's enabled views
@@ -127,6 +146,9 @@ function SwitcherNavigator({
   // calling themselves tab panels too, rather than pointing `aria-labelledby`
   // at a tab that isn't rendered.
   const showViewList = views.length > 1;
+  // The row (list shown) or header (list hidden) that carries the Add-workspace
+  // "+" — the Workspaces view, or `null` when it isn't enabled (ADR 0048).
+  const chromeHostId = chromeHostViewId(views);
 
   return (
     <div className="nav-panel">
@@ -153,38 +175,53 @@ function SwitcherNavigator({
           {...group.containerProps}
         >
           {viewRows.map((row, i) => (
-            <div
-              key={row.id}
-              {...group.getItemProps(i)}
-              role="tab"
-              id={tabId(row.id)}
-              // Selection is still announced even though it isn't painted on
-              // the row — assistive tech needs it named here, where the choice
-              // is.
-              aria-selected={row.selected}
-              // Omitted until the panel actually mounts (views mount lazily on
-              // first activation, below) — pointing at an id that isn't in the
-              // DOM yet would be a dangling reference for any view not yet
-              // visited this session.
-              aria-controls={
-                mountedViewIds.has(row.id) ? tabPanelId(row.id) : undefined
-              }
-              className="nav-view-row"
-              onClick={() => pickView(row.id)}
-            >
-              {hasIcons && (
-                <span className="nav-view-row__icon">{row.icon}</span>
+            // `role="presentation"` so the wrapper is transparent to AT and the
+            // tablist → tab relationship is preserved. It exists only to sit the
+            // Add-workspace "+" *beside* the tab rather than inside it — a
+            // focusable control within a `role="tab"` is contrary to the APG
+            // tabs pattern, and the "+" stays its own Tab stop this way without
+            // joining the arrow-key roving set (`group.count` is unchanged).
+            <div key={row.id} className="nav-view-row-wrap" role="presentation">
+              <div
+                {...group.getItemProps(i)}
+                role="tab"
+                id={tabId(row.id)}
+                // Selection is still announced even though it isn't painted on
+                // the row — assistive tech needs it named here, where the
+                // choice is.
+                aria-selected={row.selected}
+                // Omitted until the panel actually mounts (views mount lazily
+                // on first activation, below) — pointing at an id that isn't in
+                // the DOM yet would be a dangling reference for any view not
+                // yet visited this session.
+                aria-controls={
+                  mountedViewIds.has(row.id) ? tabPanelId(row.id) : undefined
+                }
+                className="nav-view-row"
+                onClick={() => pickView(row.id)}
+              >
+                {hasIcons && (
+                  <span className="nav-view-row__icon">{row.icon}</span>
+                )}
+                <span className="nav-view-row__label">{row.title}</span>
+              </div>
+              {row.id === chromeHostId && (
+                <div className="nav-view-row__chrome">
+                  <UnscopedChromeSlot ctx={ctx} />
+                </div>
               )}
-              <span className="nav-view-row__label">{row.title}</span>
             </div>
           ))}
         </div>
       )}
 
-      {/* The active view, named — and the place its actions live. They're toolbar
-          contributions on the "navigator" surface rather than anything this
-          panel knows about, which is how the workspaces + button gets here
-          without core.navigator importing a line of workspace code. */}
+      {/* The active view, named — and the place its *scoped* actions live
+          (toolbar contributions on the "navigator" surface `when`-bound to this
+          view). Unscoped chrome — the Add-workspace "+" — rides the Workspaces
+          row above instead (ADR 0048); it only falls to this header when the
+          list is hidden (one enabled view), which is the sole case
+          `chromeHostId` can match `activeView.id` here. Either way core.navigator
+          imports not a line of workspace code. */}
       {activeView && (
         // `data-focus-chrome`: header controls (the contributed toolbar), not
         // content — keyboard region-entry skips past this to land in the
@@ -201,6 +238,9 @@ function SwitcherNavigator({
             target={{ viewId: activeView.id }}
             showMenu={ctx.ui.showMenu}
           />
+          {!showViewList && chromeHostId != null && (
+            <UnscopedChromeSlot ctx={ctx} />
+          )}
         </div>
       )}
 
@@ -253,6 +293,10 @@ function StackedNavigator({
   collapsed: readonly string[];
 }) {
   const collapsed = new Set(collapsedIds);
+  // The section header that carries the Add-workspace "+" — the Workspaces
+  // section, or nowhere when that view isn't enabled (ADR 0048; no "top
+  // section" fallback any more).
+  const chromeHostId = chromeHostViewId(views);
 
   function toggle(viewId: string) {
     navigatorPrefsService.set({
@@ -298,6 +342,7 @@ function StackedNavigator({
                 target={{ viewId: view.id }}
                 showMenu={ctx.ui.showMenu}
               />
+              {view.id === chromeHostId && <UnscopedChromeSlot ctx={ctx} />}
             </div>
             <div className="nav-stack-body" hidden={isCollapsed}>
               <ErrorBoundary name={view.id}>

--- a/packages/extensions-core/src/navigator/index.tsx
+++ b/packages/extensions-core/src/navigator/index.tsx
@@ -3,7 +3,11 @@ import { navigatorViewRegistry } from "@silo-code/extension-host/internal";
 import { NavigatorPanel } from "./NavigatorPanel";
 import { NavigatorSettingsPanel } from "./NavigatorSettingsPanel";
 import { initNavigatorPrefs, navigatorPrefsService } from "./navigator-prefs";
-import { resolveViewList, stackedChromeHostId } from "./navigator-views";
+import {
+  chromeHostViewId,
+  resolveViewList,
+  UNSCOPED_CHROME_TARGET,
+} from "./navigator-views";
 import type { NavigatorExtensionAPI } from "./navigator-api";
 
 /**
@@ -43,17 +47,17 @@ export const extension: Extension<NavigatorExtensionAPI> = {
 
     return {
       SettingsPanel: NavigatorSettingsPanel,
-      stackedChromeHostViewId() {
-        const prefs = navigatorPrefsService.getState();
+      unscopedChromeTarget() {
         const { enabled } = resolveViewList(
           navigatorViewRegistry.list(),
-          prefs,
+          navigatorPrefsService.getState(),
         );
-        // Stacked needs >1 view to render as a stack (see NavigatorPanel);
-        // with one it falls through to the plain single-view render, where
-        // unscoped chrome belongs on that view like one-at-a-time.
-        if (prefs.arrangement !== "stacked" || enabled.length <= 1) return null;
-        return stackedChromeHostId(enabled) ?? null;
+        // The slot exists in every arrangement — the renderer decides *where*
+        // (row / header / section). All this answers is whether it exists at
+        // all, i.e. whether the Workspaces view is enabled.
+        return chromeHostViewId(enabled) === null
+          ? null
+          : UNSCOPED_CHROME_TARGET;
       },
     };
   },

--- a/packages/extensions-core/src/navigator/navigator-api.ts
+++ b/packages/extensions-core/src/navigator/navigator-api.ts
@@ -10,11 +10,16 @@ export interface NavigatorExtensionAPI {
   /** The **Navigator** settings tab's body — reorder / enable views. */
   SettingsPanel: ComponentType;
   /**
-   * In the **stacked** arrangement, the id of the view whose section should
-   * carry otherwise-unscoped `"navigator"` toolbar chrome (the Add-workspace
-   * "+") — so it appears once, not on every section. `null` in the
-   * one-at-a-time arrangement, where such chrome shows on every view as
-   * before. `core.workspaces` reads this to scope its "+" in stacked mode.
+   * The synthetic `ToolbarItemContext["navigator"].viewId` the Navigator passes
+   * from its single **unscoped-chrome slot** — the Add-workspace "+"'s home:
+   * the Workspaces View List row (one-at-a-time), that view's View Header when
+   * the list is hidden, or its stacked section header (ADR 0048). An item whose
+   * `when` matches this value renders there and nowhere else; a normal per-view
+   * item matches a real view id and never sees it.
+   *
+   * `null` when the Workspaces view is disabled — the slot isn't rendered and
+   * the "+" lives only on the workspace status-bar item. `core.workspaces`
+   * reads this to place its "+".
    */
-  stackedChromeHostViewId(): string | null;
+  unscopedChromeTarget(): string | null;
 }

--- a/packages/extensions-core/src/navigator/navigator-views.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.test.ts
@@ -6,10 +6,10 @@ import {
   buildViewRows,
   moveViewInOrder,
   reorderSavedViews,
+  chromeHostViewId,
   resolveActiveView,
   resolveViewList,
   setViewDisabled,
-  stackedChromeHostId,
   toggleIdInList,
 } from "./navigator-views";
 
@@ -258,22 +258,22 @@ describe("reorderSavedViews", () => {
   });
 });
 
-describe("stackedChromeHostId", () => {
-  it("is the Workspaces view when it's enabled", () => {
+describe("chromeHostViewId", () => {
+  it("is the Workspaces view when it's enabled, wherever it sits in order", () => {
     const enabled = [
       view("ext.status", "Agents"),
       view(DEFAULT_VIEW_ID, "Workspaces"),
     ];
-    expect(stackedChromeHostId(enabled)).toBe(DEFAULT_VIEW_ID);
+    expect(chromeHostViewId(enabled)).toBe(DEFAULT_VIEW_ID);
   });
 
-  it("falls back to the top view when Workspaces is hidden", () => {
+  it("is null when Workspaces is not enabled — no top-view fallback (ADR 0048)", () => {
     const enabled = [view("ext.status", "Agents"), view("ext.tasks", "Tasks")];
-    expect(stackedChromeHostId(enabled)).toBe("ext.status");
+    expect(chromeHostViewId(enabled)).toBeNull();
   });
 
-  it("is undefined when nothing is enabled", () => {
-    expect(stackedChromeHostId([])).toBeUndefined();
+  it("is null when nothing is enabled", () => {
+    expect(chromeHostViewId([])).toBeNull();
   });
 });
 

--- a/packages/extensions-core/src/navigator/navigator-views.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.ts
@@ -158,17 +158,26 @@ export function resolveActiveView(
 }
 
 /**
- * In the **stacked** arrangement, the one section that carries otherwise-
- * unscoped `"navigator"` toolbar chrome — today just `core.workspaces`'
- * Add-workspace "+". It sits on the Workspaces section, or on the top section
- * if Workspaces is hidden. `undefined` only when nothing is enabled (which
- * {@link resolveViewList} prevents). One-at-a-time mode doesn't call this —
- * there, unscoped chrome shows on every view as before.
+ * The synthetic `viewId` the Navigator passes from its single **unscoped-chrome
+ * slot** — the Add-workspace "+"'s home (ADR 0048). Deliberately not any real
+ * view's id: a per-view header item's `when` only ever sees a real id and never
+ * matches this, while `core.workspaces.add` matches only this.
  */
-export function stackedChromeHostId(
+export const UNSCOPED_CHROME_TARGET = "core.navigator:unscoped-chrome";
+
+/**
+ * The view whose row (one-at-a-time) or section header (stacked) carries
+ * otherwise-unscoped `"navigator"` toolbar chrome — today just
+ * `core.workspaces`' Add-workspace "+". It is the **Workspaces** view when
+ * enabled, and `null` when it is not: the "+" then lives only on the workspace
+ * status-bar item, not anywhere in the Navigator (ADR 0048). Unlike the old
+ * stacked-only helper this has no "…or the top view" fallback — the "+" is the
+ * Workspaces affordance or it is absent.
+ */
+export function chromeHostViewId(
   enabled: readonly NavigatorView[],
-): string | undefined {
-  return (enabled.find((v) => v.id === DEFAULT_VIEW_ID) ?? enabled[0])?.id;
+): string | null {
+  return enabled.find((v) => v.id === DEFAULT_VIEW_ID)?.id ?? null;
 }
 
 /**

--- a/packages/extensions-core/src/workspaces/index.tsx
+++ b/packages/extensions-core/src/workspaces/index.tsx
@@ -65,29 +65,24 @@ export const extension: Extension = {
       component: (props) => <WorkspacesView ctx={ctx} {...props} />,
     });
 
-    // "Add workspace" in the Navigator header. A toolbar contribution rather
-    // than panel chrome, which is what lets core.navigator stay ignorant of
-    // workspaces.
-    //
-    // One-at-a-time arrangement: unscoped, on every view's header, so
-    // New-workspace stays one click away wherever you are (RFC 0023).
-    // Stacked arrangement: every view's header is on screen at once, so it
-    // would repeat down the panel — `core.navigator` names the single section
-    // that should carry it (the Workspaces section, or the top one if
-    // Workspaces is hidden) and this scopes to that.
+    // "Add workspace" — a toolbar contribution rather than panel chrome, which
+    // is what lets `core.navigator` stay ignorant of workspaces. `core.navigator`
+    // renders it in exactly one place — the Workspaces view's row / header /
+    // section (ADR 0048) — and passes its `unscopedChromeTarget()` sentinel as
+    // the `viewId`, so this `when` is a plain equality: it matches that slot and
+    // nothing else, and returns false (target ≠ null) when the Workspaces view
+    // is disabled, taking the "+" out of the Navigator entirely.
     ctx.registerToolbarItem({
       id: "core.workspaces.add",
       surface: "navigator",
       icon: "Plus",
       label: "Add workspace",
       tooltip: "Add workspace",
-      when: (_keys, target) => {
-        const host =
-          ctx
-            .getExtension<NavigatorExtensionAPI>("core.navigator")
-            ?.api?.stackedChromeHostViewId() ?? null;
-        return host === null || target.viewId === host;
-      },
+      when: (_keys, target) =>
+        target.viewId ===
+        ctx
+          .getExtension<NavigatorExtensionAPI>("core.navigator")
+          ?.api?.unscopedChromeTarget(),
       menu: () => ctx.workspaces.getOpenWorkspaceMenuItems(),
     });
 
@@ -111,6 +106,16 @@ export const extension: Extension = {
           console.error("create workspace failed", err);
         });
       },
+    });
+
+    // A keyboard path to "new workspace" that doesn't depend on the Navigator's
+    // "+" being visible — it isn't when the Workspaces view is disabled, and the
+    // "+" is pointer-only regardless (ADR 0048). `cmd+shift+n` mirrors the
+    // native File-menu `cmd+n` (new file).
+    ctx.registerKeybinding({
+      id: "workspace.new",
+      key: "cmd+shift+n",
+      command: "workspace.new",
     });
 
     ctx.registerCommand({


### PR DESCRIPTION
## Summary

The **+** button that creates a workspace no longer appears on every panel in
the Navigator. It now belongs to the Workspaces list itself:

- On the Workspaces row (or, in the stacked layout, the Workspaces section header).
- If someone hides the Workspaces list from the Navigator entirely, the **+**
  goes with it — you add a workspace from the bottom-left status item or the new
  `Cmd/Ctrl+Shift+N` shortcut instead.

Previously the **+** followed you onto Agents, Tasks, and any other view, where
it read as an action for that view even though it only ever makes a workspace.

This is visual/behavioural only — no public SDK change, nothing behind a flag.
The design is recorded in ADR 0048 (in this PR); it revises one consequence of
ADR 0038 and one implementation detail of RFC 0030.

## Details

### Placement rule (ADR 0048)

Otherwise-unscoped `"navigator"`-surface toolbar chrome — today just
`core.workspaces.add` — renders once, in a slot owned by the Workspaces view:

| Arrangement | Slot |
| --- | --- |
| one-at-a-time, View List shown | trailing button on the **Workspaces row** |
| one-at-a-time, list hidden (one enabled view) | the **View Header** (ADR 0038's existing single-view fallback) |
| stacked | the **Workspaces section header** (as ADR 0044 already did) |
| Workspaces view disabled | **nothing** — the "+" is absent from the Navigator |

Per-view header items (`silo.agents.group-by`, `when`-bound to
`silo.agents.by-status`) are untouched — they still render in their view's header.

### Mechanism — no `@silo-code/sdk` change

`core.navigator` renders two kinds of `ContributedToolbar` on the `"navigator"`
surface:

1. **Per-view** — `target: { viewId: <real view id> }` — on each View Header /
   section header, as today. Catches scoped items.
2. **The unscoped-chrome slot** — `target: { viewId: <sentinel> }` — rendered
   only in the one place above. The sentinel (`"core.navigator:unscoped-chrome"`,
   `UNSCOPED_CHROME_TARGET`) is a reserved non-real view id owned by
   `core.navigator` and surfaced on its bundled-only `NavigatorExtensionAPI` as
   `unscopedChromeTarget(): string | null` (`null` when the Workspaces view is
   disabled).

`core.workspaces.add`'s `when` collapses from a three-branch host-state check to
`(_keys, target) => target.viewId === navApi.unscopedChromeTarget()`. The
`core.navigator` ⇄ `core.workspaces` boundary is unchanged (arrow points
workspaces → navigator, as it already did).

`stackedChromeHostViewId()` / the internal `stackedChromeHostId()` are replaced
by `unscopedChromeTarget()` / `chromeHostViewId()`. `chromeHostViewId` drops the
old "…or the top view if Workspaces is hidden" fallback — the "+" is the
Workspaces affordance or it is absent.

### Keyboard / AT

The Workspaces row is a `role="tab"` in a `role="tablist"` with `useFocusGroup`
roving focus. The "+" renders as a **sibling** of the tab element inside a
`role="presentation"` wrapper — not a child (a focusable control inside
`role="tab"` is contrary to the APG tabs pattern). As a sibling it:

- stays out of the arrow-key roving set (`useFocusGroup` `count` unchanged), so
  ↑/↓ still move only between view rows;
- is its own Tab stop, right after the Workspaces row — normal for a per-row
  action, and it keeps "new workspace" keyboard-reachable.

`workspace.new` also gains a default `cmd+shift+n` keybinding (mirrors the native
File-menu `cmd+n`), so the command path works when the "+" is absent.

### Files

- `navigator-views.ts` — `chromeHostViewId` (`string | null`, no top-view
  fallback) + `UNSCOPED_CHROME_TARGET`.
- `navigator-api.ts` — `unscopedChromeTarget()`.
- `navigator/index.tsx` — implements it.
- `NavigatorPanel.tsx` — `UnscopedChromeSlot`; row wrapper + slot placement in
  both `SwitcherNavigator` and `StackedNavigator`.
- `NavigatorPanel.css` — `.nav-view-row-wrap` (owns hover + radius),
  `.nav-view-row__chrome` (toolbar flattened, same treatment as the header).
- `workspaces/index.tsx` — `when` predicate + keybinding.

### Tests / verification

- `navigator-views.test.ts` — `chromeHostViewId` incl. "null when Workspaces
  disabled, no top-view fallback".
- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` (11 packages) —
  all green.
- Not yet driven in the running app — screenshots of the four placements to
  follow.

### Docs

- ADR 0048 added; decisions index + `domain-language.md` "Open Workspace menu"
  updated.
- ADR 0038's "unscoped items keep a fixed position in the View Header"
  consequence annotated as revised here.
- RFC 0030's stacked-chrome detail annotated as revised here.

### Sequencing

Branched off #485 (now merged as `964cf9ef`) and rebased onto `main` — the diff
is only the "+" change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLa3J2zMwUtyPT6yHJ4Knc
