### PR TITLE
feat(navigator): rework active-workspace and colored-group visuals

### DIFF
--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -68,6 +68,21 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
     prefs,
   );
 
+  // The colored-group wash (WorkspacesView.css) reads --ws-group-wash-user off
+  // the document root. Mirror the pref there while the Navigator is mounted, so
+  // dragging the settings slider repaints the groups live; the CSS falls back
+  // to 1 when the Navigator isn't open.
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty(
+      "--ws-group-wash-user",
+      String(prefs.groupColorIntensity),
+    );
+    return () => {
+      root.style.removeProperty("--ws-group-wash-user");
+    };
+  }, [prefs.groupColorIntensity]);
+
   return prefs.arrangement === "stacked" && views.length > 1 ? (
     <StackedNavigator
       ctx={ctx}

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
@@ -73,30 +73,25 @@
 
 /* ── Group color intensity ─────────────────────────────────────────────── */
 
-.nav-settings-intensity {
+/* SettingRow control: a compact live preview with an up/down stepper docked
+   beside it, sized to sit in the row's right-hand control cell. */
+.nav-group-color {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: 6px;
+  align-items: stretch;
+  gap: 6px;
 }
 
-.nav-settings-intensity-slider {
-  width: 100%;
-  margin: 0;
-  accent-color: var(--silo-color-accent);
-}
-
-/* Live preview. The wash formula is kept in sync with `.ws-group--colored` in
-   WorkspacesView.css — same percentages, same per-theme factor — driven here
-   by --preview-wash (the pref value, set inline). */
-.nav-settings-intensity-preview {
+/* The preview tile. Its wash formula is kept in sync with `.ws-group--colored`
+   in WorkspacesView.css — same percentages, same per-theme factor — driven
+   here by --preview-wash (the pref value, set inline). */
+.nav-group-color-preview {
   --preview-wash-theme: 1;
   --preview-w: calc(var(--preview-wash, 1) * var(--preview-wash-theme));
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  padding: 8px 10px;
+  position: relative;
+  width: 144px;
+  padding: 7px 9px 9px;
   border-radius: var(--silo-radius-sm);
+  overflow: hidden;
   background:
     radial-gradient(
       120% 90% at 50% 0%,
@@ -114,30 +109,43 @@
     );
 }
 
-[data-theme="light"] .nav-settings-intensity-preview {
+[data-theme="light"] .nav-group-color-preview {
   --preview-wash-theme: 1.5;
 }
 
-.nav-settings-intensity-preview-header {
+.nav-group-color-preview-label {
+  display: block;
   font-family: var(--silo-font-ui);
-  font-size: var(--silo-font-size-chrome);
+  font-size: calc(var(--silo-font-size-chrome) - 1px);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--silo-color-text-lo);
 }
 
-/* Faux workspace rows — just tinted bars so the eye reads "list under a wash". */
-.nav-settings-intensity-preview-row {
-  height: 8px;
+/* A single faux workspace row under the header. */
+.nav-group-color-preview-bar {
+  display: block;
+  width: 64%;
+  height: 6px;
+  margin-top: 7px;
   border-radius: 3px;
   background: var(--silo-color-bg-hover);
 }
 
-.nav-settings-intensity-preview-row:first-of-type {
-  width: 70%;
+.nav-group-color-preview-val {
+  position: absolute;
+  right: 6px;
+  bottom: 5px;
+  font-family: var(--silo-font-ui);
+  font-size: calc(var(--silo-font-size-chrome) - 1px);
+  font-variant-numeric: tabular-nums;
+  color: var(--silo-color-text-hi);
 }
 
-.nav-settings-intensity-preview-row:last-of-type {
-  width: 52%;
+.nav-group-color-stepper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
 }

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
@@ -70,3 +70,74 @@
 .nav-settings-arrangement {
   margin-top: 6px;
 }
+
+/* ── Group color intensity ─────────────────────────────────────────────── */
+
+.nav-settings-intensity {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.nav-settings-intensity-slider {
+  width: 100%;
+  margin: 0;
+  accent-color: var(--silo-color-accent);
+}
+
+/* Live preview. The wash formula is kept in sync with `.ws-group--colored` in
+   WorkspacesView.css — same percentages, same per-theme factor — driven here
+   by --preview-wash (the pref value, set inline). */
+.nav-settings-intensity-preview {
+  --preview-wash-theme: 1;
+  --preview-w: calc(var(--preview-wash, 1) * var(--preview-wash-theme));
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 8px 10px;
+  border-radius: var(--silo-radius-sm);
+  background:
+    radial-gradient(
+      120% 90% at 50% 0%,
+      color-mix(
+        in srgb,
+        var(--ws-group-color) calc(6% * var(--preview-w)),
+        transparent
+      ),
+      transparent 72%
+    ),
+    color-mix(
+      in srgb,
+      var(--ws-group-color) calc(15% * var(--preview-w)),
+      transparent
+    );
+}
+
+[data-theme="light"] .nav-settings-intensity-preview {
+  --preview-wash-theme: 1.5;
+}
+
+.nav-settings-intensity-preview-header {
+  font-family: var(--silo-font-ui);
+  font-size: var(--silo-font-size-chrome);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--silo-color-text-lo);
+}
+
+/* Faux workspace rows — just tinted bars so the eye reads "list under a wash". */
+.nav-settings-intensity-preview-row {
+  height: 8px;
+  border-radius: 3px;
+  background: var(--silo-color-bg-hover);
+}
+
+.nav-settings-intensity-preview-row:first-of-type {
+  width: 70%;
+}
+
+.nav-settings-intensity-preview-row:last-of-type {
+  width: 52%;
+}

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.css
@@ -1,5 +1,28 @@
 /* The Navigator settings tab (RFC 0030). Chrome only — Section, Switch,
-   IconButton, Tooltip are the SDK's. Design tokens only. */
+   IconButton, Tooltip, SettingRow are the SDK's. Design tokens only. */
+
+/* A labelled block inside a Section — the "Views" section holds two (the view
+   list and the arrangement picker), neither of which is a single right-aligned
+   control, so they can't be SettingRows. Match SettingRow's vertical rhythm and
+   hairline divider so the section still reads as a set of labelled fields. */
+.nav-settings-field {
+  padding: 10px 0;
+}
+
+.nav-settings-field:first-child {
+  padding-top: 0;
+}
+
+.nav-settings-field + .nav-settings-field {
+  border-top: 1px solid var(--silo-color-border-strong);
+}
+
+/* Field label — same size/color as SettingRow's `.silo-setting-row-label`. */
+.nav-settings-sublabel {
+  font-size: var(--silo-font-size-base);
+  color: var(--silo-color-text-hi);
+  margin-bottom: 4px;
+}
 
 .nav-settings-hint {
   margin: 0 0 12px;

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
@@ -26,10 +26,11 @@ import {
 import "./NavigatorSettingsPanel.css";
 
 /**
- * The **Navigator** settings tab's body — reorder the Navigator's views and
- * turn ones off. Owned by `core.navigator` (it owns the `navigatorPrefs`
- * store) and published for `core.layout` to compose into the Layout settings
- * page (RFC 0030).
+ * The **Navigator** settings tab's body — the "Views" section (reorder / turn
+ * off views, pick the arrangement) plus "Workspace groups" (group color
+ * intensity). Owned by `core.navigator` (it owns the `navigatorPrefs` store)
+ * and published for `core.layout` to compose into the Layout settings page
+ * (RFC 0030).
  */
 export function NavigatorSettingsPanel() {
   const prefs = useServiceState(navigatorPrefsService);
@@ -62,89 +63,96 @@ export function NavigatorSettingsPanel() {
   return (
     <>
       <Section label="Views">
-        <p className="nav-settings-hint">
-          Reorder the Navigator&rsquo;s views, or turn off the ones you
-          don&rsquo;t use. The Navigator opens on the first enabled view.
-        </p>
-        <ul className="nav-settings-list">
-          {ordered.map((view, i) => {
-            const on = enabledIds.has(view.id);
-            const isLastEnabled = on && enabled.length === 1;
-            return (
-              <li
-                key={view.id}
-                className="nav-settings-row"
-                data-off={on ? undefined : "true"}
-              >
-                <span className="nav-settings-move">
-                  <IconButton
-                    size="sm"
-                    aria-label={`Move ${view.title} up`}
-                    disabled={i === 0}
-                    onClick={() => move(view.id, -1)}
-                  >
-                    <ArrowUp size={13} weight="bold" />
-                  </IconButton>
-                  <IconButton
-                    size="sm"
-                    aria-label={`Move ${view.title} down`}
-                    disabled={i === ordered.length - 1}
-                    onClick={() => move(view.id, 1)}
-                  >
-                    <ArrowDown size={13} weight="bold" />
-                  </IconButton>
-                </span>
-                {hasIcons && (
-                  <span className="nav-settings-icon">{view.icon}</span>
-                )}
-                <span className="nav-settings-label">{view.title}</span>
-                {isLastEnabled ? (
-                  <Tooltip content="At least one view must stay on">
-                    {/* Wrapper span so the tooltip has a hover target while the
-                      Switch itself is disabled. */}
-                    <span className="nav-settings-toggle-lock">
-                      <Switch
-                        checked
-                        disabled
-                        onChange={() => {}}
-                        aria-label={`Show ${view.title}`}
-                      />
-                    </span>
-                  </Tooltip>
-                ) : (
-                  <Switch
-                    checked={on}
-                    onChange={(next) => toggle(view.id, next)}
-                    aria-label={`Show ${view.title}`}
-                  />
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      </Section>
+        <div className="nav-settings-field">
+          <div className="nav-settings-sublabel">Shown views</div>
+          <p className="nav-settings-hint">
+            Reorder the Navigator&rsquo;s views, or turn off the ones you
+            don&rsquo;t use. The Navigator opens on the first enabled view.
+          </p>
+          <ul className="nav-settings-list">
+            {ordered.map((view, i) => {
+              const on = enabledIds.has(view.id);
+              const isLastEnabled = on && enabled.length === 1;
+              return (
+                <li
+                  key={view.id}
+                  className="nav-settings-row"
+                  data-off={on ? undefined : "true"}
+                >
+                  <span className="nav-settings-move">
+                    <IconButton
+                      size="sm"
+                      aria-label={`Move ${view.title} up`}
+                      disabled={i === 0}
+                      onClick={() => move(view.id, -1)}
+                    >
+                      <ArrowUp size={13} weight="bold" />
+                    </IconButton>
+                    <IconButton
+                      size="sm"
+                      aria-label={`Move ${view.title} down`}
+                      disabled={i === ordered.length - 1}
+                      onClick={() => move(view.id, 1)}
+                    >
+                      <ArrowDown size={13} weight="bold" />
+                    </IconButton>
+                  </span>
+                  {hasIcons && (
+                    <span className="nav-settings-icon">{view.icon}</span>
+                  )}
+                  <span className="nav-settings-label">{view.title}</span>
+                  {isLastEnabled ? (
+                    <Tooltip content="At least one view must stay on">
+                      {/* Wrapper span so the tooltip has a hover target while
+                        the Switch itself is disabled. */}
+                      <span className="nav-settings-toggle-lock">
+                        <Switch
+                          checked
+                          disabled
+                          onChange={() => {}}
+                          aria-label={`Show ${view.title}`}
+                        />
+                      </span>
+                    </Tooltip>
+                  ) : (
+                    <Switch
+                      checked={on}
+                      onChange={(next) => toggle(view.id, next)}
+                      aria-label={`Show ${view.title}`}
+                    />
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
 
-      <Section label="View arrangement">
-        <div className="nav-settings-arrangement">
-          <RadioGroup
-            value={prefs.arrangement}
-            onChange={(v) =>
-              navigatorPrefsService.set({
-                arrangement: v as ViewArrangement,
-              })
-            }
-          >
-            <RadioCard
-              value="one-at-a-time"
-              title="One at a time"
-              description="A list of your views sits at the top of the Navigator; click one to show it."
-            />
-            <RadioCard
-              value="stacked"
-              title="Stacked"
-              description="No list — every enabled view is stacked in the order above, each collapsible."
-            />
-          </RadioGroup>
+        <div className="nav-settings-field">
+          <div className="nav-settings-sublabel">Arrangement</div>
+          <p className="nav-settings-hint">
+            How the Navigator lays out your enabled views.
+          </p>
+          <div className="nav-settings-arrangement">
+            <RadioGroup
+              value={prefs.arrangement}
+              onChange={(v) =>
+                navigatorPrefsService.set({
+                  arrangement: v as ViewArrangement,
+                })
+              }
+            >
+              <RadioCard
+                value="one-at-a-time"
+                title="One at a time"
+                description="A list of your views sits at the top of the Navigator; click one to show it."
+              />
+              <RadioCard
+                value="stacked"
+                title="Stacked"
+                description="No list — every enabled view is stacked in the order above, each collapsible."
+              />
+            </RadioGroup>
+          </div>
         </div>
       </Section>
 

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { ArrowUp, ArrowDown } from "@phosphor-icons/react";
 import {
   IconButton,
@@ -10,7 +10,12 @@ import {
   useServiceState,
 } from "@silo-code/sdk";
 import { navigatorViewRegistry } from "@silo-code/extension-host/internal";
-import { navigatorPrefsService, type ViewArrangement } from "./navigator-prefs";
+import {
+  navigatorPrefsService,
+  GROUP_COLOR_INTENSITY_MIN,
+  GROUP_COLOR_INTENSITY_MAX,
+  type ViewArrangement,
+} from "./navigator-prefs";
 import {
   reorderSavedViews,
   resolveViewList,
@@ -138,6 +143,45 @@ export function NavigatorSettingsPanel() {
               description="No list — every enabled view is stacked in the order above, each collapsible."
             />
           </RadioGroup>
+        </div>
+      </Section>
+
+      <Section label="Group color">
+        <p className="nav-settings-hint">
+          How strongly a colored workspace group washes its rows. Groups still
+          keep whatever color you pick for them.
+        </p>
+        <div className="nav-settings-intensity">
+          <input
+            type="range"
+            className="nav-settings-intensity-slider"
+            min={GROUP_COLOR_INTENSITY_MIN}
+            max={GROUP_COLOR_INTENSITY_MAX}
+            step={0.1}
+            value={prefs.groupColorIntensity}
+            aria-label="Group color intensity"
+            onChange={(e) =>
+              navigatorPrefsService.set({
+                groupColorIntensity: Number(e.target.value),
+              })
+            }
+          />
+          <div
+            className="nav-settings-intensity-preview"
+            style={
+              {
+                "--ws-group-color": "var(--silo-color-accent)",
+                "--preview-wash": prefs.groupColorIntensity,
+              } as CSSProperties
+            }
+            aria-hidden="true"
+          >
+            <span className="nav-settings-intensity-preview-header">
+              Example group
+            </span>
+            <span className="nav-settings-intensity-preview-row" />
+            <span className="nav-settings-intensity-preview-row" />
+          </div>
         </div>
       </Section>
     </>

--- a/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorSettingsPanel.tsx
@@ -5,6 +5,7 @@ import {
   RadioCard,
   RadioGroup,
   Section,
+  SettingRow,
   Switch,
   Tooltip,
   useServiceState,
@@ -14,6 +15,7 @@ import {
   navigatorPrefsService,
   GROUP_COLOR_INTENSITY_MIN,
   GROUP_COLOR_INTENSITY_MAX,
+  stepGroupColorIntensity,
   type ViewArrangement,
 } from "./navigator-prefs";
 import {
@@ -146,43 +148,67 @@ export function NavigatorSettingsPanel() {
         </div>
       </Section>
 
-      <Section label="Group color">
-        <p className="nav-settings-hint">
-          How strongly a colored workspace group washes its rows. Groups still
-          keep whatever color you pick for them.
-        </p>
-        <div className="nav-settings-intensity">
-          <input
-            type="range"
-            className="nav-settings-intensity-slider"
-            min={GROUP_COLOR_INTENSITY_MIN}
-            max={GROUP_COLOR_INTENSITY_MAX}
-            step={0.1}
-            value={prefs.groupColorIntensity}
-            aria-label="Group color intensity"
-            onChange={(e) =>
-              navigatorPrefsService.set({
-                groupColorIntensity: Number(e.target.value),
-              })
-            }
-          />
+      <Section label="Workspace groups">
+        <SettingRow
+          label="Group color"
+          hint="How strongly a colored group washes its rows. Groups keep whatever color you pick."
+        >
           <div
-            className="nav-settings-intensity-preview"
+            className="nav-group-color"
             style={
               {
                 "--ws-group-color": "var(--silo-color-accent)",
                 "--preview-wash": prefs.groupColorIntensity,
               } as CSSProperties
             }
-            aria-hidden="true"
           >
-            <span className="nav-settings-intensity-preview-header">
-              Example group
+            <div className="nav-group-color-preview" aria-hidden="true">
+              <span className="nav-group-color-preview-label">
+                Example group
+              </span>
+              <span className="nav-group-color-preview-bar" />
+              <span className="nav-group-color-preview-val">
+                {prefs.groupColorIntensity.toFixed(1)}&times;
+              </span>
+            </div>
+            <span className="nav-group-color-stepper">
+              <IconButton
+                size="sm"
+                aria-label="Stronger group color"
+                disabled={
+                  prefs.groupColorIntensity >= GROUP_COLOR_INTENSITY_MAX
+                }
+                onClick={() =>
+                  navigatorPrefsService.set({
+                    groupColorIntensity: stepGroupColorIntensity(
+                      prefs.groupColorIntensity,
+                      1,
+                    ),
+                  })
+                }
+              >
+                <ArrowUp size={13} weight="bold" />
+              </IconButton>
+              <IconButton
+                size="sm"
+                aria-label="Weaker group color"
+                disabled={
+                  prefs.groupColorIntensity <= GROUP_COLOR_INTENSITY_MIN
+                }
+                onClick={() =>
+                  navigatorPrefsService.set({
+                    groupColorIntensity: stepGroupColorIntensity(
+                      prefs.groupColorIntensity,
+                      -1,
+                    ),
+                  })
+                }
+              >
+                <ArrowDown size={13} weight="bold" />
+              </IconButton>
             </span>
-            <span className="nav-settings-intensity-preview-row" />
-            <span className="nav-settings-intensity-preview-row" />
           </div>
-        </div>
+        </SettingRow>
       </Section>
     </>
   );

--- a/packages/extensions-core/src/navigator/navigator-prefs.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.test.ts
@@ -170,3 +170,61 @@ describe("navigator arrangement pref", () => {
     sub.dispose();
   });
 });
+
+describe("navigator group color intensity pref", () => {
+  it("defaults to 1", () => {
+    const sub = initNavigatorPrefs(fakeStorage());
+    expect(navigatorPrefsService.getState().groupColorIntensity).toBe(1);
+    sub.dispose();
+  });
+
+  it("hydrates a persisted value", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({ navigatorGroupColorIntensity: 1.8 }),
+    );
+    expect(navigatorPrefsService.getState().groupColorIntensity).toBe(1.8);
+    sub.dispose();
+  });
+
+  it("clamps a too-high value to the slider max", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({ navigatorGroupColorIntensity: 9 }),
+    );
+    expect(navigatorPrefsService.getState().groupColorIntensity).toBe(2.4);
+    sub.dispose();
+  });
+
+  it("clamps a too-low value to the slider min", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({ navigatorGroupColorIntensity: 0 }),
+    );
+    expect(navigatorPrefsService.getState().groupColorIntensity).toBe(0.4);
+    sub.dispose();
+  });
+
+  it("coerces a non-number to the default", () => {
+    const sub = initNavigatorPrefs(
+      fakeStorage({ navigatorGroupColorIntensity: "bold" }),
+    );
+    expect(navigatorPrefsService.getState().groupColorIntensity).toBe(1);
+    sub.dispose();
+  });
+
+  it("persists a change through set()", () => {
+    const storage = fakeStorage();
+    const sub = initNavigatorPrefs(storage);
+    navigatorPrefsService.set({ groupColorIntensity: 1.3 });
+    expect(storage.get<number>("navigatorGroupColorIntensity")).toBe(1.3);
+    sub.dispose();
+  });
+
+  it("picks up a value that arrives after activation", () => {
+    const storage = fakeStorage();
+    const sub = initNavigatorPrefs(storage);
+    expect(navigatorPrefsService.getState().groupColorIntensity).toBe(1);
+    storage.set("navigatorGroupColorIntensity", 2);
+    storage.emit();
+    expect(navigatorPrefsService.getState().groupColorIntensity).toBe(2);
+    sub.dispose();
+  });
+});

--- a/packages/extensions-core/src/navigator/navigator-prefs.test.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.test.ts
@@ -4,6 +4,7 @@ import {
   navigatorPrefsService,
   initNavigatorPrefs,
   clearNavigatorPrefsListeners,
+  stepGroupColorIntensity,
 } from "./navigator-prefs";
 
 /** In-memory ExtensionStorage stand-in, mirroring the host's real contract. */
@@ -226,5 +227,22 @@ describe("navigator group color intensity pref", () => {
     storage.emit();
     expect(navigatorPrefsService.getState().groupColorIntensity).toBe(2);
     sub.dispose();
+  });
+});
+
+describe("stepGroupColorIntensity", () => {
+  it("steps by 0.2 in each direction", () => {
+    expect(stepGroupColorIntensity(1, 1)).toBe(1.2);
+    expect(stepGroupColorIntensity(1, -1)).toBe(0.8);
+  });
+
+  it("rounds away floating-point drift", () => {
+    // 0.6 - 0.2 is 0.39999999999999997 without the round
+    expect(stepGroupColorIntensity(0.6, -1)).toBe(0.4);
+  });
+
+  it("clamps to the slider bounds", () => {
+    expect(stepGroupColorIntensity(2.4, 1)).toBe(2.4);
+    expect(stepGroupColorIntensity(0.4, -1)).toBe(0.4);
   });
 });

--- a/packages/extensions-core/src/navigator/navigator-prefs.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.ts
@@ -65,7 +65,18 @@ const STORAGE_KEY_GROUP_COLOR_INTENSITY = "navigatorGroupColorIntensity";
 
 export const GROUP_COLOR_INTENSITY_MIN = 0.4;
 export const GROUP_COLOR_INTENSITY_MAX = 2.4;
+export const GROUP_COLOR_INTENSITY_STEP = 0.2;
 export const DEFAULT_GROUP_COLOR_INTENSITY = 1;
+
+/** Nudge the intensity by one step, clamped and rounded to avoid FP drift. */
+export function stepGroupColorIntensity(current: number, dir: -1 | 1): number {
+  const next =
+    Math.round((current + dir * GROUP_COLOR_INTENSITY_STEP) * 100) / 100;
+  return Math.min(
+    GROUP_COLOR_INTENSITY_MAX,
+    Math.max(GROUP_COLOR_INTENSITY_MIN, next),
+  );
+}
 
 const DEFAULT_PREFS: NavigatorPrefs = {
   viewOrder: [],

--- a/packages/extensions-core/src/navigator/navigator-prefs.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.ts
@@ -50,9 +50,10 @@ export interface NavigatorPrefs {
   stackedCollapsed: readonly string[];
   /**
    * Multiplier on the color wash a colored workspace group paints over its
-   * rows. `1` is the built-in strength; the settings slider spans
-   * {@link GROUP_COLOR_INTENSITY_MIN}–{@link GROUP_COLOR_INTENSITY_MAX}. Pushed
-   * onto `--ws-group-wash-user` by the Navigator panel.
+   * rows. `1` is the built-in strength; the settings stepper moves it in
+   * {@link GROUP_COLOR_INTENSITY_STEP} increments between
+   * {@link GROUP_COLOR_INTENSITY_MIN} and {@link GROUP_COLOR_INTENSITY_MAX}.
+   * Pushed onto `--ws-group-wash-user` by the Navigator panel.
    */
   groupColorIntensity: number;
 }

--- a/packages/extensions-core/src/navigator/navigator-prefs.ts
+++ b/packages/extensions-core/src/navigator/navigator-prefs.ts
@@ -48,18 +48,31 @@ export interface NavigatorPrefs {
    * Retained across (un)registration, same as the lists above.
    */
   stackedCollapsed: readonly string[];
+  /**
+   * Multiplier on the color wash a colored workspace group paints over its
+   * rows. `1` is the built-in strength; the settings slider spans
+   * {@link GROUP_COLOR_INTENSITY_MIN}–{@link GROUP_COLOR_INTENSITY_MAX}. Pushed
+   * onto `--ws-group-wash-user` by the Navigator panel.
+   */
+  groupColorIntensity: number;
 }
 
 const STORAGE_KEY_VIEW_ORDER = "navigatorViewOrder";
 const STORAGE_KEY_DISABLED_VIEWS = "navigatorDisabledViews";
 const STORAGE_KEY_ARRANGEMENT = "navigatorArrangement";
 const STORAGE_KEY_STACKED_COLLAPSED = "navigatorStackedCollapsed";
+const STORAGE_KEY_GROUP_COLOR_INTENSITY = "navigatorGroupColorIntensity";
+
+export const GROUP_COLOR_INTENSITY_MIN = 0.4;
+export const GROUP_COLOR_INTENSITY_MAX = 2.4;
+export const DEFAULT_GROUP_COLOR_INTENSITY = 1;
 
 const DEFAULT_PREFS: NavigatorPrefs = {
   viewOrder: [],
   disabledViews: [],
   arrangement: DEFAULT_ARRANGEMENT,
   stackedCollapsed: [],
+  groupColorIntensity: DEFAULT_GROUP_COLOR_INTENSITY,
 };
 
 /** Coerce persisted JSON to a string array — anything else becomes `[]`. */
@@ -71,6 +84,17 @@ function coerceIdList(v: unknown): readonly string[] {
 
 function coerceArrangement(v: unknown): ViewArrangement {
   return v === "stacked" || v === "one-at-a-time" ? v : DEFAULT_ARRANGEMENT;
+}
+
+/** Clamp a persisted intensity to the slider's range; non-numbers → default. */
+function coerceGroupColorIntensity(v: unknown): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) {
+    return DEFAULT_GROUP_COLOR_INTENSITY;
+  }
+  return Math.min(
+    GROUP_COLOR_INTENSITY_MAX,
+    Math.max(GROUP_COLOR_INTENSITY_MIN, v),
+  );
 }
 
 function sameList(a: readonly string[], b: readonly string[]): boolean {
@@ -97,6 +121,10 @@ export const navigatorPrefsService: ReactiveService<NavigatorPrefs> & {
     backingStorage?.set(STORAGE_KEY_STACKED_COLLAPSED, [
       ...prefs.stackedCollapsed,
     ]);
+    backingStorage?.set(
+      STORAGE_KEY_GROUP_COLOR_INTENSITY,
+      prefs.groupColorIntensity,
+    );
     for (const l of listeners) l(prefs);
   },
 };
@@ -127,11 +155,18 @@ export function initNavigatorPrefs(storage: ExtensionStorage): {
         prefs.stackedCollapsed,
       ),
     );
+    const groupColorIntensity = coerceGroupColorIntensity(
+      storage.get<unknown>(
+        STORAGE_KEY_GROUP_COLOR_INTENSITY,
+        prefs.groupColorIntensity,
+      ),
+    );
     if (
       !sameList(viewOrder, prefs.viewOrder) ||
       !sameList(disabledViews, prefs.disabledViews) ||
       arrangement !== prefs.arrangement ||
-      !sameList(stackedCollapsed, prefs.stackedCollapsed)
+      !sameList(stackedCollapsed, prefs.stackedCollapsed) ||
+      groupColorIntensity !== prefs.groupColorIntensity
     ) {
       prefs = {
         ...prefs,
@@ -139,6 +174,7 @@ export function initNavigatorPrefs(storage: ExtensionStorage): {
         disabledViews,
         arrangement,
         stackedCollapsed,
+        groupColorIntensity,
       };
       for (const l of listeners) l(prefs);
     }

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -448,60 +448,58 @@
   --ws-group-neutral-ink: var(--silo-color-input-text);
 }
 
-/* The whole group becomes one bordered card */
+/* Colored group: the color is a soft wash over the whole group, not card
+   chrome — a faint flat tint, a touch stronger toward the top, plus a 1px
+   inset edge so the group still reads as one contained block. The header and
+   rows keep neutral chrome. Driven entirely by the stored --ws-group-color
+   (a hex, or a color-mix() string from the neutral swatches). */
 .ws-group--colored {
-  --ws-group-mix: 20%;
-  --ws-group-mix-hover: 30%;
-  border: 2px solid
-    color-mix(in srgb, var(--ws-group-color) var(--ws-group-mix), transparent);
+  /* Scales every mix below. Bumped on light themes, where the same percentage
+     of a mid-tone color barely registers against a light ground. */
+  --ws-group-wash: 1;
   border-radius: var(--silo-radius-sm);
   margin-inline: 4px;
   margin-bottom: 4px;
+  padding-block: 3px;
   /* margin-top intentionally omitted — controlled by .ws-group base rule */
+  background:
+    radial-gradient(
+      120% 90% at 50% 0%,
+      color-mix(
+        in srgb,
+        var(--ws-group-color) calc(3% * var(--ws-group-wash)),
+        transparent
+      ),
+      transparent 72%
+    ),
+    color-mix(
+      in srgb,
+      var(--ws-group-color) calc(6% * var(--ws-group-wash)),
+      transparent
+    );
+  box-shadow: inset 0 0 0 1px
+    color-mix(
+      in srgb,
+      var(--ws-group-color) calc(10% * var(--ws-group-wash)),
+      transparent
+    );
 }
 
 [data-theme="light"] .ws-group--colored {
-  --ws-group-mix: 35%;
-  --ws-group-mix-hover: 45%;
-  /* Darken the group color for readable text on the tinted header. On dark
-     themes this isn't set, so `var(--ws-group-text-color)` falls through to
-     `var(--ws-group-color)`, which already contrasts well against dark bg. */
-  --ws-group-text-color: color-mix(in srgb, var(--ws-group-color) 80%, black);
+  --ws-group-wash: 1.7;
 }
 
-/* Header fills the top of the card with a subtle tint */
+/* Header and body sit directly on the wash — no separate fill. */
 .ws-group--colored .ws-group-header {
-  background: color-mix(
-    in srgb,
-    var(--ws-group-color) var(--ws-group-mix),
-    transparent
-  );
   margin: 0;
-  border-radius: calc(var(--silo-radius-sm) - 2px)
-    calc(var(--silo-radius-sm) - 2px) 0 0;
 }
 
-.ws-group--colored .ws-group-header:hover {
-  background: color-mix(
-    in srgb,
-    var(--ws-group-color) var(--ws-group-mix-hover),
-    transparent
-  );
-}
-
-.ws-group--colored .ws-group-name,
-.ws-group--colored .ws-group-caret {
-  color: var(--ws-group-text-color, var(--ws-group-color));
-  opacity: 1;
-}
-
-/* Body sits inside the card — no separate border needed */
 .ws-group--colored .ws-group-body {
   margin: 0;
   padding: 4px 0 2px;
 }
 
-/* Items inside a colored group use symmetric margins matching the right side */
+/* Symmetric row insets — the wash edge stands in for the old card border. */
 .ws-group--colored .ws-group-body .ws-item {
   margin-left: 4px;
 }

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -88,6 +88,10 @@
    companion rides the stem's own ::after, which is free. */
 .ws-item .ws-active-stem {
   display: none;
+}
+
+.ws-item.active .ws-active-stem {
+  display: block;
   position: absolute;
   /* Centred under the 20px icon: row padding-left 10 + half of (20 - 2). */
   left: 19px;
@@ -95,19 +99,8 @@
   bottom: 1px;
   width: 2px;
   border-radius: 2px;
-  pointer-events: none;
-}
-
-/* Hovering an inactive row previews the marker at low strength, so the row
-   shows exactly where the stem would land once it's selected. */
-.ws-item:hover:not(.active) .ws-active-stem {
-  display: block;
-  background: color-mix(in srgb, var(--silo-color-accent) 22%, transparent);
-}
-
-.ws-item.active .ws-active-stem {
-  display: block;
   background: color-mix(in srgb, var(--silo-color-accent) 70%, transparent);
+  pointer-events: none;
 }
 
 /* Companion: same line, touching the key on its content-facing side. The key

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -78,10 +78,14 @@
   bottom: -1px;
 }
 
-/* Active workspace: no background fill — a vertical accent "stem" drops from
-   under the icon, down the icon column, ending just past the row's content.
-   It's a real element (not ::before/::after) so it never collides with the
-   drag reorder lines, which own both row pseudo-elements. */
+/* Active workspace: no background fill — a vertical two-tone accent "stem"
+   drops from under the icon, down the icon column, ending just past the row's
+   content. A full-strength key line sits against a translucent companion (no
+   gap), echoing the duotone icon's solid-stroke-plus-tint pairing.
+
+   It's a real element (not the row's ::before/::after) so it never collides
+   with the drag reorder lines, which own both row pseudo-elements — the
+   companion rides the stem's own ::after, which is free. */
 .ws-item .ws-active-stem {
   display: none;
 }
@@ -97,6 +101,19 @@
   border-radius: 2px;
   background: var(--silo-color-accent);
   pointer-events: none;
+}
+
+/* Companion: same line, touching the key on its content-facing side, at 20%
+   so it reads as depth rather than a second mark. */
+.ws-item.active .ws-active-stem::after {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--silo-color-accent) 20%, transparent);
 }
 
 .ws-item .ws-icon {

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -453,9 +453,14 @@
    header and rows keep neutral chrome. Driven entirely by the stored
    --ws-group-color (a hex, or a color-mix() string from the neutral swatches). */
 .ws-group--colored {
-  /* Scales the mixes below. Bumped on light themes, where the same percentage
-     of a mid-tone color barely registers against a light ground. */
-  --ws-group-wash: 1;
+  /* Final wash strength = the user's setting (--ws-group-wash-user, pushed onto
+     :root by the Navigator panel from navigatorPrefs, default 1) times a
+     per-theme factor — light themes need more, since the same percentage of a
+     mid-tone color barely registers against a light ground. */
+  --ws-group-wash-theme: 1;
+  --ws-group-wash: calc(
+    var(--ws-group-wash-user, 1) * var(--ws-group-wash-theme)
+  );
   border-radius: var(--silo-radius-sm);
   margin-inline: 4px;
   margin-bottom: 4px;
@@ -479,7 +484,7 @@
 }
 
 [data-theme="light"] .ws-group--colored {
-  --ws-group-wash: 1.5;
+  --ws-group-wash-theme: 1.5;
 }
 
 /* Header and body sit directly on the wash — no separate fill. */

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -78,8 +78,25 @@
   bottom: -1px;
 }
 
-.ws-item.active {
-  background: var(--silo-color-bg-active);
+/* Active workspace: no background fill — a vertical accent "stem" drops from
+   under the icon, down the icon column, ending just past the row's content.
+   It's a real element (not ::before/::after) so it never collides with the
+   drag reorder lines, which own both row pseudo-elements. */
+.ws-item .ws-active-stem {
+  display: none;
+}
+
+.ws-item.active .ws-active-stem {
+  display: block;
+  position: absolute;
+  /* Centred under the 20px icon: row padding-left 10 + half of (20 - 2). */
+  left: 19px;
+  top: 31px;
+  bottom: 1px;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--silo-color-accent);
+  pointer-events: none;
 }
 
 .ws-item .ws-icon {

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -449,12 +449,11 @@
 }
 
 /* Colored group: the color is a soft wash over the whole group, not card
-   chrome — a faint flat tint, a touch stronger toward the top, plus a 1px
-   inset edge so the group still reads as one contained block. The header and
-   rows keep neutral chrome. Driven entirely by the stored --ws-group-color
-   (a hex, or a color-mix() string from the neutral swatches). */
+   chrome — a faint flat tint, a touch stronger toward the top. No border; the
+   header and rows keep neutral chrome. Driven entirely by the stored
+   --ws-group-color (a hex, or a color-mix() string from the neutral swatches). */
 .ws-group--colored {
-  /* Scales every mix below. Bumped on light themes, where the same percentage
+  /* Scales the mixes below. Bumped on light themes, where the same percentage
      of a mid-tone color barely registers against a light ground. */
   --ws-group-wash: 1;
   border-radius: var(--silo-radius-sm);
@@ -475,12 +474,6 @@
     color-mix(
       in srgb,
       var(--ws-group-color) calc(6% * var(--ws-group-wash)),
-      transparent
-    );
-  box-shadow: inset 0 0 0 1px
-    color-mix(
-      in srgb,
-      var(--ws-group-color) calc(10% * var(--ws-group-wash)),
       transparent
     );
 }

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -448,24 +448,48 @@
   --ws-group-neutral-ink: var(--silo-color-input-text);
 }
 
-/* Colored group: the color reads as a rail down the group's left edge — the
-   same idiom as the active workspace stem — not as card chrome. Nothing else
-   is tinted; the header and rows keep neutral chrome. Driven entirely by the
-   stored --ws-group-color (a hex, or a color-mix() from the neutral swatches).
-
-   The rail is an inset box-shadow, not a ::before, so it never collides with
-   the group's drag reorder pseudo-elements; it clips to the border radius. */
+/* Colored group: the color is a soft wash over the whole group, not card
+   chrome — a faint flat tint, a touch stronger toward the top, plus a 1px
+   inset edge so the group still reads as one contained block. The header and
+   rows keep neutral chrome. Driven entirely by the stored --ws-group-color
+   (a hex, or a color-mix() string from the neutral swatches). */
 .ws-group--colored {
+  /* Scales every mix below. Bumped on light themes, where the same percentage
+     of a mid-tone color barely registers against a light ground. */
+  --ws-group-wash: 1;
   border-radius: var(--silo-radius-sm);
   margin-inline: 4px;
   margin-bottom: 4px;
   padding-block: 3px;
-  padding-left: 4px;
   /* margin-top intentionally omitted — controlled by .ws-group base rule */
-  box-shadow: inset 3px 0 0 0
-    color-mix(in srgb, var(--ws-group-color) 60%, transparent);
+  background:
+    radial-gradient(
+      120% 90% at 50% 0%,
+      color-mix(
+        in srgb,
+        var(--ws-group-color) calc(3% * var(--ws-group-wash)),
+        transparent
+      ),
+      transparent 72%
+    ),
+    color-mix(
+      in srgb,
+      var(--ws-group-color) calc(6% * var(--ws-group-wash)),
+      transparent
+    );
+  box-shadow: inset 0 0 0 1px
+    color-mix(
+      in srgb,
+      var(--ws-group-color) calc(10% * var(--ws-group-wash)),
+      transparent
+    );
 }
 
+[data-theme="light"] .ws-group--colored {
+  --ws-group-wash: 1.7;
+}
+
+/* Header and body sit directly on the wash — no separate fill. */
 .ws-group--colored .ws-group-header {
   margin: 0;
 }
@@ -475,10 +499,9 @@
   padding: 4px 0 2px;
 }
 
-/* Symmetric row insets — the group's own padding-left clears the rail, so the
-   items only need to match the 4px right margin. */
+/* Symmetric row insets — the wash edge stands in for the old card border. */
 .ws-group--colored .ws-group-body .ws-item {
-  margin-left: 0;
+  margin-left: 4px;
 }
 
 /* ── Group color swatch palette ─────────────────────────────────────────── */

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -99,12 +99,13 @@
   bottom: 1px;
   width: 2px;
   border-radius: 2px;
-  background: var(--silo-color-accent);
+  background: color-mix(in srgb, var(--silo-color-accent) 70%, transparent);
   pointer-events: none;
 }
 
-/* Companion: same line, touching the key on its content-facing side, at 20%
-   so it reads as depth rather than a second mark. */
+/* Companion: same line, touching the key on its content-facing side. The key
+   sits at 70% and this at 20%, so the pair reads as one line with depth
+   rather than two marks. */
 .ws-item.active .ws-active-stem::after {
   content: "";
   position: absolute;

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -466,14 +466,14 @@
       120% 90% at 50% 0%,
       color-mix(
         in srgb,
-        var(--ws-group-color) calc(4% * var(--ws-group-wash)),
+        var(--ws-group-color) calc(6% * var(--ws-group-wash)),
         transparent
       ),
       transparent 72%
     ),
     color-mix(
       in srgb,
-      var(--ws-group-color) calc(10% * var(--ws-group-wash)),
+      var(--ws-group-color) calc(15% * var(--ws-group-wash)),
       transparent
     );
 }

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -448,48 +448,24 @@
   --ws-group-neutral-ink: var(--silo-color-input-text);
 }
 
-/* Colored group: the color is a soft wash over the whole group, not card
-   chrome — a faint flat tint, a touch stronger toward the top, plus a 1px
-   inset edge so the group still reads as one contained block. The header and
-   rows keep neutral chrome. Driven entirely by the stored --ws-group-color
-   (a hex, or a color-mix() string from the neutral swatches). */
+/* Colored group: the color reads as a rail down the group's left edge — the
+   same idiom as the active workspace stem — not as card chrome. Nothing else
+   is tinted; the header and rows keep neutral chrome. Driven entirely by the
+   stored --ws-group-color (a hex, or a color-mix() from the neutral swatches).
+
+   The rail is an inset box-shadow, not a ::before, so it never collides with
+   the group's drag reorder pseudo-elements; it clips to the border radius. */
 .ws-group--colored {
-  /* Scales every mix below. Bumped on light themes, where the same percentage
-     of a mid-tone color barely registers against a light ground. */
-  --ws-group-wash: 1;
   border-radius: var(--silo-radius-sm);
   margin-inline: 4px;
   margin-bottom: 4px;
   padding-block: 3px;
+  padding-left: 4px;
   /* margin-top intentionally omitted — controlled by .ws-group base rule */
-  background:
-    radial-gradient(
-      120% 90% at 50% 0%,
-      color-mix(
-        in srgb,
-        var(--ws-group-color) calc(3% * var(--ws-group-wash)),
-        transparent
-      ),
-      transparent 72%
-    ),
-    color-mix(
-      in srgb,
-      var(--ws-group-color) calc(6% * var(--ws-group-wash)),
-      transparent
-    );
-  box-shadow: inset 0 0 0 1px
-    color-mix(
-      in srgb,
-      var(--ws-group-color) calc(10% * var(--ws-group-wash)),
-      transparent
-    );
+  box-shadow: inset 3px 0 0 0
+    color-mix(in srgb, var(--ws-group-color) 60%, transparent);
 }
 
-[data-theme="light"] .ws-group--colored {
-  --ws-group-wash: 1.7;
-}
-
-/* Header and body sit directly on the wash — no separate fill. */
 .ws-group--colored .ws-group-header {
   margin: 0;
 }
@@ -499,9 +475,10 @@
   padding: 4px 0 2px;
 }
 
-/* Symmetric row insets — the wash edge stands in for the old card border. */
+/* Symmetric row insets — the group's own padding-left clears the rail, so the
+   items only need to match the 4px right margin. */
 .ws-group--colored .ws-group-body .ws-item {
-  margin-left: 4px;
+  margin-left: 0;
 }
 
 /* ── Group color swatch palette ─────────────────────────────────────────── */

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -512,6 +512,12 @@
   margin-left: 4px;
 }
 
+/* Rows inside a colored group get the same hue-tinted hover as the header,
+   instead of the generic grey. */
+.ws-group--colored .ws-group-body .ws-item:hover {
+  background: color-mix(in srgb, var(--ws-group-color) 22%, transparent);
+}
+
 /* ── Group color swatch palette ─────────────────────────────────────────── */
 
 .ws-group-palette {

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -103,8 +103,9 @@
   pointer-events: none;
 }
 
-/* Companion: same line, touching the key on its content-facing side, at the
-   same 70% — together they read as one 4px-wide marker. */
+/* Companion: same line, touching the key on its content-facing side. The key
+   sits at 70% and this at 15%, so the pair reads as one line with depth
+   rather than two marks. */
 .ws-item.active .ws-active-stem::after {
   content: "";
   position: absolute;
@@ -113,7 +114,7 @@
   bottom: 0;
   width: 2px;
   border-radius: 2px;
-  background: color-mix(in srgb, var(--silo-color-accent) 70%, transparent);
+  background: color-mix(in srgb, var(--silo-color-accent) 15%, transparent);
 }
 
 .ws-item .ws-icon {

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -466,20 +466,20 @@
       120% 90% at 50% 0%,
       color-mix(
         in srgb,
-        var(--ws-group-color) calc(3% * var(--ws-group-wash)),
+        var(--ws-group-color) calc(4% * var(--ws-group-wash)),
         transparent
       ),
       transparent 72%
     ),
     color-mix(
       in srgb,
-      var(--ws-group-color) calc(6% * var(--ws-group-wash)),
+      var(--ws-group-color) calc(10% * var(--ws-group-wash)),
       transparent
     );
 }
 
 [data-theme="light"] .ws-group--colored {
-  --ws-group-wash: 1.7;
+  --ws-group-wash: 1.5;
 }
 
 /* Header and body sit directly on the wash — no separate fill. */

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -103,9 +103,8 @@
   pointer-events: none;
 }
 
-/* Companion: same line, touching the key on its content-facing side. The key
-   sits at 70% and this at 20%, so the pair reads as one line with depth
-   rather than two marks. */
+/* Companion: same line, touching the key on its content-facing side, at the
+   same 70% — together they read as one 4px-wide marker. */
 .ws-item.active .ws-active-stem::after {
   content: "";
   position: absolute;
@@ -114,7 +113,7 @@
   bottom: 0;
   width: 2px;
   border-radius: 2px;
-  background: color-mix(in srgb, var(--silo-color-accent) 20%, transparent);
+  background: color-mix(in srgb, var(--silo-color-accent) 70%, transparent);
 }
 
 .ws-item .ws-icon {

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -88,10 +88,6 @@
    companion rides the stem's own ::after, which is free. */
 .ws-item .ws-active-stem {
   display: none;
-}
-
-.ws-item.active .ws-active-stem {
-  display: block;
   position: absolute;
   /* Centred under the 20px icon: row padding-left 10 + half of (20 - 2). */
   left: 19px;
@@ -99,8 +95,19 @@
   bottom: 1px;
   width: 2px;
   border-radius: 2px;
-  background: color-mix(in srgb, var(--silo-color-accent) 70%, transparent);
   pointer-events: none;
+}
+
+/* Hovering an inactive row previews the marker at low strength, so the row
+   shows exactly where the stem would land once it's selected. */
+.ws-item:hover:not(.active) .ws-active-stem {
+  display: block;
+  background: color-mix(in srgb, var(--silo-color-accent) 22%, transparent);
+}
+
+.ws-item.active .ws-active-stem {
+  display: block;
+  background: color-mix(in srgb, var(--silo-color-accent) 70%, transparent);
 }
 
 /* Companion: same line, touching the key on its content-facing side. The key

--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -492,6 +492,16 @@
   margin: 0;
 }
 
+/* Hover deepens the group's own color rather than dropping to the generic
+   grey hover — a translucent layer of --ws-group-color that stacks over the
+   group wash beneath, so it reads as a darker/lighter patch of the same hue.
+   Fixed alpha (not scaled by --ws-group-wash) so the hover still registers at
+   low intensity settings. */
+.ws-group--colored .ws-group-header:hover {
+  background: color-mix(in srgb, var(--ws-group-color) 22%, transparent);
+  color: var(--silo-color-text-hi);
+}
+
 .ws-group--colored .ws-group-body {
   margin: 0;
   padding: 4px 0 2px;

--- a/packages/extensions-core/src/workspaces/WorkspacesView.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.tsx
@@ -332,6 +332,7 @@ export function WorkspacesView({
         }}
       >
         <WorkspaceIcon className="ws-icon" size={20} weight="duotone" />
+        <span className="ws-active-stem" aria-hidden="true" />
         <div className="ws-name-row">
           <span className="ws-name">{ws.name}</span>
           {service.getBadges(ws.id).map((b) => (

--- a/packages/extensions-core/src/workspaces/group-properties.tsx
+++ b/packages/extensions-core/src/workspaces/group-properties.tsx
@@ -60,11 +60,15 @@ function GroupPropertiesContent({
   initial,
   onCancel,
   onSave,
+  onPreviewColor,
 }: {
   mode: "create" | "edit";
   initial: GroupDraft;
   onCancel: () => void;
   onSave: (changes: GroupDraft) => void;
+  /** Edit mode only: called on every swatch click so the group in the
+      Navigator repaints live. The caller reverts if the modal is cancelled. */
+  onPreviewColor?: (color: string | undefined) => void;
 }) {
   const [name, setName] = useState(initial.name);
   const [color, setColor] = useState<string | undefined>(initial.color);
@@ -102,7 +106,10 @@ function GroupPropertiesContent({
         style={entry.value ? { background: entry.value } : undefined}
         aria-label={entry.label}
         aria-pressed={color === entry.value}
-        onClick={() => setColor(entry.value)}
+        onClick={() => {
+          setColor(entry.value);
+          onPreviewColor?.(entry.value);
+        }}
       />
     );
   }
@@ -156,13 +163,19 @@ export async function openGroupProperties(
         initial={{ name: group.name, color: group.color }}
         onCancel={() => close()}
         onSave={(c) => close(c)}
+        onPreviewColor={(c) => setGroupColor(group.id, c)}
       />
     ),
     { title: "Group Properties", size: "sm" },
   );
   if (changes) {
     if (changes.name !== group.name) renameGroup(group.id, changes.name);
+    // The color was already applied live by the preview; this reconciles the
+    // final value (and is a no-op when they match).
     if (changes.color !== group.color) setGroupColor(group.id, changes.color);
+  } else {
+    // Cancelled or dismissed — undo whatever the preview left behind.
+    setGroupColor(group.id, group.color);
   }
 }
 

--- a/packages/extensions-core/src/workspaces/group-properties.tsx
+++ b/packages/extensions-core/src/workspaces/group-properties.tsx
@@ -47,13 +47,12 @@ const PALETTE: Swatch[] = [
 const neutral = (pct: number): string =>
   `color-mix(in srgb, var(--ws-group-neutral-ink) ${pct}%, var(--silo-color-bg))`;
 
+// Just the two extremes of the neutral ramp — a faint tint and a strong one.
+// (Both invert per theme, so "faint"/"strong" describes the wash weight, not a
+// fixed light/dark value.)
 const GREYSCALE: Swatch[] = [
-  { label: "Gray 1", value: neutral(40) },
-  { label: "Gray 2", value: neutral(52) },
-  { label: "Gray 3", value: neutral(64) },
-  { label: "Gray 4", value: neutral(76) },
-  { label: "Gray 5", value: neutral(88) },
-  { label: "Gray 6", value: neutral(100) },
+  { label: "Gray faint", value: neutral(40) },
+  { label: "Gray strong", value: neutral(100) },
 ];
 
 function GroupPropertiesContent({


### PR DESCRIPTION
## Summary

Three related changes to how the Navigator shows workspace state:

1. **The active workspace** is now marked by a thin accent line that drops from under its icon down the row, instead of a filled background highlight. The line is two-tone — a solid stroke against a faint one — echoing the workspace icon's own look.
2. **Colored workspace groups** are now a soft, translucent wash of the group's color over the whole group, instead of a bordered card with a tinted header. The color reads as a light background tint; the rows and header stay plain. Hovering the group's header or any row inside it deepens that same color instead of showing the generic grey hover.
3. **A new "Group color" setting** (Layout → Navigator) lets you dial that wash stronger or weaker with an up/down stepper, next to a small live preview. The group properties dialog also previews a color the moment you click a swatch, before you save. The group color picker's grey shades were trimmed from six to two (a faint one and a strong one).

The Navigator settings tab was also tidied so its controls follow the same label-and-description layout the rest of Layout settings uses.

All visual/preference changes — no behavior or data changes.

## Details

### Active workspace stem
- `.ws-active-stem` — a real `<span>` in the row (not a row pseudo-element, which the drag reorder lines own). Key line at 70% `--silo-color-accent`, companion at 15% via its own `::after`, flush on the content-facing side. Replaces the `--silo-color-bg-active` fill on `.ws-item.active`.

### Colored group wash
- `.ws-group--colored` drops the 2px border + tinted-header + colored header text. New background: a `radial-gradient` (6%, stronger toward the top) over a flat 15% `color-mix` of `--ws-group-color`, no inset edge.
- Strength = `--ws-group-wash-user` (the setting, default 1) × `--ws-group-wash-theme` (1 dark / 1.5 light — light grounds need more of a mid-tone color to register).
- Hover on `.ws-group--colored`'s header and its `.ws-item` rows is `color-mix(--ws-group-color 22%, transparent)` — a fixed-alpha layer that stacks over the wash, so it reads as a deeper patch of the same hue and still registers at low intensity. Uncolored groups keep `--silo-color-bg-hover`.
- Iterated on the wash percentages live; also tried a left rail (reverted) before settling on the wash.

### Group color intensity setting
- `navigatorPrefs.groupColorIntensity` — persisted number, clamped 0.4–2.4, default 1. `stepGroupColorIntensity()` nudges it 0.2 at a time (rounded to avoid FP drift).
- `NavigatorPanel` mirrors it onto `--ws-group-wash-user` on `document.documentElement` while mounted, falling back to 1 otherwise — this is the one cross-extension seam: a `core.navigator` pref driving how `core.workspaces` paints groups, done through a CSS var rather than shared state.
- `NavigatorSettingsPanel` renders it as a `SettingRow` (label + hint left, control right) with a compact wash preview and an `ArrowUp`/`ArrowDown` `IconButton` stepper.
- `group-properties.tsx` — swatch clicks call `setGroupColor(group.id, …)` immediately in edit mode for a live preview; cancel/dismiss reverts, Save reconciles. `GREYSCALE` cut to `neutral(40)` / `neutral(100)`.

### Settings panel cleanup
- The "Views" and "View arrangement" sections merged into one "Views" section with two labelled `.nav-settings-field` blocks ("Shown views", "Arrangement"), matching `SettingRow`'s rhythm and hairline divider. Controls unchanged.

### Tests
- `navigator-prefs.test.ts` — default, hydrate, clamp high/low, non-number coercion, persist, late-arrival for `groupColorIntensity`; step/round/clamp for `stepGroupColorIntensity`.
- `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, `pnpm test` all green.

### Not done (follow-up candidates)
- `apps/docs/public/img/guide/workspaces-panel.png` / `workspaces-open.png` still show the old bg-fill active highlight and pre-wash groups.
- `docs/domain-language.md` has no entry yet for the active-workspace "stem" or the group-color "wash".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLa3J2zMwUtyPT6yHJ4Knc
