### PR TITLE
fix(terminal): reap the PTY a cancelled init spawned

### DIFF
--- a/packages/extensions-core/src/terminal/TerminalPanel.tsx
+++ b/packages/extensions-core/src/terminal/TerminalPanel.tsx
@@ -66,6 +66,7 @@ import {
 } from "./terminal-link-policy";
 import {
   findTerminalOwnerId,
+  planCancelledInit,
   planExitStreamEnd,
   planSessionGoneAfterAttach,
 } from "./terminal-lifecycle";
@@ -616,11 +617,20 @@ export function TerminalPanel(
         }
         if (cancelled) {
           endRestore(true);
+          // This run is being abandoned while holding a live session. A session
+          // it *spawned* is referenced by nothing (the `tRec.sessionId`
+          // assignment is below this bail), so it would leak as a shell with no
+          // tab — reap it, exactly as `ensureSession` reaps its own orphan. A
+          // session it merely *attached* to belongs to the record and the user;
+          // killing that one would destroy a live terminal.
+          const plan = planCancelledInit({ needsCreate });
+          if (plan === "reap") void session.kill();
           logTerminalAttachTrace("ui_init_cancelled", {
             terminalId,
             workspaceId: activeWsId,
             sessionId: session.id,
             needsCreate,
+            disposition: plan,
           });
           return;
         }

--- a/packages/extensions-core/src/terminal/terminal-lifecycle.test.ts
+++ b/packages/extensions-core/src/terminal/terminal-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   findTerminalOwnerId,
   MAX_EXIT_RECONNECTS,
+  planCancelledInit,
   planExitStreamEnd,
   planSessionGoneAfterAttach,
 } from "./terminal-lifecycle";
@@ -79,5 +80,19 @@ describe("planSessionGoneAfterAttach", () => {
     expect(planSessionGoneAfterAttach({ pendingExitCode: null })).toBe(
       "recreate",
     );
+  });
+});
+
+describe("planCancelledInit", () => {
+  it("reaps a session this run spawned — nothing references it", () => {
+    // The cancelled bail returns above the `tRec.sessionId` assignment, so a
+    // spawned session left alive is a shell with no tab until the app quits.
+    expect(planCancelledInit({ needsCreate: true })).toBe("reap");
+  });
+
+  it("leaves an attached session alone — the record still points at it", () => {
+    // Killing here would destroy a live terminal the user is using; this is
+    // the guard, not a nicety.
+    expect(planCancelledInit({ needsCreate: false })).toBe("leave");
   });
 });

--- a/packages/extensions-core/src/terminal/terminal-lifecycle.ts
+++ b/packages/extensions-core/src/terminal/terminal-lifecycle.ts
@@ -58,3 +58,27 @@ export function planSessionGoneAfterAttach(opts: {
 }): SessionGonePlan {
   return opts.pendingExitCode !== null ? "exited" : "recreate";
 }
+
+/**
+ * What to do with the session in hand when {@link TerminalPanel}'s init effect
+ * is cancelled after the session has already come up.
+ *
+ * The effect can re-run — a StrictMode double-invoke in dev, or a fast remount
+ * — and the in-flight run then reaches its `cancelled` check holding a live
+ * session. That check sits **above** the `tRec.sessionId` assignment, so a
+ * session this run *spawned* is referenced by nothing once it returns: a live
+ * shell with no tab, surviving until the app quits. `ensureSession` already
+ * reaps its equivalent orphan; this is the same rule for the panel's path.
+ *
+ * The `needsCreate` guard is load-bearing, not defensive. `kill()` deletes the
+ * persistent session, and on the **attach** path that session predates this run
+ * and the terminal record still points at it — reaping there would destroy a
+ * live terminal the user is using.
+ */
+export type CancelledInitPlan = "reap" | "leave";
+
+export function planCancelledInit(opts: {
+  needsCreate: boolean;
+}): CancelledInitPlan {
+  return opts.needsCreate ? "reap" : "leave";
+}


### PR DESCRIPTION
## Summary

Fixes a leak where Silo could leave stray shell processes running in the background, invisibly, until you quit the app.

When a terminal panel starts up, it can occasionally get restarted mid-startup — a fast remount, or React's development-mode double-run. The abandoned attempt had already started a real shell, and nothing shut it down or kept a reference to it. The result was a live shell with no tab attached to it, sitting there for the rest of the session. Open and close enough terminals and you accumulate them.

Nothing visibly changes for users. This is purely stopping the leak.

The care in the change is in *which* shell gets cleaned up: only one the abandoned attempt started itself. If it had instead reconnected to an existing terminal, that one belongs to the user and must be left alone — shutting it down would close a terminal someone was working in.

Independent of PR #491; this touches no planning docs and #491 touches no code.

## Details

`TerminalPanel`'s init effect can re-run (StrictMode double-invoke in dev, or a fast remount). The in-flight run reaches its `cancelled` check holding a live session and returned without disposing of it.

That check sits **above** the `tRec.sessionId` assignment, so a session the run had just spawned was referenced by nothing once it returned. `ensureSession` already reaps its equivalent orphan (`terminal-service.ts:260`); the panel's path did not.

### The guard is the fix, not a nicety

`session.kill()` is `deleteTerminal(id)` — it destroys the persistent session. On the **attach** path (`needsCreate === false`) the session predates this run and `tRec.sessionId` still points at it, so reaping there would destroy a live terminal. Only a session this run spawned is an orphan.

### Changes

- `planCancelledInit` in `terminal-lifecycle.ts`, beside the existing `plan*` helpers — the rule is a pure function with unit coverage rather than a condition buried in an effect. Follows `.agents/skills/silo-testing/SKILL.md` (extract testable logic; no `@testing-library/react`).
- `TerminalPanel.tsx` calls it at the bail and reaps when the plan says `reap`.
- The `ui_init_cancelled` attach trace carries the `disposition`, so a `terminal.log` post-mortem distinguishes a reap from an attach (AGENTS.md: terminal lifecycle is diagnosed from `terminal.log`, not the Output panel).

### What this is *not*

RFC 0033 records a known issue that "the launch line is occasionally typed twice." This is **not** that, and the note is stale. A double drain is already impossible:

- `TerminalPanel.tsx:900` guards the drain behind `if (needsCreate)`, which goes false once `tRec.sessionId` is assigned;
- `takePendingLaunch` is remove-on-read, so the second of the two drain paths gets `null`;
- this bail returns *above* both the assignment and the drain, so an abandoned run types nothing.

A leaked session is never drained into. The "typed twice" symptom belonged to the pre-RFC-0033 `kind` shim (`setTimeout(() => session.write(cmd), 150)`, no dedupe), which phase 1 deleted. Correcting that paragraph is queued as a collapse-time task in RFC 0033's planning package.

### Test plan

- `terminal-lifecycle.test.ts` — cancelled-after-spawn plans `reap`; cancelled-after-attach plans `leave`.
- `pnpm test` green (pre-commit hook ran the full suite across all 27 packages).
- `tsc --noEmit` clean for `apps/desktop`.
- Boundary lint green.

Runtime verification is awkward by nature — the leak is invisible and the trigger is a race. The `disposition` field in `terminal.log` is what makes it observable after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVJyBsCnTSD9m5NaD2FczZ
