### PR TITLE
feat(navigator): bold the active row's label in the View List

### DIFF
--- a/packages/extensions-core/src/navigator/NavigatorPanel.css
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.css
@@ -17,7 +17,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 15px 6px 18px;
+  padding: 15px 6px 8px;
   position: sticky;
   top: 0;
   z-index: 1;
@@ -39,9 +39,9 @@
   background: var(--silo-color-bg-hover);
 }
 
-/* Deliberately unhighlighted when selected — `.nav-view-header` below names
-   the open view instead. Hover is the only row state, so the list reads as a
-   set of destinations rather than a segmented control. */
+/* No background/border for the selected state — only the label's weight
+   changes (below) — so the list still reads as a set of destinations rather
+   than a segmented control. */
 .nav-view-row {
   display: flex;
   flex: 1;
@@ -88,6 +88,14 @@
   white-space: nowrap;
 }
 
+/* The one bit of selected-state styling the row above gets: its label goes
+   bold. Everything else about the row (background, border) stays plain — the
+   list still reads as a set of destinations, just with the current one
+   distinguishable by weight instead of unmarked entirely. */
+.nav-view-row[data-selected="true"] .nav-view-row__label {
+  font-weight: 600;
+}
+
 /* Names the open view and hosts its contributed actions. Reads as a section
    heading over the view body — the same uppercase treatment the views use for
    their own section headings, so the hierarchy is [destinations][you are
@@ -95,6 +103,11 @@
 .nav-view-header {
   display: flex;
   align-items: center;
+  /* The title (when rendered) is flex:1 and pushes everything after it to the
+     end on its own; with the title hidden (list shown — EXPERIMENT above)
+     nothing does that job, so state it directly instead of leaving the
+     toolbar to fall back to the start. */
+  justify-content: flex-end;
   gap: 6px;
   padding: 4px 12px;
   /* --silo-color-border is transparent in dark theme (theme.css), so it reads
@@ -108,6 +121,18 @@
 /* No view list above means no seam to draw under it. */
 .nav-view-header[data-view-list="false"] {
   border-top: none;
+}
+
+/* With the title gone (list shown — the bold row above names the view
+   instead), the header has no seam to draw and no content to hold its old
+   vertical padding open — collapse both, so it's just the toolbar floating
+   over the active view. The list's own bottom padding, above, is what
+   separates list from view now. */
+.nav-view-header[data-view-list="true"] {
+  border-top: none;
+  border-bottom: none;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .nav-view-header__title {

--- a/packages/extensions-core/src/navigator/NavigatorPanel.tsx
+++ b/packages/extensions-core/src/navigator/NavigatorPanel.tsx
@@ -95,8 +95,8 @@ export function NavigatorPanel({ ctx }: { ctx: ExtensionContext }) {
 }
 
 /** The default arrangement: a list of every enabled view at the top, one of
- * them shown below. Unchanged from ADR 0038 apart from operating on the
- * enabled/ordered set rather than the raw registry. */
+ * them shown below. Operates on the enabled/ordered set rather than the raw
+ * registry (ADR 0038). */
 function SwitcherNavigator({
   ctx,
   views,
@@ -169,9 +169,9 @@ function SwitcherNavigator({
     <div className="nav-panel">
       {/* Every enabled view, named and one click away — no menu (RFC 0023's
           selector was a dropdown; the list is the same choice made visible).
-          Which one is open is said by the header below rather than by
-          highlighting a row up here, so the list reads as a set of
-          destinations rather than a control with a stuck state.
+          The active row's label goes bold; nothing else about a row changes
+          (no background, no border), so the list still reads as a set of
+          destinations rather than a segmented control.
 
           Dropped entirely below two views: a one-row list of destinations you
           are already at is pure chrome, and the header below still names the
@@ -205,6 +205,7 @@ function SwitcherNavigator({
                 // the row — assistive tech needs it named here, where the
                 // choice is.
                 aria-selected={row.selected}
+                data-selected={row.selected ? "true" : undefined}
                 // Omitted until the panel actually mounts (views mount lazily
                 // on first activation, below) — pointing at an id that isn't in
                 // the DOM yet would be a dangling reference for any view not
@@ -230,13 +231,19 @@ function SwitcherNavigator({
         </div>
       )}
 
-      {/* The active view, named — and the place its *scoped* actions live
+      {/* The active view's header — the place its *scoped* actions live
           (toolbar contributions on the "navigator" surface `when`-bound to this
           view). Unscoped chrome — the Add-workspace "+" — rides the Workspaces
           row above instead (ADR 0048); it only falls to this header when the
           list is hidden (one enabled view), which is the sole case
           `chromeHostId` can match `activeView.id` here. Either way core.navigator
-          imports not a line of workspace code. */}
+          imports not a line of workspace code.
+
+          Named here only when the list above is hidden: with the list shown,
+          the active row's bold label already says which view is open, so
+          repeating the name here would be redundant. With the list hidden
+          (one enabled view) this header is the only place the view is named
+          at all. */}
       {activeView && (
         // `data-focus-chrome`: header controls (the contributed toolbar), not
         // content — keyboard region-entry skips past this to land in the
@@ -247,7 +254,9 @@ function SwitcherNavigator({
           data-focus-chrome
           data-view-list={showViewList ? "true" : "false"}
         >
-          <span className="nav-view-header__title">{activeView.title}</span>
+          {!showViewList && (
+            <span className="nav-view-header__title">{activeView.title}</span>
+          )}
           <ContributedToolbar
             surface="navigator"
             target={{ viewId: activeView.id }}

--- a/packages/extensions-core/src/navigator/navigator-views.ts
+++ b/packages/extensions-core/src/navigator/navigator-views.ts
@@ -200,9 +200,9 @@ export interface ViewRow {
   id: string;
   title: string;
   icon: NavigatorView["icon"];
-  /** Whether this is the active view — the row's `aria-selected`. Not painted
-   * (ADR 0038: the view header names the active view instead), but still the
-   * one place "which row is the active one" is decided. */
+  /** Whether this is the active view — the row's `aria-selected`, and what
+   * bolds its label. The one place "which row is the active one" is
+   * decided. */
   selected: boolean;
 }
 


### PR DESCRIPTION
## Summary

When the Navigator shows one view at a time, its list of views (Workspaces, Agents, Tasks, …) gave no visual sign of which one you were currently looking at — the only indication was the name repeated in the header just below the list, which read as redundant once you noticed it.

Now the active view's name in that list is shown in bold, so you can see at a glance which view is open without reading the header underneath. Since the list itself now carries that information, the repeated name in the header is dropped for anyone with more than one view enabled (it still shows for people with just a single view, since the list of destinations doesn't appear at all in that case).

## Details

### What changed

- `SwitcherNavigator` (`NavigatorPanel.tsx`): the active row now carries `data-selected="true"`; the view header's `<span className="nav-view-header__title">` only renders when the view list is hidden (`!showViewList`) — i.e. when there's exactly one enabled view and the list itself isn't shown.
- `NavigatorPanel.css`:
  - `.nav-view-row[data-selected="true"] .nav-view-row__label` sets `font-weight: 600` — the only selected-state styling on the row; no background/border change, so the list still reads as a set of destinations rather than a segmented control.
  - `.nav-view-header` gets `justify-content: flex-end` so the contributed toolbar still sits at the trailing edge once the title (which used to push it there via `flex: 1`) is gone.
  - `.nav-view-header[data-view-list="true"]` (list shown → title hidden) drops both borders and its vertical padding — there's no title/border to hold that space open anymore, and it was reading as a dead gap above the view content.
  - `.nav-views` bottom padding trimmed from 18px to 8px to match the tighter header above it.
- `navigator-views.ts`: updated the stale `ViewRow.selected` doc comment (previously said selection was "not painted," per ADR 0038 — no longer true).

### Verification

- `pnpm --filter silo exec tsc --noEmit` — clean
- `pnpm lint` — clean
- `pnpm --filter @silo-code/extensions-core test` — 452/452 passing (no logic changes to `navigator-views.ts`, comment-only there)
- Manually exercised in the dev app: multi-view case shows the bold label with no header title and a tight, seamless header; single-view case is unchanged (header title still shows).
