### PR TITLE
fix(agents): pulse the Agents navigator activity dots on first view

### DIFF
--- a/apps/docs/api/types/functions/ActivityGlyph.md
+++ b/apps/docs/api/types/functions/ActivityGlyph.md
@@ -4,7 +4,7 @@
 function ActivityGlyph(__namedParameters): Element;
 ```
 
-Defined in: [packages/sdk/src/ActivityGlyph.tsx:26](https://github.com/silo-code/silo/blob/main/packages/sdk/src/ActivityGlyph.tsx#L26)
+Defined in: [packages/sdk/src/ActivityGlyph.tsx:31](https://github.com/silo-code/silo/blob/main/packages/sdk/src/ActivityGlyph.tsx#L31)
 
 Host-painted activity glyph — same look on workspace rows, CenterDock tabs,
 and extension UI. Pick an [Activity](../type-aliases/Activity.md); the host owns color and motion
@@ -12,6 +12,10 @@ and extension UI. Pick an [Activity](../type-aliases/Activity.md); the host owns
 
 Styled purely via host-provided `.silo-activity*` classes — no stylesheet
 import is needed in the extension.
+
+Pass `jitterKey` whenever several animated glyphs render together (a list of
+agent or workspace rows) so their pulses don't run in lockstep — and so each
+one starts mid-cycle instead of freezing on first paint.
 
 ## Parameters
 
@@ -27,6 +31,6 @@ import is needed in the extension.
 
 ```tsx
 <ActivityGlyph activity="working" size="md" />
-<ActivityGlyph activity="ready" />
+<ActivityGlyph activity="ready" jitterKey={row.id} />
 <ActivityGlyph size="sm" /> // workspace neutral (omit)
 ```

--- a/apps/docs/design/components/activity.md
+++ b/apps/docs/design/components/activity.md
@@ -43,10 +43,11 @@ import { ActivityGlyph, type Activity } from "@silo-code/sdk";
 <ActivityGlyph size="sm" />  // omit activity → gray neutral
 ```
 
-| Prop       | Type                                         | Default | Notes                                                                                                                                                                                                                            |
-| ---------- | -------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `activity` | `"working" \| "ready" \| "warn" \| "error"`? | —       | Omit only for the gray neutral fallback                                                                                                                                                                                          |
-| `size`     | `"sm" \| "md"`                               | `"sm"`  | `sm` (8px at default) is the workbench size — workspace status rows and tabs; `md` (10px) is for a list that leads with the dot. Both track `uiFontSize` — a proportion of the base size rounded to an even pixel, not fixed px. |
+| Prop        | Type                                         | Default | Notes                                                                                                                                                                                                                                                                 |
+| ----------- | -------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activity`  | `"working" \| "ready" \| "warn" \| "error"`? | —       | Omit only for the gray neutral fallback                                                                                                                                                                                                                               |
+| `size`      | `"sm" \| "md"`                               | `"sm"`  | `sm` (8px at default) is the workbench size — workspace status rows and tabs; `md` (10px) is for a list that leads with the dot. Both track `uiFontSize` — a proportion of the base size rounded to an even pixel, not fixed px.                                      |
+| `jitterKey` | `string`?                                    | —       | A stable id (row / terminal id — not an array index). Give each glyph in a list one: it desynchronizes the `working` / `ready` pulse from its neighbours and makes the animation mount already running instead of freezing on first paint. Inert on the static kinds. |
 
 ## Kinds
 
@@ -77,7 +78,9 @@ import { ActivityGlyph, activityFromAgent } from "@silo-code/sdk";
 
 const activity = activityFromAgent(agent.activity); // null for none / dead
 {
-  activity && <ActivityGlyph activity={activity} size="sm" />;
+  activity && (
+    <ActivityGlyph activity={activity} size="sm" jitterKey={agent.terminalId} />
+  );
 }
 ```
 

--- a/packages/extensions-core/src/workspaces/WorkspacesView.tsx
+++ b/packages/extensions-core/src/workspaces/WorkspacesView.tsx
@@ -75,22 +75,6 @@ function useHomeDir(): string {
   return useSyncExternalStore(subscribeHome, getHome);
 }
 
-// Deterministic per-row jitter so multiple animated activity glyphs
-// (working rings, ready throb) don't move in lockstep — hashed from the
-// stable row id (not Math.random()) so the offset doesn't jump around on
-// re-render. Expressed as a negative delay so the animation starts already in
-// progress rather than pausing on mount.
-function activityJitterStyle(id: string): React.CSSProperties {
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) {
-    hash = (hash * 31 + id.charCodeAt(i)) | 0;
-  }
-  const delaySeconds = -(((hash >>> 0) % 1000) / 1000) * 1.8;
-  return {
-    "--silo-activity-jitter": `${delaySeconds.toFixed(3)}s`,
-  } as React.CSSProperties;
-}
-
 function WorkspaceStatusRows({
   workspaceId,
   rows,
@@ -106,15 +90,11 @@ function WorkspaceStatusRows({
           <ActivityGlyph
             activity={row.activity}
             size="sm"
-            style={
-              row.activity === "working" || row.activity === "ready"
-                ? // Providers commonly reuse the same row id across every
-                  // workspace (e.g. a fixed "build-task" id) — fold in the
-                  // workspace id too, or every workspace's dot would still
-                  // land on the same delay and throb in lockstep.
-                  activityJitterStyle(`${workspaceId}:${row.id}`)
-                : undefined
-            }
+            // Providers commonly reuse the same row id across every workspace
+            // (e.g. a fixed "build-task" id) — fold in the workspace id too, or
+            // every workspace's dot would land on the same delay and throb in
+            // lockstep.
+            jitterKey={`${workspaceId}:${row.id}`}
           />
           <span className="ws-status-label">{row.label}</span>
           {row.startedAt && (

--- a/packages/extensions-silo/src/agents/agents-panel.tsx
+++ b/packages/extensions-silo/src/agents/agents-panel.tsx
@@ -299,6 +299,7 @@ function AgentRowItem({
         activity={glyphFor(row)}
         size="md"
         className="ap-row-glyph"
+        jitterKey={row.terminalId}
       />
       <div className="ap-row-text">
         <span className="ap-row-title-line">

--- a/packages/sdk/src/ActivityGlyph.tsx
+++ b/packages/sdk/src/ActivityGlyph.tsx
@@ -1,6 +1,7 @@
-import type { HTMLAttributes } from "react";
+import type { CSSProperties, HTMLAttributes } from "react";
 import {
   activityClass,
+  activityJitterStyle,
   type Activity as ActivityKind,
   type ActivitySize,
 } from "./activity";
@@ -13,10 +14,14 @@ import {
  * Styled purely via host-provided `.silo-activity*` classes — no stylesheet
  * import is needed in the extension.
  *
+ * Pass `jitterKey` whenever several animated glyphs render together (a list of
+ * agent or workspace rows) so their pulses don't run in lockstep — and so each
+ * one starts mid-cycle instead of freezing on first paint.
+ *
  * @example
  * ```tsx
  * <ActivityGlyph activity="working" size="md" />
- * <ActivityGlyph activity="ready" />
+ * <ActivityGlyph activity="ready" jitterKey={row.id} />
  * <ActivityGlyph size="sm" /> // workspace neutral (omit)
  * ```
  *
@@ -27,15 +32,31 @@ export function ActivityGlyph({
   activity,
   size = "sm",
   className,
+  jitterKey,
+  style,
   ...rest
 }: {
   activity?: ActivityKind;
   size?: ActivitySize;
+  /**
+   * Stable id (a row or terminal id — never an array index) that gives this
+   * glyph a deterministic per-instance animation offset. Desynchronizes its
+   * pulse from other glyphs rendered alongside it, and makes the animation
+   * mount already in progress rather than pausing on first paint (a WebKit
+   * quirk when the glyph appears inside a just-shown container). Inert on
+   * non-animated glyphs.
+   */
+  jitterKey?: string;
 } & Omit<HTMLAttributes<HTMLSpanElement>, "children">) {
   const classes = activityClass(activity, size);
+  const mergedStyle =
+    jitterKey != null
+      ? ({ ...activityJitterStyle(jitterKey), ...style } as CSSProperties)
+      : style;
   return (
     <span
       className={className ? `${classes} ${className}` : classes}
+      style={mergedStyle}
       aria-hidden={rest["aria-label"] == null ? true : undefined}
       {...rest}
     />

--- a/packages/sdk/src/activity.test.ts
+++ b/packages/sdk/src/activity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { activityClass, activityFromAgent } from "./activity";
+import {
+  activityClass,
+  activityFromAgent,
+  activityJitterStyle,
+} from "./activity";
 
 describe("activityClass", () => {
   it("maps kinds and sizes", () => {
@@ -31,5 +35,34 @@ describe("activityFromAgent", () => {
     expect(activityFromAgent("error")).toBe("error");
     expect(activityFromAgent("none")).toBeNull();
     expect(activityFromAgent("dead")).toBeNull();
+  });
+});
+
+describe("activityJitterStyle", () => {
+  const delay = (key: string) =>
+    Number.parseFloat(activityJitterStyle(key)["--silo-activity-jitter"]);
+
+  it("is deterministic for a given key", () => {
+    expect(activityJitterStyle("term-42")).toEqual(
+      activityJitterStyle("term-42"),
+    );
+  });
+
+  it("spreads different keys across the cycle", () => {
+    const keys = ["a", "b", "c", "d", "e", "term-1", "ws:build", "term-2"];
+    const delays = keys.map(delay);
+    // Not all landing on the same offset (the lockstep bug).
+    expect(new Set(delays).size).toBeGreaterThan(1);
+  });
+
+  it("emits a negative delay within one animation period", () => {
+    for (const key of ["", "x", "a-very-long-stable-row-identifier", "ws:1"]) {
+      const d = delay(key);
+      expect(d).toBeLessThanOrEqual(0);
+      expect(d).toBeGreaterThan(-1.8);
+      expect(activityJitterStyle(key)["--silo-activity-jitter"]).toMatch(
+        /^-?\d+\.\d{3}s$/,
+      );
+    }
   });
 });

--- a/packages/sdk/src/activity.ts
+++ b/packages/sdk/src/activity.ts
@@ -58,3 +58,35 @@ export function activityClass(
   const kind = activity ?? "none";
   return `silo-activity silo-activity-${kind} silo-activity-${size}`;
 }
+
+/**
+ * Deterministic per-instance `animation-delay` (via the `--silo-activity-jitter`
+ * custom property) for an animated {@link Activity} glyph, keyed off a stable id
+ * — a row or terminal id, not an array index. Two purposes:
+ *
+ * - **Desync.** Several `working` / `ready` glyphs rendered side by side would
+ *   otherwise pulse in perfect lockstep; a per-id offset staggers them.
+ * - **Start mid-cycle.** The value is a *negative* delay, so the animation
+ *   mounts already in progress rather than pausing on first paint — a WebKit
+ *   quirk that bites when the glyph is created inside a container that was
+ *   `display: none` moments earlier (e.g. a Navigator view on its first
+ *   activation), where a zero delay can leave the pulse frozen until the next
+ *   show/hide toggle.
+ *
+ * Hashed rather than random so the offset is stable across re-renders. Pinned
+ * by unit tests.
+ *
+ * @internal
+ */
+export function activityJitterStyle(
+  key: string,
+): Record<"--silo-activity-jitter", string> {
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) | 0;
+  }
+  // 1.8s is the longest activity animation period (`silo-activity-wave`), so the
+  // offset spans one full cycle.
+  const delaySeconds = -(((hash >>> 0) % 1000) / 1000) * 1.8;
+  return { "--silo-activity-jitter": `${delaySeconds.toFixed(3)}s` };
+}


### PR DESCRIPTION
## Summary

In the Navigator's Agents view, the little "working" and "ready" status dots
next to each agent had two glitches:

1. **Frozen on first open.** The first time you switched to the Agents view in a
   session, the dots that should have been pulsing sat completely still. Only
   after switching to another Navigator view and back did they start animating.
2. **Pulsing in unison.** Once they were animating, every dot throbbed in
   perfect sync, which reads as a single blinking block rather than a set of
   independent agents. The dots are meant to be deliberately out of phase.

Both are fixed. The dots now pulse as soon as the Agents view is shown, each on
its own rhythm. The same treatment is applied to the Workspaces view's status
dots, which shared the underlying mechanism.

## Details

### Root cause

Both symptoms trace to the Agents rows rendering `<ActivityGlyph>` with no
per-instance animation offset:

- With `animation-delay: 0s`, WebKit (the Tauri webview) can leave a CSS
  animation paused when the animated element first paints inside a container
  that was `display: none` until just before — which is exactly how Navigator
  views mount (lazily, on first activation). A show/hide toggle forces the
  restart. `WorkspacesView` had already worked around this with a negative
  delay ("starts already in progress rather than pausing on mount").
- Every row used that same `0s` delay, so all animations ran in phase.

### Change

- **`packages/sdk/src/ActivityGlyph.tsx`** — new optional `jitterKey` prop. Given
  a stable id (a row / terminal id) it applies a deterministic negative
  `--silo-activity-jitter` `animation-delay`: hashed, so it's stable across
  re-renders; negative, so the animation mounts mid-cycle instead of freezing;
  per-id, so neighbouring dots stagger. Inert on the non-animated kinds.
- **`packages/sdk/src/activity.ts`** — the hash helper (`activityJitterStyle`,
  `@internal`) moved here from `WorkspacesView`, with unit tests in
  `activity.test.ts` (determinism, spread across the cycle, negative and within
  one animation period).
- **`packages/extensions-silo/src/agents/agents-panel.tsx`** — pass
  `jitterKey={row.terminalId}`.
- **`packages/extensions-core/src/workspaces/WorkspacesView.tsx`** — use the new
  prop (`jitterKey={`${workspaceId}:${row.id}`}`) and delete the local copy of
  the helper.

### Docs

- TSDoc on the new prop and the helper.
- `pnpm docs:api` regenerated (`apps/docs/api/types/functions/ActivityGlyph.md`).
- `apps/docs/design/components/activity.md` — prop table row + updated examples.
- Roadmap unchanged: Activity chrome is already `stable`.

### Verification

- `pnpm --filter silo exec tsc --noEmit` — clean.
- `pnpm lint` — clean.
- `pnpm test` — green (SDK, extensions-core, extensions-silo, extension-host,
  silo; new `activityJitterStyle` tests pass).
- Not yet confirmed in a running build — needs a rebuild to see live.

### Note

`packages/extension-host/src/panels/DockTab.tsx` also renders `ActivityGlyph`
without `jitterKey`; left as-is since tabs rarely show several concurrent
"working" states, but it can take the same prop if the freeze shows up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)