### PR TITLE
feat(agents): split older agents out of the Workspace view

### DIFF
--- a/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
+++ b/packages/extensions-silo/src/agents/agents-panel-sections.test.ts
@@ -319,6 +319,138 @@ describe("buildAgeSections (staleDoneEnabled: true)", () => {
   });
 });
 
+describe("buildWorkspaceSections (staleDoneEnabled: true)", () => {
+  it("always returns the 'N+ hours old' heading, even with no agents at all", () => {
+    const sections = buildWorkspaceSections([], true, 8);
+    expect(sections.map((s) => s.header)).toEqual(["8+ hours old"]);
+    expect(sections[0]?.rows).toEqual([]);
+    expect(sections[0]?.collapsible).toBe(true);
+  });
+
+  it("keeps recent rows under their workspace and peels stale done rows into the shared heading", () => {
+    const sections = buildWorkspaceSections(
+      [
+        row({
+          terminalId: "fresh",
+          workspaceId: "w1",
+          workspaceName: "Alpha",
+          section: "working",
+          activity: "working",
+        }),
+        row({
+          terminalId: "recent-done",
+          workspaceId: "w1",
+          workspaceName: "Alpha",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(1),
+        }),
+        row({
+          terminalId: "stale-done",
+          workspaceId: "w1",
+          workspaceName: "Alpha",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(9),
+        }),
+        row({
+          terminalId: "long-working",
+          workspaceId: "w1",
+          workspaceName: "Alpha",
+          section: "working",
+          activity: "working",
+          since: hoursAgo(9),
+        }),
+      ],
+      true,
+      8,
+    );
+    expect(
+      sections.find((s) => s.header === "Alpha")?.rows.map((r) => r.terminalId),
+    ).toEqual(["long-working", "fresh", "recent-done"]);
+    expect(
+      sections
+        .find((s) => s.header === "8+ hours old")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["stale-done"]);
+  });
+
+  it("drops a workspace whose remaining rows are all stale", () => {
+    const sections = buildWorkspaceSections(
+      [
+        row({
+          terminalId: "stale-a",
+          workspaceId: "w-old",
+          workspaceName: "Old Only",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(9),
+        }),
+        row({
+          terminalId: "live",
+          workspaceId: "w-live",
+          workspaceName: "Still Live",
+          section: "working",
+          activity: "working",
+        }),
+      ],
+      true,
+      8,
+    );
+    expect(sections.map((s) => s.header)).toEqual([
+      "Still Live",
+      "8+ hours old",
+    ]);
+    expect(
+      sections
+        .find((s) => s.header === "8+ hours old")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["stale-a"]);
+  });
+
+  it("uses the configured threshold, not a hardcoded 8 hours", () => {
+    const sections = buildWorkspaceSections(
+      [
+        row({
+          terminalId: "t1",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(5),
+        }),
+      ],
+      true,
+      4,
+    );
+    expect(sections.map((s) => s.header)).toEqual(["4+ hours old"]);
+    expect(
+      sections
+        .find((s) => s.header === "4+ hours old")
+        ?.rows.map((r) => r.terminalId),
+    ).toEqual(["t1"]);
+  });
+});
+
+describe("buildWorkspaceSections (staleDoneEnabled: false)", () => {
+  it("omits the 'N+ hours old' heading and keeps old done rows under their workspace", () => {
+    const sections = buildWorkspaceSections(
+      [
+        row({
+          terminalId: "stale",
+          workspaceId: "w1",
+          workspaceName: "Alpha",
+          section: "done",
+          activity: "idle",
+          since: hoursAgo(9),
+        }),
+      ],
+      false,
+      8,
+    );
+    expect(sections.map((s) => s.header)).toEqual(["Alpha"]);
+    expect(sections[0]?.rows.map((r) => r.terminalId)).toEqual(["stale"]);
+  });
+});
+
 describe("buildAgeSections (staleDoneEnabled: false)", () => {
   it("omits the 'N+ hours old' heading entirely", () => {
     const sections = buildAgeSections([], false, 8, []);
@@ -392,6 +524,16 @@ describe("staleSectionStartsExpanded", () => {
     );
     expect(staleSectionStartsExpanded(sections)).toBe(true);
   });
+
+  it("is true in the workspace view when every workspace was hidden as stale", () => {
+    const sections = buildWorkspaceSections(
+      [row({ section: "done", since: hoursAgo(9) })],
+      true,
+      8,
+    );
+    expect(sections.map((s) => s.header)).toEqual(["8+ hours old"]);
+    expect(staleSectionStartsExpanded(sections)).toBe(true);
+  });
 });
 
 describe("subtitle axis", () => {
@@ -415,18 +557,21 @@ describe("subtitle axis", () => {
   it("is the status label in the by-workspace view, and is not marked as a workspace", () => {
     // The workspace is already the heading here, so a workspace glyph on the
     // subtitle would label the status as something it isn't.
-    const [group] = buildWorkspaceSections([r]);
+    const [group] = buildWorkspaceSections([r], false, 8);
     expect(group.subtitle(r)).toBe("Idle");
     expect(group.subtitleIsWorkspace).toBe(false);
   });
 
-  it("marks the stale heading the same way as the section it splits from", () => {
+  it("marks the stale heading with a workspace subtitle in every grouping", () => {
     const stale = row({ section: "done", since: hoursAgo(9) });
     for (const sections of [
       buildStatusSections([stale], true, 8),
       buildAgeSections([stale], true, 8, []),
+      buildWorkspaceSections([stale], true, 8),
     ]) {
-      expect(sections.every((s) => s.subtitleIsWorkspace)).toBe(true);
+      const staleSection = sections.find((s) => s.header === "8+ hours old");
+      expect(staleSection?.subtitleIsWorkspace).toBe(true);
+      expect(staleSection?.subtitle(stale)).toBe("ws");
     }
   });
 });

--- a/packages/extensions-silo/src/agents/agents-panel.tsx
+++ b/packages/extensions-silo/src/agents/agents-panel.tsx
@@ -140,14 +140,39 @@ export function buildStatusSections(
 
 export function buildWorkspaceSections(
   rows: readonly AgentRow[],
+  staleDoneEnabled: boolean,
+  staleDoneHours: number,
 ): PanelSection[] {
-  return groupAgentRowsByWorkspace(rows).map((group) => ({
+  const isStale = (row: AgentRow) =>
+    staleDoneEnabled &&
+    row.section === "done" &&
+    isStaleDone(row, staleDoneHours);
+  // Workspaces whose every remaining row is stale disappear rather than
+  // sitting as an empty heading — the stale agents still show under the
+  // shared "N+ hours old" section below.
+  const workspaceSections = groupAgentRowsByWorkspace(
+    rows.filter((row) => !isStale(row)),
+  ).map((group) => ({
     key: group.workspaceId,
     header: group.workspaceName,
     rows: group.rows,
-    subtitle: (row) => SECTION_LABELS[row.section],
+    subtitle: (row: AgentRow) => SECTION_LABELS[row.section],
     subtitleIsWorkspace: false,
   }));
+  if (!staleDoneEnabled) return workspaceSections;
+  return [
+    ...workspaceSections,
+    {
+      key: STALE_DONE_SECTION_KEY,
+      header: `${staleDoneHours}+ hours old`,
+      rows: rows.filter(isStale).slice().sort(compareRows),
+      // Workspace is no longer the heading here, so the subtitle switches
+      // to the workspace name (same as Status / Recent's stale section).
+      subtitle: (row) => row.workspaceName,
+      subtitleIsWorkspace: true,
+      collapsible: true,
+    },
+  ];
 }
 
 /**
@@ -157,8 +182,8 @@ export function buildWorkspaceSections(
  * {@link orderAgeRows} / `manualOrder` (see `./manual-order`) — new agents
  * prepend at the top, and positions only change on drag-and-drop. There is
  * no automatic sort by duration/`since`. The one exception is the same
- * "N+ hours old" split `buildStatusSections` uses: a done row that's sat
- * past `staleDoneHours` still peels off into its own collapsible heading
+ * "N+ hours old" split Status and Workspace grouping use: a done row that's
+ * sat past `staleDoneHours` still peels off into its own collapsible heading
  * (tagged with the same `STALE_DONE_SECTION_KEY`, so the panel's existing
  * hover-to-reveal behavior applies unchanged, and it stays un-reorderable —
  * see `agents-panel.tsx`'s render, which only wires drag handlers for
@@ -618,7 +643,7 @@ export function AgentsPanel({
 
   const sections =
     groupBy === "workspace"
-      ? buildWorkspaceSections(rows)
+      ? buildWorkspaceSections(rows, staleDoneEnabled, staleDoneHours)
       : groupBy === "age"
         ? buildAgeSections(rows, staleDoneEnabled, staleDoneHours, manualOrder)
         : buildStatusSections(rows, staleDoneEnabled, staleDoneHours);


### PR DESCRIPTION
## What

The Agents navigator's **Workspace** view kept every idle agent under its
workspace heading indefinitely, so a long-lived workspace piled up rows nobody
was still watching — while the **Status** and **Recent** views already peel
those off into a collapsed "N+ hours old" section.

This applies that same split to Workspace grouping:

- An idle agent past the cutoff leaves its workspace heading for the shared,
  collapsible "N+ hours old" section at the bottom of the view.
- A workspace left with no remaining rows is dropped entirely rather than
  rendered as an empty heading.
- Stale rows in that section carry the **workspace name** as their subtitle
  (matching Status/Recent), since the workspace heading is no longer above them.

No new setting: it reuses the existing **Collapse older agents** toggle and
**Cutoff period** (Settings → Agents → Navigator), so turning it off restores
the previous behavior exactly. Working and ready agents stay under their
workspace no matter how long they've been running, same rule as the other views.

## Implementation

`buildWorkspaceSections` (`packages/extensions-silo/src/agents/agents-panel.tsx`)
now takes `staleDoneEnabled` / `staleDoneHours` and reuses the existing
`isStaleDone` helper and `STALE_DONE_SECTION_KEY`, so the panel's hover-to-reveal
and "starts expanded when there's nothing else" behavior applies unchanged.

## Testing

`pnpm test` green via the pre-commit hook (574 tests in `extensions-silo`).
Added unit coverage in `agents-panel-sections.test.ts` for both toggle states:
the heading always rendering, recent vs. stale partitioning, a workspace being
hidden once all its rows are stale, the configured (non-default) threshold, the
subtitle axis flip, and the stale section starting expanded when every workspace
was hidden.

Not yet exercised in a running build.

Made with [Cursor](https://cursor.com)