### PR TITLE
feat(navigator): restore the active-workspace background fill

### DIFF
--- a/packages/extensions-core/src/workspaces/WorkspacesView.css
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.css
@@ -78,43 +78,20 @@
   bottom: -1px;
 }
 
-/* Active workspace: no background fill — a vertical two-tone accent "stem"
-   drops from under the icon, down the icon column, ending just past the row's
-   content. A full-strength key line sits against a translucent companion (no
-   gap), echoing the duotone icon's solid-stroke-plus-tint pairing.
-
-   It's a real element (not the row's ::before/::after) so it never collides
-   with the drag reorder lines, which own both row pseudo-elements — the
-   companion rides the stem's own ::after, which is free. */
-.ws-item .ws-active-stem {
-  display: none;
+/* Active workspace: a background fill carries the selection, and the icon
+   switches to the accent color (see `.ws-item.active .ws-icon` below). A very
+   subtle inset hairline frames the row so the selection still reads inside a
+   colored group, whose wash can sit close to the active fill. Inset box-shadow
+   (not `border`) so it adds no box and can't shift the grid. */
+.ws-item.active {
+  background: var(--silo-color-bg-active);
+  box-shadow: inset 0 0 0 1px var(--silo-color-border-strong);
 }
 
-.ws-item.active .ws-active-stem {
-  display: block;
-  position: absolute;
-  /* Centred under the 20px icon: row padding-left 10 + half of (20 - 2). */
-  left: 19px;
-  top: 31px;
-  bottom: 1px;
-  width: 2px;
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--silo-color-accent) 70%, transparent);
-  pointer-events: none;
-}
-
-/* Companion: same line, touching the key on its content-facing side. The key
-   sits at 70% and this at 15%, so the pair reads as one line with depth
-   rather than two marks. */
-.ws-item.active .ws-active-stem::after {
-  content: "";
-  position: absolute;
-  left: 2px;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--silo-color-accent) 15%, transparent);
+/* Keep the active fill visible on hover rather than dropping to the lighter
+   hover grey. */
+.ws-item.active:hover {
+  background: var(--silo-color-bg-active);
 }
 
 .ws-item .ws-icon {

--- a/packages/extensions-core/src/workspaces/WorkspacesView.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.tsx
@@ -332,7 +332,6 @@ export function WorkspacesView({
         }}
       >
         <WorkspaceIcon className="ws-icon" size={20} weight="duotone" />
-        <span className="ws-active-stem" aria-hidden="true" />
         <div className="ws-name-row">
           <span className="ws-name">{ws.name}</span>
           {service.getBadges(ws.id).map((b) => (


### PR DESCRIPTION
## Summary

The active workspace in the Navigator is once again marked with a shaded background behind the whole row, the way it was before the recent redesign. The thin accent line that briefly replaced it was too easy to miss. The active workspace's icon still picks up the accent color, and there's now a faint outline around the selected row so it still stands out when the workspace sits in a group with a colored background.

## Details

Reverts the active-workspace visual from the accent "stem" introduced in #488 back to the `--silo-color-bg-active` row fill, and:

- Keeps the fill on `:hover` instead of falling through to the lighter hover grey.
- Adds `box-shadow: inset 0 0 0 1px var(--silo-color-border-strong)` on `.ws-item.active` — an inset hairline (no box, can't shift the grid) so the selection reads against a colored group's wash, which can sit close to the active fill.
- Removes the `.ws-active-stem` element from `WorkspacesView.tsx` and its CSS (the `display:none` base rule, the active key line, and the `::after` companion).

The accent-colored active icon (`.ws-item.active .ws-icon`) is unchanged.

### Test plan

- `pnpm --filter silo exec tsc --noEmit` — clean
- `pnpm --filter @silo-code/extensions-core test` — 454 pass
- stylelint + eslint on the touched files — clean
- CSS-only visual change; verified by rebuilding the dev app

🤖 Generated with [Claude Code](https://claude.com/claude-code)