### PR TITLE
docs(agents): re-expand RFC 0033 into a phase-3 planning package

### DIFF
--- a/docs/decisions/0047-cli-command-grammar.md
+++ b/docs/decisions/0047-cli-command-grammar.md
@@ -300,6 +300,38 @@ The load-bearing cases, `*` marking a change from behavior before this ADR:
   `--wait`, or an exception to the shorthand set is an amendment to this ADR
   with a dated line in Consequences.
 
+### Amendment 2026-09-02 — the test for staying in Forward mode
+
+Rule 6 lists four execution modes as peers. Practice has shown they are not.
+Local, Disk-read, and Control each answer "**who** can answer this?" — the
+binary, the config tier on disk, the running instance. Forward answers "nobody
+does": it is a description of a limitation, not a design that was chosen. So it
+needs an entry test, which rule 6 left implicit and which RFC 0033's phase 3
+planning got wrong by reading the four modes as equally available.
+
+**A command may stay Forward only when both hold:**
+
+1. Its value **is** the side effect the user is about to look at — the window,
+   the workspace, the installed extension — not information the caller reads.
+2. It must work when **nothing is running**, so requiring a live instance would
+   break its most common invocation.
+
+`silo <path>` / `ws open`, `install`, and `uninstall` pass both: they are
+`open(1)`-shaped, and opening Silo when Silo is closed is the normal case.
+Blocking the shell to hand back an id nobody reads would make them worse.
+
+**Everything else is Control**, including any command a caller branches on, any
+command that creates something whose id is needed next, and any **new flag on a
+verb already scheduled for conversion.** That last clause is the one this
+amendment exists for: adding Forward-mode plumbing to a verb that is being
+moved to Control is writing code against a mode that verb is leaving.
+`silo agent run` is exactly that case (RFC 0034), which is why RFC 0033 phase 3
+carries `--prompt` as a **defined payload** on `agent.run` rather than as
+shipped Forward behavior.
+
+This tightens rule 7 rather than loosening it, and ratifies RFC 0034's split —
+it converts `agent run` and leaves `open` / `install` / `uninstall` alone.
+
 ## Alternatives considered
 
 - **Keep the path form as the only way to open things** ("there is no

--- a/docs/proposals/0033-agent-profiles/design.md
+++ b/docs/proposals/0033-agent-profiles/design.md
@@ -13,6 +13,8 @@ Four seams, in dependency order. Nothing here is public SDK surface.
 | `packages/extension-host/…/agents/agent-prompt.ts` **(new)**                | The whole pure core: sanitizer, dialect, delimiter, composition, refusals |
 | `packages/extension-host/…/agents/pending-launch.ts` + `agent-launch.ts`    | A launch may carry a prompt; the drain composes it                        |
 | `apps/desktop/src-tauri/…/commands/cli.rs` + `src/cli/agent-run-handler.ts` | `--prompt` parsed, forwarded, prechecked                                  |
+| `packages/extensions-core/src/agents-settings/ProfileEditorModal.tsx`       | R10 — the profile says whether it can take a prompt                       |
+| `packages/extensions-core/src/terminal/TerminalPanel.tsx`                   | R9 — the orphaned-session fix (adjacent; own commit)                      |
 
 The design deliberately puts **all** the reasoning in one pure module. The
 drain, the CLI handler, and (later) phase 5 each call the same function and act
@@ -39,6 +41,13 @@ function sanitizePromptForLineEditor(text: string): string;
 /** The dialect of the shell a terminal will actually run. */
 function shellDialect(shell: string | undefined): ShellDialect;
 
+/** The catalog agent a profile resolves to — `assumedAgentId` when set, else
+ *  matched from the command text. The single source the launch path and the
+ *  Profiles editor (R10) share, so a refusal and its warning cannot drift. */
+function resolveProfileAgentId(
+  profile: Pick<AgentProfile, "assumedAgentId" | "command">,
+): string | undefined;
+
 /** A delimiter no line of `payload` equals. */
 function heredocDelimiter(payload: string): string;
 
@@ -51,9 +60,14 @@ function composePromptLaunchLine(input: {
 }): { line: string } | { refusal: PromptRefusal };
 ```
 
-`composePromptLaunchLine` is the only place shell syntax is written, and it is
-called from exactly two points (below) with the same inputs, so a precheck and
-the eventual drain cannot disagree.
+`composePromptLaunchLine` is the only place shell syntax is written. It is
+called from two points — the CLI precheck and the drain — and the inputs that
+_can_ differ between them are deliberately narrowed to one: the **profile**,
+which phase 1 established is resolved at drain time so a mid-flight edit is
+respected. `dialect` is decided once at registration and carried on the pending
+launch, and `delivery` follows from the profile. So the two calls can only
+disagree when the user edits the profile mid-launch, which is exactly the case
+R7 documents.
 
 ### The catalog field
 
@@ -111,10 +125,27 @@ is typed. Resolution, in order:
    the host already stores).
 2. The user's login shell, from a new `default_shell` host command reading
    `$SHELL` (`/bin/bash` when unset — the same fallback `main.rs` already
-   uses), resolved once and cached host-side.
+   uses).
 
 Mapped by basename: `bash` / `zsh` / `sh` / `dash` / `ksh` → `posix`; `fish` →
 `fish`; everything else → `unsupported`.
+
+**Resolved once, at host init — not per launch.** `default_shell` is a Tauri
+`invoke` and therefore async, but `applyCliAgentRun` is synchronous and its
+callers (the warm `cli:open` emit and the cold `PendingLaunchArg` path) expect
+it to stay that way. Making the CLI handler async to fetch a value that never
+changes would push a signature change through both paths for nothing. So the
+login shell is resolved **during host initialization** and held in host state;
+every consumer reads it synchronously. This is also what lets the dialect be
+decided once per launch and carried on the pending launch, rather than
+re-derived at drain time from a record that did not exist at precheck.
+
+**Why fish gets a real transport rather than a refusal.** It doubles the
+composition surface, which is a genuine cost — but fish is common in exactly
+this product's audience, its single-quoting rule is small and exact (only `\`
+and `'` need escaping, and newlines are literal inside quotes), and the
+detection machinery is needed either way to _recognize_ fish. Refusing a whole
+shell community on a new feature to save one small function is the wrong trade.
 
 **Known limitation, accepted:** the login shell is read in the app process,
 while the session host resolves `$SHELL` in its own. They are the same value in
@@ -176,11 +207,17 @@ of prompt delivery.
 5. The resulting line is typed with one `sendInput` call.
 
 Steps 2 and 4 evaluate the same function. The precheck is what satisfies R7's
-"a refused prompt aborts the launch"; the re-evaluation at drain is what keeps
-phase 1's "resolved at drain time" promise when a profile is edited in between.
-If the drain now refuses where the precheck passed, it types **nothing** and
-logs — a launched-but-promptless agent is the outcome this phase exists to
-prevent.
+"a refused prompt aborts the launch" — it runs before anything is created, so a
+refusal costs nothing. The re-evaluation at drain is what keeps phase 1's
+"resolved at drain time" promise when a profile is edited in between; the
+dialect, decided at step 3 and carried on the pending launch, is _not_
+re-derived, so the profile is the only input that can have changed.
+
+If the drain refuses where the precheck passed, it types **nothing** and logs.
+The terminal already exists at that point and is left as a plain shell — the
+one case in which a terminal outlives a refused prompt, and the same shape as
+phase 1's "a profile deleted mid-launch drains to nothing." R7 names it
+explicitly rather than pretending the precheck is total.
 
 ### Newlines: `\n` in the model, `\r` on the wire
 
@@ -230,6 +267,28 @@ claude 'fix the
 CI'
 ```
 
+### Transport validation (spike, 2026-09-02)
+
+The whole phase rests on "a quoted heredoc typed as keystrokes into an
+interactive shell delivers its payload intact." That was verified before the
+design committed to it, by driving a real PTY — `pty.fork()`, an interactive
+shell, the composed line written as keystrokes with `\r` line endings, and the
+receiving program writing its `argv[1]` to a file for byte comparison:
+
+| Shell                      | Result                                                                                 |
+| -------------------------- | -------------------------------------------------------------------------------------- |
+| interactive `bash`         | **byte-exact** — `$HOME`, `` `date` ``, `$(uname)`, embedded newlines all literal      |
+| `zsh -f`                   | **byte-exact**; bracketed-paste mode (`ESC[?2004h`) active and harmless to typed input |
+| `zsh` with a heavy user rc | inconclusive — the spike harness got no output at all                                  |
+
+Two things follow. First, the transport is sound and the `$(cat <<'X' … X\n)"`
+form is correct as written. Second — and more important — **the third row is
+the real risk**, and no synthetic PTY can retire it: plugin-heavy line editors
+(zsh-autosuggestions, syntax highlighting, powerlevel10k instant prompt) hook
+the same keystroke path this transport uses. That verification has to happen in
+the real app against a real user shell, which is why it is a `verifier-gui`
+task rather than a unit test.
+
 Any other dialect refuses (`unsupported-shell`). Nu and PowerShell are
 deliberately not implemented: nu's raw-string forms are their own puzzle, and
 approximating a quoting rule is precisely the failure mode this phase is
@@ -274,10 +333,21 @@ All four report on the existing `silo:application` / **Application** channel via
 use, and the only place a Forward-mode CLI request can speak (ADR 0047: there
 is no stdout and no meaningful exit code until the Control API).
 
-`MAX_PROMPT_BYTES` is a documented constant. A prompt is an opening
+`MAX_PROMPT_BYTES` is **16 KiB** of sanitized UTF-8. A prompt is an opening
 instruction, not a file transfer; a bounded, stated limit that fails loudly
-beats an unbounded paste that wedges a line editor. Pick a value in the tens of
-kilobytes and state it in the CLI guide.
+beats an unbounded paste that wedges a line editor. 16 KiB is far more than any
+real instruction, far under `ARG_MAX`, and small enough to stay tractable for
+the line editor and for the history file the line lands in (R5a). The CLI guide
+states it.
+
+**PTY write chunking.** A 16 KiB composed line may exceed what a single
+`sendInput` can carry in one write. A truncated heredoc is the worst possible
+failure here: the delimiter never arrives, so the user's shell sits in an
+unterminated quote waiting for input that will never come. The send must
+therefore either be proven to carry the full line or chunk it, and the boundary
+case must be tested at exactly `MAX_PROMPT_BYTES` rather than assumed. This is
+the one place where "it worked in the spike" is not evidence — the spike's
+payloads were small.
 
 ## Testing strategy
 
@@ -330,9 +400,31 @@ workspace, and logs; a launch with no prompt is unchanged.
   prompt creates no terminal record. This is the same reasoning that kept
   phase 1 from synthesizing a profile.
 - **ADR 0047 (CLI grammar)** — `--prompt` is a flag on an existing verb, not a
-  new noun or verb. Forward mode: it asks for an action, not an answer, so it
-  needs no `--json` envelope and no Control channel. Rule 7's "never prompt"
+  new noun or verb, so the grammar is untouched. Rule 7's "never prompt"
   concerns modals, not this flag.
+
+  **The Forward-mode question, answered rather than waved past.** Rule 1 makes
+  coding agents the primary consumer, and rule 7 says a command whose failures
+  the caller cannot see is "a reason to move a command to Control, not an
+  exemption it keeps." `--prompt` adds four refusal paths; left as runtime-only
+  Output lines, an agent could not distinguish "started with my prompt" from
+  "did nothing." That would be the exact defect the ADR names.
+
+  The resolution is not a return channel — it is noticing that three of the
+  four refusals are **not runtime failures at all**. `no-agent` and
+  `agent-takes-none` are properties of the _profile_, fixed the moment it is
+  saved. `unsupported-shell` is a property of the _user's shell_, fixed for the
+  machine. Only `too-large` is a property of the invocation, and it is the
+  caller's own doing and trivially corrected. So the static three move to where
+  they are actionable (R10, the Profiles tab), and the CLI keeps only a failure
+  its caller can see coming. Forward mode is then honest about what it is
+  reporting rather than concealing configuration errors behind silence.
+
+  The staged story stays coherent as later phases land: phase 9's
+  `silo agent list --json` exposes the same fact to machines, and the Control
+  API (RFC 0034) eventually supplies real exit codes. Each phase reports as
+  much as its execution mode honestly can.
+
 - **ADR 0022 (storage layout)** — nothing new on disk.
 - **RFC 0028 (terminal identity in the environment)** — `SILO_*` is host-owned.
   The prompt rides the launch line and never enters the session environment.

--- a/docs/proposals/0033-agent-profiles/design.md
+++ b/docs/proposals/0033-agent-profiles/design.md
@@ -422,8 +422,36 @@ workspace, and logs; a launch with no prompt is unchanged.
 
   The staged story stays coherent as later phases land: phase 9's
   `silo agent list --json` exposes the same fact to machines, and the Control
-  API (RFC 0034) eventually supplies real exit codes. Each phase reports as
-  much as its execution mode honestly can.
+  API supplies real exit codes. Each phase reports as much as its execution
+  mode honestly can.
+
+- **RFC 0034 (Control API) — accepted, in flight, and it rewrites this exact
+  verb.** Its scope includes converting `silo agent run` from Forward to
+  Control: an `agent.run` op with `args: { profile, ws }`, R11 returning the
+  created terminal's id, a closed error vocabulary, and removal of this
+  command's `PendingLaunchArg` cold-launch arm (a deliberate break — cold runs
+  will need `--launch`).
+
+  Two packages therefore touch one command. Both are unimplemented, so they are
+  reconciled **now**, in documents, rather than by whoever implements second:
+  1. `--prompt` is specified as a `prompt` member of `agent.run`'s `args`, and
+     RFC 0034's package is updated to carry it. ADR 0047 rule 6 requires the
+     payload be defined before the verb ships regardless; 0034's own motivation
+     names the alternative — "every command shipped in the meantime is shaped
+     for silence, and gains its answer later as a breaking change."
+  2. Phase 3's refusals map onto 0034's **closed** error vocabulary rather than
+     inventing codes: `no-agent` and `agent-takes-none` are the caller's
+     configuration to fix, `unsupported-shell` is environmental, `too-large` is
+     a bad argument. Pick the exact codes when implementing, and raise a finding
+     against 0034 if none fits — it is still unimplemented and cheap to amend.
+
+  **Landing order does not matter, but it changes where the precheck lives.**
+  If phase 3 lands first, the precheck sits in `applyCliAgentRun` as designed
+  above, and 0034 moves it into the `agent.run` handler as part of its
+  conversion. If 0034 lands first, phase 3 writes the precheck straight into
+  that handler and skips the Forward-mode plumbing. Neither is rework of the
+  pure core, which is where this phase's real content lives — `agent-prompt.ts`
+  is untouched by the question.
 
 - **ADR 0022 (storage layout)** — nothing new on disk.
 - **RFC 0028 (terminal identity in the environment)** — `SILO_*` is host-owned.

--- a/docs/proposals/0033-agent-profiles/design.md
+++ b/docs/proposals/0033-agent-profiles/design.md
@@ -1,4 +1,4 @@
-# Design — 0033. Agent Profiles, phase 3 (Prompt delivery)
+# Design — 0033. Agent Profiles, phase 3 (Prompt delivery + ctx.agents.profiles)
 
 Design for **phase 3 only**. Phases 1 and 2 are the baseline. Working artifact
 — removed when the proposal collapses.
@@ -7,14 +7,13 @@ Design for **phase 3 only**. Phases 1 and 2 are the baseline. Working artifact
 
 Four seams, in dependency order. Nothing here is public SDK surface.
 
-| Where                                                                       | What changes                                                              |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `packages/extension-host/…/agents/agent-catalog.ts` + `catalog/*.ts`        | `AgentDefinition.promptDelivery`, populated per recon                     |
-| `packages/extension-host/…/agents/agent-prompt.ts` **(new)**                | The whole pure core: sanitizer, dialect, delimiter, composition, refusals |
-| `packages/extension-host/…/agents/pending-launch.ts` + `agent-launch.ts`    | A launch may carry a prompt; the drain composes it                        |
-| `apps/desktop/src-tauri/…/commands/cli.rs` + `src/cli/agent-run-handler.ts` | `--prompt` parsed, forwarded, prechecked                                  |
-| `packages/extensions-core/src/agents-settings/ProfileEditorModal.tsx`       | R10 — the profile says whether it can take a prompt                       |
-| `packages/extensions-core/src/terminal/TerminalPanel.tsx`                   | R9 — the orphaned-session fix (adjacent; own commit)                      |
+| Where                                                                    | What changes                                                              |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `packages/extension-host/…/agents/agent-catalog.ts` + `catalog/*.ts`     | `AgentDefinition.promptDelivery`, populated per recon                     |
+| `packages/extension-host/…/agents/agent-prompt.ts` **(new)**             | The whole pure core: sanitizer, dialect, delimiter, composition, refusals |
+| `packages/extension-host/…/agents/pending-launch.ts` + `agent-launch.ts` | A launch may carry a prompt; the drain composes it                        |
+| `packages/sdk/src/` + `packages/extension-host/…/agents-service.ts`      | `ctx.agents.profiles` — `list()` / `launch({ prompt })`, the consumer     |
+| `packages/extensions-core/src/agents-settings/ProfileEditorModal.tsx`    | R10 — the profile says whether it can take a prompt                       |
 
 The design deliberately puts **all** the reasoning in one pure module. The
 drain, the CLI handler, and (later) phase 5 each call the same function and act
@@ -154,52 +153,40 @@ covers the per-terminal case. If this ever bites, the escalation is to read the
 session's foreground leader — authoritative, no new IPC, but it makes the drain
 async — not to guess harder. Not built now.
 
-### The orphaned-session fix
+### The orphaned session — moved out of this phase
 
-`TerminalPanel`'s init effect can re-run (StrictMode double-invoke in dev, a
-fast remount). When it does, the in-flight run reaches the `cancelled` bail
-after its PTY has already come up and returns without disposing of it. Because
-the bail sits **above** the `tRec.sessionId` assignment, nothing ever references
-that session again: it is a live shell with no tab, surviving until the app
-quits.
+`TerminalPanel`'s init effect can re-run and reach its `cancelled` bail after
+its PTY has come up, returning without `session.kill()`. Because the bail sits
+above the `tRec.sessionId` assignment, nothing references that session again:
+a live shell with no tab, surviving until the app quits. `ensureSession`
+handles the identical race correctly (`terminal-service.ts:260`).
 
-The fix mirrors `ensureSession` — reap the orphan before returning — with the
-one guard that makes it safe:
+It was briefly folded into this phase. **It now ships as its own PR** — it never
+belonged to prompt delivery, and pairing a terminal-lifecycle change with a
+public SDK addition serves neither review. The fix is
+`if (needsCreate) void session.kill();` before the bail's `return`, guarded so
+the attach path never kills a session the record still points at, plus the
+disposition in the `ui_init_cancelled` trace.
 
-```ts
-if (cancelled) {
-  // Only a session this run *spawned* is an orphan. On the attach path the
-  // session predates us and the record still points at it — killing it would
-  // destroy a live terminal.
-  if (needsCreate) void session.kill();
-  …
-}
-```
-
-`session.kill()` is `deleteTerminal(id)`, which destroys the persistent
-session, so the `needsCreate` guard is load-bearing rather than defensive. The
-existing `ui_init_cancelled` attach trace gains the disposition (reaped or
-attached) so a post-mortem can tell the two apart — per AGENTS.md, terminal
-lifecycle is diagnosed from `terminal.log`, not the Output panel.
-
-This is the phase's one change outside the prompt path. It ships with its own
-test and is described in the collapsed proposal as an adjacent fix, not as part
-of prompt delivery.
+Recorded here only so the analysis is not lost: it is **not** the "launch line
+typed twice" symptom the collapsed proposal describes. A double drain is
+impossible (`needsCreate` guard at `TerminalPanel.tsx:900`, remove-on-read, and
+the bail returning above both the assignment and the drain). That note describes
+the pre-phase-1 `kind` shim, and correcting it is a collapse-time task.
 
 ## Data flow
 
-`silo agent run --profile claude-work --prompt "fix the CI"`:
+`ctx.agents.profiles.launch({ profileId, prompt })` from an extension:
 
-1. **`resolve_cli_request`** parses `--prompt` into a new `CliRequest.prompt`.
-   Warm launches carry it through the existing `cli:open` emit; cold launches
-   through `PendingLaunchArg`. No new IPC.
-2. **`applyCliAgentRun`** resolves the profile and workspace exactly as phase 2
-   does. Then, **only when a prompt is present**, it runs
-   `composePromptLaunchLine` as a **precheck** — before creating anything. A
-   refusal logs and returns: no terminal record, no workspace activation, no
-   focus change.
-3. **`launchAgentProfile({ …, prompt })`** creates the terminal record and calls
-   `requestProfileLaunch(rec.id, profileId, prompt)`.
+1. **The host service** resolves the profile (`profileId`, else
+   `resolveDefaultProfile`) and the target workspace, exactly as the `+` menu
+   and `core.newAgent` already do.
+2. **Only when a prompt is present**, it runs `composePromptLaunchLine` as a
+   **precheck** — before creating anything. A refusal is **returned to the
+   caller** as a typed value; no terminal record, no activation, no focus.
+3. **`launchAgentProfile({ …, prompt, dialect })`** creates the terminal record
+   and calls `requestProfileLaunch(rec.id, profileId, prompt, dialect)`. The id
+   goes back to the caller.
 4. **The drain** (`TerminalPanel` on ready, or `ensureSession` for a background
    workspace) resolves the profile, builds `profileLaunchLine(profile)`, and —
    when the claim carries a prompt — runs `composePromptLaunchLine` again
@@ -208,16 +195,22 @@ of prompt delivery.
 
 Steps 2 and 4 evaluate the same function. The precheck is what satisfies R7's
 "a refused prompt aborts the launch" — it runs before anything is created, so a
-refusal costs nothing. The re-evaluation at drain is what keeps phase 1's
-"resolved at drain time" promise when a profile is edited in between; the
-dialect, decided at step 3 and carried on the pending launch, is _not_
-re-derived, so the profile is the only input that can have changed.
+refusal costs nothing and the caller learns of it synchronously. The
+re-evaluation at drain keeps phase 1's "resolved at drain time" promise when a
+profile is edited in between; the dialect, decided at step 3 and carried on the
+pending launch, is _not_ re-derived, so the profile is the only input that can
+have changed.
 
 If the drain refuses where the precheck passed, it types **nothing** and logs.
-The terminal already exists at that point and is left as a plain shell — the
-one case in which a terminal outlives a refused prompt, and the same shape as
-phase 1's "a profile deleted mid-launch drains to nothing." R7 names it
-explicitly rather than pretending the precheck is total.
+The terminal already exists and is left as a plain shell — the one refusal
+`launch()` cannot return, because it has already returned. R7 names it rather
+than pretending the precheck is total.
+
+**The CLI is not in this picture.** `silo agent run --prompt` is specified as a
+`prompt` member of `agent.run`'s Control args (R6) and built with RFC 0034;
+`cli.rs` and `agent-run-handler.ts` are untouched here. The precheck then lives
+in that op's handler, which is where 0034 puts `applyCliAgentRun`'s logic
+anyway.
 
 ### Newlines: `\n` in the model, `\r` on the wire
 
@@ -296,20 +289,60 @@ avoiding.
 
 ## APIs / interfaces
 
-No `@silo-code/sdk` change. `promptDelivery`, `agent-prompt.ts`, and the
-extended pending-launch registry are all host-internal, and `--prompt` is a CLI
-flag. The `silo-docs-sync` workflow does not apply; if implementation forces a
-public symbol, it does.
+**This phase publishes SDK surface**, so `.agents/skills/silo-docs-sync/SKILL.md`
+applies in full — TSDoc, `@public`/`@beta` + `@category`, the barrel re-export,
+the hand-authored `ctx` member page, `pnpm docs:api`, and the roadmap flip.
+
+```ts
+/** A profile, as an extension sees it. Never the host's `AgentProfile`. */
+interface AgentProfileSummary {
+  readonly id: string;
+  readonly label: string;
+  /** True for the one profile marked default, if any. */
+  readonly isDefault: boolean;
+  /** Whether this profile's agent can take an opening prompt (R10's fact). */
+  readonly acceptsPrompt: boolean;
+}
+
+interface LaunchAgentProfileOptions {
+  /** Defaults to the default profile, else the first. */
+  profileId?: string;
+  workspaceId?: string;
+  cwd?: string;
+  /** An opening prompt. Refused rather than mangled — see `PromptRefusal`. */
+  prompt?: string;
+  /** Activate the workspace and focus the terminal. Defaults to true. */
+  activate?: boolean;
+}
+
+type LaunchAgentProfileResult =
+  | { ok: true; terminalId: string }
+  | { ok: false; refusal: PromptRefusal | "no-profile" | "no-workspace" };
+
+interface AgentProfilesService {
+  list(): readonly AgentProfileSummary[];
+  launch(options?: LaunchAgentProfileOptions): LaunchAgentProfileResult;
+}
+```
+
+`launch()` returning a **result** rather than `void` is the design's whole
+argument for preferring this over a Forward-mode CLI flag: the caller can see
+what happened. `PromptRefusal` becomes public here, which means its members are
+API — name them for an extension author, not for this module's internals.
+
+Mirrors phase 1's `ctx.agents.catalog()`: `@beta` on first publication,
+read-only, deeply frozen, and a summary type rather than the host record.
 
 Host-internal shapes that change:
 
 - `AgentDefinition.promptDelivery?: AgentPromptDelivery`
-- `PendingLaunch`: the `{ profileId }` arm gains `prompt?: string`. The
-  `{ rawLine }` arm (the deprecated-kind fallback) does **not** — it has no
-  profile and no agent, so there is nothing to resolve a delivery from.
-- `LaunchAgentProfileInput.prompt?: string`
-- `CliRequest.prompt: Option<String>` (Rust) / `CliAgentRunRequest.prompt?:
-string` (TS)
+- `PendingLaunch`: the `{ profileId }` arm gains `prompt?: string` and
+  `dialect`. The `{ rawLine }` arm (the deprecated-kind fallback) does **not** —
+  it has no profile and no agent, so there is nothing to resolve a delivery from.
+- `LaunchAgentProfileInput.prompt?: string`, `.dialect`
+
+**No Rust and no CLI types change in this phase.** `CliRequest.prompt` belongs
+to RFC 0034's conversion.
 
 ## Persistence
 
@@ -399,59 +432,38 @@ workspace, and logs; a launch with no prompt is unchanged.
 - **ADR 0046 (never create or destroy user data unprompted)** — a refused
   prompt creates no terminal record. This is the same reasoning that kept
   phase 1 from synthesizing a profile.
-- **ADR 0047 (CLI grammar)** — `--prompt` is a flag on an existing verb, not a
-  new noun or verb, so the grammar is untouched. Rule 7's "never prompt"
-  concerns modals, not this flag.
+- **ADR 0047 (CLI grammar), amended 2026-09-02 by this work.** The first draft
+  of this package shipped `silo agent run --prompt` in **Forward** mode, reading
+  rule 6's four execution modes as equally available and justifying the silence
+  with R10. That was decided while RFC 0034 was a `draft` with no design.
 
-  **The Forward-mode question, answered rather than waved past.** Rule 1 makes
-  coding agents the primary consumer, and rule 7 says a command whose failures
-  the caller cannot see is "a reason to move a command to Control, not an
-  exemption it keeps." `--prompt` adds four refusal paths; left as runtime-only
-  Output lines, an agent could not distinguish "started with my prompt" from
-  "did nothing." That would be the exact defect the ADR names.
+  It was wrong, and the ADR was right. Rule 7 already said Forward's inability
+  to report "is a reason to move a command to Control, not an exemption it
+  keeps" — and RFC 0034's accepted scope is converting this exact verb. Building
+  Forward plumbing onto it meant writing code against a mode the verb is
+  leaving.
 
-  The resolution is not a return channel — it is noticing that three of the
-  four refusals are **not runtime failures at all**. `no-agent` and
-  `agent-takes-none` are properties of the _profile_, fixed the moment it is
-  saved. `unsupported-shell` is a property of the _user's shell_, fixed for the
-  machine. Only `too-large` is a property of the invocation, and it is the
-  caller's own doing and trivially corrected. So the static three move to where
-  they are actionable (R10, the Profiles tab), and the CLI keeps only a failure
-  its caller can see coming. Forward mode is then honest about what it is
-  reporting rather than concealing configuration errors behind silence.
+  The amendment records the general test rather than deprecating Forward, which
+  would have been the wrong lesson: `open`, `install`, and `uninstall` stay
+  Forward legitimately, because their value **is** the side effect and they must
+  work with nothing running. Everything a caller branches on, reads an id from,
+  or hangs on a verb already scheduled for conversion is Control.
 
-  The staged story stays coherent as later phases land: phase 9's
-  `silo agent list --json` exposes the same fact to machines, and the Control
-  API supplies real exit codes. Each phase reports as much as its execution
-  mode honestly can.
+  Applied here: no CLI code ships in this phase. `--prompt` is defined as a
+  `prompt` member of `agent.run`'s Control args with its refusals mapped onto
+  RFC 0034's closed error vocabulary (rule 6 requires the payload before the
+  verb ships), and it is built with that channel. The consumer this phase does
+  ship is `ctx.agents.profiles` — where a refusal is a **return value**, which
+  is what the Forward flag could never manage.
 
-- **RFC 0034 (Control API) — accepted, in flight, and it rewrites this exact
-  verb.** Its scope includes converting `silo agent run` from Forward to
-  Control: an `agent.run` op with `args: { profile, ws }`, R11 returning the
-  created terminal's id, a closed error vocabulary, and removal of this
-  command's `PendingLaunchArg` cold-launch arm (a deliberate break — cold runs
-  will need `--launch`).
-
-  Two packages therefore touch one command. Both are unimplemented, so they are
-  reconciled **now**, in documents, rather than by whoever implements second:
-  1. `--prompt` is specified as a `prompt` member of `agent.run`'s `args`, and
-     RFC 0034's package is updated to carry it. ADR 0047 rule 6 requires the
-     payload be defined before the verb ships regardless; 0034's own motivation
-     names the alternative — "every command shipped in the meantime is shaped
-     for silence, and gains its answer later as a breaking change."
-  2. Phase 3's refusals map onto 0034's **closed** error vocabulary rather than
-     inventing codes: `no-agent` and `agent-takes-none` are the caller's
-     configuration to fix, `unsupported-shell` is environmental, `too-large` is
-     a bad argument. Pick the exact codes when implementing, and raise a finding
-     against 0034 if none fits — it is still unimplemented and cheap to amend.
-
-  **Landing order does not matter, but it changes where the precheck lives.**
-  If phase 3 lands first, the precheck sits in `applyCliAgentRun` as designed
-  above, and 0034 moves it into the `agent.run` handler as part of its
-  conversion. If 0034 lands first, phase 3 writes the precheck straight into
-  that handler and skips the Forward-mode plumbing. Neither is rework of the
-  pure core, which is where this phase's real content lives — `agent-prompt.ts`
-  is untouched by the question.
+- **RFC 0034 (Control API) — accepted, unimplemented, and it rewrites this
+  verb.** Its scope includes `agent.run` with `args: { profile, ws, prompt }`,
+  R11 returning the created terminal id, a closed error vocabulary, and removal
+  of this command's `PendingLaunchArg` cold-launch arm. Both packages were
+  unimplemented when this was written, so they were reconciled in documents:
+  0034 carries `prompt`, and this package carries the refusal mapping. Neither
+  needs rework for the other, and there is no ordering constraint — this phase
+  touches no CLI code at all.
 
 - **ADR 0022 (storage layout)** — nothing new on disk.
 - **RFC 0028 (terminal identity in the environment)** — `SILO_*` is host-owned.

--- a/docs/proposals/0033-agent-profiles/design.md
+++ b/docs/proposals/0033-agent-profiles/design.md
@@ -1,0 +1,381 @@
+# Design — 0033. Agent Profiles, phase 3 (Prompt delivery)
+
+Design for **phase 3 only**. Phases 1 and 2 are the baseline. Working artifact
+— removed when the proposal collapses.
+
+## Architecture
+
+Four seams, in dependency order. Nothing here is public SDK surface.
+
+| Where                                                                       | What changes                                                              |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `packages/extension-host/…/agents/agent-catalog.ts` + `catalog/*.ts`        | `AgentDefinition.promptDelivery`, populated per recon                     |
+| `packages/extension-host/…/agents/agent-prompt.ts` **(new)**                | The whole pure core: sanitizer, dialect, delimiter, composition, refusals |
+| `packages/extension-host/…/agents/pending-launch.ts` + `agent-launch.ts`    | A launch may carry a prompt; the drain composes it                        |
+| `apps/desktop/src-tauri/…/commands/cli.rs` + `src/cli/agent-run-handler.ts` | `--prompt` parsed, forwarded, prechecked                                  |
+
+The design deliberately puts **all** the reasoning in one pure module. The
+drain, the CLI handler, and (later) phase 5 each call the same function and act
+on its result; none of them builds shell syntax inline. That is what makes a
+phase whose risk is entirely "did we quote it right" coverable by unit tests.
+
+## Components
+
+### `agent-prompt.ts` — the pure core
+
+```ts
+/** Why a prompt could not be delivered. Each maps to one Output message. */
+type PromptRefusal =
+  | "no-agent" // the profile resolves to no catalog agent
+  | "agent-takes-none" // that agent declares no promptDelivery
+  | "unsupported-shell" // no exact quoting rule for this dialect
+  | "too-large"; // over MAX_PROMPT_BYTES after sanitizing
+
+type ShellDialect = "posix" | "fish" | "unsupported";
+
+/** Strip what a line editor would act on. Total, idempotent, pure. */
+function sanitizePromptForLineEditor(text: string): string;
+
+/** The dialect of the shell a terminal will actually run. */
+function shellDialect(shell: string | undefined): ShellDialect;
+
+/** A delimiter no line of `payload` equals. */
+function heredocDelimiter(payload: string): string;
+
+/** The whole decision: the line to type, or why not. */
+function composePromptLaunchLine(input: {
+  launchLine: string; // phase 1's `profileLaunchLine(profile)`, unchanged
+  prompt: string; // raw; this function sanitizes
+  delivery: AgentPromptDelivery | undefined;
+  dialect: ShellDialect;
+}): { line: string } | { refusal: PromptRefusal };
+```
+
+`composePromptLaunchLine` is the only place shell syntax is written, and it is
+called from exactly two points (below) with the same inputs, so a precheck and
+the eventual drain cannot disagree.
+
+### The catalog field
+
+```ts
+/** How this agent accepts an *opening* prompt on its launch line while
+ *  staying interactive. Undefined = no reconned way to hand it one. */
+promptDelivery?: AgentPromptDelivery;
+
+type AgentPromptDelivery =
+  | { kind: "argv" } // positional, appended to the command
+  | { kind: "flag"; flag: string }; // named option, e.g. `--prompt <text>`
+```
+
+A discriminated union matching `AgentResume`'s shape. **Both members are
+required by recon, not speculation** — see the table below. A third shape is
+added only when an agent's recon demands one; in particular `{ kind: "stdin" }`
+is _not_ planned, because a heredoc on stdin detaches an interactive TUI from
+the tty, which is the opposite of what this phase is for.
+
+`undefined` is the "no" answer and carries the same discipline as
+`configDirEnvVar`: the negative finding goes in that agent's `contract`, so the
+next person reads why rather than re-running the recon.
+
+#### Recon findings (2026-09-02, macOS, all seven installed locally)
+
+The distinguishing question is **not** "does it accept prompt text" but "does
+it accept prompt text **and stay interactive**." Every agent here has a
+non-interactive mode that also takes a prompt; that mode is a **no** for this
+field, because a profile launch is an interactive TUI in a tab.
+
+| Agent          | Evidence                                                                                          | `promptDelivery`                               |
+| -------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `claude`       | `claude [options] [command] [prompt]`; `-p/--print` is the non-interactive one                    | `{ kind: "argv" }`                             |
+| `codex`        | `codex [OPTIONS] [PROMPT]`, "forwarded to the interactive CLI"; `exec` is the non-interactive one | `{ kind: "argv" }`                             |
+| `grok`         | `[PROMPT]` — "Initial prompt for the interactive session, e.g. `grok \"fix the bug\"`"            | `{ kind: "argv" }`                             |
+| `cursor-agent` | `agent [options] [command] [prompt...]`; `-p/--print` is the non-interactive mode                 | `{ kind: "argv" }`                             |
+| `pi`           | `pi [options] [--] [@files...] [messages...]`                                                     | `{ kind: "argv" }` — **confirm empirically**   |
+| `opencode`     | the positional is a **project path**, not a prompt; the TUI takes `--prompt <string>`             | `{ kind: "flag", flag: "--prompt" }`           |
+| `copilot`      | "Start an interactive session…, or use `-p/--prompt` for **non-interactive** scripting"           | likely **undefined** — **confirm empirically** |
+
+`opencode` is why the union has two members: appending its prompt positionally
+would set the project directory to the prompt text.
+
+Two entries above are read from `--help` and still need the empirical run that
+`configDirEnvVar` got — whether `pi` stays in its TUI after positional
+messages, and whether `copilot -p` has any interactive form. Both default to
+`undefined` (refuse) if the run is ambiguous.
+
+### Shell dialect
+
+The transport is bash/zsh syntax, so the dialect must be known before anything
+is typed. Resolution, in order:
+
+1. `TerminalRecord.shell` when the record names one (a per-terminal override
+   the host already stores).
+2. The user's login shell, from a new `default_shell` host command reading
+   `$SHELL` (`/bin/bash` when unset — the same fallback `main.rs` already
+   uses), resolved once and cached host-side.
+
+Mapped by basename: `bash` / `zsh` / `sh` / `dash` / `ksh` → `posix`; `fish` →
+`fish`; everything else → `unsupported`.
+
+**Known limitation, accepted:** the login shell is read in the app process,
+while the session host resolves `$SHELL` in its own. They are the same value in
+every normal launch (the daemon inherits the app's environment), and rung 1
+covers the per-terminal case. If this ever bites, the escalation is to read the
+session's foreground leader — authoritative, no new IPC, but it makes the drain
+async — not to guess harder. Not built now.
+
+### The orphaned-session fix
+
+`TerminalPanel`'s init effect can re-run (StrictMode double-invoke in dev, a
+fast remount). When it does, the in-flight run reaches the `cancelled` bail
+after its PTY has already come up and returns without disposing of it. Because
+the bail sits **above** the `tRec.sessionId` assignment, nothing ever references
+that session again: it is a live shell with no tab, surviving until the app
+quits.
+
+The fix mirrors `ensureSession` — reap the orphan before returning — with the
+one guard that makes it safe:
+
+```ts
+if (cancelled) {
+  // Only a session this run *spawned* is an orphan. On the attach path the
+  // session predates us and the record still points at it — killing it would
+  // destroy a live terminal.
+  if (needsCreate) void session.kill();
+  …
+}
+```
+
+`session.kill()` is `deleteTerminal(id)`, which destroys the persistent
+session, so the `needsCreate` guard is load-bearing rather than defensive. The
+existing `ui_init_cancelled` attach trace gains the disposition (reaped or
+attached) so a post-mortem can tell the two apart — per AGENTS.md, terminal
+lifecycle is diagnosed from `terminal.log`, not the Output panel.
+
+This is the phase's one change outside the prompt path. It ships with its own
+test and is described in the collapsed proposal as an adjacent fix, not as part
+of prompt delivery.
+
+## Data flow
+
+`silo agent run --profile claude-work --prompt "fix the CI"`:
+
+1. **`resolve_cli_request`** parses `--prompt` into a new `CliRequest.prompt`.
+   Warm launches carry it through the existing `cli:open` emit; cold launches
+   through `PendingLaunchArg`. No new IPC.
+2. **`applyCliAgentRun`** resolves the profile and workspace exactly as phase 2
+   does. Then, **only when a prompt is present**, it runs
+   `composePromptLaunchLine` as a **precheck** — before creating anything. A
+   refusal logs and returns: no terminal record, no workspace activation, no
+   focus change.
+3. **`launchAgentProfile({ …, prompt })`** creates the terminal record and calls
+   `requestProfileLaunch(rec.id, profileId, prompt)`.
+4. **The drain** (`TerminalPanel` on ready, or `ensureSession` for a background
+   workspace) resolves the profile, builds `profileLaunchLine(profile)`, and —
+   when the claim carries a prompt — runs `composePromptLaunchLine` again
+   against the profile as it is _now_.
+5. The resulting line is typed with one `sendInput` call.
+
+Steps 2 and 4 evaluate the same function. The precheck is what satisfies R7's
+"a refused prompt aborts the launch"; the re-evaluation at drain is what keeps
+phase 1's "resolved at drain time" promise when a profile is edited in between.
+If the drain now refuses where the precheck passed, it types **nothing** and
+logs — a launched-but-promptless agent is the outcome this phase exists to
+prevent.
+
+### Newlines: `\n` in the model, `\r` on the wire
+
+The composed line is a normal multi-line string with `\n` separators.
+Terminals receive **`\r`** for Enter, so exactly one seam — the drain's send —
+converts `\n` → `\r` and appends the trailing `\r`. Keeping the conversion out
+of the pure core is what lets its tests assert readable expected strings; doing
+it in two places is how a heredoc silently never terminates.
+
+## The composed lines
+
+`posix` + `{ kind: "argv" }` — a quoted heredoc inside a command substitution,
+which is what kills expansion and quoting in one move and makes multi-line and
+very long payloads unremarkable:
+
+```sh
+CLAUDE_CONFIG_DIR='/Users/me/.claude-work' claude "$(cat <<'SILO_PROMPT'
+fix the CI
+SILO_PROMPT
+)"
+```
+
+Everything left of the payload is phase 1's `profileLaunchLine` verbatim — the
+`configDir` env prefix and the profile's `command` are untouched, which is what
+keeps R5's "a launch with no prompt is byte-identical" true.
+
+The delimiter is `SILO_PROMPT`, with a numeric suffix appended and incremented
+until no **line** of the sanitized payload equals it. Only a whole-line match
+can terminate a heredoc early, so that is the only collision worth handling.
+
+`posix` + `{ kind: "flag" }` — identical, with the flag between the command and
+the payload. The two members differ by one token, which is the point of making
+them a union rather than two code paths:
+
+```sh
+opencode --prompt "$(cat <<'SILO_PROMPT'
+fix the CI
+SILO_PROMPT
+)"
+```
+
+`fish` + either kind — fish has no heredocs, but its single-quoted strings are
+exact and span newlines; only `\` and `'` need escaping:
+
+```fish
+claude 'fix the
+CI'
+```
+
+Any other dialect refuses (`unsupported-shell`). Nu and PowerShell are
+deliberately not implemented: nu's raw-string forms are their own puzzle, and
+approximating a quoting rule is precisely the failure mode this phase is
+avoiding.
+
+## APIs / interfaces
+
+No `@silo-code/sdk` change. `promptDelivery`, `agent-prompt.ts`, and the
+extended pending-launch registry are all host-internal, and `--prompt` is a CLI
+flag. The `silo-docs-sync` workflow does not apply; if implementation forces a
+public symbol, it does.
+
+Host-internal shapes that change:
+
+- `AgentDefinition.promptDelivery?: AgentPromptDelivery`
+- `PendingLaunch`: the `{ profileId }` arm gains `prompt?: string`. The
+  `{ rawLine }` arm (the deprecated-kind fallback) does **not** — it has no
+  profile and no agent, so there is nothing to resolve a delivery from.
+- `LaunchAgentProfileInput.prompt?: string`
+- `CliRequest.prompt: Option<String>` (Rust) / `CliAgentRunRequest.prompt?:
+string` (TS)
+
+## Persistence
+
+**Nothing new is persisted.** `promptDelivery` is code, not user data. Pending
+launches stay in the module-level map that phase 1 deliberately kept
+off-disk — and a prompt is a stronger reason for that rule, not a weaker one:
+an intent that survived a restart would type someone's half-forgotten task into
+a terminal they reopened hours later.
+
+## Error handling
+
+| Refusal             | Cause                                                        | Message names                                      |
+| ------------------- | ------------------------------------------------------------ | -------------------------------------------------- |
+| `no-agent`          | Profile has no `assumedAgentId` and none matches its command | the profile, and that a prompt needs a known agent |
+| `agent-takes-none`  | Resolved agent declares no `promptDelivery`                  | the agent                                          |
+| `unsupported-shell` | Dialect is neither `posix` nor `fish`                        | the shell                                          |
+| `too-large`         | Sanitized prompt exceeds `MAX_PROMPT_BYTES`                  | the limit and the actual size                      |
+
+All four report on the existing `silo:application` / **Application** channel via
+`createHostChannel` — the same channel phase 2's profile and workspace misses
+use, and the only place a Forward-mode CLI request can speak (ADR 0047: there
+is no stdout and no meaningful exit code until the Control API).
+
+`MAX_PROMPT_BYTES` is a documented constant. A prompt is an opening
+instruction, not a file transfer; a bounded, stated limit that fails loudly
+beats an unbounded paste that wedges a line editor. Pick a value in the tens of
+kilobytes and state it in the CLI guide.
+
+## Testing strategy
+
+Pure-logic Vitest, co-located, no `@testing-library/react` — per
+`.agents/skills/silo-testing/SKILL.md`. The phase's risk is concentrated in one
+pure module, so the coverage is too.
+
+`agent-prompt.test.ts` — the bulk:
+
+- **Sanitizer**: CRLF and lone CR → LF; a CSI sequence stripped whole; an OSC
+  sequence stripped whole (including its terminator); C0 and C1 controls
+  removed with LF surviving; tabs expanded; already-clean text unchanged
+  (idempotence); a second pass equals the first; adversarial input does not
+  throw.
+- **Dialect**: each supported basename, an absolute path (`/opt/homebrew/bin/fish`),
+  an unknown shell, and `undefined`.
+- **Delimiter**: a payload containing `SILO_PROMPT` as a line still round-trips;
+  a payload containing it mid-line does not force a suffix.
+- **Composition**: shell metacharacters delivered literally; multi-line
+  preserved; the `configDir` prefix still leads; `\n` separators (not `\r`) in
+  the returned string; fish escaping of `\` and `'`.
+- **Refusals**: one test per `PromptRefusal`, including the size boundary at
+  exactly the limit and one byte over.
+
+`pending-launch.test.ts` — a claim carries its prompt; remove-on-read still
+yields `null` to the second caller; the drain sends the composed line; a claim
+with **no** prompt sends a line byte-identical to today's.
+
+`agent-launch.test.ts` — `prompt` threads through to the registry; the
+background branch behaves as before.
+
+`cli.rs` unit tests, beside the existing `agent_run_*` ones — `--prompt <text>`,
+`--prompt=<text>`, a value beginning with `-`, a bare trailing `--prompt`, and
+`--prompt` combined with `--profile` and `--ws` in mixed order.
+
+`agent-run-handler` — a refused prompt creates no terminal, activates no
+workspace, and logs; a launch with no prompt is unchanged.
+
+## Constraints and existing decisions
+
+- **ADR 0028 (sealed detection)** — a prompt says nothing about identity. It
+  never writes `AgentInfo.agentId` and never seeds `isAgent`; the terminal
+  becomes an agent when detection says so, exactly as in phase 1.
+- **ADR 0041 / 0042 (modular agent catalog)** — `promptDelivery` is a catalog
+  fact. Every entry touched updates `contract`, `lastVerified`, and
+  `verifiedAgainstVersion`, and the recon question joins
+  `docs/adding-a-coding-agent.md` Step 1 so the next agent answers it
+  deliberately.
+- **ADR 0046 (never create or destroy user data unprompted)** — a refused
+  prompt creates no terminal record. This is the same reasoning that kept
+  phase 1 from synthesizing a profile.
+- **ADR 0047 (CLI grammar)** — `--prompt` is a flag on an existing verb, not a
+  new noun or verb. Forward mode: it asks for an action, not an answer, so it
+  needs no `--json` envelope and no Control channel. Rule 7's "never prompt"
+  concerns modals, not this flag.
+- **ADR 0022 (storage layout)** — nothing new on disk.
+- **RFC 0028 (terminal identity in the environment)** — `SILO_*` is host-owned.
+  The prompt rides the launch line and never enters the session environment.
+- **AGENTS.md** — host logging goes to the Output panel via `createHostChannel`,
+  never `console.*`. No raw `@tauri-apps/*` in extension packages; the new host
+  command is called from host code.
+
+## Risks
+
+**The "typed twice" issue does not reach the prompt path — traced, not
+assumed.** The collapsed proposal records the launch line as occasionally being
+typed twice, which with a prompt attached would mean an agent started twice on
+the same task. Reading the code, a double _drain_ is structurally impossible
+and this phase does not inherit the problem:
+
+- `TerminalPanel.tsx:900` guards the drain behind `if (needsCreate)`, and
+  `needsCreate` is false once `tRec.sessionId` is assigned — so a re-run that
+  attaches to the existing session never drains.
+- `takePendingLaunch` is remove-on-read, so whichever of the two drain paths
+  (panel, `ensureSession`) arrives second gets `null`.
+- At the `cancelled` bail (`TerminalPanel.tsx:617`) the effect returns _before_
+  both the `sessionId` assignment and the drain, so an abandoned run types
+  nothing at all.
+
+What is real at that bail is a **leaked PTY**: it returns without
+`session.kill()`. `ensureSession` handles the identical race correctly
+(`terminal-service.ts:260` reaps its orphan before returning).
+
+**Decision: fix it in this phase** (see "The orphaned-session fix" below). It is
+adjacent rather than required — a leaked session is never drained into, so
+prompt delivery works either way — but it is four lines beside code this phase
+already touches, and leaving a known leak next to a new launch path invites
+misattributing the next terminal oddity to prompt delivery.
+
+**The proposal's "typed twice" note is stale and gets corrected here.** It
+describes phase 1's _predecessor_: the old `kind`-based shim was a bare
+`setTimeout(() => session.write(cmd), 150)` with no dedupe, which double-types
+on any re-run. Phase 1 deleted it and replaced it with the remove-on-read
+registry. Phase 3 rewrites that paragraph in the collapsed proposal to describe
+the double-**spawn** that actually survives, so a future reader stops chasing a
+symptom the code no longer has.
+
+**Two recon entries are still `--help`-only.** `pi` and `copilot` are read from
+their help text rather than an empirical run (see the findings table). Both
+default to `undefined` — refuse — if the run is ambiguous, so the failure mode
+is a prompt that is declined with a clear message, never one delivered wrongly.

--- a/docs/proposals/0033-agent-profiles/proposal.md
+++ b/docs/proposals/0033-agent-profiles/proposal.md
@@ -1,5 +1,5 @@
 ---
-status: accepted # phases 1–2 shipped; phase 3 in progress; phases 4–9 remain
+status: accepted # phases 1–2 shipped; phase 3 in progress; phases 4, 6–9 remain
 created: 2026-08-31
 ---
 
@@ -8,12 +8,13 @@ created: 2026-08-31
 **Phases 1 and 2 shipped 2026-09-01.** Everything below the planning scope is
 the collapsed record: the durable intent, the decisions that outlive each
 planning package, and what each phase actually delivered. The `status` stays
-`accepted` because phases 4–9 are still planned; it becomes `implemented` only
+`accepted` because phases 4 and 6–9 are still planned; it becomes `implemented` only
 once every committed phase has shipped.
 
 ## Planning scope
 
-**This package covers phase 3 — "Prompt delivery" — only.**
+**This package covers phase 3 — "Prompt delivery, and `ctx.agents.profiles`" —
+only.**
 
 Phases 1 and 2 shipped 2026-09-01 and were collapsed back into the durable
 proposal before this package was written. Treat them as the **implementation
@@ -42,36 +43,45 @@ execution as the user. Phase 3 builds the safe answer and proves it:
    shell's line editor as keystrokes. ESC and C1 sequences fire keybindings, a
    lone CR submits the line early, and a tab triggers completion. The prompt is
    sanitized before it is ever composed into a line.
-4. **`silo agent run --prompt <text>`** — the transport's first caller.
+4. **`ctx.agents.profiles`** — `list()` and `launch({ prompt })`, the public SDK
+   surface that makes the transport reachable. This was originally phase 5;
+   merging it in is the substantive change from the first draft of this package
+   (below).
 5. **The Profiles tab says whether a prompt is possible at all** — whether an
    agent can take an opening prompt is a static fact about the profile, so it
-   belongs where the profile is authored, not only in a runtime refusal. This
-   is also what keeps the CLI flag honest against ADR 0047: a Forward-mode
-   command must not hide configuration errors behind silence.
+   belongs where the profile is authored, not only in a runtime refusal.
 
-Item 4 is a **deliberate scope addition to the phase table**, made when this
-package was planned and recorded in the durable proposal's "The command line"
-section. Without it phase 3 ships three pieces of transport that nothing calls
-until phase 5 — whose own first consumer (RFC 0031's **Start Task**) lives in
-`silo-code/silo-extensions` and rides the _published_ SDK, so it could not
-exercise this for months. This repo grows in layers that already work, and
-`--prompt` is the cheapest honest consumer: phase 2 built the whole
-`silo agent run` path, so the flag is a few lines of parser plus a field, and
-it makes every requirement below verifiable by a human at a real shell.
+### Why phase 5 merged in, and why `--prompt` did not
+
+The first draft of this package added `silo agent run --prompt <text>` as the
+transport's consumer, to avoid shipping three pieces of plumbing nothing calls.
+That was reasoned while RFC 0034 was a `draft` with no design. RFC 0034 is now
+an accepted package whose scope is **converting `silo agent run` from Forward
+to Control** — so that flag would have been built in a mode the verb is
+leaving, then deleted. ADR 0047's 2026-09-02 amendment generalizes the lesson.
+
+The consumer prompt delivery actually wanted was the one already on the phase
+table: `ctx.agents.profiles.launch({ prompt })`. It is public SDK surface — the
+product's central bet — callable from an extension the day it ships, and the
+blocker on RFC 0031's **Start Task**. A seam and its first real consumer are one
+shippable slice, not two, so phase 5 folds into phase 3 and phase 3 gets
+smaller in the bargain: no Forward plumbing, no CLI flag, no throwaway.
+
+`--prompt` is still **specified** here — as a `prompt` member of `agent.run`'s
+Control args, with its refusals mapped onto RFC 0034's closed error vocabulary
+— because ADR 0047 rule 6 requires a mutating verb's payload before it ships.
+It lands when the channel does.
 
 Out of scope, and unchanged from the phase table below: resume composition
-(phase 4), the public `ctx.agents.profiles` surface including
-`launch({ prompt })` (phase 5), per-account hooks (phase 6),
-`SILO_AGENT_PROFILE` (phase 7), per-workspace defaults (phase 8), and the CLI's
-read-back half (phase 9). Phase 3 builds the prompt seam **host-internal**; it
-deliberately does not publish it.
+(phase 4), per-account hooks (phase 6), `SILO_AGENT_PROFILE` (phase 7),
+per-workspace defaults (phase 8), and the CLI's read-back half (phase 9).
 
-Phase 3 adds **no `@silo-code/sdk` surface**. `promptDelivery` is a field on the
-sealed host catalog, the sanitizer and transport are host-internal, and
-`--prompt` is a CLI flag. The docs-sync workflow and the roadmap's
-`ctx.agents.profiles` badge are therefore untouched. The **user-facing CLI
-guide** (`apps/docs/guide/cli.md`), `silo --help`, and the agent-recon guide
-(`docs/adding-a-coding-agent.md`) are not — they all change in this phase.
+**Phase 3 now adds public `@silo-code/sdk` surface**, which the first draft did
+not. `ctx.agents.profiles` means the `silo-docs-sync` workflow applies in full —
+TSDoc, `@public`/`@beta` + `@category` tags, the barrel re-export, the
+hand-authored `ctx` member page, `pnpm docs:api`, and flipping the roadmap's
+`ctx.agents.profiles` entry to `stable`. That is the phase's largest addition
+and it is deliberate: publishing the surface is what makes the transport real.
 
 ## Summary
 
@@ -362,7 +372,7 @@ verbs; that ADR owns the shape.
 silo agent run --profile claude-work   # launch that profile             → shipped (phase 2)
 silo agent run                         # no --profile → the default        → shipped (phase 2)
 silo agent run --ws ~/code/app         # …in a named workspace             → shipped (phase 2)
-silo agent run --prompt "fix the CI"   # …and hand it an opening prompt    → phase 3
+silo agent run --prompt "fix the CI"   # …and hand it an opening prompt    → with RFC 0034
                                        # …an interactive picker            → phase 9
 silo agent list [--json]               # the profiles, with their ids      → phase 9
 ```
@@ -372,15 +382,25 @@ are user-authored, short, and editable rather than derived-and-frozen — and wh
 a rename that retires a `core.newAgent.<id>` binding warns first rather than
 being forbidden.
 
-**`--prompt` is a flag on an existing verb, not new grammar** — ADR 0047 reads
-the same with or without it. It exists because prompt delivery (phase 3) is
-otherwise three pieces of transport with no caller until phase 5, whose own
-first consumer lives in another repo and rides the published SDK. A phase that
-ships only a seam cannot be exercised by a human, and this repo grows in layers
-that already work. `--prompt` is the cheapest honest consumer: phase 2 built the
-whole `silo agent run` path, so the flag is the transport's proof rather than a
-second product surface. It stays **Forward** mode — it asks for an action, not
-for an answer, so it needs no return channel.
+**`--prompt` ships with the Control conversion, not before it.** It was briefly
+planned as phase 3's consumer, on the reasoning that a flag on an existing verb
+is cheap and ADR 0047 reads the same with or without it. That was decided while
+RFC 0034 was a `draft` with no design. It is now an accepted package whose scope
+is **converting `silo agent run` from Forward to Control** — so building
+Forward-mode plumbing for `--prompt` would mean writing code against a mode this
+verb is leaving, and deleting it weeks later.
+
+Phase 3 therefore defines `--prompt` as a `prompt` member of `agent.run`'s
+Control args, with its refusals mapped onto RFC 0034's closed error vocabulary,
+and lets the flag land when that channel does. ADR 0047's amendment of
+2026-09-02 records the general rule this case produced: a new flag on a verb
+already scheduled for conversion is Control, never Forward.
+
+The transport's consumer is instead `ctx.agents.profiles.launch({ prompt })` —
+public SDK surface, callable by any extension the day it ships, and the thing
+RFC 0031's **Start Task** has been waiting on. That was originally phase 5; it
+is now part of phase 3, because a seam and its first real consumer are one
+shippable slice rather than two.
 
 **Which workspace it runs in** follows ADR 0047's resolution order: an explicit
 `--ws <folder | . | ws_<uuid>>`, else the workspace **containing** the shell's
@@ -406,17 +426,17 @@ activity state, and handing the launched terminal's id back to the caller.
 
 ## Phases
 
-| Phase                                        | Scope                                                                                                                                                                                                                                                                                                                                                                                                           | Status                   |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| **1 — Populate and use the `+` menu**        | The record, persistence, `configDirEnvVar`, `TerminalRecord.profileId` + `TerminalKind` deprecation, the pending-launch model (+ the `SILO_TERMINAL_ID` repair), the Profiles settings tab, the `+` menu and the terminal context menu's Agents submenu, `ctx.agents.catalog()` + icon relocation, Hooks → Sessions rename.                                                                                     | **shipped** (2026-09-01) |
-| **2 — Addressing a profile by name**         | `core.newAgent.<profileId>` per profile + generic `core.newAgent`; the `default` flag and its two gestures; `silo agent run [--profile <id>] [--ws <folder\|.\|id>]` (reserved `agent` noun, `--ws` or cwd containment, never creating a workspace; first real caller of the background launch branch); the dangling-command-id dispatch guard; the rename warning. Plus the subscription-survival hydrate fix. | **shipped** (2026-09-01) |
-| 3 — Prompt delivery                          | `promptDelivery` on `AgentDefinition`, quoted-heredoc transport, line-editor sanitization — plus `silo agent run --prompt <text>` as the transport's first caller, so the phase ships something a human can run rather than a seam waiting on phase 5.                                                                                                                                                          | planned                  |
-| 4 — Resume composition                       | Split `buildResumeCommand` into catalog-owned `resumeArgs` + the profile's command and env prefix. First consumer of `profileId`.                                                                                                                                                                                                                                                                               | planned                  |
-| 5 — `ctx.agents.profiles`                    | Public `list()` / `launch()`. First consumer is RFC 0031's deferred **Start Task**.                                                                                                                                                                                                                                                                                                                             | planned                  |
-| 6 — Per-account hooks                        | Install strategies keyed on `(agentId, configDir)`. Depends on Managed Hooks.                                                                                                                                                                                                                                                                                                                                   | planned                  |
-| 7 — `SILO_AGENT_PROFILE` + hook confirmation | RFC 0028 designed the seam; deferred until a surface branches on "confirmed" vs "assumed".                                                                                                                                                                                                                                                                                                                      | planned                  |
-| 8 — Per-workspace default profile            | Bind a workspace to a profile so "new agent" does the right thing per repo with no menu. Revisit AgentsRoom's resolution order (per-agent override → per-project pin → global default → system `~/.claude`).                                                                                                                                                                                                    | planned                  |
-| 9 — CLI read-back (`silo agent list`)        | `silo agent list [--json]`, which reads the profiles off disk (ADR 0047's Disk-read mode — no channel needed), plus bare `silo agent run`'s interactive **picker** and returning the launched terminal's id, which need the Control API (RFC 0034).                                                                                                                                                             | planned                  |
+| Phase                                          | Scope                                                                                                                                                                                                                                                                                                                                                                                                           | Status                   |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| **1 — Populate and use the `+` menu**          | The record, persistence, `configDirEnvVar`, `TerminalRecord.profileId` + `TerminalKind` deprecation, the pending-launch model (+ the `SILO_TERMINAL_ID` repair), the Profiles settings tab, the `+` menu and the terminal context menu's Agents submenu, `ctx.agents.catalog()` + icon relocation, Hooks → Sessions rename.                                                                                     | **shipped** (2026-09-01) |
+| **2 — Addressing a profile by name**           | `core.newAgent.<profileId>` per profile + generic `core.newAgent`; the `default` flag and its two gestures; `silo agent run [--profile <id>] [--ws <folder\|.\|id>]` (reserved `agent` noun, `--ws` or cwd containment, never creating a workspace; first real caller of the background launch branch); the dangling-command-id dispatch guard; the rename warning. Plus the subscription-survival hydrate fix. | **shipped** (2026-09-01) |
+| 3 — Prompt delivery, and `ctx.agents.profiles` | `promptDelivery` on `AgentDefinition`, quoted-heredoc transport, line-editor sanitization — published through `ctx.agents.profiles` `list()` / `launch({ prompt })`, the phase's real consumer. Absorbs what was phase 5.                                                                                                                                                                                       | planned                  |
+| 4 — Resume composition                         | Split `buildResumeCommand` into catalog-owned `resumeArgs` + the profile's command and env prefix. First consumer of `profileId`.                                                                                                                                                                                                                                                                               | planned                  |
+| 5 — _(merged into phase 3)_                    | The public `ctx.agents.profiles` surface was originally its own phase. It moved into phase 3 because prompt delivery needs a consumer and this is the honest one: an SDK surface beats a CLI flag on a verb RFC 0034 is converting. The row is kept, not renumbered — RFC 0034 and ADR 0047 both cite "RFC 0033 phase 9" by number.                                                                             | merged                   |
+| 6 — Per-account hooks                          | Install strategies keyed on `(agentId, configDir)`. Depends on Managed Hooks.                                                                                                                                                                                                                                                                                                                                   | planned                  |
+| 7 — `SILO_AGENT_PROFILE` + hook confirmation   | RFC 0028 designed the seam; deferred until a surface branches on "confirmed" vs "assumed".                                                                                                                                                                                                                                                                                                                      | planned                  |
+| 8 — Per-workspace default profile              | Bind a workspace to a profile so "new agent" does the right thing per repo with no menu. Revisit AgentsRoom's resolution order (per-agent override → per-project pin → global default → system `~/.claude`).                                                                                                                                                                                                    | planned                  |
+| 9 — CLI read-back (`silo agent list`)          | `silo agent list [--json]`, which reads the profiles off disk (ADR 0047's Disk-read mode — no channel needed), plus bare `silo agent run`'s interactive **picker** and returning the launched terminal's id, which need the Control API (RFC 0034).                                                                                                                                                             | planned                  |
 
 Phases 3–9 keep the direction stated here and in each shipped phase's planning
 package history; each re-expands into its own package when its turn comes.

--- a/docs/proposals/0033-agent-profiles/proposal.md
+++ b/docs/proposals/0033-agent-profiles/proposal.md
@@ -1,16 +1,72 @@
 ---
-status: accepted # phases 1–2 shipped; phases 3–9 remain — see the phase table
+status: accepted # phases 1–2 shipped; phase 3 in progress; phases 4–9 remain
 created: 2026-08-31
 ---
 
 # 0033. Agent Profiles — naming how you start an agent
 
-**Phases 1 and 2 shipped 2026-09-01.** This is the collapsed record: the durable
-intent, the decisions that outlive each planning package, and what each phase
-actually delivered. The `status` stays `accepted` because phases 3–9 are still
-planned; it becomes `implemented` only once every committed phase has shipped.
-Each later phase re-expands into `docs/proposals/0033-agent-profiles/` with its
-own `requirements.md` / `design.md` / `tasks.md`.
+**Phases 1 and 2 shipped 2026-09-01.** Everything below the planning scope is
+the collapsed record: the durable intent, the decisions that outlive each
+planning package, and what each phase actually delivered. The `status` stays
+`accepted` because phases 4–9 are still planned; it becomes `implemented` only
+once every committed phase has shipped.
+
+## Planning scope
+
+**This package covers phase 3 — "Prompt delivery" — only.**
+
+Phases 1 and 2 shipped 2026-09-01 and were collapsed back into the durable
+proposal before this package was written. Treat them as the **implementation
+baseline**: the `AgentProfile` record and its persistence, the pending-launch
+model, `TerminalRecord.profileId`, `ctx.agents.catalog()`, the `+` menu, the
+terminal **Agents** submenu, Settings → Agents → **Profiles**, the
+`core.newAgent.<id>` commands, the `default` flag, and
+`silo agent run [--profile <id>] [--ws <folder|.|id>]` all exist and work. Do
+not re-plan or re-implement any of it.
+
+Phase 3 answers one question the proposal has deferred since it was written:
+**how does Silo hand a coding agent its opening prompt?** Today it cannot. The
+only mechanism a caller has is `ctx.terminals.sendText`, which types raw bytes
+into a live shell — and the original RFC named that as the highest-severity
+idea in its first sketch, because a quoting bug there is arbitrary code
+execution as the user. Phase 3 builds the safe answer and proves it:
+
+1. **`AgentDefinition.promptDelivery`** — one sealed-catalog field saying how
+   (or whether) each agent accepts an opening prompt, established by the same
+   empirical recon `configDirEnvVar` got. An agent with no reconned answer
+   refuses a prompt rather than guessing.
+2. **The transport** — the payload rides in a **quoted heredoc**, never
+   interpolated into the launch line, so expansion and quoting are dead by
+   construction and a multi-line or very long prompt is no special case.
+3. **Line-editor sanitization** — the bytes are _typed_, so they reach the
+   shell's line editor as keystrokes. ESC and C1 sequences fire keybindings, a
+   lone CR submits the line early, and a tab triggers completion. The prompt is
+   sanitized before it is ever composed into a line.
+4. **`silo agent run --prompt <text>`** — the transport's first caller.
+
+Item 4 is a **deliberate scope addition to the phase table**, made when this
+package was planned and recorded in the durable proposal's "The command line"
+section. Without it phase 3 ships three pieces of transport that nothing calls
+until phase 5 — whose own first consumer (RFC 0031's **Start Task**) lives in
+`silo-code/silo-extensions` and rides the _published_ SDK, so it could not
+exercise this for months. This repo grows in layers that already work, and
+`--prompt` is the cheapest honest consumer: phase 2 built the whole
+`silo agent run` path, so the flag is a few lines of parser plus a field, and
+it makes every requirement below verifiable by a human at a real shell.
+
+Out of scope, and unchanged from the phase table below: resume composition
+(phase 4), the public `ctx.agents.profiles` surface including
+`launch({ prompt })` (phase 5), per-account hooks (phase 6),
+`SILO_AGENT_PROFILE` (phase 7), per-workspace defaults (phase 8), and the CLI's
+read-back half (phase 9). Phase 3 builds the prompt seam **host-internal**; it
+deliberately does not publish it.
+
+Phase 3 adds **no `@silo-code/sdk` surface**. `promptDelivery` is a field on the
+sealed host catalog, the sanitizer and transport are host-internal, and
+`--prompt` is a CLI flag. The docs-sync workflow and the roadmap's
+`ctx.agents.profiles` badge are therefore untouched. The **user-facing CLI
+guide** (`apps/docs/guide/cli.md`), `silo --help`, and the agent-recon guide
+(`docs/adding-a-coding-agent.md`) are not — they all change in this phase.
 
 ## Summary
 
@@ -301,6 +357,7 @@ verbs; that ADR owns the shape.
 silo agent run --profile claude-work   # launch that profile             → shipped (phase 2)
 silo agent run                         # no --profile → the default        → shipped (phase 2)
 silo agent run --ws ~/code/app         # …in a named workspace             → shipped (phase 2)
+silo agent run --prompt "fix the CI"   # …and hand it an opening prompt    → phase 3
                                        # …an interactive picker            → phase 9
 silo agent list [--json]               # the profiles, with their ids      → phase 9
 ```
@@ -309,6 +366,16 @@ silo agent list [--json]               # the profiles, with their ids      → p
 are user-authored, short, and editable rather than derived-and-frozen — and why
 a rename that retires a `core.newAgent.<id>` binding warns first rather than
 being forbidden.
+
+**`--prompt` is a flag on an existing verb, not new grammar** — ADR 0047 reads
+the same with or without it. It exists because prompt delivery (phase 3) is
+otherwise three pieces of transport with no caller until phase 5, whose own
+first consumer lives in another repo and rides the published SDK. A phase that
+ships only a seam cannot be exercised by a human, and this repo grows in layers
+that already work. `--prompt` is the cheapest honest consumer: phase 2 built the
+whole `silo agent run` path, so the flag is the transport's proof rather than a
+second product surface. It stays **Forward** mode — it asks for an action, not
+for an answer, so it needs no return channel.
 
 **Which workspace it runs in** follows ADR 0047's resolution order: an explicit
 `--ws <folder | . | ws_<uuid>>`, else the workspace **containing** the shell's
@@ -334,17 +401,17 @@ activity state, and handing the launched terminal's id back to the caller.
 
 ## Phases
 
-| Phase                                        | Scope                                                                                                                                                                                                                                                                                                                       | Status                   |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| **1 — Populate and use the `+` menu**        | The record, persistence, `configDirEnvVar`, `TerminalRecord.profileId` + `TerminalKind` deprecation, the pending-launch model (+ the `SILO_TERMINAL_ID` repair), the Profiles settings tab, the `+` menu and the terminal context menu's Agents submenu, `ctx.agents.catalog()` + icon relocation, Hooks → Sessions rename. | **shipped** (2026-09-01) |
-| **2 — Addressing a profile by name**         | `core.newAgent.<profileId>` per profile + generic `core.newAgent`; the `default` flag and its two gestures; `silo agent run [--profile <id>] [--ws <folder                                                                                                                                                                  | .                        | id>]`(reserved`agent`noun,`--ws` or cwd containment, never creating a workspace; first real caller of the background launch branch); the dangling-command-id dispatch guard; the rename warning. Plus the subscription-survival hydrate fix. | **shipped** (2026-09-01) |
-| 3 — Prompt delivery                          | `promptDelivery` on `AgentDefinition`, quoted-heredoc transport, line-editor sanitization.                                                                                                                                                                                                                                  | planned                  |
-| 4 — Resume composition                       | Split `buildResumeCommand` into catalog-owned `resumeArgs` + the profile's command and env prefix. First consumer of `profileId`.                                                                                                                                                                                           | planned                  |
-| 5 — `ctx.agents.profiles`                    | Public `list()` / `launch()`. First consumer is RFC 0031's deferred **Start Task**.                                                                                                                                                                                                                                         | planned                  |
-| 6 — Per-account hooks                        | Install strategies keyed on `(agentId, configDir)`. Depends on Managed Hooks.                                                                                                                                                                                                                                               | planned                  |
-| 7 — `SILO_AGENT_PROFILE` + hook confirmation | RFC 0028 designed the seam; deferred until a surface branches on "confirmed" vs "assumed".                                                                                                                                                                                                                                  | planned                  |
-| 8 — Per-workspace default profile            | Bind a workspace to a profile so "new agent" does the right thing per repo with no menu. Revisit AgentsRoom's resolution order (per-agent override → per-project pin → global default → system `~/.claude`).                                                                                                                | planned                  |
-| 9 — CLI read-back (`silo agent list`)        | `silo agent list [--json]`, which reads the profiles off disk (ADR 0047's Disk-read mode — no channel needed), plus bare `silo agent run`'s interactive **picker** and returning the launched terminal's id, which need the Control API (RFC 0034).                                                                         | planned                  |
+| Phase                                        | Scope                                                                                                                                                                                                                                                                                                                                                                                                           | Status                   |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| **1 — Populate and use the `+` menu**        | The record, persistence, `configDirEnvVar`, `TerminalRecord.profileId` + `TerminalKind` deprecation, the pending-launch model (+ the `SILO_TERMINAL_ID` repair), the Profiles settings tab, the `+` menu and the terminal context menu's Agents submenu, `ctx.agents.catalog()` + icon relocation, Hooks → Sessions rename.                                                                                     | **shipped** (2026-09-01) |
+| **2 — Addressing a profile by name**         | `core.newAgent.<profileId>` per profile + generic `core.newAgent`; the `default` flag and its two gestures; `silo agent run [--profile <id>] [--ws <folder\|.\|id>]` (reserved `agent` noun, `--ws` or cwd containment, never creating a workspace; first real caller of the background launch branch); the dangling-command-id dispatch guard; the rename warning. Plus the subscription-survival hydrate fix. | **shipped** (2026-09-01) |
+| 3 — Prompt delivery                          | `promptDelivery` on `AgentDefinition`, quoted-heredoc transport, line-editor sanitization — plus `silo agent run --prompt <text>` as the transport's first caller, so the phase ships something a human can run rather than a seam waiting on phase 5.                                                                                                                                                          | planned                  |
+| 4 — Resume composition                       | Split `buildResumeCommand` into catalog-owned `resumeArgs` + the profile's command and env prefix. First consumer of `profileId`.                                                                                                                                                                                                                                                                               | planned                  |
+| 5 — `ctx.agents.profiles`                    | Public `list()` / `launch()`. First consumer is RFC 0031's deferred **Start Task**.                                                                                                                                                                                                                                                                                                                             | planned                  |
+| 6 — Per-account hooks                        | Install strategies keyed on `(agentId, configDir)`. Depends on Managed Hooks.                                                                                                                                                                                                                                                                                                                                   | planned                  |
+| 7 — `SILO_AGENT_PROFILE` + hook confirmation | RFC 0028 designed the seam; deferred until a surface branches on "confirmed" vs "assumed".                                                                                                                                                                                                                                                                                                                      | planned                  |
+| 8 — Per-workspace default profile            | Bind a workspace to a profile so "new agent" does the right thing per repo with no menu. Revisit AgentsRoom's resolution order (per-agent override → per-project pin → global default → system `~/.claude`).                                                                                                                                                                                                    | planned                  |
+| 9 — CLI read-back (`silo agent list`)        | `silo agent list [--json]`, which reads the profiles off disk (ADR 0047's Disk-read mode — no channel needed), plus bare `silo agent run`'s interactive **picker** and returning the launched terminal's id, which need the Control API (RFC 0034).                                                                                                                                                             | planned                  |
 
 Phases 3–9 keep the direction stated here and in each shipped phase's planning
 package history; each re-expands into its own package when its turn comes.

--- a/docs/proposals/0033-agent-profiles/proposal.md
+++ b/docs/proposals/0033-agent-profiles/proposal.md
@@ -43,6 +43,11 @@ execution as the user. Phase 3 builds the safe answer and proves it:
    lone CR submits the line early, and a tab triggers completion. The prompt is
    sanitized before it is ever composed into a line.
 4. **`silo agent run --prompt <text>`** — the transport's first caller.
+5. **The Profiles tab says whether a prompt is possible at all** — whether an
+   agent can take an opening prompt is a static fact about the profile, so it
+   belongs where the profile is authored, not only in a runtime refusal. This
+   is also what keeps the CLI flag honest against ADR 0047: a Forward-mode
+   command must not hide configuration errors behind silence.
 
 Item 4 is a **deliberate scope addition to the phase table**, made when this
 package was planned and recorded in the durable proposal's "The command line"

--- a/docs/proposals/0033-agent-profiles/requirements.md
+++ b/docs/proposals/0033-agent-profiles/requirements.md
@@ -175,18 +175,40 @@ noun, verb, or grammar, and ADR 0047 reads the same with or without it.
 - [ ] A bare trailing `--prompt` with no value is ignored, exactly as the other
       flags are — never a panic, never a partial request.
 - [ ] Omitting `--prompt` leaves phase 2's behavior untouched.
-- [ ] The flag stays **Forward** mode: it asks for an action, reports nothing on
-      stdout, and needs no return channel.
 - [ ] The Rust parser arm has unit coverage for each of the cases above,
       alongside the existing `agent run` tests.
+
+### Its Control answer is defined now, not later
+
+ADR 0047 rule 6: _"Every mutating verb gets a defined return payload in its own
+proposal **before** it ships, even while the channel can't yet deliver one."_
+RFC 0034 is accepted and converting this exact verb from Forward to Control, so
+`--prompt` must be designed against that contract rather than shaped for silence
+and retrofitted as a breaking change.
+
+- [ ] `--prompt` is specified as part of `agent.run`'s Control request — a
+      `prompt` member of its `args`, beside `profile` and `ws`.
+- [ ] Each of R7's refusals maps to a code in RFC 0034's **closed** error
+      vocabulary, chosen and written down in this package. Nothing new is
+      invented: `no-agent` and `agent-takes-none` are configuration errors the
+      caller can fix, `unsupported-shell` is environmental, and `too-large` is a
+      bad argument. If none of the existing codes fits, that is a finding to
+      raise against RFC 0034 while it is still unimplemented — not a reason to
+      add a code here.
+- [ ] Ships as **Forward** in phase 3 (the channel does not exist yet), with the
+      payload above recorded so the later conversion adds a return value rather
+      than changing a contract.
+- [ ] RFC 0034's package is updated in the same change so `agent.run`'s `args`
+      carry `prompt`. Whichever lands first, the other needs no rework.
 
 ## R7 — Refusal is visible and never partial
 
 Every reason a prompt cannot be delivered ends the same way: nothing is typed,
 no agent is started, and the user is told why.
 
-`silo agent run` is **Forward** mode — no stdout, no meaningful exit code
-(ADR 0047). ADR 0047 is explicit that this is "a reason to move a command to
+`silo agent run` is **Forward** mode _today_ — no stdout, no meaningful exit
+code (ADR 0047) — and RFC 0034 is converting it to Control. Until that lands,
+ADR 0047 is explicit that Forward's silence is "a reason to move a command to
 Control, not an exemption it keeps," so a flag whose failures are invisible to
 its caller would be adding exactly the defect that ADR warns about. R10 is the
 answer: the refusals that are **static** — properties of the profile or the

--- a/docs/proposals/0033-agent-profiles/requirements.md
+++ b/docs/proposals/0033-agent-profiles/requirements.md
@@ -62,17 +62,19 @@ depend on which transport or dialect is chosen.
 - [ ] Sanitizing an already-clean prompt returns it unchanged (idempotent, and
       no cosmetic rewriting of ordinary text).
 
-## R3 — The payload rides in a quoted heredoc, never interpolated
+## R3 — The payload is never interpolated unescaped
 
-On a POSIX-family shell the sanitized prompt is delivered inside a **quoted**
-heredoc, so parameter expansion, command substitution, and quoting are dead by
-construction. The prompt text is never spliced into the launch line as a quoted
-string, and never written to a temp file.
+Prompt text never reaches a shell as text the shell may interpret. On a
+POSIX-family shell that is a **quoted heredoc**, so parameter expansion,
+command substitution, and quoting are dead by construction; on `fish`, which
+has no heredocs, it is that dialect's exact single-quoted literal (R4). Neither
+form is a temp file, and neither splices raw text into the launch line.
 
 ### Acceptance criteria
 
-- [ ] The composed line delivers the prompt via a quoted heredoc; no code path
-      interpolates raw prompt text into the launch line.
+- [ ] On a POSIX-family shell the prompt is delivered via a quoted heredoc.
+- [ ] No code path places prompt text into a launch line without the escaping
+      its dialect requires.
 - [ ] A multi-line prompt is delivered intact, with its line breaks preserved.
 - [ ] A prompt containing shell metacharacters (`$`, `` ` ``, `\`, `"`, `'`,
       `;`, `&&`, `$(…)`, backslash-newline) is delivered as literal text and
@@ -96,10 +98,12 @@ that has none.
 
 - [ ] The dialect is resolved from the terminal's own shell when the record
       names one, and otherwise from the user's login shell.
+- [ ] The dialect is decided **once per launch**, at registration, and carried
+      on the pending launch — so the precheck and the drain cannot reach
+      different conclusions about it.
 - [ ] A POSIX-family shell (`bash`, `zsh`, `sh`, and their common variants) gets
       the heredoc transport.
-- [ ] `fish` gets a dialect-correct transport of its own, or is refused — not a
-      heredoc.
+- [ ] `fish` gets its own exact single-quoted transport, escaping `\` and `'`.
 - [ ] Any shell Silo has no exact quoting rule for (including an unrecognized
       one) **refuses** the prompt rather than approximating it.
 - [ ] Dialect selection is a pure function of the shell name, unit-tested for
@@ -124,6 +128,32 @@ Everything that model already guarantees continues to hold.
       wrapper.
 - [ ] Both drain paths — the mounted `TerminalPanel` and `ensureSession`'s lazy
       spawn for a background workspace — deliver a prompt identically.
+- [ ] The catalog agent behind a profile is resolved by one shared helper —
+      `assumedAgentId` when set, else `fallbackAgentForCommand(command)` — used
+      by the launch path and by R10's editor affordance alike.
+- [ ] A composed line at `MAX_PROMPT_BYTES` reaches the PTY **complete**. If a
+      single `sendInput` cannot carry it, the send chunks and the chunking is
+      tested at the limit; a truncated heredoc never terminates and would hang
+      the user's shell mid-quote.
+
+## R5a — The prompt is visible to the user, and that is intended
+
+The composed line is typed into the user's own interactive shell, so it appears
+in scrollback and enters shell history exactly as if they had typed it. That is
+the product's model — phase 1 chose typing into an interactive shell over
+`exec` precisely so a launch is something the user can see, edit, and re-run —
+and a prompt does not change it.
+
+### Acceptance criteria
+
+- [ ] No attempt is made to hide the prompt from scrollback or suppress it from
+      history. Silo does not manipulate the user's `HISTCONTROL` /
+      `HIST_IGNORE_SPACE`, which are opt-in and shell-specific.
+- [ ] `apps/docs/guide/cli.md` states plainly that a prompt passed to
+      `silo agent run` lands in shell history, so a user putting sensitive text
+      in one is not surprised.
+- [ ] `MAX_PROMPT_BYTES` is justified partly by this: an opening instruction,
+      not a file transfer.
 
 ## R6 — `silo agent run --prompt <text>`
 
@@ -136,8 +166,11 @@ noun, verb, or grammar, and ADR 0047 reads the same with or without it.
 - [ ] `silo agent run --prompt <text>` launches the resolved profile and hands
       the agent that text, composing with `--profile` and `--ws` in any order.
 - [ ] `--prompt=<text>` is accepted as well as `--prompt <text>`.
-- [ ] A prompt whose text begins with `-` is delivered, not silently dropped as
-      a flag.
+- [ ] Prompt text beginning with `-` is supported through the `--prompt=<text>`
+      spelling. `--prompt -foo` follows the **same** rule as every other flag on
+      this verb — a value that looks like a flag is not consumed — so the parser
+      keeps one value reader rather than two behaviors for sibling flags. The
+      CLI guide documents the `=` spelling for this case.
 - [ ] A multi-line prompt (`--prompt "$(cat notes.md)"`) is delivered intact.
 - [ ] A bare trailing `--prompt` with no value is ignored, exactly as the other
       flags are — never a panic, never a partial request.
@@ -150,22 +183,59 @@ noun, verb, or grammar, and ADR 0047 reads the same with or without it.
 ## R7 — Refusal is visible and never partial
 
 Every reason a prompt cannot be delivered ends the same way: nothing is typed,
-no agent is started, and the user is told why in the one place a
-fire-and-forget CLI request can speak.
+no agent is started, and the user is told why.
+
+`silo agent run` is **Forward** mode — no stdout, no meaningful exit code
+(ADR 0047). ADR 0047 is explicit that this is "a reason to move a command to
+Control, not an exemption it keeps," so a flag whose failures are invisible to
+its caller would be adding exactly the defect that ADR warns about. R10 is the
+answer: the refusals that are **static** — properties of the profile or the
+user's shell rather than of this invocation — are surfaced where they are
+configured, so nobody first learns about them from an Output line they were not
+watching. What is left at the CLI is a failure the caller caused and can fix.
 
 ### Acceptance criteria
 
 - [ ] A prompt is refused when the profile resolves to no catalog agent, when
       that agent's `promptDelivery` is undefined or says it takes none, when the
       target shell's dialect cannot be quoted, or when the sanitized prompt
-      exceeds the documented size limit.
+      exceeds `MAX_PROMPT_BYTES`.
 - [ ] Each refusal reports a distinct, actionable message on the Output panel
       naming the actual reason.
-- [ ] A refused prompt **aborts the launch**: no terminal is left holding a
-      promptless agent, and no partial line is typed.
+- [ ] A refusal detected at **precheck** aborts the launch: no terminal record
+      is created, no workspace is activated, nothing is focused.
+- [ ] A refusal detected only at **drain** — the profile was edited between the
+      request and the session coming up — types nothing and logs. The terminal
+      already exists and is left as a plain shell. This is the same shape as
+      phase 1's "a profile deleted mid-launch drains to nothing," and it is the
+      only case in which a terminal outlives a refused prompt.
 - [ ] A launch with no prompt is never affected by any of these checks.
-- [ ] There is a documented maximum sanitized prompt size, enforced and tested
-      at the boundary.
+- [ ] `MAX_PROMPT_BYTES` is **16 KiB** of sanitized UTF-8, enforced and tested
+      at the boundary (at the limit, and one byte over).
+
+## R10 — A profile says up front whether it can take a prompt
+
+Whether a profile can be given an opening prompt is a **static** fact — it
+depends on the catalog agent the profile resolves to, not on any particular
+launch. It therefore belongs on the Profiles tab, next to where the profile is
+authored, rather than only in a runtime refusal.
+
+This is what keeps R7's Forward-mode story honest, and it mirrors phase 1's
+treatment of `configDirEnvVar`: the editor already shows or hides the
+config-directory field based on the resolved agent's catalog entry.
+
+### Acceptance criteria
+
+- [ ] A profile whose resolved agent cannot take an opening prompt says so in
+      the profile editor, in plain language naming the agent.
+- [ ] A profile that resolves to **no** catalog agent says so too — the same
+      surface, a different reason.
+- [ ] The agent resolution behind this is the **same helper** the launch path
+      uses, so the editor and the refusal can never disagree.
+- [ ] Nothing is blocked: a profile that cannot take a prompt is still fully
+      usable for launching. This is information, not validation.
+- [ ] No new setting, no new persisted field — the fact is derived from the
+      catalog at render time.
 
 ## R8 — The user-facing story stays in sync in this change
 
@@ -196,7 +266,6 @@ correctly, and this makes the two agree.
 - [ ] The `ui_init_cancelled` attach trace records which of the two happened.
 - [ ] No change to what is typed into any terminal: this fixes a leak, not a
       delivery path.
-- [ ] Ships as its own commit, revertable without touching prompt delivery.
 
 ## Out of scope
 

--- a/docs/proposals/0033-agent-profiles/requirements.md
+++ b/docs/proposals/0033-agent-profiles/requirements.md
@@ -1,4 +1,4 @@
-# Requirements — 0033. Agent Profiles, phase 3 (Prompt delivery)
+# Requirements — 0033. Agent Profiles, phase 3 (Prompt delivery + ctx.agents.profiles)
 
 Scoped to **phase 3 only**. Phases 1 and 2 are the implementation baseline (see
 `proposal.md` → Planning scope). Working artifact — removed when the proposal
@@ -155,66 +155,79 @@ and a prompt does not change it.
 - [ ] `MAX_PROMPT_BYTES` is justified partly by this: an opening instruction,
       not a file transfer.
 
-## R6 — `silo agent run --prompt <text>`
+## R6 — `ctx.agents.profiles` — the public surface
 
-`silo agent run` gains an optional `--prompt` flag carrying the opening prompt
-for the launched agent. It is a flag on an existing verb; it introduces no new
-noun, verb, or grammar, and ADR 0047 reads the same with or without it.
+The transport's consumer, and the reason this phase ships something rather than
+a seam. `ctx.agents` gains a `profiles` member exposing the profile list and a
+launch that can carry an opening prompt. This was originally phase 5.
+
+Not `pick()` — an extension builds one from `list()` + `ctx.ui.showMenu` in a
+few lines, and `showMenu` _is_ the shared chrome. Not `get()` — that is
+`list().find()`.
 
 ### Acceptance criteria
 
-- [ ] `silo agent run --prompt <text>` launches the resolved profile and hands
-      the agent that text, composing with `--profile` and `--ws` in any order.
-- [ ] `--prompt=<text>` is accepted as well as `--prompt <text>`.
-- [ ] Prompt text beginning with `-` is supported through the `--prompt=<text>`
-      spelling. `--prompt -foo` follows the **same** rule as every other flag on
-      this verb — a value that looks like a flag is not consumed — so the parser
-      keeps one value reader rather than two behaviors for sibling flags. The
-      CLI guide documents the `=` spelling for this case.
-- [ ] A multi-line prompt (`--prompt "$(cat notes.md)"`) is delivered intact.
-- [ ] A bare trailing `--prompt` with no value is ignored, exactly as the other
-      flags are — never a panic, never a partial request.
-- [ ] Omitting `--prompt` leaves phase 2's behavior untouched.
-- [ ] The Rust parser arm has unit coverage for each of the cases above,
-      alongside the existing `agent run` tests.
+- [ ] `ctx.agents.profiles.list()` returns the profiles as a read-only,
+      deeply-frozen array of a **public summary type** — never the host's
+      `AgentProfile` record, matching how `ctx.agents.catalog()` shipped in
+      phase 1.
+- [ ] Each summary carries enough for a caller to build a picker and decide
+      whether to offer a prompt: at least the id, the label, whether it is the
+      default, and whether it can take an opening prompt (R10's fact, same
+      helper).
+- [ ] `launch({ profileId?, workspaceId?, cwd?, prompt?, activate? })` launches
+      a profile, defaulting to the resolved default profile when `profileId` is
+      omitted — the same `resolveDefaultProfile` the generic `core.newAgent`
+      command uses.
+- [ ] `launch()` **returns a result**, not `void`: the created terminal's id on
+      success, or a typed refusal. This is the whole reason the SDK is a better
+      first consumer than a Forward-mode CLI flag — an extension can see what
+      happened and tell its user.
+- [ ] A refused prompt (R7) creates no terminal and comes back as that typed
+      refusal.
+- [ ] Launching into a background workspace exercises `launchAgentProfile`'s
+      eager-spawn branch, which phase 1 built and only unit-tested.
+- [ ] The surface is `@beta` on first publication, consistent with
+      `ctx.agents.catalog()`.
+- [ ] No extension can reach the host through it: the summary types and the
+      launch input live in `@silo-code/sdk`, and nothing in the signature
+      exposes host state.
 
-### Its Control answer is defined now, not later
+### `--prompt` is specified here, and ships with RFC 0034
 
 ADR 0047 rule 6: _"Every mutating verb gets a defined return payload in its own
 proposal **before** it ships, even while the channel can't yet deliver one."_
-RFC 0034 is accepted and converting this exact verb from Forward to Control, so
-`--prompt` must be designed against that contract rather than shaped for silence
-and retrofitted as a breaking change.
+RFC 0034 is converting `silo agent run` from Forward to Control, and ADR 0047's
+2026-09-02 amendment says a new flag on a verb scheduled for conversion is
+Control, never Forward. So the flag is designed here and built there.
 
-- [ ] `--prompt` is specified as part of `agent.run`'s Control request — a
-      `prompt` member of its `args`, beside `profile` and `ws`.
+- [ ] `--prompt` is specified as a `prompt` member of `agent.run`'s Control
+      `args`, beside `profile` and `ws`.
 - [ ] Each of R7's refusals maps to a code in RFC 0034's **closed** error
-      vocabulary, chosen and written down in this package. Nothing new is
-      invented: `no-agent` and `agent-takes-none` are configuration errors the
-      caller can fix, `unsupported-shell` is environmental, and `too-large` is a
-      bad argument. If none of the existing codes fits, that is a finding to
-      raise against RFC 0034 while it is still unimplemented — not a reason to
-      add a code here.
-- [ ] Ships as **Forward** in phase 3 (the channel does not exist yet), with the
-      payload above recorded so the later conversion adds a return value rather
-      than changing a contract.
-- [ ] RFC 0034's package is updated in the same change so `agent.run`'s `args`
-      carry `prompt`. Whichever lands first, the other needs no rework.
+      vocabulary, chosen and written down. Nothing new is invented: `no-agent`
+      and `agent-takes-none` are configuration the caller can fix,
+      `unsupported-shell` is environmental, `too-large` is a bad argument. If
+      none fits, that is a finding to raise against RFC 0034 while it is still
+      unimplemented — not a reason to add a code here.
+- [ ] RFC 0034's package carries `prompt` in `agent.run`'s args, its CLI surface
+      line, and R11, so neither package needs rework for the other.
+- [ ] **No CLI code ships in this phase.** `cli.rs`, `agent-run-handler.ts`, and
+      `silo --help` are untouched by prompt delivery.
 
-## R7 — Refusal is visible and never partial
+## R7 — Refusal is typed, visible, and never partial
 
 Every reason a prompt cannot be delivered ends the same way: nothing is typed,
-no agent is started, and the user is told why.
+no agent is started, and the caller is told why **in a form they can act on**.
 
-`silo agent run` is **Forward** mode _today_ — no stdout, no meaningful exit
-code (ADR 0047) — and RFC 0034 is converting it to Control. Until that lands,
-ADR 0047 is explicit that Forward's silence is "a reason to move a command to
-Control, not an exemption it keeps," so a flag whose failures are invisible to
-its caller would be adding exactly the defect that ADR warns about. R10 is the
-answer: the refusals that are **static** — properties of the profile or the
-user's shell rather than of this invocation — are surfaced where they are
-configured, so nobody first learns about them from an Output line they were not
-watching. What is left at the CLI is a failure the caller caused and can fix.
+With `ctx.agents.profiles.launch()` as the consumer, that form is a **return
+value** — the extension gets a typed refusal and can show its own message. This
+is the concrete gain from dropping the Forward-mode CLI flag: refusals stop
+being Output-panel text that the caller never sees.
+
+R10 still matters, and for a better reason than covering for silence: the
+static refusals are knowable before anyone launches anything, so surfacing them
+where a profile is authored means users meet them at configuration time rather
+than as a failed launch.
 
 ### Acceptance criteria
 
@@ -222,15 +235,18 @@ watching. What is left at the CLI is a failure the caller caused and can fix.
       that agent's `promptDelivery` is undefined or says it takes none, when the
       target shell's dialect cannot be quoted, or when the sanitized prompt
       exceeds `MAX_PROMPT_BYTES`.
-- [ ] Each refusal reports a distinct, actionable message on the Output panel
-      naming the actual reason.
+- [ ] Each refusal is a distinct, documented member of the public refusal type
+      returned by `launch()` — not a string, not a thrown error.
 - [ ] A refusal detected at **precheck** aborts the launch: no terminal record
-      is created, no workspace is activated, nothing is focused.
+      is created, no workspace is activated, nothing is focused. `launch()`
+      returns the refusal.
 - [ ] A refusal detected only at **drain** — the profile was edited between the
-      request and the session coming up — types nothing and logs. The terminal
-      already exists and is left as a plain shell. This is the same shape as
-      phase 1's "a profile deleted mid-launch drains to nothing," and it is the
-      only case in which a terminal outlives a refused prompt.
+      request and the session coming up — types nothing and logs to the Output
+      panel. The terminal already exists and is left as a plain shell. This is
+      the same shape as phase 1's "a profile deleted mid-launch drains to
+      nothing," and it is the only case in which a terminal outlives a refused
+      prompt. It is also the only refusal `launch()` cannot return, because it
+      happens after it has already returned.
 - [ ] A launch with no prompt is never affected by any of these checks.
 - [ ] `MAX_PROMPT_BYTES` is **16 KiB** of sanitized UTF-8, enforced and tested
       at the boundary (at the limit, and one byte over).
@@ -242,9 +258,10 @@ depends on the catalog agent the profile resolves to, not on any particular
 launch. It therefore belongs on the Profiles tab, next to where the profile is
 authored, rather than only in a runtime refusal.
 
-This is what keeps R7's Forward-mode story honest, and it mirrors phase 1's
-treatment of `configDirEnvVar`: the editor already shows or hides the
-config-directory field based on the resolved agent's catalog entry.
+It mirrors phase 1's treatment of `configDirEnvVar`: the editor already shows or
+hides the config-directory field based on the resolved agent's catalog entry.
+The same fact also rides on `ctx.agents.profiles.list()` (R6), so an extension
+building a picker can grey out or annotate a profile without launching one.
 
 ### Acceptance criteria
 
@@ -263,36 +280,30 @@ config-directory field based on the resolved agent's catalog entry.
 
 ### Acceptance criteria
 
-- [ ] `silo --help` documents `--prompt` under the `agent run` options.
-- [ ] `apps/docs/guide/cli.md` documents `--prompt`, including a multi-line
-      example and what happens when an agent cannot take one.
+- [ ] The `silo-docs-sync` workflow runs **in full** for `ctx.agents.profiles`:
+      TSDoc on every new symbol, `@public`/`@beta` + `@category` tags, the
+      barrel re-export from `packages/sdk/src/index.ts`, the hand-authored `ctx`
+      member page, and `pnpm docs:api` regenerated.
+- [ ] The roadmap's `ctx.agents.profiles` entry flips from `planned` to its
+      shipped state, and its sketched surface agrees with what shipped.
 - [ ] `docs/domain-language.md` carries the phase's vocabulary if the work
       introduces or sharpens a term (see R1's recon question).
-- [ ] No `@silo-code/sdk` symbol is added or changed; if that stops being true,
-      the `silo-docs-sync` workflow runs in the same change.
-
-## R9 — A cancelled terminal init leaks no session
-
-Adjacent to prompt delivery, not part of it. `TerminalPanel`'s init effect can
-re-run and abandon a PTY it has already spawned; today that session survives
-with nothing referencing it. `ensureSession` already handles the identical race
-correctly, and this makes the two agree.
-
-### Acceptance criteria
-
-- [ ] An init run that is cancelled **after** spawning a session kills that
-      session before returning.
-- [ ] An init run that is cancelled after **attaching** to an existing session
-      does **not** kill it — the record still points at that session and it
-      belongs to the user.
-- [ ] The `ui_init_cancelled` attach trace records which of the two happened.
-- [ ] No change to what is typed into any terminal: this fixes a leak, not a
-      delivery path.
+- [ ] `docs/adding-a-coding-agent.md` Step 1 carries the prompt-delivery recon
+      question (R1).
+- [ ] **No CLI documentation changes.** `apps/docs/guide/cli.md` and
+      `silo --help` are untouched — `--prompt` ships with RFC 0034.
 
 ## Out of scope
 
-- **`ctx.agents.profiles.launch({ prompt })`** and any other public SDK surface
-  for prompts — phase 5. Phase 3 builds the seam host-internal on purpose.
+- **`silo agent run --prompt <text>`** as shipped behavior. It is specified in
+  R6 as part of `agent.run`'s Control contract and built with RFC 0034. No CLI
+  code, help text, or CLI guide changes in this phase.
+- **The orphaned-session fix at `TerminalPanel.tsx:617`.** It was briefly folded
+  into this phase; it never belonged to prompt delivery, and a terminal-lifecycle
+  change riding along with a public SDK addition helps neither review. It goes
+  out as **its own PR**: reap a session the cancelled init spawned
+  (`if (needsCreate) void session.kill()`), guarded so the attach path never
+  kills a live terminal, mirroring `ensureSession` at `terminal-service.ts:260`.
 - **Resume composition** (phase 4), per-account hooks (phase 6),
   `SILO_AGENT_PROFILE` (phase 7), per-workspace defaults (phase 8), and the
   CLI's read-back half (phase 9).
@@ -303,7 +314,9 @@ correctly, and this makes the two agree.
   _opening_ prompt on the launch line. Talking to a live agent is the
   agent-agnostic runner the proposal rejects outright.
 - **Queuing or templating prompts**, prompt history, and any UI for composing
-  one. `--prompt` is the phase's only entry point.
-- **A `--prompt` equivalent on the `+` menu or the Agents submenu.** Both are
+  one. `ctx.agents.profiles.launch()` is the phase's only entry point.
+- **A prompt field on the `+` menu or the Agents submenu.** Both are
   point-and-launch gestures with nowhere to type; adding a text field to them
   is a product call this phase does not make.
+- **RFC 0031's Start Task.** This phase unblocks it by publishing the surface;
+  building it stays in that proposal and that repo.

--- a/docs/proposals/0033-agent-profiles/requirements.md
+++ b/docs/proposals/0033-agent-profiles/requirements.md
@@ -1,0 +1,218 @@
+# Requirements — 0033. Agent Profiles, phase 3 (Prompt delivery)
+
+Scoped to **phase 3 only**. Phases 1 and 2 are the implementation baseline (see
+`proposal.md` → Planning scope). Working artifact — removed when the proposal
+collapses.
+
+The governing rule for the whole phase, which several requirements below
+restate in their own terms:
+
+> **A prompt that cannot be delivered safely fails the launch, loudly. Silo
+> never starts a promptless agent for a caller who asked for one, and never
+> types a payload it is not certain it can quote.**
+
+This is the same reasoning `configDirEnvVar` settled in phase 1 — a mechanism
+that looks like it worked and silently didn't is worse than one that isn't
+there.
+
+## R1 — The catalog says how each agent takes an opening prompt
+
+`AgentDefinition` gains a `promptDelivery` field describing how (or whether)
+that agent accepts an opening prompt on its launch line. Like every other
+catalog field it is a fact about the agent's CLI established by empirical
+recon, not a user preference and not a guess from the command text.
+
+### Acceptance criteria
+
+- [ ] `AgentDefinition.promptDelivery` exists, is optional, and is documented
+      with the same discipline as `configDirEnvVar` (what it means, what the
+      distinguishing recon question is, why an agent is left undefined).
+- [ ] The field is populated for every catalog agent whose recon establishes an
+      answer, and left **undefined** for every agent whose recon does not.
+- [ ] Every catalog entry touched records the finding in its `contract` and
+      refreshes `lastVerified` / `verifiedAgainstVersion`.
+- [ ] An agent whose `promptDelivery` is undefined is treated as "cannot take a
+      prompt" — never as "probably positional".
+- [ ] The delivery shapes form a small closed union. A new shape is added only
+      when an agent's recon actually requires it, never speculatively.
+- [ ] `docs/adding-a-coding-agent.md` Step 1 gains the prompt-delivery recon
+      question, including the distinguishing test (does the agent stay
+      **interactive** after accepting the prompt, or does it turn into a
+      one-shot non-interactive run?).
+
+## R2 — A prompt is sanitized for a line editor before it is used
+
+The payload is **typed** into a PTY, so it reaches the shell's line editor as
+keystrokes rather than arriving as an argv value. Control bytes therefore have
+effects: ESC and C1 sequences fire keybindings, a lone CR submits the line
+early, and a tab triggers completion. Sanitization is not optional and does not
+depend on which transport or dialect is chosen.
+
+### Acceptance criteria
+
+- [ ] A pure, unit-tested sanitizer exists and is applied to every prompt before
+      any line is composed from it.
+- [ ] CRLF and lone CR are normalized to LF.
+- [ ] ANSI CSI and OSC sequences are stripped **whole**, not byte-by-byte (a
+      partially stripped sequence leaves its payload as literal text).
+- [ ] Remaining C0 and C1 control characters are removed; LF survives.
+- [ ] Tabs are expanded to spaces.
+- [ ] The sanitizer is total: every input string produces an output string, and
+      no input can make it throw.
+- [ ] Sanitizing an already-clean prompt returns it unchanged (idempotent, and
+      no cosmetic rewriting of ordinary text).
+
+## R3 — The payload rides in a quoted heredoc, never interpolated
+
+On a POSIX-family shell the sanitized prompt is delivered inside a **quoted**
+heredoc, so parameter expansion, command substitution, and quoting are dead by
+construction. The prompt text is never spliced into the launch line as a quoted
+string, and never written to a temp file.
+
+### Acceptance criteria
+
+- [ ] The composed line delivers the prompt via a quoted heredoc; no code path
+      interpolates raw prompt text into the launch line.
+- [ ] A multi-line prompt is delivered intact, with its line breaks preserved.
+- [ ] A prompt containing shell metacharacters (`$`, `` ` ``, `\`, `"`, `'`,
+      `;`, `&&`, `$(…)`, backslash-newline) is delivered as literal text and
+      executes nothing.
+- [ ] The heredoc delimiter is chosen so that no line of the payload can equal
+      it; delivery of a payload that contains the default delimiter as a line
+      still succeeds.
+- [ ] The composition preserves everything phase 1 established about the launch
+      line: a profile's `configDir` env prefix still leads, and the profile's
+      `command` is still typed verbatim.
+- [ ] The composed line is produced by a pure function with unit coverage; the
+      drain does not build shell syntax inline.
+
+## R4 — A shell Silo cannot quote refuses the prompt
+
+Both heredoc forms are bash/zsh-family syntax. The transport must know which
+dialect the target terminal will run and must not type a heredoc into a shell
+that has none.
+
+### Acceptance criteria
+
+- [ ] The dialect is resolved from the terminal's own shell when the record
+      names one, and otherwise from the user's login shell.
+- [ ] A POSIX-family shell (`bash`, `zsh`, `sh`, and their common variants) gets
+      the heredoc transport.
+- [ ] `fish` gets a dialect-correct transport of its own, or is refused — not a
+      heredoc.
+- [ ] Any shell Silo has no exact quoting rule for (including an unrecognized
+      one) **refuses** the prompt rather than approximating it.
+- [ ] Dialect selection is a pure function of the shell name, unit-tested for
+      each supported dialect, for a refused one, and for an unknown one.
+
+## R5 — A launch can carry a prompt, resolved at drain time
+
+The pending-launch model from phase 1 is extended to carry an optional prompt.
+Everything that model already guarantees continues to hold.
+
+### Acceptance criteria
+
+- [ ] A launch may be registered with an optional prompt, and the drain types
+      the composed line — profile launch line plus prompt — as a single intent.
+- [ ] `takePendingLaunch` stays remove-on-read, so a prompt is delivered at most
+      once and a double-drain remains impossible.
+- [ ] Pending launches carrying a prompt are still never persisted.
+- [ ] The profile is still resolved at **drain** time; a profile deleted between
+      the request and the drain still drains to nothing, prompt included.
+- [ ] A launch registered without a prompt produces exactly the line phase 1
+      and 2 produce today — byte for byte, with no new trailing whitespace or
+      wrapper.
+- [ ] Both drain paths — the mounted `TerminalPanel` and `ensureSession`'s lazy
+      spawn for a background workspace — deliver a prompt identically.
+
+## R6 — `silo agent run --prompt <text>`
+
+`silo agent run` gains an optional `--prompt` flag carrying the opening prompt
+for the launched agent. It is a flag on an existing verb; it introduces no new
+noun, verb, or grammar, and ADR 0047 reads the same with or without it.
+
+### Acceptance criteria
+
+- [ ] `silo agent run --prompt <text>` launches the resolved profile and hands
+      the agent that text, composing with `--profile` and `--ws` in any order.
+- [ ] `--prompt=<text>` is accepted as well as `--prompt <text>`.
+- [ ] A prompt whose text begins with `-` is delivered, not silently dropped as
+      a flag.
+- [ ] A multi-line prompt (`--prompt "$(cat notes.md)"`) is delivered intact.
+- [ ] A bare trailing `--prompt` with no value is ignored, exactly as the other
+      flags are — never a panic, never a partial request.
+- [ ] Omitting `--prompt` leaves phase 2's behavior untouched.
+- [ ] The flag stays **Forward** mode: it asks for an action, reports nothing on
+      stdout, and needs no return channel.
+- [ ] The Rust parser arm has unit coverage for each of the cases above,
+      alongside the existing `agent run` tests.
+
+## R7 — Refusal is visible and never partial
+
+Every reason a prompt cannot be delivered ends the same way: nothing is typed,
+no agent is started, and the user is told why in the one place a
+fire-and-forget CLI request can speak.
+
+### Acceptance criteria
+
+- [ ] A prompt is refused when the profile resolves to no catalog agent, when
+      that agent's `promptDelivery` is undefined or says it takes none, when the
+      target shell's dialect cannot be quoted, or when the sanitized prompt
+      exceeds the documented size limit.
+- [ ] Each refusal reports a distinct, actionable message on the Output panel
+      naming the actual reason.
+- [ ] A refused prompt **aborts the launch**: no terminal is left holding a
+      promptless agent, and no partial line is typed.
+- [ ] A launch with no prompt is never affected by any of these checks.
+- [ ] There is a documented maximum sanitized prompt size, enforced and tested
+      at the boundary.
+
+## R8 — The user-facing story stays in sync in this change
+
+### Acceptance criteria
+
+- [ ] `silo --help` documents `--prompt` under the `agent run` options.
+- [ ] `apps/docs/guide/cli.md` documents `--prompt`, including a multi-line
+      example and what happens when an agent cannot take one.
+- [ ] `docs/domain-language.md` carries the phase's vocabulary if the work
+      introduces or sharpens a term (see R1's recon question).
+- [ ] No `@silo-code/sdk` symbol is added or changed; if that stops being true,
+      the `silo-docs-sync` workflow runs in the same change.
+
+## R9 — A cancelled terminal init leaks no session
+
+Adjacent to prompt delivery, not part of it. `TerminalPanel`'s init effect can
+re-run and abandon a PTY it has already spawned; today that session survives
+with nothing referencing it. `ensureSession` already handles the identical race
+correctly, and this makes the two agree.
+
+### Acceptance criteria
+
+- [ ] An init run that is cancelled **after** spawning a session kills that
+      session before returning.
+- [ ] An init run that is cancelled after **attaching** to an existing session
+      does **not** kill it — the record still points at that session and it
+      belongs to the user.
+- [ ] The `ui_init_cancelled` attach trace records which of the two happened.
+- [ ] No change to what is typed into any terminal: this fixes a leak, not a
+      delivery path.
+- [ ] Ships as its own commit, revertable without touching prompt delivery.
+
+## Out of scope
+
+- **`ctx.agents.profiles.launch({ prompt })`** and any other public SDK surface
+  for prompts — phase 5. Phase 3 builds the seam host-internal on purpose.
+- **Resume composition** (phase 4), per-account hooks (phase 6),
+  `SILO_AGENT_PROFILE` (phase 7), per-workspace defaults (phase 8), and the
+  CLI's read-back half (phase 9).
+- **Hardening `ctx.terminals.sendText`.** Its contract is "as if the user
+  typed it", raw and unfiltered, and extensions depend on that. Phase 3 adds a
+  safe path beside it; it does not change what `sendText` does.
+- **Sending a prompt to an agent that is already running.** Phase 3 delivers an
+  _opening_ prompt on the launch line. Talking to a live agent is the
+  agent-agnostic runner the proposal rejects outright.
+- **Queuing or templating prompts**, prompt history, and any UI for composing
+  one. `--prompt` is the phase's only entry point.
+- **A `--prompt` equivalent on the `+` menu or the Agents submenu.** Both are
+  point-and-launch gestures with nowhere to type; adding a text field to them
+  is a product call this phase does not make.

--- a/docs/proposals/0033-agent-profiles/tasks.md
+++ b/docs/proposals/0033-agent-profiles/tasks.md
@@ -114,6 +114,24 @@ Split finely on purpose: this module is where the phase's whole risk lives, and
       `composePromptLaunchLine` **before** creating the terminal; a refusal logs
       the specific reason on `silo:application` and returns without creating,
       activating, or focusing anything.
+- [ ] **Check RFC 0034's state first.** It is converting this verb to Control.
+      If it has landed, write the precheck into the `agent.run` handler instead
+      and skip the Forward-mode plumbing above; if not, proceed as written and
+      0034 relocates it. The pure core is unaffected either way.
+
+## Reconcile with RFC 0034 (Control API)
+
+Both packages touch `silo agent run` and both are unimplemented, so they are
+reconciled in documents now rather than by whoever implements second.
+
+- [ ] Add `prompt` to `agent.run`'s `args` in
+      `docs/proposals/0034-control-api/` — the design's wire contract, its op
+      table row, and R11's criteria as needed.
+- [ ] Map each phase-3 refusal onto 0034's **closed** error vocabulary and
+      record the choice. Invent no new codes; if none fits, raise it against
+      0034 while it is still cheap to amend.
+- [ ] Add `--prompt` to the `silo agent run` line in 0034's "New CLI surface"
+      block, so its CLI-guide and `--help` tasks cover the flag.
 
 ## Adjacent fix — the orphaned session
 

--- a/docs/proposals/0033-agent-profiles/tasks.md
+++ b/docs/proposals/0033-agent-profiles/tasks.md
@@ -1,8 +1,9 @@
-# Tasks — 0033. Agent Profiles, phase 3 (Prompt delivery)
+# Tasks — 0033. Agent Profiles, phase 3 (Prompt delivery + ctx.agents.profiles)
 
-Implementation plan for **phase 3 only**. Ordered: recon settles the catalog,
-the pure core comes next, then the launch path, then the CLI, then docs. Keep
-the checkboxes current. Working artifact — removed when the proposal collapses.
+Implementation plan for **phase 3 only** — prompt delivery _and_
+`ctx.agents.profiles`. Ordered: recon settles the catalog, the pure core comes
+next, then the launch path, then the public surface, then docs. Keep the
+checkboxes current. Working artifact — removed when the proposal collapses.
 
 ## Recon (mostly done — see the findings table in `design.md`)
 
@@ -74,8 +75,9 @@ Split finely on purpose: this module is where the phase's whole risk lives, and
 
 - [ ] Add the `default_shell` host command (`$SHELL`, falling back to
       `/bin/bash`) and resolve it **during host init** into host state, so every
-      consumer reads it synchronously. This is what keeps `applyCliAgentRun`
-      synchronous — do not make the CLI handler async.
+      consumer reads it synchronously. `ctx.agents.profiles.launch()` returns a
+      result rather than a promise, and RFC 0034's `agent.run` handler will read
+      the same value — neither should have to await a constant.
 - [ ] `PendingLaunch`'s `{ profileId }` arm gains `prompt?` **and `dialect`**;
       `requestProfileLaunch` accepts them. Leave the `{ rawLine }` arm alone.
 - [ ] `drainPendingLaunch` composes `profileLaunchLine(profile)` with the
@@ -101,57 +103,42 @@ Split finely on purpose: this module is where the phase's whole risk lives, and
 - [ ] Follow `docs/modal-design.md` and the SDK kit — no hand-rolled styling,
       design tokens only.
 
-## The CLI
+## `ctx.agents.profiles` — the public surface (R6)
 
-- [ ] `cli.rs`: `CliRequest.prompt`, parsed from `--prompt <text>` /
-      `--prompt=<text>` using the **existing** `flag_value` reader. Do not add a
-      second reader: prompt text starting with `-` goes through
-      `--prompt=<text>`, the same rule every other flag on this verb follows.
-- [ ] Add `--prompt` to the `HELP` text under the `agent run` options.
-- [ ] `CliAgentRunRequest.prompt` and the `cli:open` / `PendingLaunchArg`
-      pass-through.
-- [ ] `applyCliAgentRun`: when a prompt is present, precheck with
-      `composePromptLaunchLine` **before** creating the terminal; a refusal logs
-      the specific reason on `silo:application` and returns without creating,
-      activating, or focusing anything.
-- [ ] **Check RFC 0034's state first.** It is converting this verb to Control.
-      If it has landed, write the precheck into the `agent.run` handler instead
-      and skip the Forward-mode plumbing above; if not, proceed as written and
-      0034 relocates it. The pure core is unaffected either way.
+This is the phase's consumer and its only public API. `silo-docs-sync` applies
+in full; do the docs in this change, not after.
 
-## Reconcile with RFC 0034 (Control API)
+- [ ] `AgentProfileSummary` in `packages/sdk` — `id`, `label`, `isDefault`,
+      `acceptsPrompt`. A summary type, never the host's `AgentProfile`.
+- [ ] `LaunchAgentProfileOptions` and `LaunchAgentProfileResult`; make
+      `PromptRefusal` public and name its members for an extension author.
+- [ ] `list()` on the host service — read-only, memoized, deeply frozen, the
+      same shape `ctx.agents.catalog()` shipped in phase 1.
+- [ ] `launch()` — resolve profile (else `resolveDefaultProfile`) and workspace,
+      precheck the prompt, create the terminal, return `{ ok: true, terminalId }`
+      or `{ ok: false, refusal }`.
+- [ ] `activate` (default true) drives workspace activation and terminal focus,
+      so an extension can launch quietly.
+- [ ] Confirm the background-workspace path returns the id correctly — it takes
+      `launchAgentProfile`'s eager-spawn branch, which until now had only unit
+      coverage.
+- [ ] TSDoc on every new symbol with `@public`/`@beta` + `@category`; re-export
+      from `packages/sdk/src/index.ts`.
+- [ ] The hand-authored `ctx` member page, then `pnpm docs:api`.
+- [ ] Flip the roadmap's `ctx.agents.profiles` entry, and make sure its sketched
+      surface matches what shipped.
 
-Both packages touch `silo agent run` and both are unimplemented, so they are
-reconciled in documents now rather than by whoever implements second.
+## Specify `--prompt`, don't build it
 
-- [ ] Add `prompt` to `agent.run`'s `args` in
-      `docs/proposals/0034-control-api/` — the design's wire contract, its op
-      table row, and R11's criteria as needed.
+ADR 0047's 2026-09-02 amendment: a new flag on a verb scheduled for conversion
+is Control, never Forward. No `cli.rs`, no `agent-run-handler.ts`, no `--help`,
+no CLI guide in this phase.
+
+- [ ] Confirm `prompt` is in `agent.run`'s args in
+      `docs/proposals/0034-control-api/` — wire contract, CLI surface line, R11.
 - [ ] Map each phase-3 refusal onto 0034's **closed** error vocabulary and
-      record the choice. Invent no new codes; if none fits, raise it against
-      0034 while it is still cheap to amend.
-- [ ] Add `--prompt` to the `silo agent run` line in 0034's "New CLI surface"
-      block, so its CLI-guide and `--help` tasks cover the flag.
-
-## Adjacent fix — the orphaned session
-
-Pre-existing and independent of prompt delivery; folded into this phase because
-it is four lines beside code the phase already touches. Keep it as its own
-commit so it can be reverted without touching the prompt path.
-
-- [ ] `TerminalPanel.tsx` — at the `cancelled` bail (~line 617), reap a session
-      this run spawned: `if (needsCreate) void session.kill();` before the
-      `return`. **Guard on `needsCreate`** — on the attach path the session
-      predates this run and the record still points at it, so killing it would
-      destroy a live terminal.
-- [ ] Include the disposition (reaped / attached) in the existing
-      `ui_init_cancelled` attach trace, so `terminal.log` distinguishes the two.
-- [ ] Correct the stale "launch line is occasionally typed twice" paragraph in
-      the collapsed proposal's **launch model** section: the symptom it
-      describes belonged to the pre-phase-1 `kind` shim
-      (`setTimeout(() => session.write(cmd))`, no dedupe), which phase 1
-      deleted. What actually survives is a double-**spawn**, now fixed. Do this
-      at collapse time, with the rest of the curation.
+      record the choice there. Invent no new codes; raise a finding against 0034
+      if none fits, while it is still cheap to amend.
 
 ## Tests
 
@@ -166,48 +153,47 @@ commit so it can be reverted without touching the prompt path.
       line; a promptless claim is byte-identical to today.
 - [ ] `agent-launch.test.ts` — `prompt` threads through; the background branch
       is unchanged.
-- [ ] `cli.rs` tests — `--prompt <text>`, `--prompt=<text>`, dash-leading text
-      via the `=` form, a bare trailing `--prompt`, and mixed order with
-      `--profile` / `--ws`.
 - [ ] Chunking / size — a composed line at exactly `MAX_PROMPT_BYTES` reaches
       the PTY complete, and one byte over is refused before anything is typed.
-- [ ] `agent-run-handler` test — a refused prompt creates no terminal, activates
-      no workspace, and logs; no-prompt behavior unchanged.
-- [ ] The orphaned-session fix (R9) — cancelled after a **spawn** kills the
-      session; cancelled after an **attach** does not. Extract the disposition
-      decision as a pure helper if `TerminalPanel` is awkward to drive directly
-      (per `silo-testing`: extract testable logic rather than reaching for
-      `@testing-library/react`).
+- [ ] `ctx.agents.profiles` — `list()` shape and freezing; `launch()` returning
+      the terminal id; each refusal coming back as a typed result rather than a
+      throw; `activate: false` leaving focus alone; a refused prompt creating no
+      terminal and activating no workspace.
+- [ ] Nothing in the SDK surface leaks host state — `list()` returns summaries,
+      not `AgentProfile` records.
 
 ## Docs
 
-- [ ] `apps/docs/guide/cli.md` — document `--prompt`, with a multi-line example
-      (`--prompt "$(cat notes.md)"`), the 16 KiB limit, the `--prompt=<text>`
-      spelling for dash-leading text, which agents accept a prompt, and — per
-      R5a — that the prompt lands in shell history like anything else typed.
+- [ ] `silo-docs-sync` in full for `ctx.agents.profiles` (see that task group) —
+      this is the phase's docs work, and it is not optional.
 - [ ] `docs/domain-language.md` — add or sharpen a term only if the work
       actually introduces one; don't invent a synonym for something already
       there.
-- [ ] Confirm no `@silo-code/sdk` symbol changed. If one did, run the
-      `silo-docs-sync` workflow in this same change.
+- [ ] `docs/adding-a-coding-agent.md` Step 1 — the prompt-delivery recon
+      question (also listed under Recon).
+- [ ] **No CLI docs.** `apps/docs/guide/cli.md` and `silo --help` are untouched;
+      `--prompt` documents itself when RFC 0034 ships it.
 
 ## Verification
 
 - [ ] Every requirement in `requirements.md` is met or explicitly noted as not.
-- [ ] `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm lint` pass;
-      Rust tests pass for the `cli.rs` arm.
-- [ ] Exercised by hand at a real shell: `silo agent run --profile <id>
---prompt "…"` on a POSIX shell, a multi-line prompt, a prompt full of shell
-      metacharacters, and each refusal path.
+- [ ] `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, `pnpm lint`, and
+      `pnpm docs:api` all pass and leave no uncommitted generated output.
+- [ ] Exercised for real from an extension: launch a profile with a multi-line
+      prompt, a prompt full of shell metacharacters, and each refusal path.
+      `packages/extensions-silo`'s sdk-playground is the natural harness.
 - [ ] **Run in the real app against a plugin-heavy `zsh`** (autosuggestions,
       syntax highlighting, powerlevel10k) via the `verifier-gui` skill. The
       spike validated bash and `zsh -f`; it could not validate a customized rc,
       and those plugins hook the same keystroke path this transport uses. This
       is the phase's highest-risk unknown — do not close the phase without it.
 - [ ] Verify on `fish` too, since it takes the second transport arm.
-- [ ] Durable decisions recorded as ADRs (none expected — the transport and its
-      refusal rule are phase detail the collapsed proposal carries; write one
-      only if something outlives this change).
+- [ ] Durable decisions recorded as ADRs. ADR 0047's 2026-09-02 amendment (the
+      Forward-vs-Control test) ships with this work; nothing else is expected.
 - [ ] Proposal collapsed to a single curated `0033-agent-profiles.md` with the
-      phase table updated: phase 3 shipped, `status` stays `accepted` because
-      phases 4–9 remain. Index row repointed to `./0033-agent-profiles.md`.
+      phase table updated: phase 3 shipped and phase 5 marked merged into it,
+      `status` stays `accepted` because phases 4 and 6–9 remain. Index row
+      repointed to `./0033-agent-profiles.md`.
+- [ ] Correct the stale "launch line is occasionally typed twice" paragraph in
+      the launch-model section while curating — it describes the pre-phase-1
+      `kind` shim, which no longer exists.

--- a/docs/proposals/0033-agent-profiles/tasks.md
+++ b/docs/proposals/0033-agent-profiles/tasks.md
@@ -12,13 +12,19 @@ is recorded in `design.md` → "Recon findings". Five take a positional prompt
 `--prompt` flag because its positional is a project path, and `copilot`'s
 `-p/--prompt` is documented as non-interactive. What remains:
 
-- [ ] Confirm empirically that `pi` stays in its TUI after positional
-      `[messages...]` rather than answering and exiting. Ambiguous → leave
-      `promptDelivery` undefined.
-- [ ] Confirm empirically whether `copilot` has any interactive form that takes
-      an opening prompt. Documented answer is no; ambiguous → undefined.
-- [ ] Spot-check one `argv` agent end to end (a real launch with a prompt that
-      contains a quote and a newline) before trusting the other four.
+**Method** for each empirical check below: launch the agent in a real terminal
+with a positional prompt, then confirm two things — the agent **acted on the
+prompt**, and it **left you at its interactive UI** rather than printing and
+exiting. A process that has exited is a "no" no matter how good its answer was.
+
+- [ ] `pi` — run `pi "say hello"`; confirm it answers **and** stays in the TUI.
+      Ambiguous → leave `promptDelivery` undefined.
+- [ ] `copilot` — establish whether any interactive form takes an opening
+      prompt (`-p` is documented as non-interactive). Ambiguous → undefined.
+- [ ] Spot-check one confirmed `argv` agent end to end through Silo itself, with
+      a prompt containing a single quote, a double quote, a `$`, and a newline.
+- [ ] Spot-check `opencode`'s `--prompt` flag the same way — it is the only
+      `{ kind: "flag" }` entry, so nothing else covers that arm.
 - [ ] Write each answer — positive **and** negative — into that agent's
       `contract`, and refresh `lastVerified` / `verifiedAgainstVersion`.
 - [ ] Add the prompt-delivery recon question to `docs/adding-a-coding-agent.md`
@@ -39,37 +45,68 @@ string }`) and `AgentDefinition.promptDelivery?`, with TSDoc stating what the
 
 ## The pure core — `agents/agent-prompt.ts`
 
-- [ ] `sanitizePromptForLineEditor` — normalize CRLF/CR → LF, strip CSI and OSC
-      sequences whole, remove remaining C0/C1 controls (keep LF), expand tabs.
-      Total and idempotent.
+Split finely on purpose: this module is where the phase's whole risk lives, and
+"write the sanitizer" is not a reviewable unit.
+
+- [ ] `sanitizePromptForLineEditor` — CRLF and lone CR → LF.
+- [ ] …strip ANSI **CSI** sequences whole.
+- [ ] …strip **OSC** sequences whole, including their terminator (`BEL` and
+      `ESC \` both).
+- [ ] …remove remaining C0/C1 controls, keeping LF.
+- [ ] …expand tabs to spaces. Confirm total and idempotent.
 - [ ] `ShellDialect` + `shellDialect(shell)` — basename-mapped; `posix` for
       bash/zsh/sh/dash/ksh, `fish` for fish, `unsupported` otherwise (including
       `undefined`).
 - [ ] `heredocDelimiter(payload)` — `SILO_PROMPT`, suffixed until no line of the
       payload equals it.
-- [ ] `MAX_PROMPT_BYTES` — one documented constant.
-- [ ] `PromptRefusal` union and `composePromptLaunchLine` — returns the line to
-      type or a refusal. The only place shell syntax is written.
-- [ ] fish escaping (`\` → `\\`, `'` → `\'`) inside the same module.
+- [ ] `MAX_PROMPT_BYTES = 16 * 1024` (sanitized UTF-8 bytes, not characters).
+- [ ] `resolveProfileAgentId` — `assumedAgentId` ?? `fallbackAgentForCommand`.
+      Shared with R10's editor affordance; neither may resolve agents its own
+      way.
+- [ ] `PromptRefusal` union.
+- [ ] `composePromptLaunchLine` — the POSIX heredoc arm.
+- [ ] …the fish single-quoted arm (`\` → `\\`, `'` → `\'`).
+- [ ] …the `{ kind: "flag" }` variant for both dialects (one token's difference
+      from `argv`; do not fork the function).
+- [ ] …the four refusal returns.
 
 ## The launch path
 
-- [ ] Resolve the login shell once: a `default_shell` host command reading
-      `$SHELL` (falling back to `/bin/bash`), cached host-side.
-- [ ] `PendingLaunch`'s `{ profileId }` arm gains `prompt?`;
-      `requestProfileLaunch` accepts it. Leave the `{ rawLine }` arm alone.
-- [ ] `drainPendingLaunch` composes `profileLaunchLine(profile)` with the prompt
-      when one is claimed, re-resolving delivery and dialect at drain time; a
-      refusal types nothing and logs.
-- [ ] Convert `\n` → `\r` at the single send seam, and keep the trailing `\r`.
+- [ ] Add the `default_shell` host command (`$SHELL`, falling back to
+      `/bin/bash`) and resolve it **during host init** into host state, so every
+      consumer reads it synchronously. This is what keeps `applyCliAgentRun`
+      synchronous — do not make the CLI handler async.
+- [ ] `PendingLaunch`'s `{ profileId }` arm gains `prompt?` **and `dialect`**;
+      `requestProfileLaunch` accepts them. Leave the `{ rawLine }` arm alone.
+- [ ] `drainPendingLaunch` composes `profileLaunchLine(profile)` with the
+      prompt when one is claimed, re-resolving the **profile** (not the
+      dialect) at drain time; a refusal types nothing and logs.
+- [ ] Convert `\n` → `\r` at the **single** send seam and keep the trailing
+      `\r`. Assert there is exactly one such conversion in the codebase — doing
+      it twice leaves a heredoc that never terminates.
+- [ ] Confirm whether one `sendInput` carries a 16 KiB line to the PTY intact;
+      chunk the send if not. A truncated heredoc hangs the user's shell in an
+      unterminated quote.
 - [ ] `LaunchAgentProfileInput.prompt?` threads through `launchAgentProfile`.
 - [ ] Verify a launch with **no** prompt still produces a byte-identical line.
+
+## R10 — the Profiles tab says whether a prompt is possible
+
+- [ ] `ProfileEditorModal` surfaces, in plain language, when the resolved agent
+      cannot take an opening prompt — and when the profile resolves to no
+      catalog agent at all. Use `resolveProfileAgentId`, never a second
+      resolution path.
+- [ ] Purely informational: nothing is blocked, nothing new is persisted, the
+      fact is derived from the catalog at render time.
+- [ ] Follow `docs/modal-design.md` and the SDK kit — no hand-rolled styling,
+      design tokens only.
 
 ## The CLI
 
 - [ ] `cli.rs`: `CliRequest.prompt`, parsed from `--prompt <text>` /
-      `--prompt=<text>`. Use a value reader that does **not** reject a value
-      beginning with `-`; a bare trailing `--prompt` still yields `None`.
+      `--prompt=<text>` using the **existing** `flag_value` reader. Do not add a
+      second reader: prompt text starting with `-` goes through
+      `--prompt=<text>`, the same rule every other flag on this verb follows.
 - [ ] Add `--prompt` to the `HELP` text under the `agent run` options.
 - [ ] `CliAgentRunRequest.prompt` and the `cli:open` / `PendingLaunchArg`
       pass-through.
@@ -111,9 +148,11 @@ commit so it can be reverted without touching the prompt path.
       line; a promptless claim is byte-identical to today.
 - [ ] `agent-launch.test.ts` — `prompt` threads through; the background branch
       is unchanged.
-- [ ] `cli.rs` tests — `--prompt <text>`, `--prompt=<text>`, a value beginning
-      with `-`, a bare trailing `--prompt`, and mixed order with `--profile` /
-      `--ws`.
+- [ ] `cli.rs` tests — `--prompt <text>`, `--prompt=<text>`, dash-leading text
+      via the `=` form, a bare trailing `--prompt`, and mixed order with
+      `--profile` / `--ws`.
+- [ ] Chunking / size — a composed line at exactly `MAX_PROMPT_BYTES` reaches
+      the PTY complete, and one byte over is refused before anything is typed.
 - [ ] `agent-run-handler` test — a refused prompt creates no terminal, activates
       no workspace, and logs; no-prompt behavior unchanged.
 - [ ] The orphaned-session fix (R9) — cancelled after a **spawn** kills the
@@ -125,8 +164,9 @@ commit so it can be reverted without touching the prompt path.
 ## Docs
 
 - [ ] `apps/docs/guide/cli.md` — document `--prompt`, with a multi-line example
-      (`--prompt "$(cat notes.md)"`), the stated size limit, and what happens
-      when the agent or the shell cannot take one.
+      (`--prompt "$(cat notes.md)"`), the 16 KiB limit, the `--prompt=<text>`
+      spelling for dash-leading text, which agents accept a prompt, and — per
+      R5a — that the prompt lands in shell history like anything else typed.
 - [ ] `docs/domain-language.md` — add or sharpen a term only if the work
       actually introduces one; don't invent a synonym for something already
       there.
@@ -141,6 +181,12 @@ commit so it can be reverted without touching the prompt path.
 - [ ] Exercised by hand at a real shell: `silo agent run --profile <id>
 --prompt "…"` on a POSIX shell, a multi-line prompt, a prompt full of shell
       metacharacters, and each refusal path.
+- [ ] **Run in the real app against a plugin-heavy `zsh`** (autosuggestions,
+      syntax highlighting, powerlevel10k) via the `verifier-gui` skill. The
+      spike validated bash and `zsh -f`; it could not validate a customized rc,
+      and those plugins hook the same keystroke path this transport uses. This
+      is the phase's highest-risk unknown — do not close the phase without it.
+- [ ] Verify on `fish` too, since it takes the second transport arm.
 - [ ] Durable decisions recorded as ADRs (none expected — the transport and its
       refusal rule are phase detail the collapsed proposal carries; write one
       only if something outlives this change).

--- a/docs/proposals/0033-agent-profiles/tasks.md
+++ b/docs/proposals/0033-agent-profiles/tasks.md
@@ -1,0 +1,149 @@
+# Tasks — 0033. Agent Profiles, phase 3 (Prompt delivery)
+
+Implementation plan for **phase 3 only**. Ordered: recon settles the catalog,
+the pure core comes next, then the launch path, then the CLI, then docs. Keep
+the checkboxes current. Working artifact — removed when the proposal collapses.
+
+## Recon (mostly done — see the findings table in `design.md`)
+
+The `--help` pass was run against all seven installed agents on 2026-09-02 and
+is recorded in `design.md` → "Recon findings". Five take a positional prompt
+(`claude`, `codex`, `grok`, `cursor-agent`, `pi`), `opencode` needs a
+`--prompt` flag because its positional is a project path, and `copilot`'s
+`-p/--prompt` is documented as non-interactive. What remains:
+
+- [ ] Confirm empirically that `pi` stays in its TUI after positional
+      `[messages...]` rather than answering and exiting. Ambiguous → leave
+      `promptDelivery` undefined.
+- [ ] Confirm empirically whether `copilot` has any interactive form that takes
+      an opening prompt. Documented answer is no; ambiguous → undefined.
+- [ ] Spot-check one `argv` agent end to end (a real launch with a prompt that
+      contains a quote and a newline) before trusting the other four.
+- [ ] Write each answer — positive **and** negative — into that agent's
+      `contract`, and refresh `lastVerified` / `verifiedAgainstVersion`.
+- [ ] Add the prompt-delivery recon question to `docs/adding-a-coding-agent.md`
+      Step 1, in the shape the `configDirEnvVar` block uses, with the
+      distinguishing test stated: accepting prompt text in a **non-interactive**
+      mode is a "no" for this field.
+
+## Catalog
+
+- [ ] Add `AgentPromptDelivery` (`{ kind: "argv" } | { kind: "flag"; flag:
+string }`) and `AgentDefinition.promptDelivery?`, with TSDoc stating what the
+      field means, the distinguishing recon question, and that `undefined` is a
+      deliberate "no".
+- [ ] Populate `promptDelivery` in `catalog/*.ts` per the recon; leave it
+      undefined where recon says no.
+- [ ] Add a catalog accessor beside `configDirEnvVarForAgent` for looking the
+      field up by agent id.
+
+## The pure core — `agents/agent-prompt.ts`
+
+- [ ] `sanitizePromptForLineEditor` — normalize CRLF/CR → LF, strip CSI and OSC
+      sequences whole, remove remaining C0/C1 controls (keep LF), expand tabs.
+      Total and idempotent.
+- [ ] `ShellDialect` + `shellDialect(shell)` — basename-mapped; `posix` for
+      bash/zsh/sh/dash/ksh, `fish` for fish, `unsupported` otherwise (including
+      `undefined`).
+- [ ] `heredocDelimiter(payload)` — `SILO_PROMPT`, suffixed until no line of the
+      payload equals it.
+- [ ] `MAX_PROMPT_BYTES` — one documented constant.
+- [ ] `PromptRefusal` union and `composePromptLaunchLine` — returns the line to
+      type or a refusal. The only place shell syntax is written.
+- [ ] fish escaping (`\` → `\\`, `'` → `\'`) inside the same module.
+
+## The launch path
+
+- [ ] Resolve the login shell once: a `default_shell` host command reading
+      `$SHELL` (falling back to `/bin/bash`), cached host-side.
+- [ ] `PendingLaunch`'s `{ profileId }` arm gains `prompt?`;
+      `requestProfileLaunch` accepts it. Leave the `{ rawLine }` arm alone.
+- [ ] `drainPendingLaunch` composes `profileLaunchLine(profile)` with the prompt
+      when one is claimed, re-resolving delivery and dialect at drain time; a
+      refusal types nothing and logs.
+- [ ] Convert `\n` → `\r` at the single send seam, and keep the trailing `\r`.
+- [ ] `LaunchAgentProfileInput.prompt?` threads through `launchAgentProfile`.
+- [ ] Verify a launch with **no** prompt still produces a byte-identical line.
+
+## The CLI
+
+- [ ] `cli.rs`: `CliRequest.prompt`, parsed from `--prompt <text>` /
+      `--prompt=<text>`. Use a value reader that does **not** reject a value
+      beginning with `-`; a bare trailing `--prompt` still yields `None`.
+- [ ] Add `--prompt` to the `HELP` text under the `agent run` options.
+- [ ] `CliAgentRunRequest.prompt` and the `cli:open` / `PendingLaunchArg`
+      pass-through.
+- [ ] `applyCliAgentRun`: when a prompt is present, precheck with
+      `composePromptLaunchLine` **before** creating the terminal; a refusal logs
+      the specific reason on `silo:application` and returns without creating,
+      activating, or focusing anything.
+
+## Adjacent fix — the orphaned session
+
+Pre-existing and independent of prompt delivery; folded into this phase because
+it is four lines beside code the phase already touches. Keep it as its own
+commit so it can be reverted without touching the prompt path.
+
+- [ ] `TerminalPanel.tsx` — at the `cancelled` bail (~line 617), reap a session
+      this run spawned: `if (needsCreate) void session.kill();` before the
+      `return`. **Guard on `needsCreate`** — on the attach path the session
+      predates this run and the record still points at it, so killing it would
+      destroy a live terminal.
+- [ ] Include the disposition (reaped / attached) in the existing
+      `ui_init_cancelled` attach trace, so `terminal.log` distinguishes the two.
+- [ ] Correct the stale "launch line is occasionally typed twice" paragraph in
+      the collapsed proposal's **launch model** section: the symptom it
+      describes belonged to the pre-phase-1 `kind` shim
+      (`setTimeout(() => session.write(cmd))`, no dedupe), which phase 1
+      deleted. What actually survives is a double-**spawn**, now fixed. Do this
+      at collapse time, with the rest of the curation.
+
+## Tests
+
+- [ ] `agent-prompt.test.ts` — sanitizer (each control class, LF survival, tab
+      expansion, idempotence, totality), dialect (each supported name, an
+      absolute path, unknown, `undefined`), delimiter collision (whole-line and
+      mid-line), composition (metacharacters literal, multi-line preserved,
+      `configDir` prefix intact, `\n` not `\r`, fish escaping), and one test per
+      refusal including the size boundary at the limit and one byte over.
+- [ ] `pending-launch.test.ts` — prompt carried on the claim; remove-on-read
+      still yields `null` to the second caller; the drain sends the composed
+      line; a promptless claim is byte-identical to today.
+- [ ] `agent-launch.test.ts` — `prompt` threads through; the background branch
+      is unchanged.
+- [ ] `cli.rs` tests — `--prompt <text>`, `--prompt=<text>`, a value beginning
+      with `-`, a bare trailing `--prompt`, and mixed order with `--profile` /
+      `--ws`.
+- [ ] `agent-run-handler` test — a refused prompt creates no terminal, activates
+      no workspace, and logs; no-prompt behavior unchanged.
+- [ ] The orphaned-session fix (R9) — cancelled after a **spawn** kills the
+      session; cancelled after an **attach** does not. Extract the disposition
+      decision as a pure helper if `TerminalPanel` is awkward to drive directly
+      (per `silo-testing`: extract testable logic rather than reaching for
+      `@testing-library/react`).
+
+## Docs
+
+- [ ] `apps/docs/guide/cli.md` — document `--prompt`, with a multi-line example
+      (`--prompt "$(cat notes.md)"`), the stated size limit, and what happens
+      when the agent or the shell cannot take one.
+- [ ] `docs/domain-language.md` — add or sharpen a term only if the work
+      actually introduces one; don't invent a synonym for something already
+      there.
+- [ ] Confirm no `@silo-code/sdk` symbol changed. If one did, run the
+      `silo-docs-sync` workflow in this same change.
+
+## Verification
+
+- [ ] Every requirement in `requirements.md` is met or explicitly noted as not.
+- [ ] `pnpm test`, `pnpm --filter silo exec tsc --noEmit`, and `pnpm lint` pass;
+      Rust tests pass for the `cli.rs` arm.
+- [ ] Exercised by hand at a real shell: `silo agent run --profile <id>
+--prompt "…"` on a POSIX shell, a multi-line prompt, a prompt full of shell
+      metacharacters, and each refusal path.
+- [ ] Durable decisions recorded as ADRs (none expected — the transport and its
+      refusal rule are phase detail the collapsed proposal carries; write one
+      only if something outlives this change).
+- [ ] Proposal collapsed to a single curated `0033-agent-profiles.md` with the
+      phase table updated: phase 3 shipped, `status` stays `accepted` because
+      phases 4–9 remain. Index row repointed to `./0033-agent-profiles.md`.

--- a/docs/proposals/0034-control-api/design.md
+++ b/docs/proposals/0034-control-api/design.md
@@ -218,6 +218,19 @@ instead of logging to the Output channel, that an unresolvable workspace is an
 error rather than a create, and that a profile whose command cannot be launched
 is `failed` rather than `internal` (R11).
 
+**`args.prompt` — the opening prompt (RFC 0033 phase 3).** That phase adds
+`silo agent run --prompt <text>`, which ships in Forward mode because this
+channel does not exist yet; its payload is declared here so the conversion adds
+a return value rather than changing a contract (ADR 0047 rule 6). `prompt` is
+optional and opaque to this proposal — RFC 0033 owns sanitizing it, choosing a
+transport, and deciding whether the target agent and shell can take one at all.
+What this proposal owns is that its refusals arrive as **codes from the closed
+vocabulary above**, not as Output-panel text: a profile whose agent cannot take
+a prompt is the caller's configuration to fix, an unquotable shell is
+environmental, and an oversized prompt is a bad argument. Both packages were
+unimplemented when this was written, so neither has to be reworked for the
+other; whichever lands first, `prompt` is already in the contract.
+
 ## Data flow
 
 ### `silo ws list --json` — Disk-read base, live overlay
@@ -234,7 +247,7 @@ is `failed` rather than `internal` (R11).
 
 ### `silo agent run` — the mutate path
 
-1. `control_request` yields `{ op: "agent.run", args: { profile, ws }, cwd }`.
+1. `control_request` yields `{ op: "agent.run", args: { profile, ws, prompt }, cwd }`.
 2. Client connects. Refused → `not-running` (exit 3), or, with `--launch`,
    launch and poll `status` for readiness to the deadline (R7).
 3. Client writes `{ id, op, args, cwd }\n` and blocks on the read deadline.
@@ -313,7 +326,7 @@ the breaking change this proposal exists to avoid.
 ```
 silo status  [--json] [--launch]
 silo ws list [--json]
-silo agent run [--profile <id>] [--ws <folder|.|ws_id>] [--json] [--launch]
+silo agent run [--profile <id>] [--ws <folder|.|ws_id>] [--prompt <text>] [--json] [--launch]
 ```
 
 `ws list` takes no `--launch`: it is Disk-read and already answers with no app

--- a/docs/proposals/0034-control-api/design.md
+++ b/docs/proposals/0034-control-api/design.md
@@ -218,18 +218,25 @@ instead of logging to the Output channel, that an unresolvable workspace is an
 error rather than a create, and that a profile whose command cannot be launched
 is `failed` rather than `internal` (R11).
 
-**`args.prompt` — the opening prompt (RFC 0033 phase 3).** That phase adds
-`silo agent run --prompt <text>`, which ships in Forward mode because this
-channel does not exist yet; its payload is declared here so the conversion adds
-a return value rather than changing a contract (ADR 0047 rule 6). `prompt` is
-optional and opaque to this proposal — RFC 0033 owns sanitizing it, choosing a
-transport, and deciding whether the target agent and shell can take one at all.
-What this proposal owns is that its refusals arrive as **codes from the closed
-vocabulary above**, not as Output-panel text: a profile whose agent cannot take
-a prompt is the caller's configuration to fix, an unquotable shell is
-environmental, and an oversized prompt is a bad argument. Both packages were
-unimplemented when this was written, so neither has to be reworked for the
-other; whichever lands first, `prompt` is already in the contract.
+**`args.prompt` — the opening prompt (RFC 0033 phase 3).** That phase builds
+prompt delivery and publishes it as `ctx.agents.profiles.launch({ prompt })`.
+It deliberately ships **no CLI code**: `silo agent run --prompt <text>` is the
+same capability at the command line, and ADR 0047's 2026-09-02 amendment says a
+new flag on a verb already scheduled for conversion is Control, never Forward.
+So the flag is specified there and **built here**, as part of this conversion.
+
+`prompt` is optional and opaque to this proposal — RFC 0033 owns sanitizing it,
+choosing a transport, and deciding whether the target agent and shell can take
+one at all. What this proposal owns is the flag itself and the fact that its
+refusals arrive as **codes from the closed vocabulary above** rather than
+Output-panel text: a profile whose agent cannot take a prompt is the caller's
+configuration to fix, an unquotable shell is environmental, and an oversized
+prompt is a bad argument.
+
+Implementation note: RFC 0033 phase 3 leaves a host-side precheck that returns
+a typed refusal before creating anything. `agent.run`'s handler calls it and
+maps the refusal onto a code — the CLI work here is the flag, the arg, and that
+mapping, not the delivery mechanism.
 
 ## Data flow
 

--- a/docs/proposals/0034-control-api/requirements.md
+++ b/docs/proposals/0034-control-api/requirements.md
@@ -233,13 +233,15 @@ The proving mutate-tier consumer, converted from Forward mode.
 - [ ] A profile whose command cannot be launched fails `failed` with a message
       naming the command, not `internal`.
 - [ ] A failed run leaves no half-created terminal.
-- [ ] `args` carries an optional `prompt` (RFC 0033 phase 3's
-      `--prompt <text>`). This proposal treats it as opaque — RFC 0033 owns
-      sanitizing, transport, and deliverability — but its refusals return codes
-      from the closed vocabulary rather than Output-panel text. Declared here
-      because ADR 0047 rule 6 requires a mutating verb's payload to exist before
-      it ships, and because both packages were unimplemented when this was
-      written, so neither needs rework for the other.
+- [ ] `args` carries an optional `prompt`, and `silo agent run` gains
+      `--prompt <text>`. RFC 0033 phase 3 builds prompt delivery and publishes
+      it on `ctx.agents.profiles`, ships **no CLI code**, and specifies this
+      flag; ADR 0047's 2026-09-02 amendment puts a new flag on a
+      conversion-bound verb in Control, so the flag is built here.
+- [ ] This proposal treats the prompt as opaque — RFC 0033 owns sanitizing,
+      transport, and deliverability — and calls its host-side precheck, mapping
+      any refusal onto a code from the closed vocabulary rather than
+      Output-panel text.
 - [ ] **Breaking change:** with no instance running the command exits
       `not-running` instead of launching Silo and running the agent on startup.
       `--launch` restores the launch-and-run behavior explicitly. The

--- a/docs/proposals/0034-control-api/requirements.md
+++ b/docs/proposals/0034-control-api/requirements.md
@@ -233,6 +233,13 @@ The proving mutate-tier consumer, converted from Forward mode.
 - [ ] A profile whose command cannot be launched fails `failed` with a message
       naming the command, not `internal`.
 - [ ] A failed run leaves no half-created terminal.
+- [ ] `args` carries an optional `prompt` (RFC 0033 phase 3's
+      `--prompt <text>`). This proposal treats it as opaque — RFC 0033 owns
+      sanitizing, transport, and deliverability — but its refusals return codes
+      from the closed vocabulary rather than Output-panel text. Declared here
+      because ADR 0047 rule 6 requires a mutating verb's payload to exist before
+      it ships, and because both packages were unimplemented when this was
+      written, so neither needs rework for the other.
 - [ ] **Breaking change:** with no instance running the command exits
       `not-running` instead of launching Silo and running the agent on startup.
       `--launch` restores the launch-and-run behavior explicitly. The

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -122,5 +122,5 @@ don't get a proposal at all — see below.
 | [0030](./0030-navigator-view-arrangement.md)                  | Navigator view arrangement — reorder, disable, and a stacked mode | 2026-08-27 | implemented |
 | [0031](./0031-tasks-extension/proposal.md)                    | Tasks extension — Silo tasks, third-party trackers as sources     | 2026-08-30 | accepted    |
 | [0032](./0032-ctx-extension-storage-directory.md)             | A per-extension storage directory on `ctx`                        | 2026-08-30 | implemented |
-| [0033](./0033-agent-profiles.md)                              | Agent Profiles — naming how you start an agent                    | 2026-08-31 | accepted    |
+| [0033](./0033-agent-profiles/proposal.md)                     | Agent Profiles — naming how you start an agent                    | 2026-08-31 | accepted    |
 | [0034](./0034-control-api/proposal.md)                        | Control API — a return channel for the `silo` command             | 2026-09-01 | accepted    |


### PR DESCRIPTION
## Summary

Planning only — no product code changes, nothing ships to users from this PR.

This lays out the next slice of Agent Profiles: **giving a coding agent its opening prompt when you start it.** Today Silo can launch an agent into a terminal but has no way to hand it a task, so you start it and then type what you wanted. This phase designs the safe way to do that, and adds one thing you can actually use — `silo agent run --prompt "fix the CI"` — so the work ships something a person can run rather than plumbing that sits unused until a later phase.

Two decisions were made while planning and written into the permanent proposal rather than left implicit:

1. **The command-line flag joined this phase.** As originally scoped, the phase built three pieces of machinery that nothing would call for months. The flag is a few lines and makes every part of the design testable by hand.
2. **A pre-existing terminal bug gets fixed here.** When a terminal panel restarts mid-startup, it can abandon a running shell that nothing ever closes — it stays alive until the app quits. It's next to the code this phase touches, so it's folded in as its own revertable commit. No visible behavior change; it stops leaking invisible processes.

Also fixes the proposal's phase table, which had been silently corrupted into an unreadable five-column mess — phases 3 through 9 were impossible to read, which is what prompted this work.

Reviewers: this is the plan, not the build. The useful question is whether the scope and the two decisions above are right, not whether the code is.

## Details

Stage 2 re-expansion per `docs/change-planning-convention.md` → Multi-phase changes. Phases 1–2 shipped and collapsed (#471, #483); this re-expands `0033-agent-profiles.md` into a planning package scoped to phase 3 only.

### Durable proposal changes

- **Phases table repaired.** Unescaped `|` inside `[--ws <folder|.|id>]` split the phase-2 row into extra columns; Prettier then reflowed the whole table to five columns with a stray `.` cell and ate the spacing around backticks. Pipes escaped, separator reset to three columns, reformatted.
- **Phase-3 row amended** to name `silo agent run --prompt <text>` as the transport's first caller.
- **"The command line" section** gains the `--prompt` form and the rationale. ADR 0047 needs no amendment: `--prompt` is a flag on an existing verb, introduces no noun or verb, and stays Forward mode (it asks for an action, not an answer).

### Package contents

- `proposal.md` — the collapsed record (git-moved) plus a `## Planning scope` section naming phase 3, phases 1–2 as the baseline, and the scope addition as deliberate.
- `requirements.md` — R1 catalog `promptDelivery`, R2 line-editor sanitization, R3 quoted-heredoc transport, R4 shell-dialect refusal, R5 pending-launch carrying a prompt, R6 the CLI flag, R7 visible refusal, R8 docs, R9 the orphaned-session fix. Governing rule: *a prompt that cannot be delivered safely fails the launch loudly — Silo never starts a promptless agent for a caller who asked for one.*
- `design.md` — one pure module (`agents/agent-prompt.ts`) holding all shell-syntax reasoning, called from two points (precheck before the terminal record is created; again at drain). Exact composed lines for POSIX and fish. The `\n`-in-model / `\r`-on-the-wire seam. Dialect resolution with its accepted limitation.
- `tasks.md` — 41 ordered checkboxes.

### Agent recon (done, and it shaped the design)

All seven catalog agents were probed locally (2026-09-02, macOS). The distinguishing question is not "does it accept prompt text" but "does it accept prompt text **and stay interactive**" — every one of them has a non-interactive mode that also takes a prompt, and that mode is a "no" for this field.

Five take a positional prompt (`claude`, `codex`, `grok`, `cursor-agent`, `pi`). `opencode` does **not** — its positional is a project path, so appending a prompt there would set the working directory to the prompt text; it needs `--prompt <string>`. `copilot`'s `-p/--prompt` is documented as non-interactive only.

Consequence: `AgentPromptDelivery` is a two-member union (`{ kind: "argv" }` / `{ kind: "flag"; flag: string }`) from the start, justified by recon rather than speculation. `pi` and `copilot` remain `--help`-only and are tasks; both default to `undefined` (refuse) if the empirical run is ambiguous, so an unconfirmed agent declines a prompt rather than mangling one.

### The "typed twice" note is stale

The collapsed proposal records the launch line as occasionally typed twice. Traced against the code — it cannot happen: `TerminalPanel.tsx:900` guards the drain behind `if (needsCreate)`, `takePendingLaunch` is remove-on-read, and the `cancelled` bail at `TerminalPanel.tsx:617` returns *above* both the `tRec.sessionId` assignment and the drain. That note describes phase 1's predecessor — the old `kind`-based shim was a bare `setTimeout(() => session.write(cmd), 150)` with no dedupe — which phase 1 deleted.

What actually survives is a double **spawn**: the bail returns without `session.kill()`, leaking a live PTY that nothing references. `ensureSession` handles the identical race correctly (`terminal-service.ts:260`). R9 fixes it, guarded on `needsCreate` — on the attach path the session predates the run and the record still points at it, so killing it would destroy a live terminal. A task at collapse time corrects the stale paragraph.

### Verification

- `apps/docs/checks/doc-indexes.sync.test.ts` passes (168 tests); index row repointed to `./0033-agent-profiles/proposal.md`.
- `~/.claude/sdd/sdd-state.sh 0033` reports `shape: planning-package`, `status: accepted`, scope marker present, phase table intact, 0/41 tasks checked.
- Pre-commit hook ran boundary lint, Prettier, and the full unit suite — green.
- `status` stays `accepted`: phases 4–9 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVJyBsCnTSD9m5NaD2FczZ
