### PR TITLE
feat(git-explorer): branches modal keyboard nav + folder switcher

### DIFF
--- a/apps/docs/design/index.md
+++ b/apps/docs/design/index.md
@@ -52,7 +52,7 @@ import {
 } from "@silo-code/sdk";
 
 ctx.ui.showModal((close) => <MyPicker onDone={close} />, {
-  title: "Switch branches",
+  title: "Branches",
   size: "md",
   dismissible: true,
 });

--- a/apps/docs/guide/building-modals.md
+++ b/apps/docs/guide/building-modals.md
@@ -34,7 +34,7 @@ if (name === null) return; // cancelled
 // 3. Custom content — you render the inside, the host renders the shell
 const result = await ctx.ui.showModal<string>(
   (close) => <MyPicker onPick={(id) => close(id)} />,
-  { title: "Switch branches", size: "md", dismissible: true },
+  { title: "Branches", size: "md", dismissible: true },
 );
 ```
 
@@ -112,7 +112,7 @@ Rules embodied above: primary action rightmost and disabled until valid;
 
 ## Recipe: a picker modal {#recipe-a-picker-modal}
 
-Filter-above-list — the pattern behind Switch Branches. There's no combined
+Filter-above-list — the pattern behind Branches. There's no combined
 component on purpose; the composition is the API:
 
 ```tsx
@@ -172,7 +172,7 @@ That renders as:
 
 <div class="silo-demo silo-demo-block">
   <div class="silo-demo-modal" style="max-width:460px;">
-    <div class="modal-title">Switch branches</div>
+    <div class="modal-title">Branches</div>
     <div class="silo-search-input" style="margin-bottom:10px;">
       <svg class="icon" width="13" height="13" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="5.2" stroke="currentColor" stroke-width="1.4"/><path d="M11 11l3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
       <input placeholder="Filter branches…" readonly>

--- a/packages/extensions-silo/src/git-explorer/BranchManager.tsx
+++ b/packages/extensions-silo/src/git-explorer/BranchManager.tsx
@@ -2,7 +2,10 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
+  useSyncExternalStore,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import {
@@ -38,11 +41,15 @@ import {
 import { ForceDeleteDialog } from "./ForceDeleteDialog";
 import { BranchNameDialog } from "./BranchNameDialog";
 import { ICON_PUSH } from "./git-icons";
+import type { FolderSelection } from "./folder-selection";
 
 export interface BranchManagerProps {
   ctx: ExtensionContext;
-  /** The repo working directory whose branches are managed. */
-  folder: string;
+  /**
+   * Which repo working directory's branches are managed — shared with the
+   * modal title's folder switcher, see folder-selection.ts.
+   */
+  selection: FolderSelection;
   /** Close the host modal. */
   close: () => void;
   /** Called after a switch/create so the panel re-reads status. */
@@ -60,16 +67,42 @@ export interface BranchManagerProps {
  */
 export function BranchManager({
   ctx,
-  folder,
+  selection,
   close,
   onSwitched,
   notifyError,
 }: BranchManagerProps) {
+  // Shared with the modal title's folder switcher — see folder-selection.ts.
+  const folder = useSyncExternalStore(
+    selection.subscribe,
+    selection.get,
+    selection.get,
+  );
   const [branches, setBranches] = useState<GitBranch[] | null>(null);
   const [query, setQuery] = useState("");
   const [busy, setBusy] = useState(false);
   const [fetching, setFetching] = useState(false);
   const [pushing, setPushing] = useState<string | null>(null);
+  const [switching, setSwitching] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Picking a different folder starts over: an old query could otherwise
+  // hide every branch in the newly-selected repo.
+  useEffect(() => {
+    setQuery("");
+  }, [folder]);
+
+  // ↓ from the search box hands off to the list's own roving-tabindex item
+  // (List/useFocusGroup then own ↑/↓ + Enter from there).
+  function handleSearchKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowDown") return;
+    const item = listRef.current?.querySelector<HTMLElement>(
+      '[data-focus-item][tabindex="0"]',
+    );
+    if (!item) return;
+    e.preventDefault();
+    item.focus();
+  }
 
   // ADR 0037. Branches aren't part of the store's live snapshot (they only
   // change via the mutators below, all of which live here) — reload() stays
@@ -185,7 +218,11 @@ export function BranchManager({
   async function switchTo(b: GitBranch) {
     if (b.current || busy) return;
     setBusy(true);
+    setSwitching(b.name);
     try {
+      // Paint the row as selected before switching: local checkouts resolve
+      // fast enough that closing right away reads as "nothing happened".
+      await new Promise((r) => setTimeout(r, 150));
       if (b.remote) await store.createBranch(localNameFor(b.name), b.name);
       else await store.switchBranch(b.name);
       onSwitched();
@@ -193,6 +230,7 @@ export function BranchManager({
     } catch (err) {
       notifyError(`Switch to "${b.name}" failed`, err);
       setBusy(false);
+      setSwitching(null);
     }
   }
 
@@ -283,6 +321,9 @@ export function BranchManager({
   }
 
   function rowTrailing(b: GitBranch) {
+    if (switching === b.name) {
+      return <ArrowsClockwise size={14} className="git-branch-spin" />;
+    }
     const parts: ReactNode[] = [];
     if (b.current) {
       parts.push(
@@ -300,6 +341,7 @@ export function BranchManager({
         >
           <IconButton
             size="sm"
+            tabIndex={-1}
             aria-label={published ? `Push ${b.name}` : `Publish ${b.name}`}
             disabled={pushing === b.name}
             onClick={() => void pushBranch(b)}
@@ -319,6 +361,7 @@ export function BranchManager({
           <Tooltip key="rename" content="Rename branch">
             <IconButton
               size="sm"
+              tabIndex={-1}
               aria-label={`Rename ${b.name}`}
               onClick={() => void rename(b)}
             >
@@ -328,6 +371,7 @@ export function BranchManager({
           <Tooltip key="delete" content="Delete branch">
             <IconButton
               size="sm"
+              tabIndex={-1}
               aria-label={`Delete ${b.name}`}
               onClick={() => void del(b)}
             >
@@ -342,14 +386,16 @@ export function BranchManager({
 
   return (
     <div className="git-branch-modal">
-      <SearchInput
-        value={query}
-        onValueChange={setQuery}
-        placeholder="Filter branches…"
-        autoFocus
-      />
+      <div onKeyDown={handleSearchKeyDown}>
+        <SearchInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Filter branches…"
+          autoFocus
+        />
+      </div>
 
-      <div className="git-branch-list-scroll silo-scroll">
+      <div ref={listRef} className="git-branch-list-scroll silo-scroll">
         {branches === null ? (
           <EmptyState
             icon={<ArrowsClockwise size={22} className="git-branch-spin" />}
@@ -362,7 +408,7 @@ export function BranchManager({
             {visible.map((b) => (
               <ListRow
                 key={(b.remote ? "r:" : "l:") + b.name}
-                selected={b.current}
+                selected={switching ? switching === b.name : b.current}
                 leading={
                   b.remote ? <Cloud size={15} /> : <GitBranchIcon size={15} />
                 }

--- a/packages/extensions-silo/src/git-explorer/BranchModalTitle.tsx
+++ b/packages/extensions-silo/src/git-explorer/BranchModalTitle.tsx
@@ -1,0 +1,64 @@
+import { useSyncExternalStore } from "react";
+import {
+  MenuButton,
+  useServiceState,
+  type ExtensionContext,
+} from "@silo-code/sdk";
+import { folderLabel, workspaceFolders } from "./branch-model";
+import type { FolderSelection } from "./folder-selection";
+
+export interface BranchModalTitleProps {
+  ctx: ExtensionContext;
+  /** Workspace whose folders populate the switcher (mirrors `folder`). */
+  workspaceId: string;
+  /** Shared with `BranchManager` — see folder-selection.ts. */
+  selection: FolderSelection;
+}
+
+/**
+ * The Branches modal's `title` (`ctx.ui.showModal`'s `title` accepts any
+ * `ReactNode` — not a plain string): "Branches" plus, in a multi-root
+ * workspace, a folder switcher. A single-folder workspace just names the
+ * folder — the dropdown affordance would have nothing else to offer.
+ */
+export function BranchModalTitle({
+  ctx,
+  workspaceId,
+  selection,
+}: BranchModalTitleProps) {
+  const folder = useSyncExternalStore(
+    selection.subscribe,
+    selection.get,
+    selection.get,
+  );
+  const wsState = useServiceState(ctx.workspaces);
+  const ws = wsState.all.find((w) => w.id === workspaceId);
+  const folders = ws ? workspaceFolders(ws) : [folder];
+
+  return (
+    <span className="git-branch-modal-title">
+      Branches
+      {folders.length > 1 ? (
+        <MenuButton
+          label={folderLabel(folder)}
+          onClick={(e) =>
+            void ctx.ui.showMenu({
+              anchor: e.currentTarget,
+              align: "end",
+              items: folders.map((f) => ({
+                label: folderLabel(f),
+                title: f,
+                checked: f === folder,
+                run: () => selection.set(f),
+              })),
+            })
+          }
+        />
+      ) : (
+        <span className="git-branch-modal-title-folder">
+          {folderLabel(folder)}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
+++ b/packages/extensions-silo/src/git-explorer/GitExplorerPanel.css
@@ -678,6 +678,22 @@
   font-family: var(--silo-font-ui);
 }
 
+/* Branches modal title (ctx.ui.showModal's `title` — see BranchModalTitle):
+ * "Branches" plus the folder switcher in a multi-root workspace. */
+.git-branch-modal-title {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+/* Single-folder case: name the folder, but it isn't a control (nothing else
+ * to switch to) — muted and un-bolded so it doesn't compete with the heading. */
+.git-branch-modal-title-folder {
+  font-weight: 400;
+  font-size: var(--silo-font-size-base);
+  color: var(--silo-color-text-lo);
+}
+
 /* Short how-to line above the worktree list (not a Callout — body copy). */
 .git-wt-lead {
   margin: 0;

--- a/packages/extensions-silo/src/git-explorer/GitView.tsx
+++ b/packages/extensions-silo/src/git-explorer/GitView.tsx
@@ -468,7 +468,7 @@ export function GitView({
   // Open the branch manager modal. The host owns the chrome; refresh() re-reads
   // status after a switch/create so the header reflects the new branch.
   function openBranchManager() {
-    showBranchManager(ctx, { folder, onSwitched: refresh });
+    showBranchManager(ctx, { folder, workspaceId, onSwitched: refresh });
   }
 
   // Open the worktree manager modal for this repo. Everything inside is

--- a/packages/extensions-silo/src/git-explorer/branch-model.test.ts
+++ b/packages/extensions-silo/src/git-explorer/branch-model.test.ts
@@ -3,10 +3,12 @@ import type { GitBranch } from "../git/git-api";
 import {
   branchActions,
   filterBranches,
+  folderLabel,
   isPublished,
   localNameFor,
   orderBranches,
   remoteBranchNames,
+  workspaceFolders,
 } from "./branch-model";
 
 const local = (name: string, current = false): GitBranch => ({
@@ -131,5 +133,28 @@ describe("branchActions", () => {
   it("limits the current branch to push/publish (no switch/rename/delete)", () => {
     expect(branchActions(local("main", true), true)).toEqual(["push"]);
     expect(branchActions(local("main", true), false)).toEqual(["publish"]);
+  });
+});
+
+describe("folderLabel", () => {
+  it("returns the trailing path segment", () => {
+    expect(folderLabel("/Users/dave/code/silo")).toBe("silo");
+    expect(folderLabel("/repo/")).toBe("repo");
+  });
+
+  it("returns the input unchanged when there is no segment", () => {
+    expect(folderLabel("/")).toBe("/");
+  });
+});
+
+describe("workspaceFolders", () => {
+  it("puts the primary folder first, then any extras", () => {
+    expect(
+      workspaceFolders({ folder: "/repo", extraFolders: ["/wt-a", "/wt-b"] }),
+    ).toEqual(["/repo", "/wt-a", "/wt-b"]);
+  });
+
+  it("returns just the primary folder when there are no extras", () => {
+    expect(workspaceFolders({ folder: "/repo" })).toEqual(["/repo"]);
   });
 });

--- a/packages/extensions-silo/src/git-explorer/branch-model.ts
+++ b/packages/extensions-silo/src/git-explorer/branch-model.ts
@@ -77,3 +77,19 @@ export function branchActions(
   if (!branch.current) actions.push("rename", "delete");
   return actions;
 }
+
+/** Basename of a folder path, for the multi-root folder switcher's label. */
+export function folderLabel(folder: string): string {
+  return folder.split("/").filter(Boolean).pop() ?? folder;
+}
+
+/**
+ * A workspace's folders in display order — the primary folder first, then any
+ * extras (multi-root) — for the Branches modal's folder switcher.
+ */
+export function workspaceFolders(ws: {
+  folder: string;
+  extraFolders?: readonly string[];
+}): string[] {
+  return [ws.folder, ...(ws.extraFolders ?? [])];
+}

--- a/packages/extensions-silo/src/git-explorer/folder-selection.test.ts
+++ b/packages/extensions-silo/src/git-explorer/folder-selection.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { createFolderSelection } from "./folder-selection";
+
+describe("createFolderSelection", () => {
+  it("starts at the given initial folder", () => {
+    expect(createFolderSelection("/repo").get()).toBe("/repo");
+  });
+
+  it("updates the current folder and notifies subscribers", () => {
+    const selection = createFolderSelection("/repo");
+    const onChange = vi.fn();
+    selection.subscribe(onChange);
+    selection.set("/repo-b");
+    expect(selection.get()).toBe("/repo-b");
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify when set to the already-current folder", () => {
+    const selection = createFolderSelection("/repo");
+    const onChange = vi.fn();
+    selection.subscribe(onChange);
+    selection.set("/repo");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("stops notifying an unsubscribed listener", () => {
+    const selection = createFolderSelection("/repo");
+    const onChange = vi.fn();
+    const unsubscribe = selection.subscribe(onChange);
+    unsubscribe();
+    selection.set("/repo-b");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("notifies every subscriber on a change", () => {
+    const selection = createFolderSelection("/repo");
+    const a = vi.fn();
+    const b = vi.fn();
+    selection.subscribe(a);
+    selection.subscribe(b);
+    selection.set("/repo-b");
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/extensions-silo/src/git-explorer/folder-selection.ts
+++ b/packages/extensions-silo/src/git-explorer/folder-selection.ts
@@ -1,0 +1,31 @@
+/**
+ * The Branches modal's "which folder" state. The modal's `title` (the folder
+ * switcher) and its content (`BranchManager`) are separate elements handed to
+ * `ctx.ui.showModal` — siblings under the host's `<Modal>`, not nested inside
+ * one another — so they can't share state via props or React context. Both
+ * read this external store instead (via `useSyncExternalStore`), the same
+ * shared-state-across-independent-instances idiom `pending-worktree-remove.ts`
+ * uses for the Worktrees modal.
+ */
+export interface FolderSelection {
+  get(): string;
+  set(folder: string): void;
+  subscribe(onChange: () => void): () => void;
+}
+
+export function createFolderSelection(initial: string): FolderSelection {
+  let current = initial;
+  const subscribers = new Set<() => void>();
+  return {
+    get: () => current,
+    set(folder) {
+      if (folder === current) return;
+      current = folder;
+      for (const notify of subscribers) notify();
+    },
+    subscribe(onChange) {
+      subscribers.add(onChange);
+      return () => subscribers.delete(onChange);
+    },
+  };
+}

--- a/packages/extensions-silo/src/git-explorer/open-branch-manager.test.ts
+++ b/packages/extensions-silo/src/git-explorer/open-branch-manager.test.ts
@@ -11,11 +11,15 @@ const state = {
 
 describe("resolveManageBranchesTarget", () => {
   it("defaults to the active workspace's primary folder", () => {
-    expect(resolveManageBranchesTarget(state)).toEqual({ folder: "/repo-a" });
+    expect(resolveManageBranchesTarget(state)).toEqual({
+      workspaceId: "a",
+      folder: "/repo-a",
+    });
   });
 
   it("honors an explicit workspaceId", () => {
     expect(resolveManageBranchesTarget(state, { workspaceId: "b" })).toEqual({
+      workspaceId: "b",
       folder: "/repo-b",
     });
   });
@@ -26,7 +30,7 @@ describe("resolveManageBranchesTarget", () => {
         workspaceId: "a",
         folder: "/repo-a-feat",
       }),
-    ).toEqual({ folder: "/repo-a-feat" });
+    ).toEqual({ workspaceId: "a", folder: "/repo-a-feat" });
   });
 
   it("returns null when the workspace is missing", () => {

--- a/packages/extensions-silo/src/git-explorer/open-branch-manager.tsx
+++ b/packages/extensions-silo/src/git-explorer/open-branch-manager.tsx
@@ -2,6 +2,8 @@ import type { ExtensionContext, NotifyOptions } from "@silo-code/sdk";
 import { GitErrorModal } from "./GitErrorModal";
 import { summarizeGitError } from "./notify-error";
 import { BranchManager } from "./BranchManager";
+import { BranchModalTitle } from "./BranchModalTitle";
+import { createFolderSelection } from "./folder-selection";
 
 /** Command id — opened from the Git panel menu, a keybinding, or the palette. */
 export const MANAGE_BRANCHES_COMMAND = "silo.git.manageBranches";
@@ -24,6 +26,7 @@ export function showBranchManager(
   ctx: ExtensionContext,
   opts: {
     folder: string;
+    workspaceId: string;
     /** Called after a switch/create so a live Git view can re-read status. */
     onSwitched?: () => void;
   },
@@ -46,17 +49,31 @@ export function showBranchManager(
     ctx.ui.notify("error", summary, options);
   };
 
+  // Shared with the title's folder switcher — see folder-selection.ts for why
+  // this can't just be component state.
+  const selection = createFolderSelection(opts.folder);
+
   ctx.ui.showModal(
     (close) => (
       <BranchManager
         ctx={ctx}
-        folder={opts.folder}
+        selection={selection}
         close={close}
         onSwitched={opts.onSwitched ?? (() => {})}
         notifyError={notifyError}
       />
     ),
-    { title: "Switch branches", size: "md", dismissible: true },
+    {
+      title: (
+        <BranchModalTitle
+          ctx={ctx}
+          workspaceId={opts.workspaceId}
+          selection={selection}
+        />
+      ),
+      size: "md",
+      dismissible: true,
+    },
   );
 }
 
@@ -70,10 +87,10 @@ export function resolveManageBranchesTarget(
     all: readonly { id: string; folder: string }[];
   },
   args?: ManageBranchesArgs,
-): { folder: string } | null {
+): { workspaceId: string; folder: string } | null {
   const ws = args?.workspaceId
     ? state.all.find((w) => w.id === args.workspaceId)
     : state.all.find((w) => w.id === state.activeId);
   if (!ws) return null;
-  return { folder: args?.folder ?? ws.folder };
+  return { workspaceId: ws.id, folder: args?.folder ?? ws.folder };
 }


### PR DESCRIPTION
## Summary

The "Switch branches" modal (now titled "Branches") is quicker to drive from the keyboard: typing filters immediately, ↓ jumps into the branch list, and Enter now visibly selects a branch before switching to it and closing the modal, instead of the modal just vanishing. The row icon buttons (push/rename/delete) no longer steal Tab focus, so Tab moves past the whole list in one step.

When a workspace has more than one folder open — a second project root, or a git worktree opened alongside — the modal also shows which one you're viewing, next to its title, with a dropdown to switch between them without closing and reopening the dialog.

## Details

### Keyboard navigation (`BranchManager.tsx`)
- `SearchInput` keeps `autoFocus`; ↓ now hands focus to the list's roving-tabindex item, letting `List`'s existing focus group own ↑/↓ and Enter from there.
- Enter/click now shows a brief (150ms) "selected" state — background highlight + spinner — before the actual `switchBranch`/`createBranch` call and modal close, so an instant local checkout doesn't read as "nothing happened."
- The row-level push/rename/delete `IconButton`s get `tabIndex={-1}` — mouse-only now, so the list itself is the single tab stop.

### Title rename
- Modal title changed from "Switch branches" to "Branches" (`open-branch-manager.tsx`), with matching updates to the two doc examples that referenced it (`apps/docs/guide/building-modals.md`, `apps/docs/design/index.md`).

### Folder switcher
- `showBranchManager` / `resolveManageBranchesTarget` now thread `workspaceId` through (mirrors the existing Worktrees modal), so the modal can see the workspace's full folder list (`ws.folder` + `ws.extraFolders`).
- New `BranchModalTitle.tsx` renders "Branches" plus the current folder — plain text in a single-folder workspace, or a `MenuButton` dropdown (checkmark on the current folder) when there's more than one. Font size and baseline alignment match the "Branches" heading.
- New `folder-selection.ts`: a tiny external store shared between the modal's `title` and its content, since `ctx.ui.showModal` hands those in as sibling elements rather than nesting one inside the other — the same shared-store idiom `pending-worktree-remove.ts` already uses for the Worktrees modal. `BranchManager` reads the folder reactively via `useSyncExternalStore` and resets its search query on folder switch.
- New pure helpers `folderLabel` / `workspaceFolders` in `branch-model.ts`.

### Tests
- `branch-model.test.ts`: `folderLabel`, `workspaceFolders`.
- `folder-selection.test.ts`: get/set/subscribe/unsubscribe/no-op-on-same-value.
- `open-branch-manager.test.ts`: updated for `resolveManageBranchesTarget`'s new `{ workspaceId, folder }` return shape.

### Verification
- `pnpm --filter silo exec tsc --noEmit` — clean
- `pnpm test` (`@silo-code/extensions-silo`) — 564 passed
- `pnpm lint` (ESLint boundaries + Stylelint design-token rule) — clean
- Not run against the live app in this session — the author (@davideweaver) exercised the keyboard nav and switch-feedback behavior manually in an earlier pass; the folder switcher and other changes since then have not been run in the app yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kpz9ytTbLXpmzbjs4i813m